### PR TITLE
fix(composition): define wrap contracts

### DIFF
--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -46,7 +46,7 @@ That's the whole rule. Consequences:
 - Reuse a shield instance across call sites → those call sites share the circuit breaker's state, the rate limiter's token bucket, the concurrency limit's slots.
 - Build a new shield (even with identical configuration) → fresh, independent state.
 - `Wrap` and `Compose` don't copy state — they reference the wrapped shield, so the sharing above works across merged shields too.
-- Stateless custom strategy instances may appear more than once in one chain. Kevlar rejects duplicate references to built-in stateful breakers and limiters because nesting the same instance can deadlock or double-count.
+- Stateless custom strategy instances may appear more than once in one chain. Kevlar rejects duplicate references to built-in stateful breakers and limiters because nesting the same instance can deadlock or double-count. A stateful custom `Strategy` can opt into the same protection by overriding `IsDuplicateReferenceUnsafe` and returning `true`.
 
 This is deliberate. A circuit breaker that doesn't share state across the call sites hitting the same dependency isn't protecting anything; a rate limiter with per-call-site buckets isn't limiting anything.
 

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -34,7 +34,7 @@ var combined = Shield.Compose(timeoutShield, retryShield, breakerShield);  // fi
 ```
 
 :::note What survives a merge
-`Wrap` and `Compose` carry the *strategies* (with their state) forward. `Compose` also keeps the first non-null name and `TimeProvider` among its inputs, and the last input's ambient [handling clause](handling-failures.md) stays ambient for further chaining. `outer.Wrap(inner)` keeps the outer shield's clause, name and time provider.
+`Wrap` and `Compose` carry the *strategies* (with their state) forward. Both keep the first non-null name and `TimeProvider` from outer to inner, while the innermost available ambient [handling clause](handling-failures.md) stays ambient for further chaining. In `outer.Wrap(inner)`, outer metadata therefore wins when present, and the inner clause wins when present.
 :::
 
 ## The state-sharing rule
@@ -46,6 +46,7 @@ That's the whole rule. Consequences:
 - Reuse a shield instance across call sites → those call sites share the circuit breaker's state, the rate limiter's token bucket, the concurrency limit's slots.
 - Build a new shield (even with identical configuration) → fresh, independent state.
 - `Wrap` and `Compose` don't copy state — they reference the wrapped shield, so the sharing above works across merged shields too.
+- Stateless custom strategy instances may appear more than once in one chain. Kevlar rejects duplicate references to built-in stateful breakers and limiters because nesting the same instance can deadlock or double-count.
 
 This is deliberate. A circuit breaker that doesn't share state across the call sites hitting the same dependency isn't protecting anything; a rate limiter with per-call-site buckets isn't limiting anything.
 

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual Kevlar.Strategy.IsDuplicateReferenceUnsafe.get -> bool

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -261,7 +261,7 @@ public sealed class Shield
         {
             for (var j = 0; j < i; j++)
             {
-                if (ReferenceEquals(strategies[i], strategies[j]))
+                if (ReferenceEquals(strategies[i], strategies[j]) && strategies[i].IsDuplicateReferenceUnsafe)
                 {
                     throw new InvalidOperationException(
                         $"This chain contains the same strategy instance ({strategies[i].Describe()}) " +

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -257,6 +257,21 @@ public sealed class Shield
 
     internal static void ValidateChain(Strategy[] strategies)
     {
+        for (var i = 1; i < strategies.Length; i++)
+        {
+            for (var j = 0; j < i; j++)
+            {
+                if (ReferenceEquals(strategies[i], strategies[j]))
+                {
+                    throw new InvalidOperationException(
+                        $"This chain contains the same strategy instance ({strategies[i].Describe()}) " +
+                        $"at positions {j + 1} and {i + 1}. Reusing one stateful instance inside a " +
+                        "single chain can deadlock or double-count. Create independent strategy " +
+                        "instances, or share the instance across separate shields instead.");
+                }
+            }
+        }
+
         // A fallback that shares its handling clause with an outer retry, hedge or breaker
         // swallows the failures that strategy exists to see, making it unreachable.
         for (var i = 1; i < strategies.Length; i++)

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -148,20 +148,35 @@ public static class ShieldExtensions
         return shield.Append(strategy);
     }
 
-    /// <summary>Wraps <paramref name="inner"/> inside <paramref name="outer"/>: the outer shield's strategies run first.</summary>
+    /// <summary>
+    /// Wraps <paramref name="inner"/> inside <paramref name="outer"/>: the outer shield's strategies
+    /// run first. The first non-null name and time provider win; the last handling clause stays ambient.
+    /// </summary>
     public static Shield Wrap(this Shield outer, Shield inner)
     {
         Throw.IfNull(outer, nameof(outer));
         Throw.IfNull(inner, nameof(inner));
-        return new Shield(Shield.Concat(outer.Strategies, inner.Strategies), outer.Ambient, outer.Name, outer.Time);
+        return new Shield(
+            Shield.Concat(outer.Strategies, inner.Strategies),
+            inner.Ambient ?? outer.Ambient,
+            outer.Name ?? inner.Name,
+            outer.Time ?? inner.Time);
     }
 
-    /// <summary>Wraps a result-aware <paramref name="inner"/> shield inside <paramref name="outer"/>, producing a result-aware shield.</summary>
+    /// <summary>
+    /// Wraps a result-aware <paramref name="inner"/> shield inside <paramref name="outer"/>, producing
+    /// a result-aware shield. The first non-null name and time provider win; the last handling clause
+    /// stays ambient.
+    /// </summary>
     public static Shield<TResult> Wrap<TResult>(this Shield outer, Shield<TResult> inner)
     {
         Throw.IfNull(outer, nameof(outer));
         Throw.IfNull(inner, nameof(inner));
-        return new Shield<TResult>(Shield.Concat(outer.Strategies, inner.Strategies), inner.Ambient, outer.Name ?? inner.Name, outer.Time ?? inner.Time);
+        return new Shield<TResult>(
+            Shield.Concat(outer.Strategies, inner.Strategies),
+            inner.Ambient ?? outer.Ambient,
+            outer.Name ?? inner.Name,
+            outer.Time ?? inner.Time);
     }
 
     /// <summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -195,18 +195,32 @@ public sealed class Shield<TResult>
 
     // ── Composition ─────────────────────────────────────────────────────────────────────
 
-    /// <summary>Wraps <paramref name="inner"/> inside this shield: this shield's strategies run outermost.</summary>
+    /// <summary>
+    /// Wraps <paramref name="inner"/> inside this shield: this shield's strategies run outermost.
+    /// The first non-null name and time provider win; the last handling clause stays ambient.
+    /// </summary>
     public Shield<TResult> Wrap(Shield inner)
     {
         Throw.IfNull(inner, nameof(inner));
-        return new Shield<TResult>(Shield.Concat(Strategies, inner.Strategies), Ambient, Name, Time);
+        return new Shield<TResult>(
+            Shield.Concat(Strategies, inner.Strategies),
+            inner.Ambient ?? Ambient,
+            Name ?? inner.Name,
+            Time ?? inner.Time);
     }
 
-    /// <summary>Wraps <paramref name="inner"/> inside this shield: this shield's strategies run outermost.</summary>
+    /// <summary>
+    /// Wraps <paramref name="inner"/> inside this shield: this shield's strategies run outermost.
+    /// The first non-null name and time provider win; the last handling clause stays ambient.
+    /// </summary>
     public Shield<TResult> Wrap(Shield<TResult> inner)
     {
         Throw.IfNull(inner, nameof(inner));
-        return new Shield<TResult>(Shield.Concat(Strategies, inner.Strategies), Ambient ?? inner.Ambient, Name, Time);
+        return new Shield<TResult>(
+            Shield.Concat(Strategies, inner.Strategies),
+            inner.Ambient ?? Ambient,
+            Name ?? inner.Name,
+            Time ?? inner.Time);
     }
 
     /// <summary>Returns a copy of this shield with a diagnostic name (surfaced as <see cref="KevlarContext.ShieldName"/>).</summary>

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -15,7 +15,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 
-    internal override bool IsDuplicateReferenceUnsafe => true;
+    protected internal override bool IsDuplicateReferenceUnsafe => true;
 
     public override string Describe() => _core.Describe();
 

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -15,6 +15,8 @@ internal sealed class CircuitBreakerStrategy : Strategy
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 
+    internal override bool IsDuplicateReferenceUnsafe => true;
+
     public override string Describe() => _core.Describe();
 
     public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -10,6 +10,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly int _capacity;
     private int _pending;
 
+    internal override bool IsDuplicateReferenceUnsafe => true;
+
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
     {
         Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -10,7 +10,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly int _capacity;
     private int _pending;
 
-    internal override bool IsDuplicateReferenceUnsafe => true;
+    protected internal override bool IsDuplicateReferenceUnsafe => true;
 
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
     {

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -29,6 +29,8 @@ internal sealed class RateLimitStrategy : Strategy
     private Reservation? _queueTail;
     private int _queuedReservations;
 
+    internal override bool IsDuplicateReferenceUnsafe => true;
+
     public RateLimitStrategy(RateLimitOptions options)
     {
         Throw.IfOutOfRange(options.Permits <= 0, nameof(options), "Permits must be positive.");

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -29,7 +29,7 @@ internal sealed class RateLimitStrategy : Strategy
     private Reservation? _queueTail;
     private int _queuedReservations;
 
-    internal override bool IsDuplicateReferenceUnsafe => true;
+    protected internal override bool IsDuplicateReferenceUnsafe => true;
 
     public RateLimitStrategy(RateLimitOptions options)
     {

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -42,8 +42,12 @@ public abstract class Strategy
     /// <summary>Marks fallback strategies for chain-order validation.</summary>
     internal virtual bool IsFallback => false;
 
-    /// <summary>Marks stateful built-in strategies that cannot safely appear twice in one chain.</summary>
-    internal virtual bool IsDuplicateReferenceUnsafe => false;
+    /// <summary>
+    /// Gets whether reusing this strategy instance within one chain is unsafe.
+    /// Stateful custom strategies should override this property and return <see langword="true"/>
+    /// when duplicate use could deadlock or corrupt their accounting.
+    /// </summary>
+    protected internal virtual bool IsDuplicateReferenceUnsafe => false;
 }
 
 /// <summary>

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -41,6 +41,9 @@ public abstract class Strategy
 
     /// <summary>Marks fallback strategies for chain-order validation.</summary>
     internal virtual bool IsFallback => false;
+
+    /// <summary>Marks stateful built-in strategies that cannot safely appear twice in one chain.</summary>
+    internal virtual bool IsDuplicateReferenceUnsafe => false;
 }
 
 /// <summary>

--- a/tests/Kevlar.Tests/CompositionContractTests.cs
+++ b/tests/Kevlar.Tests/CompositionContractTests.cs
@@ -275,6 +275,15 @@ public class CompositionContractTests
         await Assert.That(calls).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task Custom_Stateful_Strategy_Can_Reject_Duplicate_References()
+    {
+        var strategy = new StatefulCustomStrategy();
+        var stateful = Shield.Use(strategy);
+
+        await Assert.That(() => stateful.Wrap(stateful)).Throws<InvalidOperationException>();
+    }
+
     private static ValueTask<int> ExecuteWrappedAsync(
         WrapKind kind,
         Shield untypedOuter,
@@ -318,5 +327,14 @@ public class CompositionContractTests
             _record(context);
             return next.InvokeAsync(context);
         }
+    }
+
+    private sealed class StatefulCustomStrategy : Strategy
+    {
+        protected internal override bool IsDuplicateReferenceUnsafe => true;
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
     }
 }

--- a/tests/Kevlar.Tests/CompositionContractTests.cs
+++ b/tests/Kevlar.Tests/CompositionContractTests.cs
@@ -1,0 +1,287 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class CompositionContractTests
+{
+    [Test]
+    [Arguments(WrapKind.UntypedUntyped)]
+    [Arguments(WrapKind.UntypedTyped)]
+    [Arguments(WrapKind.TypedUntyped)]
+    [Arguments(WrapKind.TypedTyped)]
+    public async Task Every_Wrap_Form_Preserves_Outer_To_Inner_Order(WrapKind kind)
+    {
+        var log = new List<string>();
+        var outerStrategy = new RecordingStrategy(context => log.Add("outer"));
+        var innerStrategy = new RecordingStrategy(context => log.Add("inner"));
+
+        await ExecuteWrappedAsync(
+            kind,
+            Shield.Use(outerStrategy),
+            Shield<int>.Empty.Use(outerStrategy),
+            Shield.Use(innerStrategy),
+            Shield<int>.Empty.Use(innerStrategy));
+
+        await Assert.That(log).IsEquivalentTo(["outer", "inner"]);
+    }
+
+    [Test]
+    [Arguments(WrapKind.UntypedUntyped)]
+    [Arguments(WrapKind.UntypedTyped)]
+    [Arguments(WrapKind.TypedUntyped)]
+    [Arguments(WrapKind.TypedTyped)]
+    public async Task Every_Wrap_Form_Uses_First_Available_Metadata(WrapKind kind)
+    {
+        string? seenName = null;
+        TimeProvider? seenTimeProvider = null;
+        var innerTimeProvider = new FakeTimeProvider();
+        var observer = new RecordingStrategy(context =>
+        {
+            seenName = context.ShieldName;
+            seenTimeProvider = context.TimeProvider;
+        });
+
+        await ExecuteWrappedAsync(
+            kind,
+            Shield.Empty,
+            Shield<int>.Empty,
+            Shield.Use(observer).WithName("inner").WithTimeProvider(innerTimeProvider),
+            Shield<int>.Empty.Use(observer).WithName("inner").WithTimeProvider(innerTimeProvider));
+
+        await Assert.That(seenName).IsEqualTo("inner");
+        await Assert.That(ReferenceEquals(seenTimeProvider, innerTimeProvider)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(WrapKind.UntypedUntyped)]
+    [Arguments(WrapKind.UntypedTyped)]
+    [Arguments(WrapKind.TypedUntyped)]
+    [Arguments(WrapKind.TypedTyped)]
+    public async Task Every_Wrap_Form_Prefers_Outer_Metadata(WrapKind kind)
+    {
+        string? seenName = null;
+        TimeProvider? seenTimeProvider = null;
+        var outerTimeProvider = new FakeTimeProvider();
+        var innerTimeProvider = new FakeTimeProvider();
+        var observer = new RecordingStrategy(context =>
+        {
+            seenName = context.ShieldName;
+            seenTimeProvider = context.TimeProvider;
+        });
+
+        await ExecuteWrappedAsync(
+            kind,
+            Shield.Empty.WithName("outer").WithTimeProvider(outerTimeProvider),
+            Shield<int>.Empty.WithName("outer").WithTimeProvider(outerTimeProvider),
+            Shield.Use(observer).WithName("inner").WithTimeProvider(innerTimeProvider),
+            Shield<int>.Empty.Use(observer).WithName("inner").WithTimeProvider(innerTimeProvider));
+
+        await Assert.That(seenName).IsEqualTo("outer");
+        await Assert.That(ReferenceEquals(seenTimeProvider, outerTimeProvider)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(WrapKind.UntypedUntyped)]
+    [Arguments(WrapKind.UntypedTyped)]
+    [Arguments(WrapKind.TypedUntyped)]
+    [Arguments(WrapKind.TypedTyped)]
+    public async Task Every_Wrap_Form_Uses_Inner_Ambient_Clause_For_Appended_Strategies(WrapKind kind)
+    {
+        var untypedOuter = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromMinutes(1));
+        var typedOuter = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromMinutes(1));
+        var untypedInner = Shield.When<ArgumentException>().Timeout(TimeSpan.FromMinutes(1));
+        var typedInner = Shield.For<int>().When<ArgumentException>().Timeout(TimeSpan.FromMinutes(1));
+
+        if (kind == WrapKind.UntypedUntyped)
+        {
+            var fallbackCalls = 0;
+            var wrapped = untypedOuter.Wrap(untypedInner).Fallback((_, _) =>
+            {
+                fallbackCalls++;
+                return default;
+            });
+            Func<CancellationToken, ValueTask> action = _ => throw new ArgumentException();
+
+            await wrapped.ExecuteAsync(action);
+
+            await Assert.That(fallbackCalls).IsEqualTo(1);
+            return;
+        }
+
+        var typedWrapped = kind switch
+        {
+            WrapKind.UntypedTyped => untypedOuter.Wrap(typedInner),
+            WrapKind.TypedUntyped => typedOuter.Wrap(untypedInner),
+            WrapKind.TypedTyped => typedOuter.Wrap(typedInner),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+        var result = await typedWrapped.Fallback(42).ExecuteAsync(_ => throw new ArgumentException());
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Reusing_A_Builder_Does_Not_Mutate_An_Existing_Shield()
+    {
+        var builder = Shield.When<InvalidOperationException>();
+        var first = builder.Retry(1, Backoff.None);
+        var second = builder.Or<ArgumentException>().Retry(1, Backoff.None);
+        var firstAttempts = 0;
+        var secondAttempts = 0;
+
+        await Assert.That(async () => await first.ExecuteAsync<int>(_ =>
+        {
+            firstAttempts++;
+            throw new ArgumentException();
+        })).Throws<ArgumentException>();
+
+        var result = await second.ExecuteAsync(_ =>
+        {
+            secondAttempts++;
+            return secondAttempts == 1
+                ? throw new ArgumentException()
+                : new ValueTask<int>(42);
+        });
+
+        await Assert.That(firstAttempts).IsEqualTo(1);
+        await Assert.That(secondAttempts).IsEqualTo(2);
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Exception_Predicates_Run_In_Order_And_ShortCircuit()
+    {
+        var calls = new List<string>();
+        var attempts = 0;
+        var shield = Shield
+            .When(exception =>
+            {
+                calls.Add("first");
+                return exception is ArgumentNullException;
+            })
+            .OrWhen(exception =>
+            {
+                calls.Add("second");
+                return exception is ArgumentException;
+            })
+            .OrWhen(_ =>
+            {
+                calls.Add("third");
+                throw new InvalidOperationException("must be short-circuited");
+            })
+            .Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return attempts == 1
+                ? throw new ArgumentOutOfRangeException()
+                : new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(calls).IsEquivalentTo(["first", "second"]);
+    }
+
+    [Test]
+    public async Task Result_Equality_Handles_Null_And_Default()
+    {
+        string? nullValue = null;
+        var defaultValue = default(int);
+        var nullShield = Shield.For<string?>().WhenResult(nullValue).Fallback("null");
+        var defaultShield = Shield.For<int>().WhenResult(defaultValue).Fallback(42);
+
+        var nullResult = await nullShield.ExecuteAsync(_ => new ValueTask<string?>((string?)null));
+        var defaultResult = await defaultShield.ExecuteAsync(_ => new ValueTask<int>(0));
+
+        await Assert.That(nullResult).IsEqualTo("null");
+        await Assert.That(defaultResult).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Predicate_Failure_Surfaces_The_Original_Instance()
+    {
+        var predicateFailure = new InvalidOperationException("predicate failed");
+        var shield = Shield.When(_ => throw predicateFailure).Retry(1, Backoff.None);
+        Exception? caught = null;
+
+        try
+        {
+            await shield.ExecuteAsync<int>(_ => throw new ArgumentException());
+        }
+        catch (Exception exception)
+        {
+            caught = exception;
+        }
+
+        await Assert.That(ReferenceEquals(caught, predicateFailure)).IsTrue();
+    }
+
+    [Test]
+    public async Task Reusing_One_Strategy_Instance_In_A_Chain_Is_Rejected()
+    {
+        var limiter = Shield.ConcurrencyLimit(1);
+        InvalidOperationException? error = null;
+
+        try
+        {
+            _ = limiter.Wrap(limiter);
+        }
+        catch (InvalidOperationException caught)
+        {
+            error = caught;
+        }
+
+        await Assert.That(error).IsNotNull();
+        await Assert.That(error!.Message).Contains("same strategy instance");
+        await Assert.That(error.Message).Contains("deadlock or double-count");
+    }
+
+    [Test]
+    public async Task Independently_Created_Equivalent_Strategies_Are_Allowed()
+    {
+        var shield = Shield.ConcurrencyLimit(1).Wrap(Shield.ConcurrencyLimit(1));
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    private static ValueTask<int> ExecuteWrappedAsync(
+        WrapKind kind,
+        Shield untypedOuter,
+        Shield<int> typedOuter,
+        Shield untypedInner,
+        Shield<int> typedInner) =>
+        kind switch
+        {
+            WrapKind.UntypedUntyped => untypedOuter.Wrap(untypedInner).ExecuteAsync(_ => new ValueTask<int>(42)),
+            WrapKind.UntypedTyped => untypedOuter.Wrap(typedInner).ExecuteAsync(_ => new ValueTask<int>(42)),
+            WrapKind.TypedUntyped => typedOuter.Wrap(untypedInner).ExecuteAsync(_ => new ValueTask<int>(42)),
+            WrapKind.TypedTyped => typedOuter.Wrap(typedInner).ExecuteAsync(_ => new ValueTask<int>(42)),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    public enum WrapKind
+    {
+        UntypedUntyped,
+        UntypedTyped,
+        TypedUntyped,
+        TypedTyped,
+    }
+
+    private sealed class RecordingStrategy : Strategy
+    {
+        private readonly Action<KevlarContext> _record;
+
+        public RecordingStrategy(Action<KevlarContext> record) => _record = record;
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            _record(context);
+            return next.InvokeAsync(context);
+        }
+    }
+}

--- a/tests/Kevlar.Tests/CompositionContractTests.cs
+++ b/tests/Kevlar.Tests/CompositionContractTests.cs
@@ -22,7 +22,9 @@ public class CompositionContractTests
             Shield.Use(innerStrategy),
             Shield<int>.Empty.Use(innerStrategy));
 
-        await Assert.That(log).IsEquivalentTo(["outer", "inner"]);
+        await Assert.That(log).IsEquivalentTo(
+            ["outer", "inner"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -180,7 +182,9 @@ public class CompositionContractTests
         });
 
         await Assert.That(result).IsEqualTo(42);
-        await Assert.That(calls).IsEquivalentTo(["first", "second"]);
+        await Assert.That(calls).IsEquivalentTo(
+            ["first", "second"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -218,14 +222,24 @@ public class CompositionContractTests
     }
 
     [Test]
-    public async Task Reusing_One_Strategy_Instance_In_A_Chain_Is_Rejected()
+    [Arguments(StatefulStrategyKind.ConcurrencyLimit)]
+    [Arguments(StatefulStrategyKind.RateLimit)]
+    [Arguments(StatefulStrategyKind.CircuitBreaker)]
+    public async Task Reusing_One_Stateful_Strategy_Instance_In_A_Chain_Is_Rejected(
+        StatefulStrategyKind kind)
     {
-        var limiter = Shield.ConcurrencyLimit(1);
+        var stateful = kind switch
+        {
+            StatefulStrategyKind.ConcurrencyLimit => Shield.ConcurrencyLimit(1),
+            StatefulStrategyKind.RateLimit => Shield.RateLimit(1, TimeSpan.FromSeconds(1)),
+            StatefulStrategyKind.CircuitBreaker => Shield.CircuitBreaker(1, TimeSpan.FromSeconds(1)),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
         InvalidOperationException? error = null;
 
         try
         {
-            _ = limiter.Wrap(limiter);
+            _ = stateful.Wrap(stateful);
         }
         catch (InvalidOperationException caught)
         {
@@ -245,6 +259,20 @@ public class CompositionContractTests
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
 
         await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Reusing_A_Stateless_Strategy_Instance_In_A_Chain_Is_Allowed()
+    {
+        var calls = 0;
+        var strategy = new RecordingStrategy(_ => calls++);
+        var reusable = Shield.Use(strategy);
+        var shield = reusable.Wrap(reusable);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(calls).IsEqualTo(2);
     }
 
     private static ValueTask<int> ExecuteWrappedAsync(
@@ -268,6 +296,13 @@ public class CompositionContractTests
         UntypedTyped,
         TypedUntyped,
         TypedTyped,
+    }
+
+    public enum StatefulStrategyKind
+    {
+        ConcurrencyLimit,
+        RateLimit,
+        CircuitBreaker,
     }
 
     private sealed class RecordingStrategy : Strategy

--- a/tests/Kevlar.Tests/CompositionEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/CompositionEdgeCaseTests.cs
@@ -11,6 +11,24 @@ public class CompositionEdgeCaseTests
     }
 
     [Test]
+    public async Task Compose_With_One_Shield_Preserves_Its_Strategy()
+    {
+        var calls = 0;
+        var composed = Shield.Compose(Shield.Retry(1, Backoff.None));
+
+        var result = await composed.ExecuteAsync(_ =>
+        {
+            calls++;
+            return calls == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException())
+                : new ValueTask<int>(7);
+        });
+
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Compose_Shares_Stateful_Strategies()
     {
         var breaker = Shield.CircuitBreaker(1, TimeSpan.FromMinutes(1));


### PR DESCRIPTION
## Summary

- make all four typed/untyped `Wrap` forms use outer-first name/time precedence and the last ambient handling clause
- reject duplicate strategy instance identity before a composed pipeline can deadlock or double-count
- add a table-driven composition matrix covering order, metadata, ambient clauses, builder immutability, predicate grammar, null/default equality, and independent stateful strategies

Closes #17

## Validation

- `dotnet build Kevlar.slnx -c Release --no-incremental`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (359 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wrapping shields now consistently preserve metadata and handling behavior using clear outer-to-inner precedence rules.
  * Stateful built-in strategies can no longer be reused multiple times within the same chain, preventing unsafe configurations.
  * Stateless strategies and independently created equivalent strategies remain reusable.
* **Documentation**
  * Updated composition guidance to explain metadata precedence, ambient handling inheritance, and strategy reuse rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->