### PR TITLE
test(ci): enforce coverage and mutation gates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.11",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    },
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/coverage.runsettings
+++ b/.github/coverage.runsettings
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage">
+        <Configuration>
+          <ModulePaths>
+            <Include>
+              <ModulePath>.*[\\/]Kevlar(?:\.[^\\/]+)?\.dll$</ModulePath>
+            </Include>
+            <Exclude>
+              <ModulePath>.*Tests\.dll$</ModulePath>
+              <ModulePath>.*Benchmarks\.dll$</ModulePath>
+            </Exclude>
+          </ModulePaths>
+          <Sources>
+            <Exclude>
+              <Source>.*[\\/]benchmarks[\\/].*</Source>
+              <Source>.*[\\/]obj[\\/].*</Source>
+            </Exclude>
+          </Sources>
+          <Attributes>
+            <Exclude>
+              <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+              <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+            </Exclude>
+          </Attributes>
+          <IncludeTestAssembly>False</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/.github/mutation-baseline.md
+++ b/.github/mutation-baseline.md
@@ -1,12 +1,12 @@
 # Mutation baseline
 
-The baseline was measured on 21 August 2026 with `dotnet-stryker` 4.16.0, the Release `net10.0` build, and all 289 unit tests. The core-strategy score was 74.25%: 304 mutants were killed, 101 survived, and 19 timed out. CI fails below 74%.
+The baseline was measured on 21 August 2026 with `dotnet-stryker` 4.16.0, the Release `net10.0` build, and all 289 unit tests. Of 435 score-eligible core-strategy mutants, 304 were killed, 19 timed out, 101 survived, and 11 had no coverage, producing a 74.25% score. Stryker also classified 154 mutants as compile errors and 490 as ignored; neither status enters the score. CI fails below 74%.
 
-No mutation category or source file is ignored. The HTML and JSON artifacts retain every survivor for review. The initial survivors fall into these audited groups:
+Within the configured `Strategies/**/*.cs` scope, no mutation category or source file is excluded by repository configuration. The HTML and JSON artifacts retain every survivor for review. The initial survivors fall into these audited groups:
 
 - Description and validation-message string mutations. These do not change resilience behavior; exact message/description contracts are expanded under issues #17 and #19.
-- Synchronous-completion versus awaited-path mutations whose branches produce the same `Outcome<T>`. These are equivalent for the exercised completed operation; callback failure and asynchronous branch contracts are expanded under issues #20 and #21.
+- Synchronous-completion versus awaited-path mutations whose branches produce the same `Outcome<T>`. These are equivalent for the exercised completed operation; callback-failure and asynchronous-branch contracts are expanded under issues #20 and #21.
 - Concurrency and timing mutations in circuit breaking, hedging, rate limiting, concurrency limiting, retry, and timeout. Mutants that deadlock are bounded and reported as timeouts. Deterministic race coverage is tracked by issues #10 and #13-#24; model/property invariants are tracked by issue #31.
-- Remaining arithmetic and state-transition survivors. Their exact lines remain visible in the report rather than being suppressed, and the 74% ratchet prevents the aggregate baseline from regressing while those focused suites land.
+- Remaining arithmetic and state-transition survivors are owned by the focused strategy issues: circuit breaker #22 and #24, fallback #20, hedging #14, rate limiting #15, concurrency limiting #23, retry #19 and #21, and timeout #13. Cross-strategy model invariants are owned by #31. Their exact lines remain visible in the report rather than being suppressed, and the 74% ratchet prevents the aggregate baseline from regressing while those suites land.
 
 Raise the checked-in threshold when new tests improve the measured score. A new behavior-sensitive survivor must be killed or documented here with its owning follow-up issue; do not add broad `ignore-mutations` entries.

--- a/.github/mutation-baseline.md
+++ b/.github/mutation-baseline.md
@@ -1,0 +1,12 @@
+# Mutation baseline
+
+The baseline was measured on 21 August 2026 with `dotnet-stryker` 4.16.0, the Release `net10.0` build, and all 289 unit tests. The core-strategy score was 74.25%: 304 mutants were killed, 101 survived, and 19 timed out. CI fails below 74%.
+
+No mutation category or source file is ignored. The HTML and JSON artifacts retain every survivor for review. The initial survivors fall into these audited groups:
+
+- Description and validation-message string mutations. These do not change resilience behavior; exact message/description contracts are expanded under issues #17 and #19.
+- Synchronous-completion versus awaited-path mutations whose branches produce the same `Outcome<T>`. These are equivalent for the exercised completed operation; callback failure and asynchronous branch contracts are expanded under issues #20 and #21.
+- Concurrency and timing mutations in circuit breaking, hedging, rate limiting, concurrency limiting, retry, and timeout. Mutants that deadlock are bounded and reported as timeouts. Deterministic race coverage is tracked by issues #10 and #13-#24; model/property invariants are tracked by issue #31.
+- Remaining arithmetic and state-transition survivors. Their exact lines remain visible in the report rather than being suppressed, and the 74% ratchet prevents the aggregate baseline from regressing while those focused suites land.
+
+Raise the checked-in threshold when new tests improve the measured score. A new behavior-sensitive survivor must be killed or documented here with its owning follow-up issue; do not add broad `ignore-mutations` entries.

