### PR TITLE
test: add deterministic race orchestration

### DIFF
--- a/tests/Kevlar.Tests/CircuitBreakerTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTests.cs
@@ -156,8 +156,7 @@ public class CircuitBreakerTests
             .Throws<InvalidOperationException>();
 
         using var cancellation = new CancellationTokenSource();
-        cancellation.CancelAfter(0);
-        await Task.Delay(10);
+        cancellation.Cancel();
 
         await Assert.That(async () => await shield.ExecuteAsync<int>(
             async token =>

--- a/tests/Kevlar.Tests/CompositionTests.cs
+++ b/tests/Kevlar.Tests/CompositionTests.cs
@@ -103,6 +103,7 @@ public class CompositionTests
     {
         var fakeTime = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
         var attempts = 0;
+        var attemptsStarted = new AsyncCounter("total-timeout attempts");
         var shield = Shield
             .Timeout(TimeSpan.FromSeconds(3))
             .When<InvalidOperationException>()
@@ -112,14 +113,15 @@ public class CompositionTests
         var task = shield.ExecuteAsync<int>(_ =>
         {
             attempts++;
+            attemptsStarted.Signal();
             throw new InvalidOperationException();
         }).AsTask();
 
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 2);
+        await attemptsStarted.WaitForAsync(2);
 
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 3);
+        await attemptsStarted.WaitForAsync(3);
 
         // The third second trips the outer total timeout while the retry is sleeping.
         fakeTime.Advance(TimeSpan.FromSeconds(1));

--- a/tests/Kevlar.Tests/ConcurrencyLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyLimitEdgeCaseTests.cs
@@ -76,38 +76,39 @@ public class BulkheadEdgeCaseTests
         var shield = Shield.ConcurrencyLimit(MaxConcurrency, maxQueue: 50);
         var current = 0;
         var peak = 0;
+        var barrier = new AsyncBarrier("maximum concurrent executions", MaxConcurrency);
 
         var tasks = Enumerable.Range(0, 40).Select(_ => shield.ExecuteAsync(async _ =>
         {
             var now = Interlocked.Increment(ref current);
             InterlockedMax(ref peak, now);
-            await Task.Delay(10);
+            await barrier.SignalAndWaitAsync();
             Interlocked.Decrement(ref current);
             return 0;
         }).AsTask()).ToArray();
 
+        await barrier.WaitForAllAsync();
+        await Assert.That(Volatile.Read(ref peak)).IsEqualTo(MaxConcurrency);
+        barrier.Release();
         await Task.WhenAll(tasks);
 
         await Assert.That(Volatile.Read(ref peak) <= MaxConcurrency).IsTrue();
-        await Assert.That(Volatile.Read(ref peak) >= 1).IsTrue();
     }
 
     [Test]
     public async Task Overload_Beyond_Capacity_Rejects_Exactly_The_Overflow()
     {
         var shield = Shield.ConcurrencyLimit(maxConcurrency: 2, maxQueue: 3);
-        var gate = new TaskCompletionSource();
-        var startedCount = 0;
+        var barrier = new AsyncBarrier("both concurrency slots", 2);
 
         // Fill both concurrency slots.
         var running = Enumerable.Range(0, 2).Select(_ => shield.ExecuteAsync(async _ =>
         {
-            Interlocked.Increment(ref startedCount);
-            await gate.Task;
+            await barrier.SignalAndWaitAsync();
             return 1;
         }).AsTask()).ToArray();
 
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref startedCount) == 2);
+        await barrier.WaitForAllAsync();
 
         // Fill the queue.
         var queued = Enumerable.Range(0, 3).Select(_ => shield.ExecuteAsync(_ => new ValueTask<int>(2)).AsTask()).ToArray();
@@ -125,7 +126,7 @@ public class BulkheadEdgeCaseTests
 
         await Assert.That(rejections).IsEqualTo(4);
 
-        gate.SetResult();
+        barrier.Release();
         await Task.WhenAll(running);
         await Task.WhenAll(queued);
     }

--- a/tests/Kevlar.Tests/ConcurrencyTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyTests.cs
@@ -125,17 +125,19 @@ public class ConcurrencyTests
 
         var probeGate = new TaskCompletionSource();
         var probes = 0;
+        var probesStarted = new AsyncCounter("half-open probes");
 
         var outcomes = Enumerable.Range(0, 16).Select(_ =>
             shield.ExecuteOutcomeAsync(async _ =>
             {
                 Interlocked.Increment(ref probes);
+                probesStarted.Signal();
                 await probeGate.Task;
                 return 1;
             }).AsTask()).ToArray();
 
         // Exactly one execution won the probe slot; every other one was rejected immediately.
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref probes) == 1);
+        await probesStarted.WaitForAsync(1);
         var rejected = outcomes.Count(task => task.IsCompletedSuccessfully && task.Result.Exception is CircuitOpenException);
         await Assert.That(rejected).IsEqualTo(15);
 

