### PR TITLE
fix(context): harden pooled state contracts

### DIFF
--- a/docs/docs/custom-strategies.md
+++ b/docs/docs/custom-strategies.md
@@ -78,6 +78,14 @@ public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
 
 The exception is only thrown once — at the pipeline boundary, back in the caller's frame, with its original stack trace intact.
 
+## Context properties
+
+`KevlarContext.Properties` is isolated per execution. A `KevlarKey<T>` is identified by both
+its case-sensitive name and `T`: keys with the same name and different value types do not
+collide, while new key instances with the same name and type address the same value. Empty names
+are valid. Stored `null` is present and distinct from a missing key, so `TryGet` returns `true`
+with a `null` value and `GetOrDefault` does not substitute its fallback.
+
 ## KevlarContext
 
 The context flows through the whole pipeline:

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -9,7 +9,9 @@ namespace Kevlar;
 /// </summary>
 public sealed class KevlarContext
 {
-    private static readonly ObjectPool<KevlarContext, PoolPolicy> Pool = new(maxCapacity: 128);
+    internal const int PoolCapacity = 128;
+
+    private static readonly ObjectPool<KevlarContext, PoolPolicy> Pool = new(maxCapacity: PoolCapacity);
 
     private KevlarContext()
     {

--- a/src/Kevlar/KevlarProperties.cs
+++ b/src/Kevlar/KevlarProperties.cs
@@ -1,3 +1,5 @@
+using Kevlar.Internal;
+
 namespace Kevlar;
 
 /// <summary>
@@ -13,12 +15,17 @@ public sealed class KevlarProperties
     }
 
     /// <summary>Stores a value under the given key, replacing any existing value.</summary>
-    public void Set<T>(KevlarKey<T> key, T value) => (_items ??= [])[new(key.Name, typeof(T))] = value;
+    public void Set<T>(KevlarKey<T> key, T value)
+    {
+        var identity = GetIdentity(key);
+        (_items ??= [])[identity] = value;
+    }
 
     /// <summary>Attempts to read the value stored under the given key.</summary>
     public bool TryGet<T>(KevlarKey<T> key, out T value)
     {
-        if (_items is not null && _items.TryGetValue(new(key.Name, typeof(T)), out var stored))
+        var identity = GetIdentity(key);
+        if (_items is not null && _items.TryGetValue(identity, out var stored))
         {
             value = (T)stored!;
             return true;
@@ -46,6 +53,12 @@ public sealed class KevlarProperties
         {
             items[pair.Key] = pair.Value;
         }
+    }
+
+    private static PropertyIdentity GetIdentity<T>(KevlarKey<T> key)
+    {
+        Throw.IfNull(key.Name, nameof(key));
+        return new(key.Name, typeof(T));
     }
 
     private readonly record struct PropertyIdentity(string Name, Type ValueType);

--- a/src/Kevlar/KevlarProperties.cs
+++ b/src/Kevlar/KevlarProperties.cs
@@ -6,21 +6,21 @@ namespace Kevlar;
 /// </summary>
 public sealed class KevlarProperties
 {
-    private Dictionary<string, object?>? _items;
+    private Dictionary<PropertyIdentity, object?>? _items;
 
     internal KevlarProperties()
     {
     }
 
     /// <summary>Stores a value under the given key, replacing any existing value.</summary>
-    public void Set<T>(KevlarKey<T> key, T value) => (_items ??= [])[key.Name] = value;
+    public void Set<T>(KevlarKey<T> key, T value) => (_items ??= [])[new(key.Name, typeof(T))] = value;
 
     /// <summary>Attempts to read the value stored under the given key.</summary>
     public bool TryGet<T>(KevlarKey<T> key, out T value)
     {
-        if (_items is not null && _items.TryGetValue(key.Name, out var stored) && stored is T typed)
+        if (_items is not null && _items.TryGetValue(new(key.Name, typeof(T)), out var stored))
         {
-            value = typed;
+            value = (T)stored!;
             return true;
         }
 
@@ -47,4 +47,6 @@ public sealed class KevlarProperties
             items[pair.Key] = pair.Value;
         }
     }
+
+    private readonly record struct PropertyIdentity(string Name, Type ValueType);
 }

--- a/tests/Kevlar.Tests/ContextLifecycleTests.cs
+++ b/tests/Kevlar.Tests/ContextLifecycleTests.cs
@@ -1,0 +1,323 @@
+using System.Collections.Concurrent;
+using Kevlar.Strategies;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+[NotInParallel]
+public class ContextLifecycleTests
+{
+    private static readonly KevlarKey<string> DirtyProperty = new("dirty");
+
+    [Test]
+    public async Task Every_Exit_Path_Resets_Every_Pooled_Context_Field()
+    {
+        foreach (var exitPath in Enum.GetValues<ExitPath>())
+        {
+            await AssertResetAfter(exitPath);
+        }
+    }
+
+    [Test]
+    public async Task Pool_Pressure_Beyond_Capacity_Returns_Only_Clean_Contexts()
+    {
+        const int pressureCount = 160;
+        const int poolCapacity = 128;
+        using var dirtyCancellation = new CancellationTokenSource();
+        var dirtyTimeProvider = new FakeTimeProvider();
+        var dirty = new PressureStrategy(
+            pressureCount,
+            DirtyProperty,
+            setDirty: true,
+            dirtyCancellation.Token,
+            dirtyTimeProvider);
+        var dirtyShield = Shield.Use(dirty)
+            .WithName("dirty-pressure")
+            .WithTimeProvider(dirtyTimeProvider);
+        var dirtyExecutions = Enumerable.Range(0, pressureCount)
+            .Select(index => dirtyShield.ExecuteAsync(
+                _ => new ValueTask<int>(index),
+                dirtyCancellation.Token).AsTask())
+            .ToArray();
+
+        await dirty.AllEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(dirty.DirtyContexts).IsEqualTo(0);
+        await Assert.That(dirty.Contexts.Distinct().Count()).IsEqualTo(pressureCount);
+        dirty.Release.TrySetResult();
+        await Task.WhenAll(dirtyExecutions).WaitAsync(TimeSpan.FromSeconds(5));
+
+        var clean = new PressureStrategy(
+            poolCapacity,
+            DirtyProperty,
+            setDirty: false,
+            default,
+            TimeProvider.System);
+        var cleanShield = Shield.Use(clean).WithName("clean-pressure");
+        var cleanExecutions = Enumerable.Range(0, poolCapacity)
+            .Select(index => cleanShield.ExecuteAsync(_ => new ValueTask<int>(index)).AsTask())
+            .ToArray();
+
+        await clean.AllEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(clean.DirtyContexts).IsEqualTo(0);
+        await Assert.That(clean.Contexts.Distinct().Count()).IsEqualTo(poolCapacity);
+        clean.Release.TrySetResult();
+        await Task.WhenAll(cleanExecutions).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Reentrant_Execution_Never_Reuses_The_InUse_Outer_Context()
+    {
+        var strategy = new ReentrantStrategy(DirtyProperty);
+        var result = await Shield.Use(strategy).ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(strategy.InnerUsedDifferentContext).IsTrue();
+        await Assert.That(strategy.OuterPropertySurvived).IsTrue();
+    }
+
+    [Test]
+    public async Task Forks_Copy_Initial_Properties_Without_Sharing_Later_Writes()
+    {
+        var key = new KevlarKey<string>("fork-value");
+        var parent = KevlarContext.Rent(default, isSynchronous: false, TimeProvider.System, "parent");
+        parent.Properties.Set(key, "initial");
+        var first = parent.Fork(default);
+        var second = parent.Fork(default);
+
+        try
+        {
+            await Assert.That(first.Properties.GetOrDefault<string>(key)).IsEqualTo("initial");
+            await Assert.That(second.Properties.GetOrDefault<string>(key)).IsEqualTo("initial");
+            await Assert.That(ReferenceEquals(parent.Properties, first.Properties)).IsFalse();
+            await Assert.That(ReferenceEquals(first.Properties, second.Properties)).IsFalse();
+
+            first.Properties.Set(key, "first");
+            second.Properties.Set(key, "second");
+
+            await Assert.That(parent.Properties.GetOrDefault<string>(key)).IsEqualTo("initial");
+            await Assert.That(first.Properties.GetOrDefault<string>(key)).IsEqualTo("first");
+            await Assert.That(second.Properties.GetOrDefault<string>(key)).IsEqualTo("second");
+        }
+        finally
+        {
+            KevlarContext.Return(first);
+            KevlarContext.Return(second);
+            KevlarContext.Return(parent);
+        }
+    }
+
+    private static async Task AssertResetAfter(ExitPath exitPath)
+    {
+        var observer = new ContextObserverStrategy(DirtyProperty);
+        var timeProvider = new FakeTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var shield = CreateShield(exitPath, observer)
+            .WithName("dirty-context")
+            .WithTimeProvider(timeProvider);
+
+        switch (exitPath)
+        {
+            case ExitPath.AsyncSuccess:
+                await shield.ExecuteAsync(_ => new ValueTask<int>(42), cancellation.Token);
+                break;
+            case ExitPath.AsyncFailure:
+                await Assert.That(async () => await shield.ExecuteAsync<int>(
+                    _ => throw new InvalidOperationException("failure"),
+                    cancellation.Token)).Throws<InvalidOperationException>();
+                break;
+            case ExitPath.AsyncCancellation:
+                await Assert.That(async () => await shield.ExecuteAsync<int>(token =>
+                {
+                    cancellation.Cancel();
+                    token.ThrowIfCancellationRequested();
+                    return new ValueTask<int>(42);
+                }, cancellation.Token)).Throws<OperationCanceledException>();
+                break;
+            case ExitPath.CallbackFailure:
+                await Assert.That(async () => await shield.ExecuteAsync<int>(
+                    _ => throw new InvalidOperationException("handled"),
+                    cancellation.Token)).Throws<ApplicationException>();
+                break;
+            case ExitPath.OutcomeFailure:
+                var outcome = await shield.ExecuteOutcomeAsync<int>(
+                    _ => throw new InvalidOperationException("captured"),
+                    cancellation.Token);
+                await Assert.That(outcome.IsSuccess).IsFalse();
+                break;
+            case ExitPath.SyncSuccess:
+                await Assert.That(shield.Execute(_ => 42, cancellation.Token)).IsEqualTo(42);
+                break;
+            case ExitPath.SyncFailure:
+                await Assert.That(() => shield.Execute<int>(
+                    _ => throw new InvalidOperationException("sync failure"),
+                    cancellation.Token)).Throws<InvalidOperationException>();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(exitPath), exitPath, null);
+        }
+
+        var snapshot = observer.Snapshot
+            ?? throw new InvalidOperationException($"{exitPath}: observer did not run.");
+        await Assert.That(snapshot.Name).IsEqualTo("dirty-context");
+        await Assert.That(ReferenceEquals(snapshot.TimeProvider, timeProvider)).IsTrue();
+        await Assert.That(snapshot.CancellationToken).IsEqualTo(cancellation.Token);
+        await Assert.That(snapshot.IsSynchronous).IsEqualTo(exitPath is ExitPath.SyncSuccess or ExitPath.SyncFailure);
+        await Assert.That(snapshot.PropertiesWereInitiallyClean).IsTrue();
+
+        var returned = observer.Context!;
+        await Assert.That(returned.CancellationToken).IsEqualTo(default(CancellationToken));
+        await Assert.That(returned.IsSynchronous).IsFalse();
+        await Assert.That(returned.ShieldName).IsNull();
+        await Assert.That(ReferenceEquals(returned.TimeProvider, TimeProvider.System)).IsTrue();
+        await Assert.That(returned.Properties.TryGet(DirtyProperty, out _)).IsFalse();
+    }
+
+    private static Shield CreateShield(ExitPath exitPath, ContextObserverStrategy observer)
+    {
+        var shield = Shield.Use(observer);
+        return exitPath == ExitPath.CallbackFailure
+            ? shield.Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = _ => throw new ApplicationException("callback failure");
+            })
+            : shield;
+    }
+
+    private enum ExitPath
+    {
+        AsyncSuccess,
+        AsyncFailure,
+        AsyncCancellation,
+        CallbackFailure,
+        OutcomeFailure,
+        SyncSuccess,
+        SyncFailure,
+    }
+
+    private sealed class ContextObserverStrategy(KevlarKey<string> dirtyProperty) : Strategy
+    {
+        public KevlarContext? Context { get; private set; }
+
+        public ContextSnapshot? Snapshot { get; private set; }
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            Context = context;
+            Snapshot = new ContextSnapshot(
+                context.ShieldName,
+                context.TimeProvider,
+                context.CancellationToken,
+                context.IsSynchronous,
+                !context.Properties.TryGet(dirtyProperty, out _));
+            context.Properties.Set(dirtyProperty, "dirty");
+            return next.InvokeAsync(context);
+        }
+    }
+
+    private sealed class PressureStrategy : Strategy
+    {
+        private readonly int _expectedCount;
+        private readonly KevlarKey<string> _dirtyProperty;
+        private readonly bool _setDirty;
+        private readonly CancellationToken _expectedToken;
+        private readonly TimeProvider _expectedTimeProvider;
+        private int _entered;
+        private int _dirtyContexts;
+
+        public PressureStrategy(
+            int expectedCount,
+            KevlarKey<string> dirtyProperty,
+            bool setDirty,
+            CancellationToken expectedToken,
+            TimeProvider expectedTimeProvider)
+        {
+            _expectedCount = expectedCount;
+            _dirtyProperty = dirtyProperty;
+            _setDirty = setDirty;
+            _expectedToken = expectedToken;
+            _expectedTimeProvider = expectedTimeProvider;
+        }
+
+        public ConcurrentBag<KevlarContext> Contexts { get; } = [];
+
+        public TaskCompletionSource AllEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int DirtyContexts => Volatile.Read(ref _dirtyContexts);
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            Contexts.Add(context);
+            if (context.Properties.TryGet(_dirtyProperty, out _)
+                || context.ShieldName != (_setDirty ? "dirty-pressure" : "clean-pressure")
+                || context.IsSynchronous
+                || context.CancellationToken != _expectedToken
+                || !ReferenceEquals(context.TimeProvider, _expectedTimeProvider))
+            {
+                Interlocked.Increment(ref _dirtyContexts);
+            }
+
+            if (_setDirty)
+            {
+                context.Properties.Set(_dirtyProperty, "dirty");
+            }
+
+            if (Interlocked.Increment(ref _entered) == _expectedCount)
+            {
+                AllEntered.TrySetResult();
+            }
+
+            await Release.Task.ConfigureAwait(false);
+            return await next.InvokeAsync(context).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class ReentrantStrategy(KevlarKey<string> key) : Strategy
+    {
+        public bool InnerUsedDifferentContext { get; private set; }
+
+        public bool OuterPropertySurvived { get; private set; }
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            context.Properties.Set(key, "outer");
+            var inner = new InnerObserverStrategy(context, key);
+            _ = await Shield.Use(inner).ExecuteAsync(_ => new ValueTask<int>(1)).ConfigureAwait(false);
+
+            InnerUsedDifferentContext = inner.UsedDifferentContext;
+            OuterPropertySurvived = context.Properties.GetOrDefault<string>(key) == "outer";
+            return await next.InvokeAsync(context).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class InnerObserverStrategy(KevlarContext outer, KevlarKey<string> key) : Strategy
+    {
+        public bool UsedDifferentContext { get; private set; }
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            UsedDifferentContext = !ReferenceEquals(context, outer)
+                && !context.Properties.TryGet(key, out _);
+            context.Properties.Set(key, "inner");
+            return next.InvokeAsync(context);
+        }
+    }
+
+    private sealed record ContextSnapshot(
+        string? Name,
+        TimeProvider TimeProvider,
+        CancellationToken CancellationToken,
+        bool IsSynchronous,
+        bool PropertiesWereInitiallyClean);
+}

