### PR TITLE
fix(circuit-breaker): normalize shared timelines

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -52,6 +52,8 @@ var result = await pending;
 
 `WithTimeProvider` returns a new shield (shields are immutable) with every time-dependent strategy — retry backoff, timeouts, circuit breaker break durations and sampling windows, rate-limit windows, hedging delays — driven by the provider you supply.
 
+Copies still share stateful strategies. Circuit breakers and rate limiters normalize each provider's monotonic timestamp onto one elapsed-time timeline, so copies can safely use providers with different UTC epochs. Move time with the provider's normal advance mechanism; changing UTC alone does not advance break durations or sampling windows.
+
 :::warning Advance *after* the execution is in flight
 Start the execution first (note the `.AsTask()` without `await`), *then* advance time. If you advance before the shield has scheduled its delay, there's nothing to advance past and the pending task will hang waiting for a tick that already happened.
 :::

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -14,8 +14,7 @@ internal sealed class CircuitBreakerCore
     private static readonly double SecondsPerSystemTimestamp = 1d / Stopwatch.Frequency;
 
     private readonly Lock _gate = new();
-    private readonly long _systemTimestampOrigin = Stopwatch.GetTimestamp();
-    private readonly ConditionalWeakTable<TimeProvider, CustomTimestampOrigin> _customTimestampOrigins = new();
+    private readonly ConditionalWeakTable<TimeProvider, TimestampOrigin> _timestampOrigins = new();
     private readonly int? _consecutiveFailureLimit;
     private readonly double? _failureRatio;
     private readonly int _minimumThroughput;
@@ -310,22 +309,17 @@ internal sealed class CircuitBreakerCore
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private double GetCurrentTimestamp(TimeProvider timeProvider)
     {
-        if (ReferenceEquals(timeProvider, TimeProvider.System))
-        {
-            return UpdateTimeline(Stopwatch.GetTimestamp() - _systemTimestampOrigin);
-        }
-
         var timestamp = timeProvider.GetTimestamp();
-        if (!_customTimestampOrigins.TryGetValue(timeProvider, out var origin))
+        if (!_timestampOrigins.TryGetValue(timeProvider, out var origin))
         {
-            origin = new CustomTimestampOrigin(timeProvider, timestamp);
-            _customTimestampOrigins.Add(timeProvider, origin);
-            return UpdateTimeline(origin.SystemTimestamp - _systemTimestampOrigin);
+            origin = new TimestampOrigin(timeProvider, timestamp, _latestTimestamp);
+            _timestampOrigins.Add(timeProvider, origin);
+            return _latestTimestamp;
         }
 
         return UpdateTimeline(
-            origin.SystemTimestamp - _systemTimestampOrigin
-            + ((timestamp - origin.ProviderTimestamp) * origin.TimestampScale));
+            origin.TimelineTimestamp
+            + ((double)((decimal)timestamp - origin.ProviderTimestamp) * origin.TimestampScale));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -343,18 +337,21 @@ internal sealed class CircuitBreakerCore
             : TimeSpan.FromTicks((long)ticks);
     }
 