--- a/tests/Kevlar.Tests/HedgingEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/HedgingEdgeCaseTests.cs
@@ -91,16 +91,18 @@ public class HedgingEdgeCaseTests
     {
         using var cancellation = new CancellationTokenSource();
         var started = 0;
+        var attemptsStarted = new AsyncCounter("hedged attempts");
         var shield = Shield.Hedge(2, TimeSpan.Zero);
 
         var task = shield.ExecuteAsync(async token =>
         {
             Interlocked.Increment(ref started);
+            attemptsStarted.Signal();
             await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
             return 1;
         }, cancellation.Token).AsTask();
 
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref started) == 2);
+        await attemptsStarted.WaitForAsync(2);
         cancellation.Cancel();
 
         await Assert.That(async () => await task).Throws<OperationCanceledException>();

--- a/tests/Kevlar.Tests/Infrastructure/AsyncBarrier.cs
+++ b/tests/Kevlar.Tests/Infrastructure/AsyncBarrier.cs
@@ -1,0 +1,62 @@
+namespace Kevlar.Tests;
+
+internal sealed class AsyncBarrier
+{
+    private readonly object _sync = new();
+    private readonly string _name;
+    private readonly int _participantCount;
+    private readonly TaskCompletionSource _allArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _arrived;
+
+    public AsyncBarrier(string name, int participantCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(participantCount);
+        _name = name;
+        _participantCount = participantCount;
+    }
+
+    public int ArrivedCount
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _arrived;
+            }
+        }
+    }
+
+    public async Task SignalAndWaitAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_sync)
+        {
+            if (_released.Task.IsCompleted)
+            {
+                return;
+            }
+
+            _arrived++;
+            if (_arrived > _participantCount)
+            {
+                throw new InvalidOperationException(
+                    $"Barrier '{_name}' received more than {_participantCount} participants before release.");
+            }
+
+            if (_arrived == _participantCount)
+            {
+                _allArrived.TrySetResult();
+            }
+        }
+
+        var release = cancellationToken.CanBeCanceled
+            ? _released.Task.WaitAsync(cancellationToken)
+            : _released.Task;
+        await TestHelpers.WaitAsync(release, $"barrier '{_name}' to be released");
+    }
+
+    public Task WaitForAllAsync() =>
+        TestHelpers.WaitAsync(_allArrived.Task, $"all {_participantCount} participants at barrier '{_name}'");
+
+    public void Release() => _released.TrySetResult();
+}

--- a/tests/Kevlar.Tests/Infrastructure/AsyncCounter.cs
+++ b/tests/Kevlar.Tests/Infrastructure/AsyncCounter.cs
@@ -1,0 +1,77 @@
+namespace Kevlar.Tests;
+
+internal sealed class AsyncCounter(string name)
+{
+    private readonly object _sync = new();
+    private readonly List<Waiter> _waiters = [];
+    private int _count;
+
+    public int Count => Volatile.Read(ref _count);
+
+    public int Signal()
+    {
+        List<Waiter>? completed = null;
+        int count;
+
+        lock (_sync)
+        {
+            count = ++_count;
+            for (var index = _waiters.Count - 1; index >= 0; index--)
+            {
+                if (_waiters[index].Target > count)
+                {
+                    continue;
+                }
+
+                completed ??= [];
+                completed.Add(_waiters[index]);
+                _waiters.RemoveAt(index);
+            }
+        }
+
+        if (completed is not null)
+        {
+            foreach (var waiter in completed)
+            {
+                waiter.Completion.TrySetResult(count);
+            }
+        }
+
+        return count;
+    }
+
+    public async Task<int> WaitForAsync(int target)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(target);
+        Waiter waiter;
+
+        lock (_sync)
+        {
+            if (_count >= target)
+            {
+                return _count;
+            }
+
+            waiter = new Waiter(target);
+            _waiters.Add(waiter);
+        }
+
+        try
+        {
+            return await TestHelpers.WaitAsync(waiter.Completion.Task, $"counter '{name}' to reach {target}");
+        }
+        finally
+        {
+            lock (_sync)
+            {
+                _waiters.Remove(waiter);
+            }
+        }
+    }
+
+    private sealed record Waiter(int Target)
+    {
+        public TaskCompletionSource<int> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}

--- a/tests/Kevlar.Tests/Infrastructure/AsyncGate.cs
+++ b/tests/Kevlar.Tests/Infrastructure/AsyncGate.cs
@@ -1,0 +1,24 @@
+namespace Kevlar.Tests;
+
+internal sealed class AsyncGate(string name)
+{
+    private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public bool IsEntered => _entered.Task.IsCompleted;
+
+    public bool IsReleased => _released.Task.IsCompleted;
+
+    public async Task EnterAsync(CancellationToken cancellationToken = default)
+    {
+        _entered.TrySetResult();
+        var release = cancellationToken.CanBeCanceled
+            ? _released.Task.WaitAsync(cancellationToken)
+            : _released.Task;
+        await TestHelpers.WaitAsync(release, $"gate '{name}' to be released");
+    }
+
+    public Task WaitForEntryAsync() => TestHelpers.WaitAsync(_entered.Task, $"gate '{name}' to be entered");
+
+    public void Release() => _released.TrySetResult();
+}

