### PR TITLE
fix(hedging): suppress post-cancel launches

### DIFF
--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -41,6 +41,7 @@ Multiple invocations of your delegate may be in flight at once — it must be sa
 :::
 
 - Losing attempts are cancelled through their token (use the token you're handed!).
+- Caller cancellation prevents any later hedge from launching, even when it races a completed stagger delay. `OnHedge` runs only for attempts that actually launch.
 - Each attempt gets a forked context — `Properties` are copied at launch time, so attempts don't see each other's writes.
 - What counts as a failure is the ambient [handling clause](../handling-failures.md), like every reactive strategy.
 

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -42,6 +42,7 @@ Multiple invocations of your delegate may be in flight at once — it must be sa
 
 - Losing attempts are cancelled through their token (use the token you're handed!).
 - Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside `OnHedge`. A cancellation already observable at the launch boundary suppresses `OnHedge` too.
+- The `kevlar.hedges` counter records only attempts that launch after `OnHedge` returns successfully and cancellation is rechecked. Suppressed launches and failing callbacks are not counted.
 - Each attempt gets a forked context — `Properties` are copied at launch time, so attempts don't see each other's writes.
 - What counts as a failure is the ambient [handling clause](../handling-failures.md), like every reactive strategy.
 

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -41,7 +41,7 @@ Multiple invocations of your delegate may be in flight at once — it must be sa
 :::
 
 - Losing attempts are cancelled through their token (use the token you're handed!).
-- Caller cancellation prevents any later hedge from launching, even when it races a completed stagger delay. `OnHedge` runs only for attempts that actually launch.
+- Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside `OnHedge`. A cancellation already observable at the launch boundary suppresses `OnHedge` too.
 - Each attempt gets a forked context — `Properties` are copied at launch time, so attempts don't see each other's writes.
 - What counts as a failure is the ambient [handling clause](../handling-failures.md), like every reactive strategy.
 

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -160,6 +160,7 @@ internal sealed class HedgingStrategy : Strategy
         {
             KevlarMetrics.Hedge(context.ShieldName);
             _onHedge?.Invoke(new HedgeEvent(attemptNumber, context));
+            context.CancellationToken.ThrowIfCancellationRequested();
         }
 
         var cancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -158,9 +158,9 @@ internal sealed class HedgingStrategy : Strategy
     {
         if (attemptNumber > 1)
         {
-            KevlarMetrics.Hedge(context.ShieldName);
             _onHedge?.Invoke(new HedgeEvent(attemptNumber, context));
             context.CancellationToken.ThrowIfCancellationRequested();
+            KevlarMetrics.Hedge(context.ShieldName);
         }
 
         var cancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -149,6 +149,7 @@ internal sealed class HedgingStrategy : Strategy
 
     private void Launch<T, TState>(List<HedgeAttempt<T>> pending, Continuation<T, TState> next, KevlarContext context, ref int launched)
     {
+        context.CancellationToken.ThrowIfCancellationRequested();
         var attemptNumber = ++launched;
         pending.Add(StartAttempt(next, context, attemptNumber).AsPending());
     }

--- a/tests/Kevlar.Tests/HedgingRaceTests.cs
+++ b/tests/Kevlar.Tests/HedgingRaceTests.cs
@@ -1,0 +1,379 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class HedgingRaceTests
+{
+    [Test]
+    public async Task Caller_Cancellation_During_Finite_Stagger_Does_Not_Launch_Hedges()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        var hedgeEvents = 0;
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.Delay = TimeSpan.FromSeconds(1);
+            options.OnHedge = _ => hedgeEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            Interlocked.Increment(ref attempts);
+            started.TrySetResult();
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(hedgeEvents).IsEqualTo(0);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_During_Infinite_Stagger_Does_Not_Launch_Hedges()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        var hedgeEvents = 0;
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.Delay = System.Threading.Timeout.InfiniteTimeSpan;
+            options.OnHedge = _ => hedgeEvents++;
+        });
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            Interlocked.Increment(ref attempts);
+            started.TrySetResult();
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(hedgeEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Timer_Before_Caller_Cancellation_Launches_Only_One_Hedge()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        var hedgeEvents = 0;
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.Delay = TimeSpan.FromSeconds(1);
+            options.OnHedge = _ => hedgeEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            if (Interlocked.Increment(ref attempts) == 2)
+            {
+                secondStarted.TrySetResult();
+            }
+
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token).AsTask();
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await secondStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(hedgeEvents).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Simultaneous_Acceptable_Outcomes_Complete_Both_Attempts_Safely()
+    {
+        var releases = new[]
+        {
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+        };
+        var completions = new[]
+        {
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+        };
+        var allStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        var shield = Shield.Hedge(2, TimeSpan.Zero);
+
+        var execution = shield.ExecuteAsync(async _ =>
+        {
+            var attempt = Interlocked.Increment(ref attempts) - 1;
+            if (attempts == 2)
+            {
+                allStarted.TrySetResult();
+            }
+
+            try
+            {
+                await releases[attempt].Task;
+                return attempt + 1;
+            }
+            finally
+            {
+                completions[attempt].TrySetResult();
+            }
+        }).AsTask();
+
+        await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releases[0].SetResult();
+        releases[1].SetResult();
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.WhenAll(completions.Select(completion => completion.Task)).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result is 1 or 2).IsTrue();
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public Task Unhandled_Exception_Wins_When_Released_First() =>
+        RunUnhandledExceptionAndSuccessRace(unhandledExceptionWins: true);
+
+    [Test]
+    public Task Success_Wins_When_Released_First() =>
+        RunUnhandledExceptionAndSuccessRace(unhandledExceptionWins: false);
+
+    [Test]
+    public async Task Attempts_Mutate_Isolated_Context_Properties()
+    {
+        var key = new KevlarKey<int>("attempt");
+        var parentObserver = new ParentPropertyObserver(key);
+        var forkObserver = new ForkPropertyObserver(key, participantCount: 2);
+        var shield = Shield
+            .Use(parentObserver)
+            .Hedge(2, TimeSpan.Zero)
+            .Use(forkObserver);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(forkObserver.ObservedValues.Count).IsEqualTo(2);
+        await Assert.That(forkObserver.ObservedValues[1]).IsEqualTo(1);
+        await Assert.That(forkObserver.ObservedValues[2]).IsEqualTo(2);
+        await Assert.That(parentObserver.Before).IsEqualTo(-1);
+        await Assert.That(parentObserver.After).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task OnHedge_Failure_Cancels_Primary_And_Next_Execution_Is_Healthy()
+    {
+        var callbackFailure = new ApplicationException("hedge callback failed");
+        var callbackCalls = 0;
+        var primaryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var primaryCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedge = _ =>
+            {
+                if (Interlocked.Increment(ref callbackCalls) == 1)
+                {
+                    throw callbackFailure;
+                }
+            };
+        });
+
+        var failed = await shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            Interlocked.Increment(ref attempts);
+            using var registration = token.Register(() => primaryCancelled.TrySetResult());
+            primaryStarted.TrySetResult();
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        });
+
+        await primaryStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await primaryCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var recovered = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(ReferenceEquals(failed.Exception, callbackFailure)).IsTrue();
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(recovered).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Repeated_Late_Loser_Failures_Do_Not_Contaminate_Pooled_State()
+    {
+        var shield = Shield.Hedge(2, TimeSpan.Zero);
+
+        for (var iteration = 0; iteration < 32; iteration++)
+        {
+            var releaseLoser = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var loserCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var attempts = 0;
+
+            var result = await shield.ExecuteAsync(async _ =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    try
+                    {
+                        await releaseLoser.Task;
+                        throw new ApplicationException($"late loser {iteration}");
+                    }
+                    finally
+                    {
+                        loserCompleted.TrySetResult();
+                    }
+                }
+
+                return iteration;
+            });
+
+            releaseLoser.SetResult();
+            await loserCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(result).IsEqualTo(iteration);
+            await Assert.That(attempts).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task Concurrent_Executions_Of_One_Shield_Isolate_Attempts()
+    {
+        var shield = Shield.Hedge(2, TimeSpan.Zero);
+        var executions = Enumerable.Range(0, 64).Select(async executionId =>
+        {
+            var attempts = 0;
+            var primaryCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var result = await shield.ExecuteAsync(async token =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    using var registration = token.Register(() => primaryCancelled.TrySetResult());
+                    await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+                }
+
+                return executionId;
+            });
+
+            await primaryCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            return (result, attempts);
+        });
+
+        var results = await Task.WhenAll(executions).WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(results.Select(result => result.result))
+            .IsEquivalentTo(Enumerable.Range(0, 64));
+        await Assert.That(results.All(result => result.attempts == 2)).IsTrue();
+    }
+
+    private static async Task RunUnhandledExceptionAndSuccessRace(bool unhandledExceptionWins)
+    {
+        var releases = new[]
+        {
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+        };
+        var allStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        var unhandled = new ArgumentException("unhandled");
+        var shield = Shield.When<InvalidOperationException>().Hedge(2, TimeSpan.Zero);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            var attempt = Interlocked.Increment(ref attempts) - 1;
+            if (attempts == 2)
+            {
+                allStarted.TrySetResult();
+            }
+
+            await releases[attempt].Task.WaitAsync(token);
+            if (attempt == 0)
+            {
+                throw unhandled;
+            }
+
+            return 42;
+        }).AsTask();
+
+        await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releases[unhandledExceptionWins ? 0 : 1].SetResult();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        if (unhandledExceptionWins)
+        {
+            await Assert.That(ReferenceEquals(outcome.Exception, unhandled)).IsTrue();
+        }
+        else
+        {
+            await Assert.That(outcome.Result).IsEqualTo(42);
+        }
+    }
+
+    private sealed class ForkPropertyObserver(KevlarKey<int> key, int participantCount) : Strategy
+    {
+        private readonly TaskCompletionSource _allArrived =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _arrived;
+
+        public System.Collections.Concurrent.ConcurrentDictionary<int, int> ObservedValues { get; } = new();
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            var attempt = Interlocked.Increment(ref _arrived);
+            context.Properties.Set(key, attempt);
+            if (attempt == participantCount)
+            {
+                _allArrived.TrySetResult();
+            }
+
+            await _allArrived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            ObservedValues[attempt] = context.Properties.GetOrDefault(key, -1);
+            return await next.InvokeAsync(context);
+        }
+    }
+
+    private sealed class ParentPropertyObserver(KevlarKey<int> key) : Strategy
+    {
+        public int Before { get; private set; }
+
+        public int After { get; private set; }
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            Before = context.Properties.GetOrDefault(key, -1);
+            try
+            {
+                return await next.InvokeAsync(context);
+            }
+            finally
+            {
+                After = context.Properties.GetOrDefault(key, -1);
+            }
+        }
+    }
+}