-    private sealed class CustomTimestampOrigin
+    private sealed class TimestampOrigin
     {
-        public CustomTimestampOrigin(TimeProvider timeProvider, long providerTimestamp)
+        public TimestampOrigin(
+            TimeProvider timeProvider,
+            long providerTimestamp,
+            double timelineTimestamp)
         {
-            SystemTimestamp = Stopwatch.GetTimestamp();
             ProviderTimestamp = providerTimestamp;
+            TimelineTimestamp = timelineTimestamp;
             TimestampScale = Stopwatch.Frequency / (double)timeProvider.TimestampFrequency;
         }
 
-        public long SystemTimestamp { get; }
-
         public long ProviderTimestamp { get; }
+
+        public double TimelineTimestamp { get; }
 
         public double TimestampScale { get; }
     }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -9,23 +11,29 @@ namespace Kevlar.Strategies;
 internal sealed class CircuitBreakerCore
 {
     private const int BucketCount = 10;
+    private static readonly double SecondsPerSystemTimestamp = 1d / Stopwatch.Frequency;
 
     private readonly Lock _gate = new();
+    private readonly long _systemTimestampOrigin = Stopwatch.GetTimestamp();
+    private readonly ConditionalWeakTable<TimeProvider, CustomTimestampOrigin> _customTimestampOrigins = new();
     private readonly int? _consecutiveFailureLimit;
     private readonly double? _failureRatio;
     private readonly int _minimumThroughput;
     private readonly TimeSpan _samplingWindow;
-    private readonly TimeSpan _bucketDuration;
+    private readonly double _bucketDurationTimestampUnits;
     private readonly TimeSpan _breakDuration;
+    private readonly double _breakDurationTimestampUnits;
     private readonly Action<CircuitStateChangedEvent>? _onStateChanged;
     private readonly CircuitBreakerMonitor? _monitor;
 
     private readonly int[] _bucketFailures = new int[BucketCount];
     private readonly int[] _bucketSuccesses = new int[BucketCount];
-    private long _currentBucket = -1;
+    private double _currentBucketStart = double.NaN;
+    private int _currentBucketIndex;
 
     private CircuitState _state = CircuitState.Closed;
-    private DateTimeOffset _openUntil;
+    private double _latestTimestamp;
+    private double _openUntilTimestamp;
     private int _consecutiveFailures;
     private bool _probeInFlight;
     private Exception? _lastException;
@@ -43,8 +51,9 @@ internal sealed class CircuitBreakerCore
         _consecutiveFailureLimit = options.FailureRatio is null ? options.ConsecutiveFailures ?? 5 : null;
         _samplingWindow = options.SamplingWindow;
         _minimumThroughput = options.MinimumThroughput;
-        _bucketDuration = TimeSpan.FromTicks(Math.Max(1, options.SamplingWindow.Ticks / BucketCount));
+        _bucketDurationTimestampUnits = options.SamplingWindow.TotalSeconds * Stopwatch.Frequency / BucketCount;
         _breakDuration = options.BreakDuration;
+        _breakDurationTimestampUnits = options.BreakDuration.TotalSeconds * Stopwatch.Frequency;
         _onStateChanged = options.OnStateChanged;
         _monitor = options.Monitor;
         _monitor?.Bind(this);
@@ -91,15 +100,23 @@ internal sealed class CircuitBreakerCore
                     allowed = false;
                     break;
 
-                case CircuitState.Open when timeProvider.GetUtcNow() >= _openUntil:
-                    transition = ChangeState(CircuitState.HalfOpen);
-                    _probeInFlight = true;
-                    allowed = true;
-                    break;
-
                 case CircuitState.Open:
-                    rejection = new CircuitOpenException(_openUntil - timeProvider.GetUtcNow(), isIsolated: false, _lastException);
-                    allowed = false;
+                    var timestamp = GetCurrentTimestamp(timeProvider);
+                    if (timestamp >= _openUntilTimestamp)
+                    {
+                        transition = ChangeState(CircuitState.HalfOpen);
+                        _probeInFlight = true;
+                        allowed = true;
+                    }
+                    else
+                    {
+                        rejection = new CircuitOpenException(
+                            GetElapsedTime(_openUntilTimestamp - timestamp),
+                            isIsolated: false,
+                            _lastException);
+                        allowed = false;
+                    }
+
                     break;
 
                 default: // HalfOpen
@@ -158,13 +175,25 @@ internal sealed class CircuitBreakerCore
             if (_state == CircuitState.HalfOpen)
             {
                 _probeInFlight = false;
-                _openUntil = timeProvider.GetUtcNow() + _breakDuration;
+                _openUntilTimestamp = GetCurrentTimestamp(timeProvider) + _breakDurationTimestampUnits;
                 transition = ChangeState(CircuitState.Open);
             }
-            else if (_state == CircuitState.Closed && IsTripped(timeProvider))
+            else if (_state == CircuitState.Closed)
             {
-                _openUntil = timeProvider.GetUtcNow() + _breakDuration;
-                transition = ChangeState(CircuitState.Open);
+                var timestamp = _failureRatio is null
+                    ? 0
+                    : GetCurrentTimestamp(timeProvider);
+
+                if (IsTripped(timestamp))
+                {
+                    if (_failureRatio is null)
+                    {
+                        timestamp = GetCurrentTimestamp(timeProvider);
+                    }
+
+                    _openUntilTimestamp = timestamp + _breakDurationTimestampUnits;
+                    transition = ChangeState(CircuitState.Open);
+                }
             }
         }
 