--- a/tests/Kevlar.Tests/Infrastructure/CancellationProbe.cs
+++ b/tests/Kevlar.Tests/Infrastructure/CancellationProbe.cs
@@ -1,0 +1,25 @@
+namespace Kevlar.Tests;
+
+internal sealed class CancellationProbe : IDisposable
+{
+    private readonly TaskCompletionSource _observed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly CancellationTokenRegistration _registration;
+    private int _count;
+
+    public CancellationProbe(CancellationToken cancellationToken)
+    {
+        _registration = cancellationToken.Register(static state => ((CancellationProbe)state!).OnCancellation(), this);
+    }
+
+    public int Count => Volatile.Read(ref _count);
+
+    public Task WaitAsync() => TestHelpers.WaitAsync(_observed.Task, "cancellation registration to run");
+
+    public void Dispose() => _registration.Dispose();
+
+    private void OnCancellation()
+    {
+        Interlocked.Increment(ref _count);
+        _observed.TrySetResult();
+    }
+}

--- a/tests/Kevlar.Tests/Infrastructure/ControlledTimeProvider.cs
+++ b/tests/Kevlar.Tests/Infrastructure/ControlledTimeProvider.cs
@@ -1,0 +1,167 @@
+namespace Kevlar.Tests;
+
+internal sealed class ControlledTimeProvider : TimeProvider
+{
+    private readonly object _sync = new();
+    private readonly List<ControlledTimer> _timers = [];
+    private readonly AsyncCounter _createdTimers = new("controlled timers created");
+    private DateTimeOffset _utcNow = DateTimeOffset.UnixEpoch;
+    private long _timestamp;
+    private int _queuedCallbackCount;
+
+    public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+    public int TimerCount
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _timers.Count;
+            }
+        }
+    }
+
+    public int QueuedCallbackCount => Volatile.Read(ref _queuedCallbackCount);
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        lock (_sync)
+        {
+            return _utcNow;
+        }
+    }
+
+    public override long GetTimestamp() => Interlocked.Read(ref _timestamp);
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        var timer = new ControlledTimer(callback, state, dueTime, period);
+        lock (_sync)
+        {
+            _timers.Add(timer);
+        }
+
+        _createdTimers.Signal();
+        return timer;
+    }
+
+    public Task<int> WaitForTimersAsync(int count) => _createdTimers.WaitForAsync(count);
+
+    public void Advance(TimeSpan elapsed)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(elapsed, TimeSpan.Zero);
+        lock (_sync)
+        {
+            _utcNow += elapsed;
+            _timestamp = checked(_timestamp + elapsed.Ticks);
+        }
+    }
+
+    public void FireTimer(int timerIndex) => GetTimer(timerIndex).Fire();
+
+    public QueuedTimerCallback QueueTimerCallback(int timerIndex)
+    {
+        var timer = GetTimer(timerIndex);
+        timer.EnsureActive();
+        Interlocked.Increment(ref _queuedCallbackCount);
+        return new QueuedTimerCallback(timer.FireCaptured, OnQueuedCallbackCompleted);
+    }
+
+    public bool IsTimerDisposed(int timerIndex) => GetTimer(timerIndex).IsDisposed;
+
+    private ControlledTimer GetTimer(int timerIndex)
+    {
+        lock (_sync)
+        {
+            return _timers[timerIndex];
+        }
+    }
+
+    private void OnQueuedCallbackCompleted() => Interlocked.Decrement(ref _queuedCallbackCount);
+
+    internal sealed class QueuedTimerCallback(Action callback, Action completed)
+    {
+        private int _fired;
+
+        public bool IsPending => Volatile.Read(ref _fired) == 0;
+
+        public void Fire()
+        {
+            if (Interlocked.Exchange(ref _fired, 1) != 0)
+            {
+                throw new InvalidOperationException("The queued timer callback has already fired.");
+            }
+
+            try
+            {
+                callback();
+            }
+            finally
+            {
+                completed();
+            }
+        }
+    }
+
+    private sealed class ControlledTimer(
+        TimerCallback callback,
+        object? state,
+        TimeSpan dueTime,
+        TimeSpan period) : ITimer
+    {
+        private readonly object _sync = new();
+        private int _disposed;
+
+        public bool IsDisposed => Volatile.Read(ref _disposed) != 0;
+
+        public TimeSpan DueTime { get; private set; } = dueTime;
+
+        public TimeSpan Period { get; private set; } = period;
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            lock (_sync)
+            {
+                if (IsDisposed)
+                {
+                    return false;
+                }
+
+                DueTime = dueTime;
+                Period = period;
+                return true;
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_sync)
+            {
+                Interlocked.Exchange(ref _disposed, 1);
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return default;
+        }
+
+        public void Fire()
+        {
+            EnsureActive();
+            callback(state);
+        }
+
+        public void FireCaptured() => callback(state);
+
+        public void EnsureActive()
+        {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(ControlledTimer));
+            }
+        }
+    }
+}

