### PR TITLE
fix(options): harden numeric boundaries

### DIFF
--- a/src/Kevlar/Backoff.cs
+++ b/src/Kevlar/Backoff.cs
@@ -24,6 +24,7 @@ public abstract class Backoff
     public static Backoff Constant(TimeSpan delay)
     {
         Throw.IfOutOfRange(delay < TimeSpan.Zero, nameof(delay), "Delay must not be negative.");
+        Throw.IfOutOfRange(delay > DelayHelper.MaximumDelay, nameof(delay), "Delay exceeds the runtime timer limit.");
         return new ConstantBackoff(delay);
     }
 
@@ -31,6 +32,7 @@ public abstract class Backoff
     public static Backoff Linear(TimeSpan step, TimeSpan? maxDelay = null)
     {
         Throw.IfOutOfRange(step < TimeSpan.Zero, nameof(step), "Step must not be negative.");
+        ValidateMaxDelay(maxDelay);
         return new LinearBackoff(step, maxDelay);
     }
 
@@ -43,7 +45,11 @@ public abstract class Backoff
     public static Backoff Exponential(TimeSpan initialDelay, double factor = 2.0, TimeSpan? maxDelay = null, bool jitter = true)
     {
         Throw.IfOutOfRange(initialDelay < TimeSpan.Zero, nameof(initialDelay), "Initial delay must not be negative.");
-        Throw.IfOutOfRange(factor < 1.0, nameof(factor), "Factor must be at least 1.");
+        Throw.IfOutOfRange(
+            factor < 1.0 || double.IsNaN(factor) || double.IsInfinity(factor),
+            nameof(factor),
+            "Factor must be finite and at least 1.");
+        ValidateMaxDelay(maxDelay);
         return new ExponentialBackoff(initialDelay, factor, maxDelay, jitter);
     }
 
@@ -56,6 +62,15 @@ public abstract class Backoff
 
     /// <summary>Returns the delay before the given 1-based retry attempt.</summary>
     public abstract TimeSpan GetDelay(int attempt);
+
+    private protected static void ValidateAttempt(int attempt) =>
+        Throw.IfOutOfRange(attempt < 1, nameof(attempt), "Attempt must be at least 1.");
+
+    private static void ValidateMaxDelay(TimeSpan? maxDelay)
+    {
+        Throw.IfOutOfRange(maxDelay.HasValue && maxDelay.Value < TimeSpan.Zero, nameof(maxDelay), "Maximum delay must not be negative.");
+        Throw.IfOutOfRange(maxDelay > DelayHelper.MaximumDelay, nameof(maxDelay), "Maximum delay exceeds the runtime timer limit.");
+    }
 
     private static TimeSpan FromTicksClamped(double ticks, TimeSpan? maxDelay)
     {
@@ -74,7 +89,11 @@ public abstract class Backoff
 
         public ConstantBackoff(TimeSpan delay) => _delay = delay;
 
-        public override TimeSpan GetDelay(int attempt) => _delay;
+        public override TimeSpan GetDelay(int attempt)
+        {
+            ValidateAttempt(attempt);
+            return _delay;
+        }
 
         public override string ToString() =>
             _delay == TimeSpan.Zero ? "no delay" : $"constant {DescribeHelper.Time(_delay)}";
@@ -91,8 +110,11 @@ public abstract class Backoff
             _maxDelay = maxDelay;
         }
 
