### PR TITLE
perf: speed up uncontended rate limiting

### DIFF
--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -6,18 +8,21 @@ namespace Kevlar.Strategies;
 /// Token bucket with reservations: the bucket refills continuously at Permits/Window. When empty,
 /// up to QueueLimit executions may reserve future tokens (driving the balance negative) and wait
 /// for their replenishment time; beyond that, executions are rejected immediately.
+/// Uses GCRA's atomic theoretical-arrival schedule, which is equivalent to a token bucket.
 /// </summary>
 internal sealed class RateLimitStrategy : Strategy
 {
-    private readonly object _gate = new();
+    private static readonly double SecondsPerSystemTimestamp = 1d / Stopwatch.Frequency;
+
     private readonly int _permits;
     private readonly TimeSpan _window;
-    private readonly double _permitsPerSecond;
-    private readonly double _burst;
+    private readonly int _burst;
     private readonly int _queueLimit;
+    private readonly double _timestampUnitsPerPermit;
+    private readonly double _burstTolerance;
+    private readonly double _queueTolerance;
 
-    private double _tokens;
-    private long _lastRefillTimestamp = -1;
+    private double _theoreticalArrival;
 
     public RateLimitStrategy(RateLimitOptions options)
     {
@@ -28,80 +33,78 @@ internal sealed class RateLimitStrategy : Strategy
 
         _permits = options.Permits;
         _window = options.Window;
-        _permitsPerSecond = options.Permits / options.Window.TotalSeconds;
         _burst = options.Burst ?? options.Permits;
         _queueLimit = options.QueueLimit;
-        _tokens = _burst;
+        _timestampUnitsPerPermit = options.Window.TotalSeconds * Stopwatch.Frequency / options.Permits;
+        _burstTolerance = (_burst - 1) * _timestampUnitsPerPermit;
+        _queueTolerance = _queueLimit * _timestampUnitsPerPermit;
     }
 
     public override string Describe()
     {
         var queue = _queueLimit > 0 ? $", queue {_queueLimit}" : string.Empty;
-        var burst = (int)_burst != _permits ? $", burst {(int)_burst}" : string.Empty;
+        var burst = _burst != _permits ? $", burst {_burst}" : string.Empty;
         return $"RateLimit({_permits}/{DescribeHelper.Time(_window)}{burst}{queue})";
     }
 
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         if (!TryAcquire(context.TimeProvider, out var wait, out var retryAfter))
         {
             KevlarMetrics.Rejection(context.ShieldName, "rate_limit");
-            return Outcome<T>.FromException(new RateLimitExceededException(retryAfter));
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(new RateLimitExceededException(retryAfter)));
         }
 