--- a/tests/Kevlar.Tests/Infrastructure/GatedDelegate.cs
+++ b/tests/Kevlar.Tests/Infrastructure/GatedDelegate.cs
@@ -1,0 +1,26 @@
+namespace Kevlar.Tests;
+
+internal sealed class GatedDelegate<T>
+{
+    private readonly AsyncCounter _invocations;
+    private readonly AsyncGate _gate;
+    private readonly Func<int, CancellationToken, ValueTask<T>> _completion;
+
+    public GatedDelegate(string name, Func<int, CancellationToken, ValueTask<T>> completion)
+    {
+        _invocations = new AsyncCounter($"{name} invocations");
+        _gate = new AsyncGate(name);
+        _completion = completion;
+    }
+
+    public async ValueTask<T> InvokeAsync(CancellationToken cancellationToken)
+    {
+        var invocation = _invocations.Signal();
+        await _gate.EnterAsync();
+        return await _completion(invocation, cancellationToken);
+    }
+
+    public Task<int> WaitForInvocationsAsync(int count) => _invocations.WaitForAsync(count);
+
+    public void Release() => _gate.Release();
+}

--- a/tests/Kevlar.Tests/Infrastructure/RaceIteration.cs
+++ b/tests/Kevlar.Tests/Infrastructure/RaceIteration.cs
@@ -1,0 +1,27 @@
+namespace Kevlar.Tests;
+
+internal readonly record struct RaceIteration(
+    string Name,
+    int Iteration,
+    int Seed,
+    RaceOrder Order)
+{
+    public string Description =>
+        $"race '{Name}', iteration {Iteration}, seed {Seed}, order {Order}";
+
+    public Random CreateRandom() => new(Seed);
+
+    public void Apply(Action first, Action second)
+    {
+        if (Order == RaceOrder.FirstThenSecond)
+        {
+            first();
+            second();
+        }
+        else
+        {
+            second();
+            first();
+        }
+    }
+}

--- a/tests/Kevlar.Tests/Infrastructure/RaceOrder.cs
+++ b/tests/Kevlar.Tests/Infrastructure/RaceOrder.cs
@@ -1,0 +1,7 @@
+namespace Kevlar.Tests;
+
+internal enum RaceOrder
+{
+    FirstThenSecond,
+    SecondThenFirst,
+}

--- a/tests/Kevlar.Tests/Infrastructure/RaceRunner.cs
+++ b/tests/Kevlar.Tests/Infrastructure/RaceRunner.cs
@@ -1,0 +1,42 @@
+namespace Kevlar.Tests;
+
+internal static class RaceRunner
+{
+    public static async Task RunBothOrdersAsync(
+        string name,
+        int repetitions,
+        Func<RaceIteration, Task> race,
+        int seed = 0x4B45564C)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(repetitions);
+
+        for (var repetition = 0; repetition < repetitions; repetition++)
+        {
+            var iterationSeed = unchecked(seed + (repetition * 397));
+            var firstOrder = new Random(iterationSeed).Next(2) == 0
+                ? RaceOrder.FirstThenSecond
+                : RaceOrder.SecondThenFirst;
+
+            for (var orderIndex = 0; orderIndex < 2; orderIndex++)
+            {
+                var order = orderIndex == 0
+                    ? firstOrder
+                    : Reverse(firstOrder);
+                var context = new RaceIteration(name, (repetition * 2) + orderIndex, iterationSeed, order);
+
+                try
+                {
+                    await TestHelpers.WaitAsync(race(context), context.Description);
+                }
+                catch (Exception exception)
+                {
+                    throw new InvalidOperationException($"Race failed: {context.Description}.", exception);
+                }
+            }
+        }
+    }
+
+    private static RaceOrder Reverse(RaceOrder order) => order == RaceOrder.FirstThenSecond
+        ? RaceOrder.SecondThenFirst
+        : RaceOrder.FirstThenSecond;
+}

--- a/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
@@ -106,6 +106,7 @@ public class RetryEdgeCaseTests
     {
         var fakeTime = new FakeTimeProvider();
         var attempts = 0;
+        var attemptsStarted = new AsyncCounter("max-delay attempts");
         var seenDelays = new List<TimeSpan>();
         var shield = Shield
             .Retry(options =>
@@ -120,12 +121,13 @@ public class RetryEdgeCaseTests
         var task = shield.ExecuteAsync<int>(_ =>
         {
             Interlocked.Increment(ref attempts);
+            attemptsStarted.Signal();
             throw new InvalidOperationException();
         }).AsTask();
 
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 1);
+        await attemptsStarted.WaitForAsync(1);
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 2);
+        await attemptsStarted.WaitForAsync(2);
 
         await Assert.That(async () => await task).Throws<InvalidOperationException>();
         await Assert.That(seenDelays).IsEquivalentTo([TimeSpan.FromSeconds(1)]);