-        public override TimeSpan GetDelay(int attempt) =>
-            FromTicksClamped((double)_step.Ticks * attempt, _maxDelay);
+        public override TimeSpan GetDelay(int attempt)
+        {
+            ValidateAttempt(attempt);
+            return FromTicksClamped((double)_step.Ticks * attempt, _maxDelay);
+        }
 
         public override string ToString()
         {
@@ -118,6 +140,7 @@ public abstract class Backoff
 
         public override TimeSpan GetDelay(int attempt)
         {
+            ValidateAttempt(attempt);
             var ticks = _initialDelay.Ticks * Math.Pow(_factor, attempt - 1);
 
             if (_jitter)
@@ -144,8 +167,9 @@ public abstract class Backoff
 
         public override TimeSpan GetDelay(int attempt)
         {
+            ValidateAttempt(attempt);
             var delay = _delayFactory(attempt);
-            return delay < TimeSpan.Zero ? TimeSpan.Zero : delay;
+            return delay < TimeSpan.Zero ? TimeSpan.Zero : DelayHelper.Clamp(delay);
         }
 
         public override string ToString() => "custom backoff";

--- a/src/Kevlar/Backoff.cs
+++ b/src/Kevlar/Backoff.cs
@@ -74,6 +74,11 @@ public abstract class Backoff
 
     private static TimeSpan FromTicksClamped(double ticks, TimeSpan? maxDelay)
     {
+        if (double.IsNaN(ticks))
+        {
+            return TimeSpan.Zero;
+        }
+
         var max = maxDelay ?? TimeSpan.FromDays(1);
         if (ticks >= max.Ticks)
         {

--- a/src/Kevlar/Internal/DelayHelper.cs
+++ b/src/Kevlar/Internal/DelayHelper.cs
@@ -2,6 +2,22 @@ namespace Kevlar.Internal;
 
 internal static class DelayHelper
 {
+    public static readonly TimeSpan MaximumDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1d);
+
+    public static TimeSpan Clamp(TimeSpan delay) => delay > MaximumDelay ? MaximumDelay : delay;
+
+    public static TimeSpan FromSecondsClamped(double seconds)
+    {
+        if (double.IsNaN(seconds) || seconds <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        return seconds >= MaximumDelay.TotalSeconds
+            ? MaximumDelay
+            : TimeSpan.FromSeconds(seconds);
+    }
+
     /// <summary>
     /// Waits for <paramref name="delay"/> honouring the context's <see cref="TimeProvider"/> and
     /// cancellation token. In synchronous executions the wait blocks the calling thread so the

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -91,6 +91,7 @@ internal sealed class CircuitBreakerCore
 
         lock (_gate)
         {
+            var now = _state == CircuitState.Open ? timeProvider.GetUtcNow() : default;
             switch (_state)
             {
                 case CircuitState.Closed:

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -25,8 +25,8 @@ internal sealed class CircuitBreakerCore
     private readonly Action<CircuitStateChangedEvent>? _onStateChanged;
     private readonly CircuitBreakerMonitor? _monitor;
 
-    private readonly int[] _bucketFailures = new int[BucketCount];
-    private readonly int[] _bucketSuccesses = new int[BucketCount];
+    private readonly long[] _bucketFailures = new long[BucketCount];
+    private readonly long[] _bucketSuccesses = new long[BucketCount];
     private double _currentBucketStart = double.NaN;
     private int _currentBucketIndex;
 
@@ -40,7 +40,10 @@ internal sealed class CircuitBreakerCore
     public CircuitBreakerCore(CircuitBreakerOptions options)
     {
         Throw.IfOutOfRange(options.ConsecutiveFailures is <= 0, nameof(options), "ConsecutiveFailures must be positive.");
-        Throw.IfOutOfRange(options.FailureRatio is <= 0 or > 1, nameof(options), "FailureRatio must be between 0 (exclusive) and 1 (inclusive).");
+        Throw.IfOutOfRange(
+            options.FailureRatio is { } ratio && (double.IsNaN(ratio) || ratio <= 0 || ratio > 1),
+            nameof(options.FailureRatio),
+            "FailureRatio must be between 0 (exclusive) and 1 (inclusive).");
         Throw.IfOutOfRange(options.ConsecutiveFailures is not null && options.FailureRatio is not null, nameof(options), "Configure either ConsecutiveFailures or FailureRatio, not both.");
         Throw.IfOutOfRange(options.MinimumThroughput < 1, nameof(options), "MinimumThroughput must be at least 1.");
         Throw.IfOutOfRange(options.SamplingWindow <= TimeSpan.Zero, nameof(options), "SamplingWindow must be positive.");
@@ -253,7 +256,7 @@ internal sealed class CircuitBreakerCore
         var bucket = AdvanceBucket(timestamp);
         _bucketFailures[bucket]++;
 
-        int failures = 0, total = 0;
+        long failures = 0, total = 0;
         for (var i = 0; i < BucketCount; i++)
         {
             failures += _bucketFailures[i];

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -16,6 +16,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     {
         Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");
         Throw.IfOutOfRange(options.MaxQueue < 0, nameof(options), "MaxQueue must not be negative.");
+        Throw.IfOutOfRange(options.MaxQueue > int.MaxValue - options.MaxConcurrency, nameof(options.MaxQueue), "MaxConcurrency plus MaxQueue must not exceed Int32.MaxValue.");
 
         _semaphore = new SemaphoreSlim(options.MaxConcurrency, options.MaxConcurrency);
         _maxConcurrency = options.MaxConcurrency;

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -7,8 +7,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly SemaphoreSlim _semaphore;
     private readonly int _maxConcurrency;
     private readonly int _maxQueue;
-    private readonly int _capacity;
-    private int _pending;
+    private readonly long _capacity;
+    private long _pending;
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 
@@ -16,12 +16,10 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     {
         Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");
         Throw.IfOutOfRange(options.MaxQueue < 0, nameof(options), "MaxQueue must not be negative.");
-        Throw.IfOutOfRange(options.MaxQueue > int.MaxValue - options.MaxConcurrency, nameof(options.MaxQueue), "MaxConcurrency plus MaxQueue must not exceed Int32.MaxValue.");
-
         _semaphore = new SemaphoreSlim(options.MaxConcurrency, options.MaxConcurrency);
         _maxConcurrency = options.MaxConcurrency;
         _maxQueue = options.MaxQueue;
-        _capacity = options.MaxConcurrency + options.MaxQueue;
+        _capacity = options.MaxConcurrency + (long)options.MaxQueue;
     }
 
     public override string Describe() =>

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -14,6 +14,7 @@ internal sealed class HedgingStrategy : Strategy
     {
         Throw.IfOutOfRange(options.MaxAttempts < 1, nameof(options), "MaxAttempts must be at least 1.");
         Throw.IfOutOfRange(options.Delay < TimeSpan.Zero && options.Delay != System.Threading.Timeout.InfiniteTimeSpan, nameof(options), "Delay must be non-negative or Timeout.InfiniteTimeSpan.");
+        Throw.IfOutOfRange(options.Delay > DelayHelper.MaximumDelay, nameof(options.Delay), "Delay exceeds the runtime timer limit.");
 
         _judge = judge;
         _maxAttempts = options.MaxAttempts;

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -299,9 +299,10 @@ internal sealed class RateLimitStrategy : Strategy
             timeProvider,
             static provider => new CustomTimestampOrigin(provider));
         var timestamp = timeProvider.GetTimestamp();
+        var elapsedTimestamp = unchecked(timestamp - origin.ProviderTimestamp);
 
         return origin.SystemTimestamp - _systemTimestampOrigin
-            + ((double)((decimal)timestamp - origin.ProviderTimestamp) * origin.TimestampScale);
+            + (elapsedTimestamp * origin.TimestampScale);
     }
 
     private sealed class CustomTimestampOrigin

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -293,7 +293,11 @@ internal sealed class RateLimitStrategy : Strategy
             return TimeSpan.Zero;
         }
 
-        return seconds >= TimeSpan.MaxValue.TotalSeconds
+        // Scaling through provider timestamp units can lose a few ULPs at TimeSpan.MaxValue.
+        const double doubleMachineEpsilon = 2.2204460492503131e-16;
+        var maximumSeconds = TimeSpan.MaxValue.TotalSeconds;
+        var maximumRoundingTolerance = maximumSeconds * (4 * doubleMachineEpsilon);
+        return seconds >= maximumSeconds - maximumRoundingTolerance
             ? TimeSpan.MaxValue
             : TimeSpan.FromSeconds(seconds);
     }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -129,7 +129,7 @@ internal sealed class RateLimitStrategy : Strategy
 
             if (delayTimestampUnits > 0)
             {
-                retryAfter = DelayHelper.FromSecondsClamped(delayTimestampUnits * SecondsPerSystemTimestamp);
+                retryAfter = GetRetryAfter(delayTimestampUnits);
                 return false;
             }
 
@@ -164,8 +164,7 @@ internal sealed class RateLimitStrategy : Strategy
                 if (_queuedReservations >= _queueLimit)
                 {
                     reservation = null;
-                    retryAfter = DelayHelper.FromSecondsClamped(
-                        Math.Max(0, delayTimestampUnits) * SecondsPerSystemTimestamp);
+                    retryAfter = GetRetryAfter(Math.Max(0, delayTimestampUnits));
                     return false;
                 }
 
@@ -284,6 +283,19 @@ internal sealed class RateLimitStrategy : Strategy
     {
         var bits = BitConverter.DoubleToInt64Bits(timestamp);
         return BitConverter.Int64BitsToDouble(timestamp < 0 ? bits - 1 : bits + 1);
+    }
+
+    private static TimeSpan GetRetryAfter(double delayTimestampUnits)
+    {
+        var seconds = delayTimestampUnits * SecondsPerSystemTimestamp;
+        if (double.IsNaN(seconds) || seconds <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        return seconds >= TimeSpan.MaxValue.TotalSeconds
+            ? TimeSpan.MaxValue
+            : TimeSpan.FromSeconds(seconds);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -301,7 +301,7 @@ internal sealed class RateLimitStrategy : Strategy
         var timestamp = timeProvider.GetTimestamp();
 
         return origin.SystemTimestamp - _systemTimestampOrigin
-            + (((double)timestamp - origin.ProviderTimestamp) * origin.TimestampScale);
+            + ((double)((decimal)timestamp - origin.ProviderTimestamp) * origin.TimestampScale);
     }
 
     private sealed class CustomTimestampOrigin

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -129,7 +129,7 @@ internal sealed class RateLimitStrategy : Strategy
 
             if (delayTimestampUnits > 0)
             {
-                retryAfter = TimeSpan.FromSeconds(delayTimestampUnits * SecondsPerSystemTimestamp);
+                retryAfter = DelayHelper.FromSecondsClamped(delayTimestampUnits * SecondsPerSystemTimestamp);
                 return false;
             }
 
@@ -164,7 +164,7 @@ internal sealed class RateLimitStrategy : Strategy
                 if (_queuedReservations >= _queueLimit)
                 {
                     reservation = null;
-                    retryAfter = TimeSpan.FromSeconds(
+                    retryAfter = DelayHelper.FromSecondsClamped(
                         Math.Max(0, delayTimestampUnits) * SecondsPerSystemTimestamp);
                     return false;
                 }
@@ -206,7 +206,7 @@ internal sealed class RateLimitStrategy : Strategy
             var delayTimestampUnits = reservation.DueTimestamp - GetCurrentTimestamp(timeProvider);
             if (delayTimestampUnits > 0)
             {
-                wait = TimeSpan.FromSeconds(delayTimestampUnits * SecondsPerSystemTimestamp);
+                wait = DelayHelper.FromSecondsClamped(delayTimestampUnits * SecondsPerSystemTimestamp);
                 nextTurn = null;
                 return false;
             }
@@ -301,7 +301,7 @@ internal sealed class RateLimitStrategy : Strategy
         var timestamp = timeProvider.GetTimestamp();
 
         return origin.SystemTimestamp - _systemTimestampOrigin
-            + ((timestamp - origin.ProviderTimestamp) * origin.TimestampScale);
+            + (((double)timestamp - origin.ProviderTimestamp) * origin.TimestampScale);
     }
 
     private sealed class CustomTimestampOrigin

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -16,6 +16,8 @@ internal sealed class RetryStrategy : Strategy
     {
         Throw.IfOutOfRange(options.MaxRetries < 0, nameof(options), "MaxRetries must not be negative.");
         Throw.IfNull(options.Backoff, nameof(options));
+        Throw.IfOutOfRange(options.MaxDelay.HasValue && options.MaxDelay.Value < TimeSpan.Zero, nameof(options.MaxDelay), "MaxDelay must not be negative.");
+        Throw.IfOutOfRange(options.MaxDelay > DelayHelper.MaximumDelay, nameof(options.MaxDelay), "MaxDelay exceeds the runtime timer limit.");
 
         _judge = judge;
         _maxRetries = options.MaxRetries;
@@ -68,7 +70,9 @@ internal sealed class RetryStrategy : Strategy
                 {
                     // MaxDelay is an absolute bound: it also caps generator-supplied delays
                     // such as a server's Retry-After suggestion.
-                    delay = _maxDelay is { } absolute && custom > absolute ? absolute : custom;
+                    delay = _maxDelay is { } absolute && custom > absolute
+                        ? absolute
+                        : DelayHelper.Clamp(custom);
                 }
 
                 if (_onRetry is not null || _onRetryAsync is not null)

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -16,6 +16,7 @@ internal sealed class TimeoutStrategy : Strategy
     public TimeoutStrategy(TimeoutOptions options)
     {
         Throw.IfOutOfRange(options.Timeout <= TimeSpan.Zero, nameof(options), "Timeout must be positive.");
+        Throw.IfOutOfRange(options.Timeout > DelayHelper.MaximumDelay, nameof(options.Timeout), "Timeout exceeds the runtime timer limit.");
         _timeout = options.Timeout;
         _onTimeout = options.OnTimeout;
     }

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -187,6 +187,19 @@ public class NumericBoundaryTests
         await Assert.That(result).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task Rate_Limit_Preserves_Timestamp_Rollover()
+    {
+        var timeProvider = new FixedTimestampTimeProvider(long.MaxValue, timestampFrequency: 1);
+        var shield = Shield.RateLimit(1, TimeSpan.FromSeconds(1)).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        timeProvider.Advance();
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(2));
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
     private static async Task AssertOutOfRangeAsync(Action action, string paramName)
     {
         var exception = await Assert.That(action).Throws<ArgumentOutOfRangeException>();

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -4,7 +4,7 @@ namespace Kevlar.Tests;
 
 public class NumericBoundaryTests
 {
-    private static readonly TimeSpan MaximumRuntimeDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1d);
+    private static readonly TimeSpan MaximumRuntimeDelay = Kevlar.Internal.DelayHelper.MaximumDelay;
 
     [Test]
     public async Task Backoff_Factories_Reject_Invalid_Caps_And_Factors()
@@ -202,7 +202,18 @@ public class NumericBoundaryTests
         var rejection = await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(2)))
             .Throws<RateLimitExceededException>();
 
-        await Assert.That(rejection!.RetryAfter).IsEqualTo(MaximumRuntimeDelay);
+        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.MaxValue);
+
+        var longWindowShield = Shield
+            .RateLimit(1, TimeSpan.FromDays(100))
+            .WithTimeProvider(new FakeTimeProvider());
+
+        await longWindowShield.ExecuteAsync(_ => new ValueTask<int>(1));
+        var longWindowRejection = await Assert.That(
+                async () => await longWindowShield.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+
+        await Assert.That(longWindowRejection!.RetryAfter).IsEqualTo(TimeSpan.FromDays(100));
     }
 
     [Test]
@@ -229,6 +240,8 @@ public class NumericBoundaryTests
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(2));
 
         await Assert.That(result).IsEqualTo(2);
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(3)))
+            .Throws<RateLimitExceededException>();
     }
 
     private static async Task AssertOutOfRangeAsync(Action action, string paramName)

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -109,7 +109,11 @@ public class NumericBoundaryTests
 
         var rejection = await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(42)))
             .Throws<CircuitOpenException>();
-        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.FromTicks(1));
+        await Assert.That(rejection!.RetryAfter).IsNull();
+
+        timeProvider.Advance(TimeSpan.FromTicks(1));
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(42)))
+            .Throws<CircuitOpenException>();
     }
 
     [Test]