--- a/tests/Kevlar.Tests/ContextLifecycleTests.cs
+++ b/tests/Kevlar.Tests/ContextLifecycleTests.cs
@@ -22,7 +22,6 @@ public class ContextLifecycleTests
     public async Task Pool_Pressure_Beyond_Capacity_Returns_Only_Clean_Contexts()
     {
         const int pressureCount = 160;
-        const int poolCapacity = 128;
         using var dirtyCancellation = new CancellationTokenSource();
         var dirtyTimeProvider = new FakeTimeProvider();
         var dirty = new PressureStrategy(
@@ -40,27 +39,41 @@ public class ContextLifecycleTests
                 dirtyCancellation.Token).AsTask())
             .ToArray();
 
-        await dirty.AllEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await Assert.That(dirty.DirtyContexts).IsEqualTo(0);
-        await Assert.That(dirty.Contexts.Distinct().Count()).IsEqualTo(pressureCount);
-        dirty.Release.TrySetResult();
+        try
+        {
+            await dirty.AllEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(dirty.DirtyContexts).IsEqualTo(0);
+            await Assert.That(dirty.Contexts.Distinct().Count()).IsEqualTo(pressureCount);
+        }
+        finally
+        {
+            dirty.Release.TrySetResult();
+        }
+
         await Task.WhenAll(dirtyExecutions).WaitAsync(TimeSpan.FromSeconds(5));
 
         var clean = new PressureStrategy(
-            poolCapacity,
+            KevlarContext.PoolCapacity,
             DirtyProperty,
             setDirty: false,
             default,
             TimeProvider.System);
         var cleanShield = Shield.Use(clean).WithName("clean-pressure");