@@ -172,6 +174,7 @@ public class RetryEdgeCaseTests
     public async Task OnRetryAsync_Is_Awaited_Before_The_Next_Attempt()
     {
         var order = new List<string>();
+        var callbackGate = new AsyncGate("OnRetryAsync callback");
         var shield = Shield.Retry(options =>
         {
             options.MaxRetries = 1;
@@ -180,17 +183,22 @@ public class RetryEdgeCaseTests
             options.OnRetryAsync = async _ =>
             {
                 order.Add("async-start");
-                await Task.Delay(20);
+                await callbackGate.EnterAsync();
                 order.Add("async-end");
             };
         });
 
-        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        var execution = shield.ExecuteAsync<int>(_ =>
         {
             order.Add("attempt");
             throw new InvalidOperationException();
-        })).Throws<InvalidOperationException>();
+        }).AsTask();
 
+        await callbackGate.WaitForEntryAsync();
+        await Assert.That(order).IsEquivalentTo(["attempt", "sync", "async-start"]);
+        callbackGate.Release();
+
+        await Assert.That(async () => await execution).Throws<InvalidOperationException>();
         await Assert.That(order).IsEquivalentTo(["attempt", "sync", "async-start", "async-end", "attempt"]);
     }
 

--- a/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
@@ -195,11 +195,15 @@ public class RetryEdgeCaseTests
         }).AsTask();
 
         await callbackGate.WaitForEntryAsync();
