### PR TITLE
Eliminate hedging happy-path allocations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <!-- Core (netstandard2.0 only) -->
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
+    <PackageVersion Include="Reservoir" Version="1.4.0" />
 
     <!-- Satellites -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kevlar
 
-**Fast, zero-dependency resilience for .NET.** Retries, circuit breakers, timeouts, rate limiting, concurrency limiting, hedging and fallbacks — composed through one fluent, allocation-conscious Shield API.
+**Fast, allocation-conscious resilience for .NET.** Retries, circuit breakers, timeouts, rate limiting, concurrency limiting, hedging and fallbacks — composed through one fluent Shield API.
 
 ```csharp
 using Kevlar;
@@ -61,7 +61,7 @@ One clause up top decides what "failure" means for every strategy below it — e
 
 | Package | Purpose |
 |---|---|
-| `Kevlar` | The core: all strategies, zero dependencies |
+| `Kevlar` | The core: all strategies |
 | `Kevlar.Extensions.DependencyInjection` | Named shields, config-bound shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ One clause up top decides what "failure" means for every strategy below it — e
 - **Hard to hold wrong.** Impossible chain orders throw at build time with the fix in the message, and the `Kevlar.Analyzers` package flags delegates that ignore their `CancellationToken` at compile time.
 - **Observable out of the box.** `shield.ToString()` prints the whole pipeline; every shield publishes metrics through a built-in `Meter` — no telemetry package, no setup.
 - **Composable.** Shields merge with `Wrap` and `Compose`, chain fluently, and stateful strategies (breakers, limiters) intentionally share their state wherever the same shield instance is reused.
-- **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net8.0` targets. The core has zero third-party dependencies.
+- **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net8.0` targets.
 
 ## Packages
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -17,7 +17,7 @@ dotnet add package Kevlar.Extensions.DependencyInjection   # named shields + IKe
 dotnet add package Kevlar.Extensions.Http                  # HttpClientFactory integration
 ```
 
-The core targets `netstandard2.0` (so .NET Framework 4.6.2+ works) and `net8.0`, with zero third-party dependencies.
+The core targets `netstandard2.0` (so .NET Framework 4.6.2+ works) and `net8.0`.
 
 ## Your first shield
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -28,7 +28,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 - **Hard to hold wrong.** `Task` and `ValueTask` delegates both flow straight in; impossible chain orders throw at build time with a fix in the message; the `Kevlar.Analyzers` package flags delegates that ignore their `CancellationToken` at compile time.
 - **Observable out of the box.** Every shield describes itself (`shield.ToString()` prints the whole pipeline) and publishes metrics through a built-in `Meter` — no telemetry package, no setup.
 - **Composable.** Shields merge with `Wrap` and `Compose`, chain fluently, and stateful strategies (breakers, limiters) intentionally share their state wherever the same shield instance is reused.
-- **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net8.0` targets. The core has zero third-party dependencies.
+- **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net8.0` targets.
 
 ## Packages
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,7 +5,7 @@ slug: /intro
 
 # Introduction
 