@@ -215,14 +244,14 @@ internal sealed class CircuitBreakerCore
         Publish(transition);
     }
 
-    private bool IsTripped(TimeProvider timeProvider)
+    private bool IsTripped(double timestamp)
     {
         if (_consecutiveFailureLimit is { } limit)
         {
             return ++_consecutiveFailures >= limit;
         }
 
-        var bucket = AdvanceBucket(timeProvider);
+        var bucket = AdvanceBucket(timestamp);
         _bucketFailures[bucket]++;
 
         int failures = 0, total = 0;
@@ -235,36 +264,99 @@ internal sealed class CircuitBreakerCore
         return total >= _minimumThroughput && (double)failures / total >= _failureRatio!.Value;
     }
 
-    private int AdvanceBucket(TimeProvider timeProvider)
+    private int AdvanceBucket(TimeProvider timeProvider) => AdvanceBucket(GetCurrentTimestamp(timeProvider));
+
+    private int AdvanceBucket(double timestamp)
     {
-        var absoluteBucket = timeProvider.GetUtcNow().UtcTicks / _bucketDuration.Ticks;
-
-        if (_currentBucket == -1)
+        if (double.IsNaN(_currentBucketStart))
         {
-            _currentBucket = absoluteBucket;
+            _currentBucketStart = timestamp;
         }
-        else if (absoluteBucket > _currentBucket)
+        else
         {
-            var advance = Math.Min(absoluteBucket - _currentBucket, BucketCount);
-            for (long i = 1; i <= advance; i++)
+            var elapsed = timestamp - _currentBucketStart;
+            if (elapsed >= _bucketDurationTimestampUnits)
             {
-                var index = (int)((_currentBucket + i) % BucketCount);
-                _bucketFailures[index] = 0;
-                _bucketSuccesses[index] = 0;
-            }
+                var advance = elapsed >= _bucketDurationTimestampUnits * BucketCount
+                    ? BucketCount
+                    : (int)(elapsed / _bucketDurationTimestampUnits);
 
-            _currentBucket = absoluteBucket;
+                for (var i = 1; i <= advance; i++)
+                {
+                    var index = (_currentBucketIndex + i) % BucketCount;
+                    _bucketFailures[index] = 0;
+                    _bucketSuccesses[index] = 0;
+                }
+
+                _currentBucketIndex = (_currentBucketIndex + advance) % BucketCount;
+                _currentBucketStart = advance == BucketCount
+                    ? timestamp
+                    : _currentBucketStart + (advance * _bucketDurationTimestampUnits);
+            }
         }
 