-        await Assert.That(order).IsEquivalentTo(["attempt", "sync", "async-start"]);
+        await Assert.That(order).IsEquivalentTo(
+            ["attempt", "sync", "async-start"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
         callbackGate.Release();
 
         await Assert.That(async () => await execution).Throws<InvalidOperationException>();
-        await Assert.That(order).IsEquivalentTo(["attempt", "sync", "async-start", "async-end", "attempt"]);
+        await Assert.That(order).IsEquivalentTo(
+            ["attempt", "sync", "async-start", "async-end", "attempt"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/RetryTests.cs
+++ b/tests/Kevlar.Tests/RetryTests.cs
@@ -106,21 +106,23 @@ public class RetryTests
     {
         var fakeTime = new FakeTimeProvider();
         var attempts = 0;
+        var attemptsStarted = new AsyncCounter("backoff attempts");
         var shield = Shield.Retry(2, Backoff.Constant(TimeSpan.FromSeconds(1))).WithTimeProvider(fakeTime);
 
         var task = shield.ExecuteAsync<int>(_ =>
         {
             attempts++;
+            attemptsStarted.Signal();
             throw new InvalidOperationException();
         }).AsTask();
 
         await Assert.That(attempts).IsEqualTo(1);
 
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 2);
+        await attemptsStarted.WaitForAsync(2);
 
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 3);
+        await attemptsStarted.WaitForAsync(3);
 
         await Assert.That(async () => await task).Throws<InvalidOperationException>();
     }

--- a/tests/Kevlar.Tests/TestHelpers.cs
+++ b/tests/Kevlar.Tests/TestHelpers.cs
@@ -2,22 +2,29 @@ namespace Kevlar.Tests;
 
 internal static class TestHelpers
 {
-    /// <summary>
-    /// Waits for a condition that is satisfied by a thread-pool continuation, bridging the gap
-    /// between a FakeTimeProvider.Advance call and the async work it unblocks.
-    /// </summary>
-    public static async Task WaitUntil(Func<bool> condition, int timeoutMilliseconds = 5000)
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+    public static async Task WaitAsync(Task task, string operation, TimeSpan? timeout = null)
     {
-        var start = Environment.TickCount64;
-
-        while (!condition())
+        try
         {
-            if (Environment.TickCount64 - start > timeoutMilliseconds)
-            {
-                throw new TimeoutException("The expected condition was not reached in time.");
-            }
+            await task.WaitAsync(timeout ?? DefaultTimeout);
+        }
+        catch (TimeoutException exception) when (!task.IsCompleted)
+        {
+            throw new TimeoutException($"Timed out waiting for {operation}.", exception);
+        }
+    }
 
-            await Task.Delay(5);
+    public static async Task<T> WaitAsync<T>(Task<T> task, string operation, TimeSpan? timeout = null)
+    {
+        try
+        {
+            return await task.WaitAsync(timeout ?? DefaultTimeout);
+        }
+        catch (TimeoutException exception) when (!task.IsCompleted)
+        {
+            throw new TimeoutException($"Timed out waiting for {operation}.", exception);
         }
     }
 }

--- a/tests/Kevlar.Tests/TestInfrastructureTests.cs
+++ b/tests/Kevlar.Tests/TestInfrastructureTests.cs
@@ -1,0 +1,102 @@
+namespace Kevlar.Tests;
+
+public class TestInfrastructureTests
+{
+    [Test]
+    public async Task Gate_Reports_Entry_And_Requires_Explicit_Release()
+    {
+        var gate = new AsyncGate("helper test");
+        var pending = gate.EnterAsync();
+
+        await gate.WaitForEntryAsync();
+        await Assert.That(pending.IsCompleted).IsFalse();
+
+        gate.Release();
+        await pending;
+    }
+
+    [Test]
+    public async Task Barrier_Reports_All_Participants_Before_Release()
+    {
+        var barrier = new AsyncBarrier("helper test", 2);
+        var first = barrier.SignalAndWaitAsync();
+        var second = barrier.SignalAndWaitAsync();
+
+        await barrier.WaitForAllAsync();
+        await Assert.That(barrier.ArrivedCount).IsEqualTo(2);
+        await Assert.That(first.IsCompleted).IsFalse();
+        await Assert.That(second.IsCompleted).IsFalse();
+
+        barrier.Release();
+        await Task.WhenAll(first, second);
+    }
+
+    [Test]
+    public async Task Cancellation_Probe_Reports_Registration_Execution()
+    {
+        using var source = new CancellationTokenSource();
+        using var probe = new CancellationProbe(source.Token);
+
+        source.Cancel();
+
+        await probe.WaitAsync();
+        await Assert.That(probe.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Controlled_Timer_Callback_Can_Outlive_Timer_Disposal()
+    {
+        var provider = new ControlledTimeProvider();
+        var fired = 0;
+        var timer = provider.CreateTimer(_ => Interlocked.Increment(ref fired), null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
+        await provider.WaitForTimersAsync(1);
+        var queued = provider.QueueTimerCallback(0);
+
+        timer.Dispose();
+        await Assert.That(provider.IsTimerDisposed(0)).IsTrue();
+        await Assert.That(provider.QueuedCallbackCount).IsEqualTo(1);
+
+        queued.Fire();
+
+        await Assert.That(fired).IsEqualTo(1);
+        await Assert.That(queued.IsPending).IsFalse();
+        await Assert.That(provider.QueuedCallbackCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Race_Runner_Names_And_Exercises_Both_Orders()
+    {
+        var orders = new List<RaceOrder>();
+        var traces = new List<(RaceOrder Order, string Trace)>();
+
+        await RaceRunner.RunBothOrdersAsync("helper ordering", 4, iteration =>
+        {
+            orders.Add(iteration.Order);
+            var trace = new List<string>();
+            iteration.Apply(() => trace.Add("first"), () => trace.Add("second"));
+            traces.Add((iteration.Order, string.Join(",", trace)));
+            return Task.CompletedTask;
+        }, seed: 1234);
+
+        await Assert.That(orders.Count).IsEqualTo(8);
+        await Assert.That(orders.Count(order => order == RaceOrder.FirstThenSecond)).IsEqualTo(4);
+        await Assert.That(orders.Count(order => order == RaceOrder.SecondThenFirst)).IsEqualTo(4);
+        await Assert.That(traces.All(item => item.Trace == (item.Order == RaceOrder.FirstThenSecond
+            ? "first,second"
+            : "second,first"))).IsTrue();
+    }
+
+    [Test]
+    public async Task Race_Runner_Preserves_Reproduction_Data_In_Failures()
+    {
+        var exception = await Assert.That(async () => await RaceRunner.RunBothOrdersAsync(
+            "reproducible failure",
+            repetitions: 1,
+            iteration => throw new InvalidOperationException(iteration.CreateRandom().Next().ToString()),
+            seed: 2468)).Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).Contains("race 'reproducible failure'");
+        await Assert.That(exception.Message).Contains("seed 2468");
+        await Assert.That(exception.Message).Contains("order");
+    }
+}

--- a/tests/Kevlar.Tests/TimeoutEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/TimeoutEdgeCaseTests.cs
@@ -7,20 +7,22 @@ public class TimeoutEdgeCaseTests
     [Test]
     public async Task A_Result_Produced_After_The_Timer_Fired_Is_Still_Delivered()
     {
+        var timeProvider = new ControlledTimeProvider();
+        var action = new GatedDelegate<int>("successful timeout-ignoring action", static (_, _) => new ValueTask<int>(7));
         var timedOut = false;
         var shield = Shield.Timeout(options =>
         {
-            options.Timeout = TimeSpan.FromMilliseconds(50);
+            options.Timeout = TimeSpan.FromMinutes(1);
             options.OnTimeout = _ => timedOut = true;
-        });
+        }).WithTimeProvider(timeProvider);
 
         // The delegate ignores its token and completes anyway; the timeout is cooperative,
         // so the successful result wins and no timeout is reported.
-        var result = await shield.ExecuteAsync(async _ =>
-        {
-            await Task.Delay(300);
-            return 7;
-        });
+        var task = shield.ExecuteAsync(action.InvokeAsync).AsTask();
+        await action.WaitForInvocationsAsync(1);
+        timeProvider.FireTimer(0);
+        action.Release();
+        var result = await task;
 
         await Assert.That(result).IsEqualTo(7);
         await Assert.That(timedOut).IsFalse();
@@ -29,13 +31,17 @@ public class TimeoutEdgeCaseTests
     [Test]
     public async Task A_NonCancellation_Failure_After_The_Timer_Fired_Is_Not_Rewritten()
     {
-        var shield = Shield.Timeout(TimeSpan.FromMilliseconds(50));
+        var timeProvider = new ControlledTimeProvider();
+        var action = new GatedDelegate<int>("failing timeout-ignoring action", static (_, _) =>
+            throw new InvalidOperationException("real failure"));
+        var shield = Shield.Timeout(TimeSpan.FromMinutes(1)).WithTimeProvider(timeProvider);
 
-        await Assert.That(async () => await shield.ExecuteAsync<int>(async _ =>
-        {
-            await Task.Delay(300);
-            throw new InvalidOperationException("real failure");
-        })).Throws<InvalidOperationException>().WithMessage("real failure");
+        var task = shield.ExecuteAsync(action.InvokeAsync).AsTask();
+        await action.WaitForInvocationsAsync(1);
+        timeProvider.FireTimer(0);
+        action.Release();
+
+        await Assert.That(async () => await task).Throws<InvalidOperationException>().WithMessage("real failure");
     }
 
     [Test]
@@ -85,7 +91,7 @@ public class TimeoutEdgeCaseTests
     {
         using var cancellation = new CancellationTokenSource();
         var timedOut = false;
-        var started = new TaskCompletionSource();
+        var probeReady = new TaskCompletionSource<CancellationProbe>(TaskCreationOptions.RunContinuationsAsynchronously);
         var shield = Shield.Timeout(options =>
         {
             options.Timeout = TimeSpan.FromMinutes(10);
@@ -94,16 +100,20 @@ public class TimeoutEdgeCaseTests
 
         var task = shield.ExecuteAsync(async token =>
         {
-            started.SetResult();
-            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            using var probe = new CancellationProbe(token);
+            probeReady.SetResult(probe);
+            await probe.WaitAsync();
+            token.ThrowIfCancellationRequested();
             return 1;
         }, cancellation.Token).AsTask();
 
-        await started.Task;
+        var cancellationProbe = await TestHelpers.WaitAsync(probeReady.Task, "timeout action to register cancellation");
         cancellation.Cancel();
+        await cancellationProbe.WaitAsync();
 
         await Assert.That(async () => await task).Throws<OperationCanceledException>();
         await Assert.That(timedOut).IsFalse();
+        await Assert.That(cancellationProbe.Count).IsEqualTo(1);
     }
 
     [Test]
@@ -111,6 +121,7 @@ public class TimeoutEdgeCaseTests
     {
         var fakeTime = new FakeTimeProvider();
         var attempts = 0;
+        var attemptsStarted = new AsyncCounter("per-attempt timeouts");
 
         // Retry is outermost, so the inner timeout budget restarts per attempt.
         var shield = Shield
@@ -121,6 +132,7 @@ public class TimeoutEdgeCaseTests
         var task = shield.ExecuteAsync(async token =>
         {
             var attempt = Interlocked.Increment(ref attempts);
+            attemptsStarted.Signal();
             if (attempt < 3)
             {
                 await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
@@ -129,11 +141,11 @@ public class TimeoutEdgeCaseTests
             return attempt;
         }).AsTask();
 
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 1);
+        await attemptsStarted.WaitForAsync(1);
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 2);
+        await attemptsStarted.WaitForAsync(2);
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 3);
+        await attemptsStarted.WaitForAsync(3);
 
         var result = await task;
         await Assert.That(result).IsEqualTo(3);
@@ -186,13 +198,21 @@ public class TimeoutEdgeCaseTests
     [Test]
     public async Task A_Queued_Custom_Timer_Callback_Cannot_Cancel_A_Later_Execution()
     {
-        var timeProvider = new QueuedCallbackTimeProvider();
+        var timeProvider = new ControlledTimeProvider();
+        ControlledTimeProvider.QueuedTimerCallback? queuedCallback = null;
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var shield = Shield
             .Timeout(TimeSpan.FromMinutes(1))
             .WithTimeProvider(timeProvider);
 
-        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        await shield.ExecuteAsync(_ =>
+        {
+            queuedCallback = timeProvider.QueueTimerCallback(0);
+            return new ValueTask<int>(1);
+        });
+
+        await Assert.That(timeProvider.IsTimerDisposed(0)).IsTrue();
+        await Assert.That(timeProvider.QueuedCallbackCount).IsEqualTo(1);
 
         var task = shield.ExecuteAsync(async token =>
         {
@@ -201,10 +221,11 @@ public class TimeoutEdgeCaseTests
             return 2;
         }).AsTask();
 
-        timeProvider.Fire(timerIndex: 0);
+        queuedCallback!.Fire();
         release.SetResult();
 
         await Assert.That(await task).IsEqualTo(2);
+        await Assert.That(timeProvider.QueuedCallbackCount).IsEqualTo(0);
     }
 
     [Test]
@@ -218,33 +239,6 @@ public class TimeoutEdgeCaseTests
         await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => timeProvider.Source!.Token).Throws<ObjectDisposedException>();
-    }
-
-    private sealed class QueuedCallbackTimeProvider : TimeProvider
-    {
-        private readonly List<QueuedTimer> _timers = [];
-
-        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
-        {
-            var timer = new QueuedTimer(callback, state);
-            _timers.Add(timer);
-            return timer;
-        }
-
-        public void Fire(int timerIndex) => _timers[timerIndex].Fire();
-
-        private sealed class QueuedTimer(TimerCallback callback, object? state) : ITimer
-        {
-            public bool Change(TimeSpan dueTime, TimeSpan period) => true;
-
-            public void Dispose()
-            {
-            }
-
-            public ValueTask DisposeAsync() => default;
-
-            public void Fire() => callback(state);
-        }
     }
 
     private sealed class ThrowingTimeProvider : TimeProvider

--- a/tests/Kevlar.Tests/TimeoutTests.cs
+++ b/tests/Kevlar.Tests/TimeoutTests.cs
@@ -80,6 +80,7 @@ public class TimeoutTests
     {
         var fakeTime = new FakeTimeProvider();
         var attempts = 0;
+        var attemptsStarted = new AsyncCounter("retry timeout attempts");
         var shield = Shield
             .When<TimeoutExceededException>()
             .Retry(1, Backoff.None)
@@ -89,12 +90,13 @@ public class TimeoutTests
         var task = shield.ExecuteAsync(async token =>
         {
             Interlocked.Increment(ref attempts);
+            attemptsStarted.Signal();
             await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
             return 1;
         }).AsTask();
 
         fakeTime.Advance(TimeSpan.FromSeconds(1));
-        await TestHelpers.WaitUntil(() => Volatile.Read(ref attempts) == 2);
+        await attemptsStarted.WaitForAsync(2);
         fakeTime.Advance(TimeSpan.FromSeconds(1));
 
         await Assert.That(async () => await task).Throws<TimeoutExceededException>();

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,16 @@
+# Deterministic asynchronous tests
+
+Unit tests in `Kevlar.Tests` must use explicit signals, gates, barriers, cancellation registrations, or a controlled `TimeProvider`. Do not use finite `Task.Delay`, polling loops, `Thread.Sleep`, or elapsed-time tolerances to make concurrent work “probably” reach a state. Integration tests may exercise real I/O timing when elapsed behavior is the contract.
+
+Helpers in `Kevlar.Tests/Infrastructure` provide the shared vocabulary:
+
+- `GatedDelegate<T>` and `AsyncGate` expose entry and explicit release.
+- `AsyncBarrier` holds a named number of participants until the test releases them.
+- `AsyncCounter` waits for a named event count without polling.
+- `CancellationProbe` observes cancellation-registration execution.
+- `ControlledTimeProvider` records timers, fires them explicitly, and captures callbacks that must outlive timer disposal.
+- `RaceRunner` executes both named orderings with a reproducible seed and includes the name, iteration, seed, and ordering in failures.
+
+Every helper wait has a five-second watchdog. The watchdog is only a deadlock bound, never the mechanism that creates the state under test. Prefer `FakeTimeProvider` when only clock advancement matters. Keep real time only for the synchronous timeout smoke test, where blocking behavior itself is the contract.
+
+An infinite `Task.Delay` tied to the execution token is also valid when “remain pending until cancellation” is the behavior under test; it does not use elapsed time to coordinate assertions.


### PR DESCRIPTION
## Summary

- add bounded named gates, barriers, event counters, cancellation probes, gated delegates, controlled timers, and seeded two-order race orchestration
- replace polling and finite-delay coordination across retry, timeout, hedging, circuit-breaker, and concurrency-limit unit tests
- explicitly capture/fire timer callbacks across disposal and preserve race name, iteration, seed, and ordering in failures
- document deterministic async-test conventions and the sole allowed real-clock synchronous smoke test

Closes #10

## Validation

- `dotnet build Kevlar.slnx -c Release` (0 warnings)
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (319 passed after rebase)
- 20 consecutive full unit-suite runs passed before the final rebase; final rebased suite passed in 678ms
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- scan confirms no finite `Task.Delay`, `WaitUntil`, or `CancelAfter` coordination in `Kevlar.Tests`; only the synchronous timeout smoke uses `Thread.Sleep`