-        var cleanExecutions = Enumerable.Range(0, poolCapacity)
+        var cleanExecutions = Enumerable.Range(0, KevlarContext.PoolCapacity)
             .Select(index => cleanShield.ExecuteAsync(_ => new ValueTask<int>(index)).AsTask())
             .ToArray();
 
-        await clean.AllEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await Assert.That(clean.DirtyContexts).IsEqualTo(0);
-        await Assert.That(clean.Contexts.Distinct().Count()).IsEqualTo(poolCapacity);
-        clean.Release.TrySetResult();
+        try
+        {
+            await clean.AllEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(clean.DirtyContexts).IsEqualTo(0);
+            await Assert.That(clean.Contexts.Distinct().Count()).IsEqualTo(KevlarContext.PoolCapacity);
+        }
+        finally
+        {
+            clean.Release.TrySetResult();
+        }
+
         await Task.WhenAll(cleanExecutions).WaitAsync(TimeSpan.FromSeconds(5));
     }
 

--- a/tests/Kevlar.Tests/OutcomeAndContextTests.cs
+++ b/tests/Kevlar.Tests/OutcomeAndContextTests.cs
@@ -14,6 +14,18 @@ public class OutcomeAndContextTests
     }
 
     [Test]
+    public async Task FromResult_Formats_Null_And_Custom_Values()
+    {
+        var nullOutcome = Outcome<string?>.FromResult(null);
+        var customOutcome = Outcome<CustomValue>.FromResult(new CustomValue());
+
+        await Assert.That(nullOutcome.IsSuccess).IsTrue();
+        await Assert.That(nullOutcome.Result).IsNull();
+        await Assert.That(nullOutcome.ToString()).IsEqualTo(string.Empty);
+        await Assert.That(customOutcome.ToString()).IsEqualTo("custom-value");
+    }
+
+    [Test]
     public async Task FromException_Is_Failure()
     {
         var exception = new InvalidOperationException("boom");
@@ -32,7 +44,7 @@ public class OutcomeAndContextTests
     [Test]
     public async Task GetResultOrRethrow_Throws_The_Original_Exception_Instance()
     {
-        var original = new InvalidOperationException("boom");
+        var original = CaptureOriginalException();
         var outcome = Outcome<int>.FromException(original);
 
         try
@@ -43,17 +55,22 @@ public class OutcomeAndContextTests
         catch (InvalidOperationException caught)
         {
             await Assert.That(ReferenceEquals(caught, original)).IsTrue();
+            await Assert.That(caught.StackTrace!.Contains(nameof(ThrowOriginal))).IsTrue();
         }
     }
 
     [Test]
     public async Task Default_Outcome_Is_A_Success_With_The_Default_Value()
     {
-        var outcome = default(Outcome<string>);
+        var referenceOutcome = default(Outcome<string>);
+        var valueOutcome = default(Outcome<int>);
 
-        await Assert.That(outcome.IsSuccess).IsTrue();
-        await Assert.That(outcome.Result).IsNull();
-        await Assert.That(outcome.ToString()).IsEqualTo(string.Empty);
+        await Assert.That(referenceOutcome.IsSuccess).IsTrue();
+        await Assert.That(referenceOutcome.Result).IsNull();
+        await Assert.That(referenceOutcome.ToString()).IsEqualTo(string.Empty);
+        await Assert.That(valueOutcome.IsSuccess).IsTrue();
+        await Assert.That(valueOutcome.Result).IsEqualTo(0);
+        await Assert.That(valueOutcome.ToString()).IsEqualTo("0");
     }
 
     [Test]
@@ -114,6 +131,48 @@ public class OutcomeAndContextTests
     }
 
     [Test]