--- a/tests/Kevlar.Tests/HedgingRaceTests.cs
+++ b/tests/Kevlar.Tests/HedgingRaceTests.cs
@@ -222,6 +222,35 @@ public class HedgingRaceTests
     }
 
     [Test]
+    public async Task OnHedge_Caller_Cancellation_Does_Not_Invoke_The_Next_Attempt()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        var hedgeEvents = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedge = _ =>
+            {
+                hedgeEvents++;
+                cancellation.Cancel();
+            };
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            Interlocked.Increment(ref attempts);
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token);
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(hedgeEvents).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Repeated_Late_Loser_Failures_Do_Not_Contaminate_Pooled_State()
     {
         var shield = Shield.Hedge(2, TimeSpan.Zero);

--- a/tests/Kevlar.Tests/HedgingRaceTests.cs
+++ b/tests/Kevlar.Tests/HedgingRaceTests.cs
@@ -172,6 +172,7 @@ public class HedgingRaceTests
             .Use(forkObserver);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+        await forkObserver.WaitForAllObservedAsync();
 
         await Assert.That(result).IsEqualTo(42);
         await Assert.That(forkObserver.ObservedValues.Count).IsEqualTo(2);
@@ -334,7 +335,10 @@ public class HedgingRaceTests
     {
         private readonly TaskCompletionSource _allArrived =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _allObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _arrived;
+        private int _observed;
 
         public System.Collections.Concurrent.ConcurrentDictionary<int, int> ObservedValues { get; } = new();
 
@@ -351,8 +355,16 @@ public class HedgingRaceTests
 
             await _allArrived.Task.WaitAsync(TimeSpan.FromSeconds(5));
             ObservedValues[attempt] = context.Properties.GetOrDefault(key, -1);
+            if (Interlocked.Increment(ref _observed) == participantCount)
+            {
+                _allObserved.TrySetResult();
+            }
+
             return await next.InvokeAsync(context);
         }
+
+        public Task WaitForAllObservedAsync() =>
+            _allObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     private sealed class ParentPropertyObserver(KevlarKey<int> key) : Strategy

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -138,4 +138,28 @@ public class MetricsTests
 
         await Assert.That(listener.Total("kevlar.hedges", "metrics-hedge")).IsEqualTo(1);
     }
