### PR TITLE
perf(fallback): add synchronous fast path

### DIFF
--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -25,13 +25,25 @@ internal sealed class FallbackStrategy<TResult> : Strategy
 
     public override string Describe() => "Fallback";
 
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
-        var outcome = await next.InvokeAsync(context).ConfigureAwait(false);
+        var execution = next.InvokeAsync(context);
+        return execution.IsCompletedSuccessfully
+            ? HandleOutcome(execution.Result, context)
+            : AwaitOutcomeAsync(execution, context);
+    }
 
+    private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(ValueTask<Outcome<T>> execution, KevlarContext context)
+    {
+        var outcome = await execution.ConfigureAwait(false);
+        return await HandleOutcome(outcome, context).ConfigureAwait(false);
+    }
+
+    private ValueTask<Outcome<T>> HandleOutcome<T>(Outcome<T> outcome, KevlarContext context)
+    {
         if (!_judge.ShouldHandle(in outcome))
         {
-            return outcome;
+            return new ValueTask<Outcome<T>>(outcome);
         }
 
         Debug.Assert(typeof(T) == typeof(TResult), "Fallback strategies only execute inside a matching Shield<TResult>.");
@@ -44,7 +56,22 @@ internal sealed class FallbackStrategy<TResult> : Strategy
 
         try
         {
-            return Outcome<T>.FromResult(await fallback(outcome, context).ConfigureAwait(false));
+            var execution = fallback(outcome, context);
+            return execution.IsCompletedSuccessfully
+                ? new ValueTask<Outcome<T>>(Outcome<T>.FromResult(execution.Result))
+                : AwaitFallbackAsync(execution);
+        }
+        catch (Exception exception)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
+        }
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitFallbackAsync<T>(ValueTask<T> execution)
+    {
+        try
+        {
+            return Outcome<T>.FromResult(await execution.ConfigureAwait(false));
         }
         catch (Exception exception)
         {

--- a/tests/Kevlar.Tests/FallbackEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/FallbackEdgeCaseTests.cs
@@ -13,6 +13,53 @@ public class FallbackEdgeCaseTests
     }
 
     [Test]
+    public async Task An_Asynchronous_Fallback_Is_Awaited()
+    {
+        var shield = Shield.For<int>().Fallback(static async _ =>
+        {
+            await Task.Yield();
+            return 42;
+        });
+
+        var result = await shield.ExecuteAsync(_ => throw new InvalidOperationException());
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task An_Asynchronous_Fallback_Exception_Is_Surfaced()
+    {
+        var shield = Shield.For<int>().Fallback(static async _ =>
+        {
+            await Task.Yield();
+            throw new ApplicationException("fallback failed");
+        });
+
+        await Assert.That(async () => await shield.ExecuteAsync(_ => throw new InvalidOperationException()))
+            .Throws<ApplicationException>().WithMessage("fallback failed");
+    }
+
+    [Test]
+    public async Task An_Asynchronous_Success_Bypasses_The_Fallback()
+    {
+        var fallbackRan = false;
+        var shield = Shield.For<int>().Fallback(_ =>
+        {
+            fallbackRan = true;
+            return new ValueTask<int>(0);
+        });
+
+        var result = await shield.ExecuteAsync(static async _ =>
+        {
+            await Task.Yield();
+            return 42;
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(fallbackRan).IsFalse();
+    }
+
+    [Test]
     public async Task Cancellation_Is_Not_Replaced_By_The_Fallback()
     {
         var shield = Shield.For<int>().Fallback(99);


### PR DESCRIPTION
## Summary

- bypass async state machines when fallback continuations complete synchronously
- preserve asynchronous continuation and fallback exception handling in isolated slow paths
- cover asynchronous success, fallback completion, and fallback failure

## Benchmark evidence

Linked run 32419743591 had two Polly wins:

| Case | Linked run | Result on this branch |
|---|---:|---:|
| Fallback pass-through | Kevlar 158.3 ns; Polly 135.7 ns | Kevlar 63.44 ns; Polly 84.56 ns |
| Timeout happy path | Kevlar 258.7 ns / 168 B; Polly 219.8 ns / 0 B | Kevlar 109.9 ns / 0 B; Polly 124.8 ns / 0 B |

Timeout pooling merged to main after linked run in PR #6, so no further timeout change is needed here. Same-machine current-main baseline measured fallback at Kevlar 88.31 ns versus Polly 84.14 ns. This branch lowers Kevlar to 63.44 ns: 28.2% faster than current main and 25.0% faster than Polly.

Triggered fallback also moves from Kevlar 1,366.55 ns versus Polly 1,325.69 ns to Kevlar 1,248.50 ns versus Polly 1,309.92 ns.

BenchmarkDotNet v0.15.8, .NET 10.0.11, Windows 11, Intel Core i7-12700K, DefaultJob.

## Validation

- dotnet build Kevlar.slnx -c Release
- unit tests: 277 passed
- integration tests: 16 passed
- analyzer tests: 6 passed
- BenchmarkDotNet Dry, Short, and Default jobs passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fallback handling for asynchronous operations.
  - Asynchronous fallback results are now awaited correctly.
  - Exceptions from asynchronous fallbacks are surfaced reliably.
  - Successful asynchronous operations now bypass fallback execution as expected.
- **Tests**
  - Added coverage for asynchronous fallback success, exception handling, and bypass behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->