### PR TITLE
perf: eliminate timeout happy-path allocations

### DIFF
--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -1,4 +1,5 @@
 using Kevlar.Internal;
+using Reservoir;
 
 namespace Kevlar.Strategies;
 
@@ -21,42 +22,95 @@ internal sealed class TimeoutStrategy : Strategy
 
     public override string Describe() => $"Timeout({DescribeHelper.Time(_timeout)})";
 
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         var priorToken = context.CancellationToken;
-        var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(priorToken);
-        var timer = context.TimeProvider.CreateTimer(
-            static state =>
-            {
-                try
-                {
-                    ((CancellationTokenSource)state!).Cancel();
-                }
-                catch (ObjectDisposedException)
-                {
-                    // The execution completed and disposed the source while the timer was firing.
-                }
-            },
-            timeoutSource,
-            _timeout,
-            System.Threading.Timeout.InfiniteTimeSpan);
+        var timeoutSource = CancellationTokenSourcePool.Shared.RentLinked(priorToken);
+        ITimer? timer = null;
 
+        if (ReferenceEquals(context.TimeProvider, TimeProvider.System))
+        {
+            timeoutSource.CancelAfter(_timeout);
+        }
+        else
+        {
+            timer = context.TimeProvider.CreateTimer(
+                static state =>
+                {
+                    try
+                    {
+                        ((CancellationTokenSource)state!).Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // The execution completed and disposed the source while the timer was firing.
+                    }
+                },
+                timeoutSource,
+                _timeout,
+                System.Threading.Timeout.InfiniteTimeSpan);
+        }
+
+        ValueTask<Outcome<T>> execution;
+
+        try
+        {
+            context.CancellationToken = timeoutSource.Token;
+            execution = next.InvokeAsync(context);
+        }
+        catch
+        {
+            Cleanup(context, priorToken, timeoutSource, timer);
+            throw;
+        }
+
+        if (!execution.IsCompletedSuccessfully)
+        {
+            return AwaitAsync(execution, context, priorToken, timeoutSource, timer);
+        }
+
+        var outcome = execution.Result;
+        var timedOut = Cleanup(context, priorToken, timeoutSource, timer);
+        return new ValueTask<Outcome<T>>(HandleOutcome(outcome, timedOut, context));
+    }
+
+    private async ValueTask<Outcome<T>> AwaitAsync<T>(
+        ValueTask<Outcome<T>> execution,
+        KevlarContext context,
+        CancellationToken priorToken,
+        CancellationTokenSource timeoutSource,
+        ITimer? timer)
+    {
         Outcome<T> outcome;
         bool timedOut;
 
         try
         {
-            context.CancellationToken = timeoutSource.Token;
-            outcome = await next.InvokeAsync(context).ConfigureAwait(false);
+            outcome = await execution.ConfigureAwait(false);
         }
         finally
         {
-            context.CancellationToken = priorToken;
-            timer.Dispose();
-            timedOut = timeoutSource.IsCancellationRequested && !priorToken.IsCancellationRequested;
-            timeoutSource.Dispose();
+            timedOut = Cleanup(context, priorToken, timeoutSource, timer);
         }
 
+        return HandleOutcome(outcome, timedOut, context);
+    }
+
+    private static bool Cleanup(
+        KevlarContext context,
+        CancellationToken priorToken,
+        CancellationTokenSource timeoutSource,
+        ITimer? timer)
+    {
+        context.CancellationToken = priorToken;
+        timer?.Dispose();
+        var timedOut = timeoutSource.IsCancellationRequested && !priorToken.IsCancellationRequested;
+        timeoutSource.Dispose();
+        return timedOut;
+    }
+
+    private Outcome<T> HandleOutcome<T>(Outcome<T> outcome, bool timedOut, KevlarContext context)
+    {
         if (timedOut && outcome.Exception is OperationCanceledException)
         {
             KevlarMetrics.Timeout(context.ShieldName);

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -25,36 +25,38 @@ internal sealed class TimeoutStrategy : Strategy
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         var priorToken = context.CancellationToken;
-        var timeoutSource = CancellationTokenSourcePool.Shared.RentLinked(priorToken);
+        var usesSystemTime = ReferenceEquals(context.TimeProvider, TimeProvider.System);
+        var timeoutSource = usesSystemTime
+            ? CancellationTokenSourcePool.Shared.RentLinked(priorToken)
+            : CancellationTokenSource.CreateLinkedTokenSource(priorToken);
         ITimer? timer = null;
-
-        if (ReferenceEquals(context.TimeProvider, TimeProvider.System))
-        {
-            timeoutSource.CancelAfter(_timeout);
-        }
-        else
-        {
-            timer = context.TimeProvider.CreateTimer(
-                static state =>
-                {
-                    try
-                    {
-                        ((CancellationTokenSource)state!).Cancel();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        // The execution completed and disposed the source while the timer was firing.
-                    }
-                },
-                timeoutSource,
-                _timeout,
-                System.Threading.Timeout.InfiniteTimeSpan);
-        }
-
         ValueTask<Outcome<T>> execution;
 
         try
         {
+            if (usesSystemTime)
+            {
+                timeoutSource.CancelAfter(_timeout);
+            }
+            else
+            {
+                timer = context.TimeProvider.CreateTimer(
+                    static state =>
+                    {
+                        try
+                        {
+                            ((CancellationTokenSource)state!).Cancel();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // A queued callback may outlive disposal of a custom provider's timer.
+                        }
+                    },
+                    timeoutSource,
+                    _timeout,
+                    System.Threading.Timeout.InfiniteTimeSpan);
+            }
+
             context.CancellationToken = timeoutSource.Token;
             execution = next.InvokeAsync(context);
         }

--- a/tests/Kevlar.Tests/TimeoutEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/TimeoutEdgeCaseTests.cs
@@ -182,4 +182,79 @@ public class TimeoutEdgeCaseTests
         await Assert.That(async () => await task).Throws<TimeoutExceededException>();
         await Assert.That(seenShieldName).IsEqualTo("timeout-shield");
     }
+
+    [Test]
+    public async Task A_Queued_Custom_Timer_Callback_Cannot_Cancel_A_Later_Execution()
+    {
+        var timeProvider = new QueuedCallbackTimeProvider();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield
+            .Timeout(TimeSpan.FromMinutes(1))
+            .WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+
+        var task = shield.ExecuteAsync(async token =>
+        {
+            await release.Task;
+            token.ThrowIfCancellationRequested();
+            return 2;
+        }).AsTask();
+
+        timeProvider.Fire(timerIndex: 0);
+        release.SetResult();
+
+        await Assert.That(await task).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_Setup_Failure_Disposes_The_Linked_Source()
+    {
+        var timeProvider = new ThrowingTimeProvider();
+        var shield = Shield
+            .Timeout(TimeSpan.FromMinutes(1))
+            .WithTimeProvider(timeProvider);
+
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => timeProvider.Source!.Token).Throws<ObjectDisposedException>();
+    }
+
+    private sealed class QueuedCallbackTimeProvider : TimeProvider
+    {
+        private readonly List<QueuedTimer> _timers = [];
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = new QueuedTimer(callback, state);
+            _timers.Add(timer);
+            return timer;
+        }
+
+        public void Fire(int timerIndex) => _timers[timerIndex].Fire();
+
+        private sealed class QueuedTimer(TimerCallback callback, object? state) : ITimer
+        {
+            public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+
+            public void Dispose()
+            {
+            }
+
+            public ValueTask DisposeAsync() => default;
+
+            public void Fire() => callback(state);
+        }
+    }
+
+    private sealed class ThrowingTimeProvider : TimeProvider
+    {
+        public CancellationTokenSource? Source { get; private set; }
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            Source = (CancellationTokenSource)state!;
+            throw new InvalidOperationException("Timer setup failed.");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- pool linked cancellation sources through Reservoir
- use `CancellationTokenSource.CancelAfter` for the system-time path while preserving custom `TimeProvider` timers
- bypass the async state machine when downstream completes synchronously

## Performance

`TimeoutBenchmarks` default run on .NET 10.0.11:

| | Before | After | Polly |
|---|---:|---:|---:|
| Happy path | 131.5 ns | **107.5 ns** | 125.7 ns |
| Allocated | 168 B | **0 B** | 0 B |

Kevlar improves 18.3% from baseline and runs 14.5% faster than Polly on this machine.

Composed pipeline default runs remain allocation-free:

| Pipeline | Kevlar | Polly |
|---|---:|---:|
| Timeout + retry + circuit breaker | **203.7 ns, 0 B** | 386.3 ns, 48 B |
| Five-strategy chain | **311.3 ns, 0 B** | 549.2 ns, 88 B |

## Validation

- `dotnet build Kevlar.slnx -c Release`
- 272 core tests passed
- 6 analyzer tests passed
- 16 integration tests passed
- BenchmarkDotNet dry, ShortRun, and default runs passed

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved timeout handling across synchronous and asynchronous operations.
  * Prevented delayed timer callbacks from affecting later executions.
  * Ensured reliable cancellation cleanup when timeout setup encounters an error.
  * Added support for consistent behavior with system and custom time providers.
  * Preserved consistent timeout outcomes after cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->