### PR TITLE
fix(rate-limit): reclaim cancelled reservations

### DIFF
--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -22,9 +22,12 @@ internal sealed class RateLimitStrategy : Strategy
     private readonly int _queueLimit;
     private readonly double _timestampUnitsPerPermit;
     private readonly double _burstTolerance;
-    private readonly double _queueTolerance;
+    private readonly object _queueGate = new();
 
     private double _theoreticalArrival = double.NegativeInfinity;
+    private Reservation? _queueHead;
+    private Reservation? _queueTail;
+    private int _queuedReservations;
 
     public RateLimitStrategy(RateLimitOptions options)
     {
@@ -39,7 +42,6 @@ internal sealed class RateLimitStrategy : Strategy
         _queueLimit = options.QueueLimit;
         _timestampUnitsPerPermit = options.Window.TotalSeconds * Stopwatch.Frequency / options.Permits;
         _burstTolerance = (_burst - 1) * _timestampUnitsPerPermit;
-        _queueTolerance = _queueLimit * _timestampUnitsPerPermit;
     }
 
     public override string Describe()
@@ -51,36 +53,87 @@ internal sealed class RateLimitStrategy : Strategy
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
-        if (!TryAcquire(context.TimeProvider, out var wait, out var retryAfter))
+        if (!TryAcquire(context.TimeProvider, out var reservation, out var retryAfter))
         {
             KevlarMetrics.Rejection(context.ShieldName, "rate_limit");
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(new RateLimitExceededException(retryAfter)));
         }
 
-        return wait > TimeSpan.Zero
-            ? ExecuteAfterDelayAsync(next, context, wait)
-            : next.InvokeAsync(context);
+        return reservation is null
+            ? next.InvokeAsync(context)
+            : ExecuteReservedAsync(next, context, reservation);
     }
 