+
+    [Test]
+    public async Task Suppressed_Hedged_Attempts_Are_Not_Counted()
+    {
+        using var listener = new KevlarMeterListener();
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedge = _ => cancellation.Cancel();
+        }).WithName("metrics-suppressed-hedge");
+
+        await shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            Interlocked.Increment(ref attempts);
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token);
+
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.hedges", "metrics-suppressed-hedge")).IsEqualTo(0);
+    }
 }


### PR DESCRIPTION
## Summary
- stop hedge launches once caller cancellation is observable
- cover finite/infinite stagger cancellation and both timer/cancel orderings
- lock simultaneous outcome races, fork isolation, callback cleanup, late losers, pooled state, and concurrent shared-shield execution
- document cancellation behavior

Closes #14

## Validation
- `dotnet build Kevlar.slnx -c Release` (0 warnings)
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (347 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- HedgingRaceTests bounded stress: 20/20 passed
- `npm run build` (docs)

## Benchmark
`HedgingBenchmarks.Kevlar_PrimaryWins` ShortRun: 140.2 ns / 0 B before; 120.0 ns / 0 B after (no regression; source guard is outside primary-win path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hedging cancellation handling to prevent additional attempts from launching after caller cancellation.
  - Ensured cancellation during hedge callbacks suppresses subsequent attempts and related metrics.
  - Improved reliability during timer, success, failure, and cancellation races.
  - Prevented late failed attempts from affecting subsequent executions.

- **Documentation**
  - Clarified hedging behavior when cancellation occurs during delays, callbacks, or launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->