-        return (int)(_currentBucket % BucketCount);
+        return _currentBucketIndex;
     }
 
     private void ResetMetrics()
     {
         _consecutiveFailures = 0;
-        _currentBucket = -1;
+        _currentBucketStart = double.NaN;
+        _currentBucketIndex = 0;
         Array.Clear(_bucketFailures, 0, BucketCount);
         Array.Clear(_bucketSuccesses, 0, BucketCount);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private double GetCurrentTimestamp(TimeProvider timeProvider)
+    {
+        if (ReferenceEquals(timeProvider, TimeProvider.System))
+        {
+            return UpdateTimeline(Stopwatch.GetTimestamp() - _systemTimestampOrigin);
+        }
+
+        var timestamp = timeProvider.GetTimestamp();
+        if (!_customTimestampOrigins.TryGetValue(timeProvider, out var origin))
+        {
+            origin = new CustomTimestampOrigin(timeProvider, timestamp);
+            _customTimestampOrigins.Add(timeProvider, origin);
+            return UpdateTimeline(origin.SystemTimestamp - _systemTimestampOrigin);
+        }
+
+        return UpdateTimeline(
+            origin.SystemTimestamp - _systemTimestampOrigin
+            + ((timestamp - origin.ProviderTimestamp) * origin.TimestampScale));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private double UpdateTimeline(double timestamp)
+    {
+        _latestTimestamp = Math.Max(_latestTimestamp, timestamp);
+        return _latestTimestamp;
+    }
+
+    private static TimeSpan GetElapsedTime(double timestampUnits)
+    {
+        var ticks = Math.Max(0, timestampUnits) * SecondsPerSystemTimestamp * TimeSpan.TicksPerSecond;
+        return ticks >= TimeSpan.MaxValue.Ticks
+            ? TimeSpan.MaxValue
+            : TimeSpan.FromTicks((long)ticks);
+    }
+
+    private sealed class CustomTimestampOrigin
+    {
+        public CustomTimestampOrigin(TimeProvider timeProvider, long providerTimestamp)
+        {
+            SystemTimestamp = Stopwatch.GetTimestamp();
+            ProviderTimestamp = providerTimestamp;
+            TimestampScale = Stopwatch.Frequency / (double)timeProvider.TimestampFrequency;
+        }
+
+        public long SystemTimestamp { get; }
+
+        public long ProviderTimestamp { get; }
+
+        public double TimestampScale { get; }
     }
 
     private CircuitStateChangedEvent ChangeState(CircuitState next)

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -317,9 +317,10 @@ internal sealed class CircuitBreakerCore
             return _latestTimestamp;
         }
 
+        var elapsedTimestamp = unchecked(timestamp - origin.ProviderTimestamp);
         return UpdateTimeline(
             origin.TimelineTimestamp
-            + ((double)((decimal)timestamp - origin.ProviderTimestamp) * origin.TimestampScale));
+            + (elapsedTimestamp * origin.TimestampScale));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Kevlar.Tests/CircuitBreakerTimelineTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTimelineTests.cs
@@ -3,6 +3,43 @@ namespace Kevlar.Tests;
 public class CircuitBreakerTimelineTests
 {
     [Test]
+    public async Task Newly_Observed_Provider_Advances_From_Current_Shared_Timeline()
+    {
+        var firstTime = new ManualTimeProvider(DateTimeOffset.UtcNow, 0);
+        var secondTime = new ManualTimeProvider(DateTimeOffset.UtcNow, 0);
+        var shield = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(30)).WithTimeProvider(firstTime);
+        var secondCopy = shield.WithTimeProvider(secondTime);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        firstTime.AdvanceTimestamp(TimeSpan.FromSeconds(10));
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+        await Assert.That(async () => await secondCopy.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+
+        secondTime.AdvanceTimestamp(TimeSpan.FromSeconds(20));
+        var result = await secondCopy.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Timestamp_Crossing_Signed_Boundary_Does_Not_Expire_Circuit()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow, long.MaxValue - 5);
+        var shield = Shield.CircuitBreaker(1, TimeSpan.FromTicks(10)).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        timeProvider.SetTimestamp(long.MinValue + 5);
+
+        var rejection = await Assert.That(async () =>
+                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+
+        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.FromTicks(10));
+    }
+
+    [Test]
     public async Task Far_Ahead_Utc_Epoch_Does_Not_Expire_A_Shared_Open_Circuit()
     {
         var firstTime = new ManualTimeProvider(DateTimeOffset.UnixEpoch, 0);
@@ -217,5 +254,7 @@ public class CircuitBreakerTimelineTests
             Volatile.Write(ref _advanceUtcAfterReadTicks, elapsed.Ticks);
 
         public void SetUtcNow(DateTimeOffset utcNow) => Volatile.Write(ref _utcTicks, utcNow.UtcTicks);
+
+        public void SetTimestamp(long timestamp) => Volatile.Write(ref _timestamp, timestamp);
     }
 }