-    private static async ValueTask<Outcome<T>> ExecuteAfterDelayAsync<T, TState>(
+    private async ValueTask<Outcome<T>> ExecuteReservedAsync<T, TState>(
         Continuation<T, TState> next,
         KevlarContext context,
-        TimeSpan wait)
+        Reservation reservation)
     {
         try
         {
-            await DelayHelper.DelayAsync(context, wait).ConfigureAwait(false);
+            while (true)
+            {
+                if (TryConsumeReservation(reservation, context.TimeProvider, out var wait, out var nextTurn))
+                {
+                    nextTurn?.Cancel();
+                    break;
+                }
+
+                if (wait == Timeout.InfiniteTimeSpan)
+                {
+                    using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                        context.CancellationToken,
+                        reservation.Turn.Token);
+                    try
+                    {
+                        await Task.Delay(Timeout.Infinite, waitCancellation.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (!context.CancellationToken.IsCancellationRequested)
+                    {
+                        continue;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw new OperationCanceledException(context.CancellationToken);
+                    }
+                }
+                else
+                {
+                    await DelayHelper.CreateDelayTask(
+                        context.TimeProvider,
+                        wait,
+                        context.CancellationToken).ConfigureAwait(false);
+                }
+            }
         }
         catch (OperationCanceledException cancelled)
         {
+            CancelReservation(reservation)?.Cancel();
+            reservation.Turn.Dispose();
             return Outcome<T>.FromException(cancelled);
         }
 
+        reservation.Turn.Dispose();
         return await next.InvokeAsync(context).ConfigureAwait(false);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool TryAcquire(TimeProvider timeProvider, out TimeSpan wait, out TimeSpan? retryAfter)
+    private bool TryAcquire(
+        TimeProvider timeProvider,
+        out Reservation? reservation,
+        out TimeSpan? retryAfter)
+    {
+        if (_queueLimit > 0)
+        {
+            return TryAcquireWithQueue(timeProvider, out reservation, out retryAfter);
+        }
+
+        reservation = null;
+        return TryAcquireWithoutQueue(timeProvider, out retryAfter);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryAcquireWithoutQueue(TimeProvider timeProvider, out TimeSpan? retryAfter)
     {
         while (true)
         {
@@ -88,9 +141,8 @@ internal sealed class RateLimitStrategy : Strategy
             var now = GetCurrentTimestamp(timeProvider);
             var delayTimestampUnits = theoreticalArrival - now - _burstTolerance;
 
-            if (delayTimestampUnits > _queueTolerance)
+            if (delayTimestampUnits > 0)
             {
-                wait = TimeSpan.Zero;
                 retryAfter = TimeSpan.FromSeconds(delayTimestampUnits * SecondsPerSystemTimestamp);
                 return false;
             }
@@ -104,13 +156,142 @@ internal sealed class RateLimitStrategy : Strategy
 
             if (Interlocked.CompareExchange(ref _theoreticalArrival, nextArrival, theoreticalArrival) == theoreticalArrival)
             {
-                wait = delayTimestampUnits > 0
-                    ? TimeSpan.FromSeconds(delayTimestampUnits * SecondsPerSystemTimestamp)
-                    : TimeSpan.Zero;
                 retryAfter = null;
                 return true;
             }
         }
+    }
+
+    private bool TryAcquireWithQueue(
+        TimeProvider timeProvider,
+        out Reservation? reservation,
+        out TimeSpan? retryAfter)
+    {
+        lock (_queueGate)
+        {
+            var now = GetCurrentTimestamp(timeProvider);
+            var theoreticalArrival = _theoreticalArrival;
+            var delayTimestampUnits = theoreticalArrival - now - _burstTolerance;
+
+            if (_queueHead is not null || delayTimestampUnits > 0)
+            {
+                if (_queuedReservations >= _queueLimit)
+                {
+                    reservation = null;
+                    retryAfter = TimeSpan.FromSeconds(
+                        Math.Max(0, delayTimestampUnits) * SecondsPerSystemTimestamp);
+                    return false;
+                }
+
+                var dueTimestamp = Math.Max(now, theoreticalArrival - _burstTolerance);
+                reservation = new Reservation(dueTimestamp);
+                EnqueueReservation(reservation);
+            }
+            else
+            {
+                reservation = null;
+            }
+
+            var arrival = Math.Max(now, theoreticalArrival);
+            var nextArrival = arrival + _timestampUnitsPerPermit;
+            _theoreticalArrival = nextArrival == arrival
+                ? GetNextRepresentableTimestamp(arrival)
+                : nextArrival;
+            retryAfter = null;
+            return true;
+        }
+    }
+
+    private bool TryConsumeReservation(
+        Reservation reservation,
+        TimeProvider timeProvider,
+        out TimeSpan wait,
+        out CancellationTokenSource? nextTurn)
+    {
+        lock (_queueGate)
+        {
+            if (!ReferenceEquals(_queueHead, reservation))
+            {
+                wait = Timeout.InfiniteTimeSpan;
+                nextTurn = null;
+                return false;
+            }
+
+            var delayTimestampUnits = reservation.DueTimestamp - GetCurrentTimestamp(timeProvider);
+            if (delayTimestampUnits > 0)
+            {
+                wait = TimeSpan.FromSeconds(delayTimestampUnits * SecondsPerSystemTimestamp);
+                nextTurn = null;
+                return false;
+            }
+
+            nextTurn = RemoveReservation(reservation);
+            wait = TimeSpan.Zero;
+            return true;
+        }
+    }
+
+    private CancellationTokenSource? CancelReservation(Reservation reservation)
+    {
+        lock (_queueGate)
+        {
+            if (!reservation.IsQueued)
+            {
+                return null;
+            }
+
+            for (var later = reservation.Next; later is not null; later = later.Next)
+            {
+                later.DueTimestamp -= _timestampUnitsPerPermit;
+            }
+
+            _theoreticalArrival -= _timestampUnitsPerPermit;
+            return RemoveReservation(reservation);
+        }
+    }
+
+    private void EnqueueReservation(Reservation reservation)
+    {
+        reservation.Previous = _queueTail;
+        if (_queueTail is null)
+        {
+            _queueHead = reservation;
+        }
+        else
+        {
+            _queueTail.Next = reservation;
+        }
+
+        _queueTail = reservation;
+        _queuedReservations++;
+    }
+
+    private CancellationTokenSource? RemoveReservation(Reservation reservation)
+    {
+        var wasHead = ReferenceEquals(_queueHead, reservation);
+        if (reservation.Previous is null)
+        {
+            _queueHead = reservation.Next;
+        }
+        else
+        {
+            reservation.Previous.Next = reservation.Next;
+        }
+
+        if (reservation.Next is null)
+        {
+            _queueTail = reservation.Previous;
+        }
+        else
+        {
+            reservation.Next.Previous = reservation.Previous;
+        }
+
+        reservation.IsQueued = false;
+        reservation.Previous = null;
+        reservation.Next = null;
+        _queuedReservations--;
+        return wasHead ? _queueHead?.Turn : null;
     }
 
     private static double GetNextRepresentableTimestamp(double timestamp)
@@ -151,5 +332,20 @@ internal sealed class RateLimitStrategy : Strategy
         public long ProviderTimestamp { get; }
 
         public double TimestampScale { get; }
+    }
+
+    private sealed class Reservation
+    {
+        public Reservation(double dueTimestamp) => DueTimestamp = dueTimestamp;
+
+        public double DueTimestamp { get; set; }
+
+        public Reservation? Previous { get; set; }
+
+        public Reservation? Next { get; set; }
+
+        public bool IsQueued { get; set; } = true;
+
+        public CancellationTokenSource Turn { get; } = new();
     }
 }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -75,27 +75,13 @@ internal sealed class RateLimitStrategy : Strategy
             {
                 if (TryConsumeReservation(reservation, context.TimeProvider, out var wait, out var nextTurn))
                 {
-                    nextTurn?.Cancel();
+                    nextTurn?.TrySetResult(true);
                     break;
                 }
 
                 if (wait == Timeout.InfiniteTimeSpan)
                 {
-                    using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-                        context.CancellationToken,
-                        reservation.Turn.Token);
-                    try
-                    {
-                        await Task.Delay(Timeout.Infinite, waitCancellation.Token).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (!context.CancellationToken.IsCancellationRequested)
-                    {
-                        continue;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        throw new OperationCanceledException(context.CancellationToken);
-                    }
+                    await reservation.WaitForTurnAsync(context.CancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -108,12 +94,10 @@ internal sealed class RateLimitStrategy : Strategy
         }
         catch (OperationCanceledException cancelled)
         {
-            CancelReservation(reservation)?.Cancel();
-            reservation.Turn.Dispose();
+            CancelReservation(reservation)?.TrySetResult(true);
             return Outcome<T>.FromException(cancelled);
         }
 
-        reservation.Turn.Dispose();
         return await next.InvokeAsync(context).ConfigureAwait(false);
     }
 
@@ -206,7 +190,7 @@ internal sealed class RateLimitStrategy : Strategy
         Reservation reservation,
         TimeProvider timeProvider,
         out TimeSpan wait,
-        out CancellationTokenSource? nextTurn)
+        out TaskCompletionSource<bool>? nextTurn)
     {
         lock (_queueGate)
         {
@@ -231,7 +215,7 @@ internal sealed class RateLimitStrategy : Strategy
         }
     }
 