-        if (wait > TimeSpan.Zero)
+        return wait > TimeSpan.Zero
+            ? ExecuteAfterDelayAsync(next, context, wait)
+            : next.InvokeAsync(context);
+    }
+
+    private static async ValueTask<Outcome<T>> ExecuteAfterDelayAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        TimeSpan wait)
+    {
+        try
         {
-            try
-            {
-                await DelayHelper.DelayAsync(context, wait).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException cancelled)
-            {
-                return Outcome<T>.FromException(cancelled);
-            }
+            await DelayHelper.DelayAsync(context, wait).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException cancelled)
+        {
+            return Outcome<T>.FromException(cancelled);
         }
 
         return await next.InvokeAsync(context).ConfigureAwait(false);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAcquire(TimeProvider timeProvider, out TimeSpan wait, out TimeSpan? retryAfter)
     {
-        lock (_gate)
+        var now = ReferenceEquals(timeProvider, TimeProvider.System)
+            ? Stopwatch.GetTimestamp()
+            : timeProvider.GetTimestamp() * (Stopwatch.Frequency / (double)timeProvider.TimestampFrequency);
+
+        while (true)
         {
-            var now = timeProvider.GetTimestamp();
+            var theoreticalArrival = Volatile.Read(ref _theoreticalArrival);
+            var delayTimestampUnits = theoreticalArrival - _burstTolerance - now;
 
-            if (_lastRefillTimestamp >= 0)
+            if (delayTimestampUnits > _queueTolerance)
             {
-                var elapsed = timeProvider.GetElapsedTime(_lastRefillTimestamp, now).TotalSeconds;
-                if (elapsed > 0)
-                {
-                    _tokens = Math.Min(_burst, _tokens + (elapsed * _permitsPerSecond));
-                }
-            }
-
-            _lastRefillTimestamp = now;
-
-            var balanceAfterTake = _tokens - 1;
-
-            if (balanceAfterTake >= 0)
-            {
-                _tokens = balanceAfterTake;
                 wait = TimeSpan.Zero;
-                retryAfter = null;
-                return true;
+                retryAfter = TimeSpan.FromSeconds(delayTimestampUnits * SecondsPerSystemTimestamp);
+                return false;
             }
 
-            if (-balanceAfterTake <= _queueLimit)
+            var nextArrival = Math.Max(now, theoreticalArrival) + _timestampUnitsPerPermit;
+            if (Interlocked.CompareExchange(ref _theoreticalArrival, nextArrival, theoreticalArrival) == theoreticalArrival)
             {
-                _tokens = balanceAfterTake;
-                wait = TimeSpan.FromSeconds(-balanceAfterTake / _permitsPerSecond);
+                wait = delayTimestampUnits > 0
+                    ? TimeSpan.FromSeconds(delayTimestampUnits * SecondsPerSystemTimestamp)
+                    : TimeSpan.Zero;
                 retryAfter = null;
                 return true;
             }
-
-            wait = TimeSpan.Zero;
-            retryAfter = TimeSpan.FromSeconds((1 - _tokens) / _permitsPerSecond);
-            return false;
         }
     }
 }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -82,13 +82,10 @@ internal sealed class RateLimitStrategy : Strategy
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAcquire(TimeProvider timeProvider, out TimeSpan wait, out TimeSpan? retryAfter)
     {
-        var now = ReferenceEquals(timeProvider, TimeProvider.System)
-            ? Stopwatch.GetTimestamp() - _systemTimestampOrigin
-            : GetCustomTimestamp(timeProvider);
-
         while (true)
         {
             var theoreticalArrival = Volatile.Read(ref _theoreticalArrival);
+            var now = GetCurrentTimestamp(timeProvider);
             var delayTimestampUnits = theoreticalArrival - _burstTolerance - now;
 
             if (delayTimestampUnits > _queueTolerance)
@@ -109,6 +106,12 @@ internal sealed class RateLimitStrategy : Strategy
             }
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private double GetCurrentTimestamp(TimeProvider timeProvider) =>
+        ReferenceEquals(timeProvider, TimeProvider.System)
+            ? Stopwatch.GetTimestamp() - _systemTimestampOrigin
+            : GetCustomTimestamp(timeProvider);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private double GetCustomTimestamp(TimeProvider timeProvider)

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -12,6 +12,9 @@ namespace Kevlar.Strategies;
 /// </summary>
 internal sealed class RateLimitStrategy : Strategy
 {
+    private const int TimestampOriginInitializing = 1;
+    private const int TimestampOriginInitialized = 2;
+
     private static readonly double SecondsPerSystemTimestamp = 1d / Stopwatch.Frequency;
 
     private readonly int _permits;
@@ -23,6 +26,8 @@ internal sealed class RateLimitStrategy : Strategy
     private readonly double _queueTolerance;
 
     private double _theoreticalArrival = double.NegativeInfinity;
+    private long _customTimestampOrigin;
+    private int _customTimestampOriginState;
 
     public RateLimitStrategy(RateLimitOptions options)
     {
@@ -82,7 +87,7 @@ internal sealed class RateLimitStrategy : Strategy
     {
         var now = ReferenceEquals(timeProvider, TimeProvider.System)
             ? Stopwatch.GetTimestamp()
-            : timeProvider.GetTimestamp() * (Stopwatch.Frequency / (double)timeProvider.TimestampFrequency);
+            : GetCustomTimestamp(timeProvider);
 
         while (true)
         {
@@ -105,6 +110,35 @@ internal sealed class RateLimitStrategy : Strategy
                 retryAfter = null;
                 return true;
             }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private double GetCustomTimestamp(TimeProvider timeProvider)
+    {
+        var timestamp = timeProvider.GetTimestamp();
+        if (Volatile.Read(ref _customTimestampOriginState) != TimestampOriginInitialized)
+        {
+            InitializeCustomTimestampOrigin(timestamp);
+        }
+
+        return (timestamp - _customTimestampOrigin)
+            * (Stopwatch.Frequency / (double)timeProvider.TimestampFrequency);
+    }
+
+    private void InitializeCustomTimestampOrigin(long timestamp)
+    {
+        if (Interlocked.CompareExchange(ref _customTimestampOriginState, TimestampOriginInitializing, 0) == 0)
+        {
+            _customTimestampOrigin = timestamp;
+            Volatile.Write(ref _customTimestampOriginState, TimestampOriginInitialized);
+            return;
+        }
+
+        var spinner = new SpinWait();
+        while (Volatile.Read(ref _customTimestampOriginState) != TimestampOriginInitialized)
+        {
+            spinner.SpinOnce();
         }
     }
 }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -22,7 +22,7 @@ internal sealed class RateLimitStrategy : Strategy
     private readonly double _burstTolerance;
     private readonly double _queueTolerance;
 
-    private double _theoreticalArrival;
+    private double _theoreticalArrival = double.NegativeInfinity;
 
     public RateLimitStrategy(RateLimitOptions options)
     {

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -17,6 +17,7 @@ internal sealed class RateLimitStrategy : Strategy
 
     private static readonly double SecondsPerSystemTimestamp = 1d / Stopwatch.Frequency;
 
+    private readonly long _systemTimestampOrigin = Stopwatch.GetTimestamp();
     private readonly int _permits;
     private readonly TimeSpan _window;
     private readonly int _burst;
@@ -27,6 +28,7 @@ internal sealed class RateLimitStrategy : Strategy
 
     private double _theoreticalArrival = double.NegativeInfinity;
     private long _customTimestampOrigin;
+    private long _customTimelineOrigin;
     private int _customTimestampOriginState;
 
     public RateLimitStrategy(RateLimitOptions options)
@@ -86,7 +88,7 @@ internal sealed class RateLimitStrategy : Strategy
     private bool TryAcquire(TimeProvider timeProvider, out TimeSpan wait, out TimeSpan? retryAfter)
     {
         var now = ReferenceEquals(timeProvider, TimeProvider.System)
-            ? Stopwatch.GetTimestamp()
+            ? Stopwatch.GetTimestamp() - _systemTimestampOrigin
             : GetCustomTimestamp(timeProvider);
 
         while (true)
@@ -122,8 +124,9 @@ internal sealed class RateLimitStrategy : Strategy
             InitializeCustomTimestampOrigin(timestamp);
         }
 
-        return (timestamp - _customTimestampOrigin)
-            * (Stopwatch.Frequency / (double)timeProvider.TimestampFrequency);
+        return _customTimelineOrigin
+            + ((timestamp - _customTimestampOrigin)
+                * (Stopwatch.Frequency / (double)timeProvider.TimestampFrequency));
     }
 
     private void InitializeCustomTimestampOrigin(long timestamp)
@@ -131,6 +134,7 @@ internal sealed class RateLimitStrategy : Strategy
         if (Interlocked.CompareExchange(ref _customTimestampOriginState, TimestampOriginInitializing, 0) == 0)
         {
             _customTimestampOrigin = timestamp;
+            _customTimelineOrigin = Stopwatch.GetTimestamp() - _systemTimestampOrigin;
             Volatile.Write(ref _customTimestampOriginState, TimestampOriginInitialized);
             return;
         }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -86,7 +86,7 @@ internal sealed class RateLimitStrategy : Strategy
         {
             var theoreticalArrival = Volatile.Read(ref _theoreticalArrival);
             var now = GetCurrentTimestamp(timeProvider);
-            var delayTimestampUnits = theoreticalArrival - _burstTolerance - now;
+            var delayTimestampUnits = theoreticalArrival - now - _burstTolerance;
 
             if (delayTimestampUnits > _queueTolerance)
             {
@@ -95,7 +95,13 @@ internal sealed class RateLimitStrategy : Strategy
                 return false;
             }
 
-            var nextArrival = Math.Max(now, theoreticalArrival) + _timestampUnitsPerPermit;
+            var arrival = Math.Max(now, theoreticalArrival);
+            var nextArrival = arrival + _timestampUnitsPerPermit;
+            if (nextArrival == arrival)
+            {
+                nextArrival = GetNextRepresentableTimestamp(arrival);
+            }
+
             if (Interlocked.CompareExchange(ref _theoreticalArrival, nextArrival, theoreticalArrival) == theoreticalArrival)
             {
                 wait = delayTimestampUnits > 0
@@ -105,6 +111,12 @@ internal sealed class RateLimitStrategy : Strategy
                 return true;
             }
         }
+    }
+
+    private static double GetNextRepresentableTimestamp(double timestamp)
+    {
+        var bits = BitConverter.DoubleToInt64Bits(timestamp);
+        return BitConverter.Int64BitsToDouble(timestamp < 0 ? bits - 1 : bits + 1);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -12,12 +12,10 @@ namespace Kevlar.Strategies;
 /// </summary>
 internal sealed class RateLimitStrategy : Strategy
 {
-    private const int TimestampOriginInitializing = 1;
-    private const int TimestampOriginInitialized = 2;
-
     private static readonly double SecondsPerSystemTimestamp = 1d / Stopwatch.Frequency;
 
     private readonly long _systemTimestampOrigin = Stopwatch.GetTimestamp();
+    private readonly ConditionalWeakTable<TimeProvider, CustomTimestampOrigin> _customTimestampOrigins = new();
     private readonly int _permits;
     private readonly TimeSpan _window;
     private readonly int _burst;
@@ -27,9 +25,6 @@ internal sealed class RateLimitStrategy : Strategy
     private readonly double _queueTolerance;
 
     private double _theoreticalArrival = double.NegativeInfinity;
-    private long _customTimestampOrigin;
-    private long _customTimelineOrigin;
-    private int _customTimestampOriginState;
 
     public RateLimitStrategy(RateLimitOptions options)
     {
@@ -118,31 +113,28 @@ internal sealed class RateLimitStrategy : Strategy
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private double GetCustomTimestamp(TimeProvider timeProvider)
     {
+        var origin = _customTimestampOrigins.GetValue(
+            timeProvider,
+            static provider => new CustomTimestampOrigin(provider));
         var timestamp = timeProvider.GetTimestamp();
-        if (Volatile.Read(ref _customTimestampOriginState) != TimestampOriginInitialized)
-        {
-            InitializeCustomTimestampOrigin(timestamp);
-        }
 
-        return _customTimelineOrigin
-            + ((timestamp - _customTimestampOrigin)
-                * (Stopwatch.Frequency / (double)timeProvider.TimestampFrequency));
+        return origin.SystemTimestamp - _systemTimestampOrigin
+            + ((timestamp - origin.ProviderTimestamp) * origin.TimestampScale);
     }
 
-    private void InitializeCustomTimestampOrigin(long timestamp)
+    private sealed class CustomTimestampOrigin
     {
-        if (Interlocked.CompareExchange(ref _customTimestampOriginState, TimestampOriginInitializing, 0) == 0)
+        public CustomTimestampOrigin(TimeProvider timeProvider)
         {
-            _customTimestampOrigin = timestamp;
-            _customTimelineOrigin = Stopwatch.GetTimestamp() - _systemTimestampOrigin;
-            Volatile.Write(ref _customTimestampOriginState, TimestampOriginInitialized);
-            return;
+            SystemTimestamp = Stopwatch.GetTimestamp();
+            ProviderTimestamp = timeProvider.GetTimestamp();
+            TimestampScale = Stopwatch.Frequency / (double)timeProvider.TimestampFrequency;
         }
 
-        var spinner = new SpinWait();
-        while (Volatile.Read(ref _customTimestampOriginState) != TimestampOriginInitialized)
-        {
-            spinner.SpinOnce();
-        }
+        public long SystemTimestamp { get; }
+
+        public long ProviderTimestamp { get; }
+
+        public double TimestampScale { get; }
     }
 }

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -72,13 +72,31 @@ public readonly struct Continuation<T, TState>
         return InvokeStrategyAsync(_next, context);
     }
 
-    private async ValueTask<Outcome<T>> InvokeStrategyAsync(StrategyNode node, KevlarContext context)
+    private ValueTask<Outcome<T>> InvokeStrategyAsync(StrategyNode node, KevlarContext context)
+    {
+        ValueTask<Outcome<T>> execution;
+
+        try
+        {
+            execution = node.Strategy.ExecuteAsync(
+                new Continuation<T, TState>(node.Next, _callback, _state),
+                context);
+        }
+        catch (Exception exception)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
+        }
+
+        return execution.IsCompletedSuccessfully
+            ? execution
+            : AwaitStrategyAsync(execution);
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitStrategyAsync(ValueTask<Outcome<T>> execution)
     {
         try
         {
-            return await node.Strategy
-                .ExecuteAsync(new Continuation<T, TState>(node.Next, _callback, _state), context)
-                .ConfigureAwait(false);
+            return await execution.ConfigureAwait(false);
         }
         catch (Exception exception)
         {

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -210,7 +210,7 @@ public class RateLimitEdgeCaseTests
     {
         var shield = Shield
             .RateLimit(1, TimeSpan.FromSeconds(1))
-            .WithTimeProvider(new NegativeTimestampTimeProvider());
+            .WithTimeProvider(new FixedTimestampTimeProvider(-TimeSpan.TicksPerSecond));
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(1));
         await Assert.That(result).IsEqualTo(1);
@@ -219,10 +219,36 @@ public class RateLimitEdgeCaseTests
             .Throws<RateLimitExceededException>();
     }
 
-    private sealed class NegativeTimestampTimeProvider : TimeProvider
+    [Test]
+    public async Task Large_Timestamp_Epoch_Preserves_High_Rate_Intervals()
     {
+        var shield = Shield
+            .RateLimit(options =>
+            {
+                options.Permits = 1_000_000;
+                options.Window = TimeSpan.FromSeconds(1);
+                options.Burst = 1;
+            })
+            .WithTimeProvider(new FixedTimestampTimeProvider(long.MaxValue / 2));
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        await Assert.That(result).IsEqualTo(1);
+
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+    }
+
+    private sealed class FixedTimestampTimeProvider : TimeProvider
+    {
+        private readonly long _timestamp;
+
+        public FixedTimestampTimeProvider(long timestamp)
+        {
+            _timestamp = timestamp;
+        }
+
         public override long TimestampFrequency => TimeSpan.TicksPerSecond;
 
-        public override long GetTimestamp() => -TimeSpan.TicksPerSecond;
+        public override long GetTimestamp() => _timestamp;
     }
 }

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -173,6 +173,30 @@ public class RateLimitEdgeCaseTests
     }
 
     [Test]
+    public async Task Contended_Acquire_Refreshes_Its_Timestamp()
+    {
+        using var timeProvider = new ContendedTimestampTimeProvider();
+        var shield = Shield
+            .RateLimit(1, TimeSpan.FromSeconds(1))
+            .WithTimeProvider(timeProvider);
+        var delayedExecution = Task.Run(async () =>
+            await shield.ExecuteAsync(_ => new ValueTask<int>(1)));
+
+        try
+        {
+            await Assert.That(timeProvider.WaitForBlockedSample(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(2))).IsEqualTo(2);
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            timeProvider.ReleaseBlockedSample();
+        }
+
+        await Assert.That(await delayedExecution).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Failures_Do_Not_Refund_Tokens()
     {
         var fakeTime = new FakeTimeProvider();
@@ -281,5 +305,39 @@ public class RateLimitEdgeCaseTests
         public override long TimestampFrequency => _timestampFrequency;
 
         public override long GetTimestamp() => _timestamp;
+    }
+
+    private sealed class ContendedTimestampTimeProvider : TimeProvider, IDisposable
+    {
+        private readonly ManualResetEventSlim _sampleCaptured = new();
+        private readonly ManualResetEventSlim _releaseSample = new();
+        private long _timestamp;
+        private int _getTimestampCalls;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp()
+        {
+            var timestamp = Volatile.Read(ref _timestamp);
+            if (Interlocked.Increment(ref _getTimestampCalls) == 2)
+            {
+                _sampleCaptured.Set();
+                _releaseSample.Wait();
+            }
+
+            return timestamp;
+        }
+
+        public void Advance(TimeSpan elapsed) => Interlocked.Add(ref _timestamp, elapsed.Ticks);
+
+        public bool WaitForBlockedSample(TimeSpan timeout) => _sampleCaptured.Wait(timeout);
+
+        public void ReleaseBlockedSample() => _releaseSample.Set();
+
+        public void Dispose()
+        {
+            _sampleCaptured.Dispose();
+            _releaseSample.Dispose();
+        }
     }
 }

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -204,4 +204,25 @@ public class RateLimitEdgeCaseTests
             .IsEqualTo(TimeSpan.FromSeconds(10))
             .Within(TimeSpan.FromMilliseconds(1));
     }
+
+    [Test]
+    public async Task Negative_Timestamp_Epoch_Allows_The_Initial_Burst()
+    {
+        var shield = Shield
+            .RateLimit(1, TimeSpan.FromSeconds(1))
+            .WithTimeProvider(new NegativeTimestampTimeProvider());
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        await Assert.That(result).IsEqualTo(1);
+
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+    }
+
+    private sealed class NegativeTimestampTimeProvider : TimeProvider
+    {
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => -TimeSpan.TicksPerSecond;
+    }
 }

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -251,16 +251,34 @@ public class RateLimitEdgeCaseTests
         await Assert.That(rejection!.RetryAfter!.Value <= TimeSpan.FromSeconds(1)).IsTrue();
     }
 