--- a/tests/Kevlar.Tests/CircuitBreakerTimelineTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTimelineTests.cs
@@ -1,0 +1,221 @@
+namespace Kevlar.Tests;
+
+public class CircuitBreakerTimelineTests
+{
+    [Test]
+    public async Task Far_Ahead_Utc_Epoch_Does_Not_Expire_A_Shared_Open_Circuit()
+    {
+        var firstTime = new ManualTimeProvider(DateTimeOffset.UnixEpoch, 0);
+        var secondTime = new ManualTimeProvider(DateTimeOffset.MaxValue.AddDays(-1), long.MaxValue / 2);
+        var shield = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(30)).WithTimeProvider(firstTime);
+        var secondCopy = shield.WithTimeProvider(secondTime);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        var rejection = await Assert.That(async () =>
+                await secondCopy.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+
+        await Assert.That(rejection!.RetryAfter >= TimeSpan.Zero).IsTrue();
+        await Assert.That(rejection.RetryAfter <= TimeSpan.FromSeconds(30)).IsTrue();
+    }
+
+    [Test]
+    public async Task Far_Behind_Utc_Epoch_Does_Not_Extend_A_Shared_Open_Circuit()
+    {
+        var firstTime = new ManualTimeProvider(DateTimeOffset.MaxValue.AddDays(-1), long.MaxValue / 2);
+        var secondTime = new ManualTimeProvider(DateTimeOffset.UnixEpoch, 0);
+        var shield = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(30)).WithTimeProvider(firstTime);
+        var secondCopy = shield.WithTimeProvider(secondTime);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        var rejection = await Assert.That(async () =>
+                await secondCopy.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+
+        await Assert.That(rejection!.RetryAfter >= TimeSpan.Zero).IsTrue();
+        await Assert.That(rejection.RetryAfter <= TimeSpan.FromSeconds(30)).IsTrue();
+    }
+
+    [Test]
+    public async Task Backward_Utc_Movement_Does_Not_Extend_The_Break_Duration()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow, 0);
+        var shield = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(30)).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        timeProvider.SetUtcNow(timeProvider.GetUtcNow() - TimeSpan.FromDays(1));
+        timeProvider.AdvanceTimestamp(TimeSpan.FromSeconds(30));
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Alternating_Provider_Epochs_Does_Not_Discard_Ratio_History()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var firstTime = new ManualTimeProvider(DateTimeOffset.UnixEpoch, 0);
+        var secondTime = new ManualTimeProvider(DateTimeOffset.MaxValue.AddDays(-1), long.MaxValue / 2);
+        var shield = CreateRatioBreaker(firstTime, monitor);
+        var secondCopy = shield.WithTimeProvider(secondTime);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        }
+
+        await secondCopy.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Alternating_Provider_Epochs_Does_Not_Keep_Expired_Ratio_History()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var firstTime = new ManualTimeProvider(DateTimeOffset.UnixEpoch, 0);
+        var secondTime = new ManualTimeProvider(DateTimeOffset.MaxValue.AddDays(-1), long.MaxValue / 2);
+        var shield = CreateRatioBreaker(firstTime, monitor);
+        var secondCopy = shield.WithTimeProvider(secondTime);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        for (var i = 0; i < 3; i++)
+        {
+            await secondCopy.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        }
+
+        firstTime.AdvanceTimestamp(TimeSpan.FromSeconds(10));
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Open_Decision_Uses_One_Time_Sample_And_NonNegative_RetryAfter()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow, 0);
+        var shield = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(30)).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        var timestampReads = timeProvider.TimestampReads;
+        timeProvider.AdvanceUtcAfterNextRead(TimeSpan.FromSeconds(31));
+
+        var rejection = await Assert.That(async () =>
+                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+
+        await Assert.That(rejection!.RetryAfter >= TimeSpan.Zero).IsTrue();
+        await Assert.That(timeProvider.TimestampReads).IsEqualTo(timestampReads + 1);
+    }
+
+    [Test]
+    public async Task NonDivisible_Sampling_Window_Does_Not_Expire_A_Tick_Early()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow, 0);
+        var shield = Shield
+            .CircuitBreaker(options =>
+            {
+                options.FailureRatio = 1;
+                options.MinimumThroughput = 4;
+                options.SamplingWindow = TimeSpan.FromTicks(11);
+                options.BreakDuration = TimeSpan.FromMinutes(1);
+                options.Monitor = monitor;
+            })
+            .WithTimeProvider(timeProvider);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        }
+
+        timeProvider.AdvanceTimestamp(TimeSpan.FromTicks(10));
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Minimum_Tick_Sampling_Window_Expires_After_One_Tick()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow, 0);
+        var shield = Shield
+            .CircuitBreaker(options =>
+            {
+                options.FailureRatio = 1;
+                options.MinimumThroughput = 4;
+                options.SamplingWindow = TimeSpan.FromTicks(1);
+                options.BreakDuration = TimeSpan.FromMinutes(1);
+                options.Monitor = monitor;
+            })
+            .WithTimeProvider(timeProvider);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        }
+
+        timeProvider.AdvanceTimestamp(TimeSpan.FromTicks(1));
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    private static Shield CreateRatioBreaker(TimeProvider timeProvider, CircuitBreakerMonitor monitor) => Shield
+        .CircuitBreaker(options =>
+        {
+            options.FailureRatio = 1;
+            options.MinimumThroughput = 4;
+            options.SamplingWindow = TimeSpan.FromSeconds(10);
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+        })
+        .WithTimeProvider(timeProvider);
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+        private int _timestampReads;
+        private long _utcTicks;
+        private long _advanceUtcAfterReadTicks;
+
+        public ManualTimeProvider(DateTimeOffset utcNow, long timestamp)
+        {
+            _utcTicks = utcNow.UtcTicks;
+            _timestamp = timestamp;
+        }
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public int TimestampReads => Volatile.Read(ref _timestampReads);
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            var utcTicks = Volatile.Read(ref _utcTicks);
+            var advance = Interlocked.Exchange(ref _advanceUtcAfterReadTicks, 0);
+            if (advance != 0)
+            {
+                Interlocked.Add(ref _utcTicks, advance);
+            }
+
+            return new DateTimeOffset(utcTicks, TimeSpan.Zero);
+        }
+
+        public override long GetTimestamp()
+        {
+            Interlocked.Increment(ref _timestampReads);
+            return Volatile.Read(ref _timestamp);
+        }
+
+        public void AdvanceTimestamp(TimeSpan elapsed) => Interlocked.Add(ref _timestamp, elapsed.Ticks);
+
+        public void AdvanceUtcAfterNextRead(TimeSpan elapsed) =>
+            Volatile.Write(ref _advanceUtcAfterReadTicks, elapsed.Ticks);
+
+        public void SetUtcNow(DateTimeOffset utcNow) => Volatile.Write(ref _utcTicks, utcNow.UtcTicks);
+    }
+}