+    public async Task Properties_Distinguish_Stored_Null_From_Missing()
+    {
+        var properties = CapturedProperties();
+        var stored = new KevlarKey<string?>("stored-null");
+
+        properties.Set(stored, null);
+
+        await Assert.That(properties.TryGet(stored, out var value)).IsTrue();
+        await Assert.That(value).IsNull();
+        await Assert.That(properties.GetOrDefault(stored, "fallback")).IsNull();
+        await Assert.That(properties.TryGet(new KevlarKey<string?>("missing"), out _)).IsFalse();
+        await Assert.That(properties.GetOrDefault(new KevlarKey<string?>("missing"), "fallback")).IsEqualTo("fallback");
+    }
+
+    [Test]
+    public async Task Properties_Use_Name_And_Value_Type_As_Key_Identity()
+    {
+        var properties = CapturedProperties();
+        var text = new KevlarKey<string>("shared");
+        var number = new KevlarKey<int>("shared");
+
+        properties.Set(text, "value");
+        properties.Set(number, 42);
+
+        await Assert.That(properties.GetOrDefault<string>(new KevlarKey<string>("shared"))).IsEqualTo("value");
+        await Assert.That(properties.GetOrDefault(new KevlarKey<int>("shared"))).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Property_Names_Are_Case_Sensitive_And_May_Be_Empty()
+    {
+        var properties = CapturedProperties();
+        properties.Set(new KevlarKey<int>("Key"), 1);
+        properties.Set(new KevlarKey<int>("key"), 2);
+        properties.Set(new KevlarKey<int>(string.Empty), 3);
+
+        await Assert.That(properties.GetOrDefault(new KevlarKey<int>("Key"))).IsEqualTo(1);
+        await Assert.That(properties.GetOrDefault(new KevlarKey<int>("key"))).IsEqualTo(2);
+        await Assert.That(properties.GetOrDefault(new KevlarKey<int>(string.Empty))).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task Properties_Are_Cleared_Between_Executions()
     {
         // The context is pooled; whatever instance an execution rents must start with
@@ -166,4 +225,24 @@ public class OutcomeAndContextTests
 
     // The internal constructor is reachable via InternalsVisibleTo.
     private static KevlarProperties CapturedProperties() => new();
+
+    private static InvalidOperationException CaptureOriginalException()
+    {
+        try
+        {
+            ThrowOriginal();
+            throw new InvalidOperationException("Unreachable.");
+        }
+        catch (InvalidOperationException exception)
+        {
+            return exception;
+        }
+    }
+
+    private static void ThrowOriginal() => throw new InvalidOperationException("boom");
+
+    private sealed class CustomValue
+    {
+        public override string ToString() => "custom-value";
+    }
 }

--- a/tests/Kevlar.Tests/OutcomeAndContextTests.cs
+++ b/tests/Kevlar.Tests/OutcomeAndContextTests.cs
@@ -101,6 +101,16 @@ public class OutcomeAndContextTests
     }
 
     [Test]
+    public async Task Properties_Reject_A_Default_Key()
+    {
+        var properties = CapturedProperties();
+
+        await Assert.That(() => properties.Set(default(KevlarKey<int>), 1)).Throws<ArgumentNullException>();
+        await Assert.That(() => properties.TryGet(default(KevlarKey<int>), out _)).Throws<ArgumentNullException>();
+        await Assert.That(() => properties.GetOrDefault(default(KevlarKey<int>))).Throws<ArgumentNullException>();
+    }
+
+    [Test]
     public async Task Properties_Set_Overwrites_An_Existing_Value()
     {
         var properties = CapturedProperties();


### PR DESCRIPTION
## Summary

- key context properties by case-sensitive name and value type so differently typed keys coexist
- preserve stored null as present and distinct from a missing property
- prove all pooled fields reset after success, failure, cancellation, callback failure, outcome execution, and synchronous exits
- deterministically exceed the 128-context pool capacity, then verify clean concurrent reuse
- cover reentrant execution, detached fork property writes, and Outcome null/default/custom formatting plus exception identity/stack
- document property identity, null, case, and empty-name semantics

Closes #18

## Validation

- `dotnet build Kevlar.slnx -c Release` (0 warnings)
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (345 passed)
- full unit suite repeated 20 times before final rebase; rebased suite passed
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `npm run build` from `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Context properties now distinguish values by both property name and value type, preventing collisions.
  * Stored `null` values are correctly distinguished from missing properties.
  * Property names remain case-sensitive and may be empty, while invalid default keys are rejected.
  * Contexts are reliably reset and isolated across success, failure, cancellation, callback, and nested execution paths.

* **Documentation**
  * Added guidance on context property isolation, typed key identity, empty names, and `null` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->