+    [Test]
+    public async Task Distinct_Custom_Provider_Copies_Share_A_Timeline()
+    {
+        var shield = Shield
+            .RateLimit(1, TimeSpan.FromSeconds(1))
+            .WithTimeProvider(new FixedTimestampTimeProvider(0, 1));
+        var secondProviderCopy = shield.WithTimeProvider(
+            new FixedTimestampTimeProvider(long.MaxValue / 2, TimeSpan.TicksPerSecond));
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+
+        var rejection = await Assert.That(async () => await secondProviderCopy.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+        await Assert.That(rejection!.RetryAfter!.Value <= TimeSpan.FromSeconds(1)).IsTrue();
+    }
+
     private sealed class FixedTimestampTimeProvider : TimeProvider
     {
         private readonly long _timestamp;
+        private readonly long _timestampFrequency;
 
-        public FixedTimestampTimeProvider(long timestamp)
+        public FixedTimestampTimeProvider(long timestamp, long timestampFrequency = TimeSpan.TicksPerSecond)
         {
             _timestamp = timestamp;
+            _timestampFrequency = timestampFrequency;
         }
 
-        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override long TimestampFrequency => _timestampFrequency;
 
         public override long GetTimestamp() => _timestamp;
     }

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -238,6 +238,19 @@ public class RateLimitEdgeCaseTests
             .Throws<RateLimitExceededException>();
     }
 
