### PR TITLE
fix(timeout): define cancellation arbitration

### DIFF
--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -31,8 +31,18 @@ Internally, the timeout strategy swaps `context.CancellationToken` for a linked 
 
 Two behaviours worth knowing:
 
-- If your delegate completes successfully *despite* the token firing, the result is still delivered — only an execution that ends in `OperationCanceledException` is converted to `TimeoutExceededException`.
+- If your delegate completes successfully *despite* the token firing, the result is still delivered.
 - Cancellation from your own outer token is **not** reported as a timeout — it propagates as a normal `OperationCanceledException`.
+
+## Cancellation arbitration
+
+When cancellation signals overlap, the outcome is decided after the delegate completes:
+
+1. If the caller's token is cancelled, caller cancellation wins. The resulting `OperationCanceledException` carries the caller's token.
+2. Otherwise, if the timeout fired and the delegate's `OperationCanceledException` carries the exact token handed to the delegate, the outcome becomes `TimeoutExceededException`.
+3. An `OperationCanceledException` for any other token is preserved unchanged.
+
+This token-identity rule also applies to nested timeouts. A cancelled outer timeout is treated as the inner timeout's caller, so only the winning scope reports `OnTimeout`. The strategy restores the prior context token and completes timer cleanup before invoking `OnTimeout`; if the callback throws, that exception is surfaced without contaminating later executions.
 
 ## Total vs per-attempt
 

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -72,8 +72,19 @@ internal sealed class TimeoutStrategy : Strategy
         }
 
         var outcome = execution.Result;
-        var timedOut = Cleanup(context, priorToken, timeoutSource, timer);
-        return new ValueTask<Outcome<T>>(HandleOutcome(outcome, timedOut, context));
+        if (outcome.Exception is not OperationCanceledException cancellationException)
+        {
+            Cleanup(context, priorToken, timeoutSource, timer);
+            return new ValueTask<Outcome<T>>(outcome);
+        }
+
+        return new ValueTask<Outcome<T>>(CompleteCancellation(
+            outcome,
+            cancellationException,
+            context,
+            priorToken,
+            timeoutSource,
+            timer));
     }
 
     private async ValueTask<Outcome<T>> AwaitAsync<T>(
@@ -84,21 +95,27 @@ internal sealed class TimeoutStrategy : Strategy
         ITimer? timer)
     {
         Outcome<T> outcome;
-        bool timedOut;
 
         try
         {
             outcome = await execution.ConfigureAwait(false);
         }
-        finally
+        catch
         {
-            timedOut = Cleanup(context, priorToken, timeoutSource, timer);
+            Cleanup(context, priorToken, timeoutSource, timer);
+            throw;
         }
 
-        return HandleOutcome(outcome, timedOut, context);
+        if (outcome.Exception is not OperationCanceledException cancellationException)
+        {
+            Cleanup(context, priorToken, timeoutSource, timer);
+            return outcome;
+        }
+
+        return CompleteCancellation(outcome, cancellationException, context, priorToken, timeoutSource, timer);
     }
 