@@ -170,6 +174,19 @@ public class NumericBoundaryTests
         await Assert.That(rejection!.RetryAfter).IsEqualTo(MaximumRuntimeDelay);
     }
 
+    [Test]
+    public async Task Rate_Limit_Preserves_Small_Advances_At_Large_Timestamps()
+    {
+        var timeProvider = new FixedTimestampTimeProvider(long.MaxValue - 1, timestampFrequency: 1);
+        var shield = Shield.RateLimit(1, TimeSpan.FromSeconds(1)).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        timeProvider.Advance();
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(2));
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
     private static async Task AssertOutOfRangeAsync(Action action, string paramName)
     {
         var exception = await Assert.That(action).Throws<ArgumentOutOfRangeException>();
@@ -183,5 +200,16 @@ public class NumericBoundaryTests
         Linear,
         Exponential,
         Custom,
+    }
+
+    private sealed class FixedTimestampTimeProvider(long timestamp, long timestampFrequency) : TimeProvider
+    {
+        private long _timestamp = timestamp;
+
+        public override long TimestampFrequency => timestampFrequency;
+
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
+
+        public void Advance() => Interlocked.Increment(ref _timestamp);
     }
 }

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -1,0 +1,187 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class NumericBoundaryTests
+{
+    private static readonly TimeSpan MaximumRuntimeDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1d);
+
+    [Test]
+    public async Task Backoff_Factories_Reject_Invalid_Caps_And_Factors()
+    {
+        await AssertOutOfRangeAsync(
+            () => Backoff.Linear(TimeSpan.FromSeconds(1), TimeSpan.FromTicks(-1)),
+            "maxDelay");
+        await AssertOutOfRangeAsync(
+            () => Backoff.Exponential(TimeSpan.FromSeconds(1), maxDelay: TimeSpan.FromTicks(-1)),
+            "maxDelay");
+        await AssertOutOfRangeAsync(
+            () => Backoff.Constant(TimeSpan.MaxValue),
+            "delay");
+        await AssertOutOfRangeAsync(
+            () => Backoff.Linear(TimeSpan.FromSeconds(1), TimeSpan.MaxValue),
+            "maxDelay");
+        await AssertOutOfRangeAsync(
+            () => Backoff.Exponential(TimeSpan.FromSeconds(1), maxDelay: TimeSpan.MaxValue),
+            "maxDelay");
+
+        foreach (var factor in new[] { double.NaN, double.NegativeInfinity, double.PositiveInfinity })
+        {
+            await AssertOutOfRangeAsync(
+                () => Backoff.Exponential(TimeSpan.FromSeconds(1), factor),
+                "factor");
+        }
+    }
+
+    [Test]
+    [Arguments(BackoffKind.None)]
+    [Arguments(BackoffKind.Constant)]
+    [Arguments(BackoffKind.Linear)]
+    [Arguments(BackoffKind.Exponential)]
+    [Arguments(BackoffKind.Custom)]
+    public async Task Every_Backoff_Rejects_NonPositive_Attempts(BackoffKind kind)
+    {
+        var backoff = kind switch
+        {
+            BackoffKind.None => Backoff.None,
+            BackoffKind.Constant => Backoff.Constant(TimeSpan.Zero),
+            BackoffKind.Linear => Backoff.Linear(TimeSpan.FromTicks(1)),
+            BackoffKind.Exponential => Backoff.Exponential(TimeSpan.FromTicks(1), jitter: false),
+            BackoffKind.Custom => Backoff.Custom(_ => TimeSpan.Zero),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+        await AssertOutOfRangeAsync(() => backoff.GetDelay(0), "attempt");
+        await AssertOutOfRangeAsync(() => backoff.GetDelay(-1), "attempt");
+    }
+
+    [Test]
+    public async Task Extreme_Backoff_Inputs_Clamp_Without_Overflow()
+    {
+        var cap = TimeSpan.FromSeconds(2);
+        var linear = Backoff.Linear(TimeSpan.MaxValue, cap);
+        var exponential = Backoff.Exponential(TimeSpan.MaxValue, double.MaxValue, cap, jitter: false);
+        var custom = Backoff.Custom(_ => TimeSpan.MaxValue);
+
+        await Assert.That(linear.GetDelay(int.MaxValue)).IsEqualTo(cap);
+        await Assert.That(exponential.GetDelay(int.MaxValue)).IsEqualTo(cap);
+        await Assert.That(custom.GetDelay(int.MaxValue)).IsEqualTo(MaximumRuntimeDelay);
+    }
+
+    [Test]
+    public async Task Strategies_Reject_Unsupported_Delay_And_Capacity_Values_Early()
+    {
+        await AssertOutOfRangeAsync(
+            () => Shield.Retry(options => options.MaxDelay = TimeSpan.FromTicks(-1)),
+            "MaxDelay");
+        await AssertOutOfRangeAsync(
+            () => Shield.Retry(options => options.MaxDelay = TimeSpan.MaxValue),
+            "MaxDelay");
+        await AssertOutOfRangeAsync(
+            () => Shield.Timeout(TimeSpan.MaxValue),
+            "Timeout");
+        await AssertOutOfRangeAsync(
+            () => Shield.Hedge(2, TimeSpan.MaxValue),
+            "Delay");
+        await AssertOutOfRangeAsync(
+            () => Shield.ConcurrencyLimit(int.MaxValue, 1),
+            "MaxQueue");
+    }
+
+    [Test]
+    public async Task Circuit_Breaker_Rejects_NaN_Ratio()
+    {
+        await AssertOutOfRangeAsync(
+            () => Shield.CircuitBreaker(options => options.FailureRatio = double.NaN),
+            "FailureRatio");
+    }
+
+    [Test]
+    public async Task Circuit_Break_Duration_Saturates_At_Maximum_Date()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.MaxValue - TimeSpan.FromTicks(1));
+        var shield = Shield
+            .CircuitBreaker(1, TimeSpan.MaxValue)
+            .WithTimeProvider(timeProvider);
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+
+        var rejection = await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(42)))
+            .Throws<CircuitOpenException>();
+        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.FromTicks(1));
+    }
+
+    [Test]
+    public async Task Maximum_Sampling_Window_Remains_Usable_Near_Maximum_Date()
+    {
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.MaxValue - TimeSpan.FromTicks(1));
+        var shield = Shield
+            .CircuitBreaker(options =>
+            {
+                options.FailureRatio = 1;
+                options.MinimumThroughput = 1;
+                options.SamplingWindow = TimeSpan.MaxValue;
+                options.BreakDuration = TimeSpan.MaxValue;
+            })
+            .WithTimeProvider(timeProvider);
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(42)))
+            .Throws<CircuitOpenException>();
+    }
+
+    [Test]
+    public async Task Retry_Generator_Delay_Is_Clamped_Before_Callbacks()
+    {
+        var callbackFailure = new InvalidOperationException("stop before waiting");
+        TimeSpan? observedDelay = null;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.DelayGenerator = _ => TimeSpan.MaxValue;
+            options.OnRetry = retry =>
+            {
+                observedDelay = retry.Delay;
+                throw callbackFailure;
+            };
+        });
+
+        var caught = await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new ArgumentException()))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(caught, callbackFailure)).IsTrue();
+        await Assert.That(observedDelay).IsEqualTo(MaximumRuntimeDelay);
+    }
+
+    [Test]
+    public async Task Extreme_Rate_Limit_Window_Returns_A_Valid_Retry_Estimate()
+    {
+        var shield = Shield
+            .RateLimit(1, TimeSpan.MaxValue)
+            .WithTimeProvider(new FakeTimeProvider());
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        var rejection = await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+
+        await Assert.That(rejection!.RetryAfter).IsEqualTo(MaximumRuntimeDelay);
+    }
+
+    private static async Task AssertOutOfRangeAsync(Action action, string paramName)
+    {
+        var exception = await Assert.That(action).Throws<ArgumentOutOfRangeException>();
+        await Assert.That(exception!.ParamName).IsEqualTo(paramName);
+    }
+
+    public enum BackoffKind
+    {
+        None,
+        Constant,
+        Linear,
+        Exponential,
+        Custom,
+    }
+}

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -69,6 +69,14 @@ public class NumericBoundaryTests
     }
 
     [Test]