+    [Test]
+    public async Task System_And_Custom_Provider_Copies_Share_A_Timeline()
+    {
+        var shield = Shield.RateLimit(1, TimeSpan.FromSeconds(1));
+        var customTimeCopy = shield.WithTimeProvider(new FixedTimestampTimeProvider(0));
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+
+        var rejection = await Assert.That(async () => await customTimeCopy.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+        await Assert.That(rejection!.RetryAfter!.Value <= TimeSpan.FromSeconds(1)).IsTrue();
+    }
+
     private sealed class FixedTimestampTimeProvider : TimeProvider
     {
         private readonly long _timestamp;

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -51,6 +51,21 @@ public class RateLimitEdgeCaseTests
     }
 
     [Test]
+    public async Task Partially_Used_Burst_Cannot_Accumulate_Beyond_The_Burst()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var shield = Shield.RateLimit(2, TimeSpan.FromSeconds(10)).WithTimeProvider(fakeTime);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        fakeTime.Advance(TimeSpan.FromMinutes(10));
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(2));
+        await shield.ExecuteAsync(_ => new ValueTask<int>(3));
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(4)))
+            .Throws<RateLimitExceededException>();
+    }
+
+    [Test]
     public async Task Burst_Can_Exceed_The_Sustained_Rate()
     {
         var fakeTime = new FakeTimeProvider();

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -113,7 +113,9 @@ public class RateLimitEdgeCaseTests
         // The queue is exhausted; the next execution is rejected with an estimate.
         var rejection = await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(4)))
             .Throws<RateLimitExceededException>();