--- a/.github/scripts/Assert-Coverage.ps1
+++ b/.github/scripts/Assert-Coverage.ps1
@@ -15,11 +15,26 @@ param(
 $ErrorActionPreference = 'Stop'
 $culture = [System.Globalization.CultureInfo]::InvariantCulture
 $resolvedReport = Resolve-Path -LiteralPath $Report
+$sourceRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..\src')
 [xml]$coverage = Get-Content -LiteralPath $resolvedReport -Raw
 $root = $coverage.coverage
 
 if ($null -eq $root -or $null -eq $root.packages.package) {
     throw "Coverage report '$resolvedReport' contains no packages."
+}
+
+$reportedAssemblies = @($root.packages.package | ForEach-Object { [string]$_.name })
+$expectedAssemblies = @(Get-ChildItem -LiteralPath $sourceRoot -Recurse -Filter '*.csproj' | ForEach-Object {
+    [xml]$project = Get-Content -LiteralPath $_.FullName -Raw
+    $assemblyName = @($project.Project.PropertyGroup.AssemblyName) |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Last 1
+
+    if ($assemblyName) { [string]$assemblyName } else { $_.BaseName }
+})
+$missingAssemblies = @($expectedAssemblies | Where-Object { $reportedAssemblies -notcontains $_ })
+if ($missingAssemblies.Count -gt 0) {
+    throw "Coverage report '$resolvedReport' omits production assemblies: $($missingAssemblies -join ', ')."
 }
 
 $validLines = [int]::Parse($root.'lines-valid', $culture)

--- a/.github/scripts/Assert-Coverage.ps1
+++ b/.github/scripts/Assert-Coverage.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$Report,
+
+    [Parameter(Mandatory)]
+    [ValidateRange(0, 100)]
+    [decimal]$MinimumLinePercent,
+
+    [Parameter(Mandatory)]
+    [ValidateRange(0, 100)]
+    [decimal]$MinimumBranchPercent
+)
+
+$ErrorActionPreference = 'Stop'
+$culture = [System.Globalization.CultureInfo]::InvariantCulture
+$resolvedReport = Resolve-Path -LiteralPath $Report
+[xml]$coverage = Get-Content -LiteralPath $resolvedReport -Raw
+$root = $coverage.coverage
+
+if ($null -eq $root -or $null -eq $root.packages.package) {
+    throw "Coverage report '$resolvedReport' contains no packages."
+}
+
+$validLines = [int]::Parse($root.'lines-valid', $culture)
+$validBranches = [int]::Parse($root.'branches-valid', $culture)
+if ($validLines -eq 0 -or $validBranches -eq 0) {
+    throw "Coverage report '$resolvedReport' contains no measurable lines or branches."
+}
+
+$linePercent = [decimal]::Parse($root.'line-rate', $culture) * 100
+$branchPercent = [decimal]::Parse($root.'branch-rate', $culture) * 100
+Write-Host ('Coverage: lines {0:F2}% (minimum {1:F2}%), branches {2:F2}% (minimum {3:F2}%).' -f
+    $linePercent, $MinimumLinePercent, $branchPercent, $MinimumBranchPercent)
+
+$failures = [System.Collections.Generic.List[string]]::new()
+if ($linePercent -lt $MinimumLinePercent) {
+    $failures.Add("Line coverage $($linePercent.ToString('F2', $culture))% is below $($MinimumLinePercent.ToString('F2', $culture))%.")
+}
+
+if ($branchPercent -lt $MinimumBranchPercent) {
+    $failures.Add("Branch coverage $($branchPercent.ToString('F2', $culture))% is below $($MinimumBranchPercent.ToString('F2', $culture))%.")
+}
+
+if ($failures.Count -gt 0) {
+    throw ($failures -join ' ')
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,23 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0  # Required for GitVersion
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 10.0.x
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.7.0
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: '6.x'
 
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.7.0
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
 
       - name: Build
         run: dotnet build Kevlar.slnx -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-reports-${{ matrix.os }}
           path: artifacts/test-results/**/*.trx
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload packages
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nuget-packages
           path: artifacts/package/release/*.nupkg
@@ -80,12 +80,14 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 10.0.x
 
@@ -119,7 +121,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: artifacts/coverage/
@@ -138,32 +140,32 @@ jobs:
       contents: write  # Create the release tag so GitVersion advances past this version
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0  # Required for GitVersion
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 10.0.x
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.7.0
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: '6.x'
 
       - name: Determine Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.7.0
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
 
       - name: Download packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: nuget-packages
           path: packages
 
       - name: NuGet login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,25 @@ jobs:
       - name: Build
         run: dotnet build Kevlar.slnx -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
 
-      - name: Test
-        run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m
+      - name: Unit tests
+        run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename unit.trx --results-directory artifacts/test-results/unit
 
-      - name: Test netstandard2.0 asset
-        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m
+      - name: netstandard2.0 asset tests
+        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename netstandard.trx --results-directory artifacts/test-results/netstandard
 
-      - name: Integration test
-        run: dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m
+      - name: Integration tests
+        run: dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename integration.trx --results-directory artifacts/test-results/integration
+
+      - name: Analyzer tests
+        run: dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename analyzers.trx --results-directory artifacts/test-results/analyzers
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.os }}
+          path: artifacts/test-results/**/*.trx
+          if-no-files-found: error
 
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
@@ -64,11 +75,62 @@ jobs:
           name: nuget-packages
           path: artifacts/package/release/*.nupkg
 
+  coverage:
+    name: Coverage
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Build
+        run: dotnet build Kevlar.slnx -c Release
+
+      - name: Prepare coverage output
+        run: mkdir -p artifacts/coverage/raw
+
+      - name: Collect unit coverage
+        run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/unit.cobertura.xml --coverage-output-format cobertura
+
+      - name: Collect netstandard2.0 asset coverage
+        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/netstandard.cobertura.xml --coverage-output-format cobertura
+
+      - name: Collect integration coverage
+        run: dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/integration.cobertura.xml --coverage-output-format cobertura
+
+      - name: Collect analyzer coverage
+        run: dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/analyzers.cobertura.xml --coverage-output-format cobertura
+
+      - name: Merge coverage reports
+        run: dotnet reportgenerator '-reports:artifacts/coverage/raw/*.cobertura.xml' '-targetdir:artifacts/coverage/report' '-reporttypes:Cobertura;Html'
+
+      - name: Enforce coverage baseline
+        shell: pwsh
+        run: ./.github/scripts/Assert-Coverage.ps1 -Report artifacts/coverage/report/Cobertura.xml -MinimumLinePercent 92 -MinimumBranchPercent 86
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: artifacts/coverage/
+          if-no-files-found: error
+          retention-days: 14
+
   # Only reachable from a manual run with the "Upload package to NuGet"
   # checkbox ticked, and only after both OS legs are green.
   publish:
     name: Publish NuGet
-    needs: build-and-test
+    needs: [build-and-test, coverage]
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nuget == true
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - '.config/dotnet-tools.json'
+      - '.github/workflows/mutation.yml'
       - 'src/Kevlar/Strategies/**'
+      - 'src/Kevlar/Kevlar.csproj'
       - 'src/Kevlar/stryker-config.json'
       - 'tests/Kevlar.Tests/**'
   schedule:
@@ -21,10 +24,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 10.0.x
 
@@ -37,7 +40,7 @@ jobs:
 
       - name: Upload mutation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mutation-report
           path: src/Kevlar/StrykerOutput/**/reports/

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.config/dotnet-tools.json'
       - '.github/workflows/mutation.yml'
+      - 'Directory.Packages.props'
       - 'src/Kevlar/**'
       - 'tests/Kevlar.Tests/**'
   schedule:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,45 @@
+name: Mutation testing
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/Kevlar/Strategies/**'
+      - 'src/Kevlar/stryker-config.json'
+      - 'tests/Kevlar.Tests/**'
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  strategies:
+    name: Core strategies
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Test strategy mutants
+        working-directory: src/Kevlar
+        run: dotnet stryker --config-file stryker-config.json
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report
+          path: src/Kevlar/StrykerOutput/**/reports/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -6,9 +6,7 @@ on:
     paths:
       - '.config/dotnet-tools.json'
       - '.github/workflows/mutation.yml'
-      - 'src/Kevlar/Strategies/**'
-      - 'src/Kevlar/Kevlar.csproj'
-      - 'src/Kevlar/stryker-config.json'
+      - 'src/Kevlar/**'
       - 'tests/Kevlar.Tests/**'
   schedule:
     - cron: '23 3 * * 1'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - '.config/dotnet-tools.json'
       - '.github/workflows/mutation.yml'
+      - 'Directory.Build.props'
       - 'Directory.Packages.props'
+      - 'src/Directory.Build.props'
       - 'src/Kevlar/**'
       - 'tests/Kevlar.Tests/**'
   schedule:

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -19,6 +19,13 @@ dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --
 dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+$coverageRoot = (New-Item -ItemType Directory -Force artifacts/coverage/raw).FullName
+dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/unit.cobertura.xml" --coverage-output-format cobertura
+dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/netstandard.cobertura.xml" --coverage-output-format cobertura
+dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/integration.cobertura.xml" --coverage-output-format cobertura
+dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/analyzers.cobertura.xml" --coverage-output-format cobertura
+dotnet reportgenerator '-reports:artifacts/coverage/raw/*.cobertura.xml' '-targetdir:artifacts/coverage/report' '-reporttypes:Cobertura;Html'
+./.github/scripts/Assert-Coverage.ps1 -Report artifacts/coverage/report/Cobertura.xml -MinimumLinePercent 92 -MinimumBranchPercent 86
 Push-Location src/Kevlar
 dotnet stryker --config-file stryker-config.json
 Pop-Location

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -4,6 +4,26 @@ sidebar_position: 10
 
 # Testing Your Shields
 
+## Repository quality gates
+
+Pull requests build on Windows and Linux, then run the unit, netstandard2.0 asset, integration, and analyzer suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
+
+The Linux coverage job merges all four suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
+
+Core strategy mutation testing runs for pull requests that change strategy code or unit tests, every Monday, and on demand. It uses the checked-in Stryker configuration and fails below the measured 74% mutation-score floor. The workflow has a 30-minute limit and publishes HTML and JSON reports as the `mutation-report` artifact. The audited initial survivors and ratchet policy are recorded in `.github/mutation-baseline.md`. Run the test and mutation gates locally with:
+
+```powershell
+dotnet tool restore
+dotnet build Kevlar.slnx -c Release
+dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+Push-Location src/Kevlar
+dotnet stryker --config-file stryker-config.json
+Pop-Location
+```
+
 Every delay, timeout and time window in Kevlar runs on a `TimeProvider`. Swap in a fake and your tests never actually wait:
 
 ```csharp

--- a/src/Kevlar/stryker-config.json
+++ b/src/Kevlar/stryker-config.json
@@ -1,0 +1,27 @@
+{
+  "stryker-config": {
+    "project": "Kevlar.csproj",
+    "test-projects": [
+      "../../tests/Kevlar.Tests/Kevlar.Tests.csproj"
+    ],
+    "test-runner": "mtp",
+    "target-framework": "net10.0",
+    "configuration": "Release",
+    "mutate": [
+      "Strategies/**/*.cs"
+    ],
+    "reporters": [
+      "progress",
+      "html",
+      "json"
+    ],
+    "report-file-name": "mutation-report",
+    "additional-timeout": 5000,
+    "concurrency": 4,
+    "thresholds": {
+      "high": 74,
+      "low": 74,
+      "break": 74
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- run unit, netstandard2.0 asset, integration, and analyzer suites on Windows and Linux with per-suite timeouts, TRX reports, and strict nonzero discovery
- collect and merge Cobertura coverage into machine-readable XML and browsable HTML, then enforce measured 92% line / 86% branch floors
- add bounded PR/scheduled Stryker coverage for core strategies with a measured 74% ratchet and audited survivor policy
- document local gates and workflow artifacts

Closes #9

## Validation

- `dotnet build Kevlar.slnx -c Release` (0 warnings)
- coverage runs with strict discovery: 289 unit, 1 netstandard asset, 16 integration, and 19 analyzer tests passed
- deliberate zero-test analyzer run exited 8
- merged coverage: 92.37% lines, 86.71% branches; ratchet pass/fail paths verified
- `dotnet stryker --config-file stryker-config.json` (74.25%; 304 killed, 101 survived, 19 timed out; 3m03s)
- `npm run build` from `docs/`
- workflow files parsed as valid YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality & Testing**
  * Added automated line and branch coverage checks with enforced minimum thresholds.
  * Added mutation testing to identify gaps in test effectiveness.
  * Separated test suites and reporting for clearer CI results.
  * Added validation for expected test counts, coverage data, and quality gates.
  * Coverage and mutation reports are retained as build artifacts.

* **Documentation**
  * Documented testing workflows, thresholds, reports, and local quality checks.
  * Added baseline information for mutation-testing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->