-**Kevlar is fast, zero-dependency resilience for .NET.** Retries, circuit breakers, timeouts, rate limiting, concurrency limits, hedging and fallbacks — composed through one fluent, allocation-conscious shield API.
+**Kevlar is fast, allocation-conscious resilience for .NET.** Retries, circuit breakers, timeouts, rate limiting, concurrency limits, hedging and fallbacks — composed through one fluent shield API.
 
 ```csharp
 using Kevlar;
@@ -34,7 +34,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 
 | Package | Purpose |
 |---|---|
-| `Kevlar` | The core: all strategies, zero dependencies |
+| `Kevlar` | The core: all strategies |
 | `Kevlar.Extensions.DependencyInjection` | Named shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -42,7 +42,7 @@ The instinct to expose `IShield` comes from the "many implementations behind one
 
 This is the same conclusion Polly v8 reached: v7's `IAsyncPolicy` interfaces were dropped in favour of the concrete `ResiliencePipeline`, because no meaningful second implementation ever existed and the interface only bought virtual dispatch on the hot path.
 
-For the same reason there is no `Kevlar.Abstractions` package. Abstractions packages exist to spare library consumers a heavy dependency graph — but Kevlar has no dependencies to spare anyone from. Referencing `Kevlar` *is* referencing the abstraction.
+For the same reason there is no `Kevlar.Abstractions` package. Kevlar keeps its dependency graph small, and `Shield` is already the abstraction consumed by library code.
 
 And for testing, you don't need a mock: `Shield.Empty` is the no-op, and fault injection works better through a real shield with a [custom strategy](custom-strategies.md) — it exercises the actual engine. See [Testing Your Shields](testing.md).
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -41,7 +41,7 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics.AddMeter(KevlarDiagno
 | `kevlar.rejections` | fail-fast rejections | `shield.name`, `kind` (`circuit_open`/`rate_limit`/`concurrency_limit`) |
 | `kevlar.circuit_breaker.transitions` | circuit state changes | `from`, `to` |
 
-The `shield.name` tag appears only for shields named via `WithName` — name the shields you dashboard. On `netstandard2.0` targets the instruments are inert (the metrics API isn't in-box there), keeping the core dependency-free.
+The `shield.name` tag appears only for shields named via `WithName` — name the shields you dashboard. On `netstandard2.0` targets the instruments are inert because the metrics API isn't in-box there.
 
 ## Compile-time checks
 

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -8,8 +8,8 @@ namespace Kevlar.Internal;
 
 /// <summary>
 /// Kevlar's built-in instruments. Real counters on .NET 8+ (where
-/// <c>System.Diagnostics.Metrics</c> is in-box); no-ops on <c>netstandard2.0</c> so the core
-/// keeps its zero-dependency promise. Every recording checks <c>Enabled</c> first, so the
+/// <c>System.Diagnostics.Metrics</c> is in-box); no-ops on <c>netstandard2.0</c>.
+/// Every recording checks <c>Enabled</c> first, so the
 /// cost without a listener is a branch.
 /// </summary>
 internal static class KevlarMetrics

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -5,13 +5,17 @@
     <RootNamespace>Kevlar</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
-    <Description>Kevlar is a fast, zero-dependency resilience library for .NET: retries, circuit breakers, timeouts, rate limiting, concurrency limiting, hedging and fallbacks, composed through one fluent, allocation-conscious Shield API.</Description>
+    <Description>Kevlar is a fast, allocation-conscious resilience library for .NET: retries, circuit breakers, timeouts, rate limiting, concurrency limiting, hedging and fallbacks, composed through one fluent Shield API.</Description>
     <PackageTags>resilience;transient-fault-handling;retry;circuit-breaker;timeout;rate-limit;concurrency-limit;hedging;fallback;polly-alternative</PackageTags>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Reservoir" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+using Reservoir;
 
 namespace Kevlar;
 
@@ -9,14 +9,11 @@ namespace Kevlar;
 /// </summary>
 public sealed class KevlarContext
 {
-    private const int MaxPooled = 128;
+    private static readonly ObjectPool<KevlarContext, PoolPolicy> Pool = new(maxCapacity: 128);
 
-    private static readonly ConcurrentQueue<KevlarContext> Pool = new();
-    private static int _pooledCount;
-
-    private readonly bool _poolable;
-
-    private KevlarContext(bool poolable) => _poolable = poolable;
+    private KevlarContext()
+    {
+    }
 
     /// <summary>
     /// The cancellation token for the current scope. Strategies such as timeouts replace this
@@ -39,14 +36,7 @@ public sealed class KevlarContext
 
     internal static KevlarContext Rent(CancellationToken cancellationToken, bool isSynchronous, TimeProvider timeProvider, string? shieldName)
     {
-        if (Pool.TryDequeue(out var context))
-        {
-            Interlocked.Decrement(ref _pooledCount);
-        }
-        else
-        {
-            context = new KevlarContext(poolable: true);
-        }
+        var context = Pool.Rent();
 
         context.CancellationToken = cancellationToken;
         context.IsSynchronous = isSynchronous;
@@ -55,27 +45,7 @@ public sealed class KevlarContext
         return context;
     }
 
-    internal static void Return(KevlarContext context)
-    {
-        if (!context._poolable)
-        {
-            return;
-        }
-
-        context.CancellationToken = default;
-        context.ShieldName = null;
-        context.TimeProvider = TimeProvider.System;
-        context.Properties.Clear();
-
-        if (Interlocked.Increment(ref _pooledCount) <= MaxPooled)
-        {
-            Pool.Enqueue(context);
-        }
-        else
-        {
-            Interlocked.Decrement(ref _pooledCount);
-        }
-    }
+    internal static void Return(KevlarContext context) => Pool.Return(context);
 
     /// <summary>
     /// Creates a detached copy of this context for a concurrent attempt (used by hedging).
@@ -83,15 +53,24 @@ public sealed class KevlarContext
     /// </summary>
     internal KevlarContext Fork(CancellationToken cancellationToken)
     {
-        var fork = new KevlarContext(poolable: false)
-        {
-            CancellationToken = cancellationToken,
-            IsSynchronous = IsSynchronous,
-            ShieldName = ShieldName,
-            TimeProvider = TimeProvider,
-        };
+        var fork = Rent(cancellationToken, IsSynchronous, TimeProvider, ShieldName);
 
         Properties.CopyTo(fork.Properties);
         return fork;
+    }
+
+    private readonly struct PoolPolicy : IPooledObjectPolicy<KevlarContext>
+    {
+        public KevlarContext Create() => new();
+
+        public bool TryReset(KevlarContext context)
+        {
+            context.CancellationToken = default;
+            context.IsSynchronous = false;
+            context.ShieldName = null;
+            context.TimeProvider = TimeProvider.System;
+            context.Properties.Clear();
+            return true;
+        }
     }
 }

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -1,4 +1,5 @@
 using Kevlar.Internal;
+using Reservoir;
 
 namespace Kevlar.Strategies;
 
@@ -24,11 +25,11 @@ internal sealed class HedgingStrategy : Strategy
 
     public override string Describe() => $"Hedge({_maxAttempts} attempts, delay {DescribeHelper.Time(_delay)})";
 
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         if (_maxAttempts == 1)
         {
-            return await next.InvokeAsync(context).ConfigureAwait(false);
+            return next.InvokeAsync(context);
         }
 
         if (context.IsSynchronous)
@@ -36,13 +37,49 @@ internal sealed class HedgingStrategy : Strategy
             throw new NotSupportedException("Hedging requires asynchronous execution. Use ExecuteAsync instead of Execute.");
         }
 
-        var pending = new List<HedgeAttempt<T>>(_maxAttempts);
-        var launched = 0;
-        var lastOutcome = default(Outcome<T>);
+        var primary = StartAttempt(next, context, attemptNumber: 1);
+        if (_delay == TimeSpan.Zero || !primary.Execution.IsCompletedSuccessfully)
+        {
+            return ExecuteCoreAsync(next, context, primary.AsPending(), launched: 1, default);
+        }
+
+        Outcome<T> outcome;
+        try
+        {
+            outcome = primary.Execution.Result;
+        }
+        finally
+        {
+            primary.Dispose();
+        }
+
+        if (!_judge.ShouldHandle(in outcome))
+        {
+            return new ValueTask<Outcome<T>>(outcome);
+        }
+
+        return ExecuteCoreAsync(next, context, initial: null, launched: 1, outcome);
+    }
+
+    private async ValueTask<Outcome<T>> ExecuteCoreAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        HedgeAttempt<T>? initial,
+        int launched,
+        Outcome<T> lastOutcome)
+    {
+        var pending = ListPool<HedgeAttempt<T>>.Shared.Rent();
 
         try
         {
-            Launch(pending, next, context, ref launched);
+            if (initial is { } primary)
+            {
+                pending.Add(primary);
+            }
+            else
+            {
+                Launch(pending, next, context, ref launched);
+            }
 
             while (true)
             {
@@ -56,7 +93,7 @@ internal sealed class HedgingStrategy : Strategy
 
                 if (launched < _maxAttempts && _delay != System.Threading.Timeout.InfiniteTimeSpan)
                 {
-                    using var delayCancellation = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+                    using var delayCancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);
                     var delayTask = DelayHelper.CreateDelayTask(context.TimeProvider, _delay, delayCancellation.Token);
                     var winner = await WhenAnyAttemptOr(pending, delayTask).ConfigureAwait(false);
 
@@ -101,22 +138,28 @@ internal sealed class HedgingStrategy : Strategy
                 attempt.Cancellation.Cancel();
                 Cleanup(attempt);
             }
+
+            ListPool<HedgeAttempt<T>>.Shared.Return(pending);
         }
     }
 
     private void Launch<T, TState>(List<HedgeAttempt<T>> pending, Continuation<T, TState> next, KevlarContext context, ref int launched)
     {
         var attemptNumber = ++launched;
+        pending.Add(StartAttempt(next, context, attemptNumber).AsPending());
+    }
 
+    private StartedAttempt<T> StartAttempt<T, TState>(Continuation<T, TState> next, KevlarContext context, int attemptNumber)
+    {
         if (attemptNumber > 1)
         {
             KevlarMetrics.Hedge(context.ShieldName);
             _onHedge?.Invoke(new HedgeEvent(attemptNumber, context));
         }
 
-        var cancellation = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+        var cancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);
         var fork = context.Fork(cancellation.Token);
-        pending.Add(new HedgeAttempt<T>(next.InvokeAsync(fork).AsTask(), cancellation));
+        return new StartedAttempt<T>(next.InvokeAsync(fork), cancellation, fork);
     }
 
     private static Task<Task> WhenAnyAttemptOr<T>(List<HedgeAttempt<T>> pending, Task delayTask)
@@ -148,7 +191,7 @@ internal sealed class HedgingStrategy : Strategy
         {
             if (ReferenceEquals(pending[i].Task, task))
             {
-                pending[i].Cancellation.Dispose();
+                pending[i].Dispose();
                 pending.RemoveAt(i);
                 return;
             }
@@ -159,13 +202,13 @@ internal sealed class HedgingStrategy : Strategy
     {
         if (attempt.Task.IsCompleted)
         {
-            attempt.Cancellation.Dispose();
+            attempt.Dispose();
             return;
         }
 
         _ = attempt.Task.ContinueWith(
-            static (_, state) => ((CancellationTokenSource)state!).Dispose(),
-            attempt.Cancellation,
+            static (_, state) => ((HedgeAttempt<T>)state!).Dispose(),
+            attempt,
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
@@ -173,14 +216,47 @@ internal sealed class HedgingStrategy : Strategy
 
     private readonly struct HedgeAttempt<T>
     {
-        public HedgeAttempt(Task<Outcome<T>> task, CancellationTokenSource cancellation)
+        public HedgeAttempt(Task<Outcome<T>> task, CancellationTokenSource cancellation, KevlarContext context)
         {
             Task = task;
             Cancellation = cancellation;
+            Context = context;
         }
 
         public Task<Outcome<T>> Task { get; }
 
         public CancellationTokenSource Cancellation { get; }
+
+        public KevlarContext Context { get; }
+
+        public void Dispose()
+        {
+            KevlarContext.Return(Context);
+            Cancellation.Dispose();
+        }
+    }
+
+    private readonly struct StartedAttempt<T>
+    {
+        public StartedAttempt(ValueTask<Outcome<T>> execution, CancellationTokenSource cancellation, KevlarContext context)
+        {
+            Execution = execution;
+            Cancellation = cancellation;
+            Context = context;
+        }
+
+        public ValueTask<Outcome<T>> Execution { get; }
+
+        private CancellationTokenSource Cancellation { get; }
+
+        private KevlarContext Context { get; }
+
+        public HedgeAttempt<T> AsPending() => new(Execution.AsTask(), Cancellation, Context);
+
+        public void Dispose()
+        {
+            KevlarContext.Return(Context);
+            Cancellation.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add a synchronous primary-completion fast path for hedging
- pool attempt contexts, cancellation sources, and pending lists
- remove stale zero-dependency claims from user-facing documentation

## Performance

BenchmarkDotNet default run on .NET 10.0.11:

| Implementation | Mean | Allocated |
|---|---:|---:|
| Kevlar before | 316.8 ns | 864 B |
| Kevlar after | 137.5 ns | 0 B |
| Polly v8 | 257.7 ns | 0 B |

Kevlar is allocation-free and about 47% faster than Polly on the primary-wins happy path.

## Validation

- release build: 0 warnings, 0 errors
- unit tests: 265 passed
- integration tests: 16 passed
- analyzer tests: 6 passed
- NuGet pack passed

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved resource pooling and context reuse to reduce allocations during request execution.
  - Added faster handling for synchronous and immediately successful operations.
  - Improved cleanup and lifecycle management for resources used during hedged execution.

- **Documentation**
  - Updated product descriptions to emphasize allocation-conscious design.
  - Clarified package dependencies, metrics behavior on .NET Standard 2.0, and guidance for library authors.
  - Refined documentation around core functionality, installation, and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->