+    public async Task Zero_Exponential_Backoff_Remains_Zero_When_The_Power_Overflows()
+    {
+        var backoff = Backoff.Exponential(TimeSpan.Zero, double.MaxValue, jitter: false);
+
+        await Assert.That(backoff.GetDelay(3)).IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
     public async Task Strategies_Reject_Unsupported_Delay_And_Capacity_Values_Early()
     {
         await AssertOutOfRangeAsync(
@@ -83,9 +91,32 @@ public class NumericBoundaryTests
         await AssertOutOfRangeAsync(
             () => Shield.Hedge(2, TimeSpan.MaxValue),
             "Delay");
-        await AssertOutOfRangeAsync(
-            () => Shield.ConcurrencyLimit(int.MaxValue, 1),
-            "MaxQueue");
+    }
+
+    [Test]
+    public async Task Concurrency_Capacity_Above_Int_MaxValue_Remains_Usable()
+    {
+        var shield = Shield.ConcurrencyLimit(int.MaxValue, 1);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Concurrency_Pending_Count_Does_Not_Wrap_At_Int_MaxValue()
+    {
+        var shield = Shield.ConcurrencyLimit(int.MaxValue);
+        var strategy = shield.Strategies.Single();
+        var pending = strategy.GetType().GetField(
+            "_pending",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        pending.SetValue(strategy, (long)int.MaxValue);
+
+        var outcome = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(outcome.Exception).IsTypeOf<ConcurrencyLimitExceededException>();
+        await Assert.That((long)pending.GetValue(strategy)!).IsEqualTo(int.MaxValue);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -128,7 +128,7 @@ public class NumericBoundaryTests
     }
 
     [Test]
-    public async Task Circuit_Break_Duration_Saturates_At_Maximum_Date()
+    public async Task Circuit_Break_Duration_Remains_Usable_At_Maximum_Date()
     {
         var timeProvider = new FakeTimeProvider(DateTimeOffset.MaxValue - TimeSpan.FromTicks(1));
         var shield = Shield
@@ -140,7 +140,7 @@ public class NumericBoundaryTests
 
         var rejection = await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(42)))
             .Throws<CircuitOpenException>();
-        await Assert.That(rejection!.RetryAfter).IsNull();
+        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.MaxValue);
 
         timeProvider.Advance(TimeSpan.FromTicks(1));
         await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(42)))


### PR DESCRIPTION
## Summary

- reject invalid backoff attempts, negative/unsupported caps, non-finite exponential factors, and overflowing concurrency capacity
- clamp dynamic retry and rate-limit delay conversions to the runtime timer limit
- saturate circuit-open deadlines near `DateTimeOffset.MaxValue` and widen sampling counters
- avoid custom timestamp subtraction overflow
- add table-driven numeric boundary tests across backoff, retry, timeout, hedge, circuit breaker, rate limit, and concurrency limit

Closes #19

## Validation

- `dotnet build Kevlar.slnx -c Release --no-incremental`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (350 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for retry, timeout, hedging, concurrency, and backoff configurations.
  * Prevented invalid, negative, infinite, or excessively large delay values.
  * Improved circuit-breaker behavior at extreme durations and metric counts.
  * Made rate-limit delays safer when handling extreme timing values.

* **Tests**
  * Added comprehensive coverage for numeric boundaries, overflow scenarios, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->