--- a/tests/Kevlar.Tests/CircuitBreakerTimelineTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTimelineTests.cs
@@ -24,7 +24,7 @@ public class CircuitBreakerTimelineTests
     }
 
     [Test]
-    public async Task Timestamp_Crossing_Signed_Boundary_Does_Not_Expire_Circuit()
+    public async Task Timestamp_Rollover_Preserves_Elapsed_Break_Duration()
     {
         var timeProvider = new ManualTimeProvider(DateTimeOffset.UtcNow, long.MaxValue - 5);
         var shield = Shield.CircuitBreaker(1, TimeSpan.FromTicks(10)).WithTimeProvider(timeProvider);
@@ -32,11 +32,9 @@ public class CircuitBreakerTimelineTests
         await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
         timeProvider.SetTimestamp(long.MinValue + 5);
 
-        var rejection = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
-            .Throws<CircuitOpenException>();
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
 
-        await Assert.That(rejection!.RetryAfter).IsEqualTo(TimeSpan.FromTicks(10));
+        await Assert.That(result).IsEqualTo(42);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- normalize circuit-breaker clocks from each TimeProvider monotonic timestamp onto one coherent elapsed timeline
- use one timestamp sample for open decisions and clamp RetryAfter to non-negative durations
- preserve exact fractional sampling buckets, including minimum-tick windows
- document shared-state behavior across WithTimeProvider copies

## Tests
- dotnet build Kevlar.slnx -c Release
- dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m (345 passed)
- dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m (16 passed)
- dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m (19 passed)
- dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m (1 passed)
- npm run build (docs)

## BenchmarkDotNet ShortRun
- Closed happy path: 106.5 ns before, 107.0 ns after; 0 B both
- Open fast-fail: 3.142 us before, 3.198 us after; 1312 B both

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circuit-breaker timing so open periods and sampling windows remain accurate when system or provider clocks move forward or backward.
  * Preserved circuit state and ratio history when multiple time providers use different UTC epochs.
  * Improved retry timing to prevent negative intervals and ensure consistent expiration behavior.

* **Documentation**
  * Added guidance for safely sharing circuit-breaker strategies across different time providers and advancing provider time correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->