-    private static bool Cleanup(
+    private static void Cleanup(
         KevlarContext context,
         CancellationToken priorToken,
         CancellationTokenSource timeoutSource,
@@ -106,14 +123,40 @@ internal sealed class TimeoutStrategy : Strategy
     {
         context.CancellationToken = priorToken;
         timer?.Dispose();
-        var timedOut = timeoutSource.IsCancellationRequested && !priorToken.IsCancellationRequested;
         timeoutSource.Dispose();
-        return timedOut;
     }
 
-    private Outcome<T> HandleOutcome<T>(Outcome<T> outcome, bool timedOut, KevlarContext context)
+    private Outcome<T> CompleteCancellation<T>(
+        Outcome<T> outcome,
+        OperationCanceledException cancellationException,
+        KevlarContext context,
+        CancellationToken priorToken,
+        CancellationTokenSource timeoutSource,
+        ITimer? timer)
     {
-        if (timedOut && outcome.Exception is OperationCanceledException)
+        context.CancellationToken = priorToken;
+        timer?.Dispose();
+
+        if (priorToken.IsCancellationRequested)
+        {
+            timeoutSource.Dispose();
+
+            if (cancellationException.CancellationToken == priorToken)
+            {
+                return outcome;
+            }
+
+            return Outcome<T>.FromException(new OperationCanceledException(
+                cancellationException.Message,
+                cancellationException,
+                priorToken));
+        }
+
+        var timedOut = timeoutSource.IsCancellationRequested
+            && cancellationException.CancellationToken == timeoutSource.Token;
+        timeoutSource.Dispose();
+
+        if (timedOut)
         {
             KevlarMetrics.Timeout(context.ShieldName);
             _onTimeout?.Invoke(new TimeoutEvent(_timeout, context));

--- a/tests/Kevlar.Tests/TimeoutArbitrationTests.cs
+++ b/tests/Kevlar.Tests/TimeoutArbitrationTests.cs
@@ -1,0 +1,338 @@
+namespace Kevlar.Tests;
+
+public class TimeoutArbitrationTests
+{
+    [Test]
+    public async Task Caller_Cancellation_Wins_After_Timeout_Fires()
+    {
+        var timeProvider = new ManualTimeProvider();
+        using var callerCancellation = new CancellationTokenSource();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutEvents = 0;
+        CancellationToken executionToken = default;
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromSeconds(1);
+            options.OnTimeout = _ => timeoutEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            executionToken = token;
+            started.SetResult();
+            await release.Task;
+            throw new OperationCanceledException(token);
+        }, callerCancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(0);
+        callerCancellation.Cancel();
+        release.SetResult();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(executionToken).IsNotEqualTo(callerCancellation.Token);
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken == callerCancellation.Token)
+            .IsTrue();
+        await Assert.That(timeoutEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_Wins_Before_Timeout_Fires()
+    {
+        var timeProvider = new ManualTimeProvider();
+        using var callerCancellation = new CancellationTokenSource();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutEvents = 0;
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromSeconds(1);
+            options.OnTimeout = _ => timeoutEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            started.SetResult();
+            await release.Task;
+            throw new OperationCanceledException(token);
+        }, callerCancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        callerCancellation.Cancel();
+        timeProvider.Fire(0);
+        release.SetResult();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken == callerCancellation.Token)
+            .IsTrue();
+        await Assert.That(timeoutEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Equal_Nested_Timeouts_Report_Only_The_Outer_Timeout()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var outerEvents = 0;
+        var innerEvents = 0;
+        var shield = Shield
+            .Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeout = _ => outerEvents++;
+            })
+            .Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeout = _ => innerEvents++;
+            })
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            started.SetResult();
+            await release.Task;
+            throw new OperationCanceledException(token);
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(1);
+        timeProvider.Fire(0);
+        release.SetResult();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<TimeoutExceededException>();
+        await Assert.That(outerEvents).IsEqualTo(1);
+        await Assert.That(innerEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Unrelated_Cancellation_After_Timer_Fires_Is_Not_Reclassified()
+    {
+        var timeProvider = new ManualTimeProvider();
+        using var unrelatedCancellation = new CancellationTokenSource();
+        var unrelated = new OperationCanceledException("unrelated", unrelatedCancellation.Token);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutEvents = 0;
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromSeconds(1);
+            options.OnTimeout = _ => timeoutEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            throw unrelated;
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(0);
+        release.SetResult();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, unrelated)).IsTrue();
+        await Assert.That(timeoutEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Success_After_Timeout_Token_Cancellation_Is_Delivered()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutEvents = 0;
+        CancellationToken executionToken = default;
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromSeconds(1);
+            options.OnTimeout = _ => timeoutEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            executionToken = token;
+            started.SetResult();
+            await release.Task;
+            return 42;
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(0);
+        release.SetResult();
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(executionToken.IsCancellationRequested).IsTrue();
+        await Assert.That(timeoutEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Outer_Strategy_Sees_Caller_Token_After_Success_And_Timeout()
+    {
+        var timeProvider = new ManualTimeProvider();
+        using var callerCancellation = new CancellationTokenSource();
+        var observer = new TokenObserverStrategy();
+        var shield = Shield.Use(observer)
+            .Timeout(TimeSpan.FromSeconds(1))
+            .WithTimeProvider(timeProvider);
+
+        var success = await shield.ExecuteAsync(_ => new ValueTask<int>(42), callerCancellation.Token);
+
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timedExecution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            started.SetResult();
+            await release.Task;
+            throw new OperationCanceledException(token);
+        }, callerCancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(1);
+        release.SetResult();
+        var timedOutcome = await timedExecution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(success).IsEqualTo(42);
+        await Assert.That(timedOutcome.Exception).IsTypeOf<TimeoutExceededException>();
+        await Assert.That(observer.Observations.Count).IsEqualTo(2);
+        foreach (var observation in observer.Observations)
+        {
+            await Assert.That(observation.Before).IsEqualTo(callerCancellation.Token);
+            await Assert.That(observation.After).IsEqualTo(callerCancellation.Token);
+        }
+    }
+
+    [Test]
+    public async Task OnTimeout_Failure_Leaves_Context_Clean_And_Next_Execution_Healthy()
+    {
+        var timeProvider = new ManualTimeProvider();
+        using var callerCancellation = new CancellationTokenSource();
+        var callbackFailure = new ApplicationException("timeout callback failed");
+        var callbackCalls = 0;
+        var observer = new TokenObserverStrategy();
+        var shield = Shield.Use(observer)
+            .Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeout = _ =>
+                {
+                    callbackCalls++;
+                    throw callbackFailure;
+                };
+            })
+            .WithTimeProvider(timeProvider);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstExecution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            started.SetResult();
+            await release.Task;
+            throw new OperationCanceledException(token);
+        }, callerCancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(0);
+        release.SetResult();
+        var failed = await firstExecution.WaitAsync(TimeSpan.FromSeconds(5));
+        var recovered = await shield.ExecuteAsync(_ => new ValueTask<int>(42), callerCancellation.Token);
+
+        await Assert.That(ReferenceEquals(failed.Exception, callbackFailure)).IsTrue();
+        await Assert.That(recovered).IsEqualTo(42);
+        await Assert.That(callbackCalls).IsEqualTo(1);
+        await Assert.That(observer.Observations.Count).IsEqualTo(2);
+        foreach (var observation in observer.Observations)
+        {
+            await Assert.That(observation.Before).IsEqualTo(callerCancellation.Token);
+            await Assert.That(observation.After).IsEqualTo(callerCancellation.Token);
+        }
+    }
+
+    [Test]
+    public async Task Queued_Stale_Timer_Cannot_Cancel_A_Later_Execution()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var shield = Shield.Timeout(TimeSpan.FromSeconds(1)).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken secondToken = default;
+        var secondExecution = shield.ExecuteAsync(async token =>
+        {
+            secondToken = token;
+            started.SetResult();
+            await release.Task;
+            token.ThrowIfCancellationRequested();
+            return 2;
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(0);
+        await Assert.That(secondToken.IsCancellationRequested).IsFalse();
+        release.SetResult();
+
+        await Assert.That(await secondExecution.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(2);
+    }
+
+    private sealed class TokenObserverStrategy : Strategy
+    {
+        public List<TokenObservation> Observations { get; } = [];
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            var before = context.CancellationToken;
+            try
+            {
+                return await next.InvokeAsync(context);
+            }
+            finally
+            {
+                Observations.Add(new TokenObservation(before, context.CancellationToken));
+            }
+        }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private readonly List<ManualTimer> _timers = [];
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(callback, state);
+            _timers.Add(timer);
+            return timer;
+        }
+
+        public void Fire(int timerIndex) => _timers[timerIndex].Fire();
+
+        private sealed class ManualTimer(TimerCallback callback, object? state) : ITimer
+        {
+            public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+
+            public void Dispose()
+            {
+            }
+
+            public ValueTask DisposeAsync() => default;
+
+            public void Fire() => callback(state);
+        }
+    }
+
+    private sealed record TokenObservation(CancellationToken Before, CancellationToken After);
+}


### PR DESCRIPTION
## Summary
- define deterministic cancellation ownership using caller and timeout token identity
- restore context and dispose timeout resources before callbacks
- cover overlapping cancellation, nested deadlines, callback failures, success-after-cancellation, and stale timers
- document timeout arbitration

Closes #13

## Validation
- `dotnet build Kevlar.slnx -c Release` (0 warnings)
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (321 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `npm run build` (docs)

## Benchmark
`TimeoutBenchmarks.Kevlar_HappyPath` MediumRun: 114.9 ns / 0 B before; 111.5 ns / 0 B after (-3.0%).