-        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.FromSeconds(3));
+        await Assert.That(rejection!.RetryAfter!.Value)
+            .IsEqualTo(TimeSpan.FromSeconds(3))
+            .Within(TimeSpan.FromMilliseconds(1));
 
         fakeTime.Advance(TimeSpan.FromSeconds(1));
         await Assert.That(await second).IsEqualTo(2);
@@ -198,6 +200,8 @@ public class RateLimitEdgeCaseTests
             .Throws<RateLimitExceededException>();
 
         // The bucket is empty; one token takes a full window to replenish.
-        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.FromSeconds(10));
+        await Assert.That(rejection!.RetryAfter!.Value)
+            .IsEqualTo(TimeSpan.FromSeconds(10))
+            .Within(TimeSpan.FromMilliseconds(1));
     }
 }

--- a/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RateLimitEdgeCaseTests.cs
@@ -263,6 +263,27 @@ public class RateLimitEdgeCaseTests
     }
 
     [Test]
+    public async Task Large_Elapsed_Timestamp_Preserves_High_Rate_Intervals()
+    {
+        var timeProvider = new FixedTimestampTimeProvider(0);
+        var shield = Shield
+            .RateLimit(options =>
+            {
+                options.Permits = 1_000_000;
+                options.Window = TimeSpan.FromSeconds(1);
+                options.Burst = 1;
+            })
+            .WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        timeProvider.AdvanceTimestamp(long.MaxValue / 2);
+        await shield.ExecuteAsync(_ => new ValueTask<int>(2));
+
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(3)))
+            .Throws<RateLimitExceededException>();
+    }
+
+    [Test]
     public async Task System_And_Custom_Provider_Copies_Share_A_Timeline()
     {
         var shield = Shield.RateLimit(1, TimeSpan.FromSeconds(1));
@@ -293,7 +314,7 @@ public class RateLimitEdgeCaseTests
 
     private sealed class FixedTimestampTimeProvider : TimeProvider
     {
-        private readonly long _timestamp;
+        private long _timestamp;
         private readonly long _timestampFrequency;
 
         public FixedTimestampTimeProvider(long timestamp, long timestampFrequency = TimeSpan.TicksPerSecond)
@@ -304,7 +325,9 @@ public class RateLimitEdgeCaseTests
 
         public override long TimestampFrequency => _timestampFrequency;
 
-        public override long GetTimestamp() => _timestamp;
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
+
+        public void AdvanceTimestamp(long delta) => Interlocked.Add(ref _timestamp, delta);
     }
 
     private sealed class ContendedTimestampTimeProvider : TimeProvider, IDisposable


### PR DESCRIPTION
## Summary

- replace locked token-bucket accounting with an atomic GCRA schedule
- bypass async state machines when rate limiting and strategy execution complete synchronously
- add regression coverage for partially used burst refill behavior

## Performance

`RateLimitBenchmarks` default run on .NET 10.0.11:

| | Before | After | Polly |
|---|---:|---:|---:|
| Uncontended acquire | 137.7 ns | **82.49 ns** | 100.58 ns |
| Allocated | 0 B | 0 B | 0 B |

Kevlar improves 40.1% and runs 18.0% faster than Polly on this machine.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- 266 core tests passed
- 6 analyzer tests passed
- 16 integration tests passed
- BenchmarkDotNet dry and default runs passed

Closes #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rate limiting for consistent request pacing during burst traffic.
  - Prevented prolonged idle periods from exceeding configured burst capacity.
  - Improved accuracy for high-rate limits and partially consumed bursts.
  - Maintained rejection and cancellation behavior during delayed operations.
  - Improved handling of immediate and delayed results, including synchronous and asynchronous errors.
  - Ensured consistent timing and rate-limit behavior across system and custom time providers.
  - Improved reliability when operating with large timestamp values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->