-    private CancellationTokenSource? CancelReservation(Reservation reservation)
+    private TaskCompletionSource<bool>? CancelReservation(Reservation reservation)
     {
         lock (_queueGate)
         {
@@ -266,7 +250,7 @@ internal sealed class RateLimitStrategy : Strategy
         _queuedReservations++;
     }
 
-    private CancellationTokenSource? RemoveReservation(Reservation reservation)
+    private TaskCompletionSource<bool>? RemoveReservation(Reservation reservation)
     {
         var wasHead = ReferenceEquals(_queueHead, reservation);
         if (reservation.Previous is null)
@@ -346,6 +330,24 @@ internal sealed class RateLimitStrategy : Strategy
 
         public bool IsQueued { get; set; } = true;
 
-        public CancellationTokenSource Turn { get; } = new();
+        public TaskCompletionSource<bool> Turn { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task WaitForTurnAsync(CancellationToken cancellationToken)
+        {
+            if (!cancellationToken.CanBeCanceled)
+            {
+                await Turn.Task.ConfigureAwait(false);
+                return;
+            }
+
+            var cancellation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = cancellationToken.Register(
+                static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true),
+                cancellation);
+
+            await Task.WhenAny(Turn.Task, cancellation.Task).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
     }
 }

--- a/tests/Kevlar.Tests/RateLimitCancellationTests.cs
+++ b/tests/Kevlar.Tests/RateLimitCancellationTests.cs
@@ -75,6 +75,36 @@ public class RateLimitCancellationTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Successor_Cancellation_Is_Safe_On_Either_Side_Of_Promotion(bool cancelFirst)
+    {
+        var fakeTime = new FakeTimeProvider();
+        var shield = CreateShield(fakeTime, queueLimit: 2);
+        using var cancellation = new CancellationTokenSource();
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(0));
+        var head = shield.ExecuteAsync(_ => new ValueTask<int>(1)).AsTask();
+        var successor = shield.ExecuteAsync(_ => new ValueTask<int>(2), cancellation.Token).AsTask();
+
+        if (cancelFirst)
+        {
+            cancellation.Cancel();
+            await Assert.That(async () => await successor).Throws<OperationCanceledException>();
+            fakeTime.Advance(TimeSpan.FromSeconds(1));
+        }
+        else
+        {
+            fakeTime.Advance(TimeSpan.FromSeconds(1));
+            await Assert.That(await head.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(1);
+            cancellation.Cancel();
+        }
+
+        await Assert.That(await head.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(1);
+        await Assert.That(async () => await successor).Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task Concurrent_Callers_Admit_Only_Burst_And_Queue_Capacity()
     {
         const int burst = 2;
@@ -114,20 +144,14 @@ public class RateLimitCancellationTests
 
         for (var permit = 1; permit <= queueLimit; permit++)
         {
+            var pending = calls.Where(call => !call.IsCompleted).ToArray();
             fakeTime.Advance(TimeSpan.FromSeconds(1));
             fakeTime.Advance(TimeSpan.FromTicks(1));
             var expectedCompleted = callerCount - queueLimit + permit;
-            if (calls.Count(call => call.IsCompleted) < expectedCompleted)
-            {
-                var pending = calls.Where(call => !call.IsCompleted).ToArray();
-                if (pending.Length > 0)
-                {
-                    var next = await WaitWithMessage(
-                        Task.WhenAny(pending),
-                        $"Permit {permit} stalled with {calls.Count(call => call.IsCompleted)} completed calls.");
-                    await next;
-                }
-            }
+            var next = await WaitWithMessage(
+                Task.WhenAny(pending),
+                $"Permit {permit} stalled with {calls.Count(call => call.IsCompleted)} completed calls.");
+            await next;
 
             await Assert.That(calls.Count(call => call.IsCompleted))
                 .IsEqualTo(expectedCompleted);
@@ -190,7 +214,9 @@ public class RateLimitCancellationTests
         {
             await shield.ExecuteAsync(_ => new ValueTask<int>(-1));
             var queued = Enumerable.Range(0, 3)
-                .Select(index => shield.ExecuteAsync(_ => new ValueTask<int>(index), cancellations[index].Token).AsTask())
+                .Select(index => shield.ExecuteAsync(
+                    _ => new ValueTask<int>(index),
+                    cancellations[index].Token).AsTask())
                 .ToArray();
 
             cancellations[cancelledIndex].Cancel();
@@ -200,16 +226,15 @@ public class RateLimitCancellationTests
 
             var replacement = shield.ExecuteAsync(_ => new ValueTask<int>(3)).AsTask();
             var active = queued.Where((_, index) => index != cancelledIndex).Append(replacement).ToArray();
-            for (var permit = 0; permit < active.Length; permit++)
-            {
-                fakeTime.Advance(TimeSpan.FromSeconds(1));
-                fakeTime.Advance(TimeSpan.FromTicks(1));
-                await WaitWithMessage(
-                    active[permit],
-                    $"Cancellation index {cancelledIndex}, permit {permit + 1} stalled.");
-                await Assert.That(active.Take(permit + 1).All(task => task.IsCompletedSuccessfully)).IsTrue();
-                await Assert.That(active.Skip(permit + 1).All(task => !task.IsCompleted)).IsTrue();
-            }
+            fakeTime.Advance(TimeSpan.FromSeconds(active.Length));
+            fakeTime.Advance(TimeSpan.FromTicks(active.Length));
+
+            var results = await WaitWithMessage(
+                Task.WhenAll(active),
+                $"Cancellation index {cancelledIndex} did not reclaim its permit debt.");
+            var expectedOrder = Enumerable.Range(0, 3).Where(index => index != cancelledIndex).Append(3).ToArray();
+
+            await Assert.That(results.SequenceEqual(expectedOrder)).IsTrue();
         }
         finally
         {

--- a/tests/Kevlar.Tests/RateLimitCancellationTests.cs
+++ b/tests/Kevlar.Tests/RateLimitCancellationTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class RateLimitCancellationTests
+{
+    [Test]
+    public async Task Cancelled_Reservation_Is_Reused_At_Its_Original_Due_Time()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var shield = CreateShield(fakeTime, queueLimit: 1);
+        using var cancellation = new CancellationTokenSource();
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(0));
+        var cancelled = shield.ExecuteAsync(_ => new ValueTask<int>(1), cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+        await Assert.That(async () => await cancelled).Throws<OperationCanceledException>();
+
+        var replacement = shield.ExecuteAsync(_ => new ValueTask<int>(2)).AsTask();
+        await Assert.That(replacement.IsCompleted).IsFalse();
+
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await Assert.That(await replacement.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    public Task Cancelling_Head_Middle_Or_Tail_Compacts_The_Queue(int cancelledIndex) =>
+        AssertCancellationCompactsQueue(cancelledIndex);
+
+    [Test]
+    public async Task Cancellation_Before_Permit_Wins_Without_Invoking_The_Delegate()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var shield = CreateShield(fakeTime, queueLimit: 1);
+        using var cancellation = new CancellationTokenSource();
+        var invoked = false;
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(0));
+        var queued = shield.ExecuteAsync(_ =>
+        {
+            invoked = true;
+            return new ValueTask<int>(1);
+        }, cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+
+        await Assert.That(async () => await queued).Throws<OperationCanceledException>();
+        await Assert.That(invoked).IsFalse();
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(2))).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Permit_Before_Cancellation_Consumes_Exactly_One_Permit()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var shield = CreateShield(fakeTime, queueLimit: 1);
+        using var cancellation = new CancellationTokenSource();
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(0));
+        var queued = shield.ExecuteAsync(_ => new ValueTask<int>(1), cancellation.Token).AsTask();
+
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await Assert.That(await queued.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(1);
+        cancellation.Cancel();
+
+        var replacement = shield.ExecuteAsync(_ => new ValueTask<int>(2)).AsTask();
+        await Assert.That(replacement.IsCompleted).IsFalse();
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await Assert.That(await replacement.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Concurrent_Callers_Admit_Only_Burst_And_Queue_Capacity()
+    {
+        const int burst = 2;
+        const int queueLimit = 3;
+        const int callerCount = 12;
+        var fakeTime = new FakeTimeProvider();
+        var shield = Shield
+            .RateLimit(options =>
+            {
+                options.Permits = 1;
+                options.Window = TimeSpan.FromSeconds(1);
+                options.Burst = burst;
+                options.QueueLimit = queueLimit;
+            })
+            .WithTimeProvider(fakeTime);
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var workers = Enumerable.Range(0, callerCount).Select(async index =>
+        {
+            await start.Task;
+            return shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(index)).AsTask();
+        }).ToArray();
+
+        start.SetResult();
+        var calls = await Task.WhenAll(workers);
+
+        var completed = calls.Where(call => call.IsCompleted).Select(call => call.Result).ToArray();
+        var rejections = completed
+            .Select(outcome => outcome.Exception)
+            .OfType<RateLimitExceededException>()
+            .ToArray();
+        await Assert.That(completed.Count(outcome => outcome.IsSuccess)).IsEqualTo(burst);
+        await Assert.That(rejections.Length).IsEqualTo(callerCount - burst - queueLimit);
+        await Assert.That(rejections.All(rejection => rejection.RetryAfter is { } retryAfter
+            && retryAfter > TimeSpan.Zero
+            && retryAfter < TimeSpan.MaxValue)).IsTrue();
+        await Assert.That(calls.Count(call => !call.IsCompleted)).IsEqualTo(queueLimit);
+
+        for (var permit = 1; permit <= queueLimit; permit++)
+        {
+            fakeTime.Advance(TimeSpan.FromSeconds(1));
+            fakeTime.Advance(TimeSpan.FromTicks(1));
+            var expectedCompleted = callerCount - queueLimit + permit;
+            if (calls.Count(call => call.IsCompleted) < expectedCompleted)
+            {
+                var pending = calls.Where(call => !call.IsCompleted).ToArray();
+                if (pending.Length > 0)
+                {
+                    var next = await WaitWithMessage(
+                        Task.WhenAny(pending),
+                        $"Permit {permit} stalled with {calls.Count(call => call.IsCompleted)} completed calls.");
+                    await next;
+                }
+            }
+
+            await Assert.That(calls.Count(call => call.IsCompleted))
+                .IsEqualTo(expectedCompleted);
+        }
+
+        await Assert.That((await Task.WhenAll(calls)).Count(outcome => outcome.IsSuccess))
+            .IsEqualTo(burst + queueLimit);
+    }
+
+    [Test]
+    public async Task Repeated_Cancel_And_Requeue_Leaves_No_Phantom_Debt()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var shield = CreateShield(fakeTime, queueLimit: 1);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(0));
+
+        for (var cycle = 0; cycle < 50; cycle++)
+        {
+            using var cancellation = new CancellationTokenSource();
+            var queued = shield.ExecuteAsync(_ => new ValueTask<int>(cycle), cancellation.Token).AsTask();
+            cancellation.Cancel();
+            await Assert.That(async () => await queued).Throws<OperationCanceledException>();
+        }
+
+        var final = shield.ExecuteAsync(_ => new ValueTask<int>(51)).AsTask();
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await Assert.That(await final.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(51);
+    }
+
+    private static Shield CreateShield(FakeTimeProvider fakeTime, int queueLimit) => Shield
+        .RateLimit(options =>
+        {
+            options.Permits = 1;
+            options.Window = TimeSpan.FromSeconds(1);
+            options.Burst = 1;
+            options.QueueLimit = queueLimit;
+        })
+        .WithTimeProvider(fakeTime);
+
+    private static async Task<T> WaitWithMessage<T>(Task<T> task, string message)
+    {
+        try
+        {
+            return await task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (TimeoutException exception)
+        {
+            throw new TimeoutException(message, exception);
+        }
+    }
+
+    private static async Task AssertCancellationCompactsQueue(int cancelledIndex)
+    {
+        var fakeTime = new FakeTimeProvider();
+        var shield = CreateShield(fakeTime, queueLimit: 3);
+        var cancellations = Enumerable.Range(0, 3).Select(_ => new CancellationTokenSource()).ToArray();
+
+        try
+        {
+            await shield.ExecuteAsync(_ => new ValueTask<int>(-1));
+            var queued = Enumerable.Range(0, 3)
+                .Select(index => shield.ExecuteAsync(_ => new ValueTask<int>(index), cancellations[index].Token).AsTask())
+                .ToArray();
+
+            cancellations[cancelledIndex].Cancel();
+            var cancellation = await Assert.That(async () => await queued[cancelledIndex])
+                .Throws<OperationCanceledException>();
+            await Assert.That(cancellation!.CancellationToken).IsEqualTo(cancellations[cancelledIndex].Token);
+
+            var replacement = shield.ExecuteAsync(_ => new ValueTask<int>(3)).AsTask();
+            var active = queued.Where((_, index) => index != cancelledIndex).Append(replacement).ToArray();
+            for (var permit = 0; permit < active.Length; permit++)
+            {
+                fakeTime.Advance(TimeSpan.FromSeconds(1));
+                fakeTime.Advance(TimeSpan.FromTicks(1));
+                await WaitWithMessage(
+                    active[permit],
+                    $"Cancellation index {cancelledIndex}, permit {permit + 1} stalled.");
+                await Assert.That(active.Take(permit + 1).All(task => task.IsCompletedSuccessfully)).IsTrue();
+                await Assert.That(active.Skip(permit + 1).All(task => !task.IsCompleted)).IsTrue();
+            }
+        }
+        finally
+        {
+            foreach (var cancellation in cancellations)
+            {
+                cancellation.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track queued permits as ordered reservations while preserving the lock-free queue-free path
- refund cancelled reservations and compact later due times without over-admission
- use one-shot asynchronous turn signals so promotion cannot race cancellation disposal
- cover head/middle/tail cancellation, both promotion/cancellation interleavings, concurrent capacity, repeated requeue, token identity, and finite retry estimates

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release` (0 warnings)
- [x] `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (299 passed)
- [x] `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- [x] `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- [x] full unit suite repeated 30 times after race fix (all passed)

## Benchmark
`RateLimitBenchmarks.Kevlar_Uncontended` on .NET 10.0.11, Windows, i7-12700K:

| | Mean | Allocated |
|---|---:|---:|
| Before | 84.77 ns | 0 B |
| After | 85.47 ns | 0 B |

Difference is +0.8%; confidence intervals overlap and allocation remains zero.

Closes #15