### PR TITLE
fix(hedging): preserve composition cancellation

### DIFF
--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -20,6 +20,21 @@ Reading top to bottom tells you exactly what happens: the outer timeout caps the
 
 This is the classic "total timeout outside, attempt timeout inside" pattern — one chain, no nesting.
 
+## Retry, hedge, and timeout scopes
+
+Order also defines how retry and hedging multiply work:
+
+- `Retry(r).Hedge(h)` creates at most `r + 1` hedge groups, each containing at most `h`
+  attempts. A new group starts only after the previous group is exhausted.
+- `Hedge(h).Retry(r)` creates at most `h` hedge attempts, each with its own retry loop of at
+  most `r + 1` invocations.
+- The maximum in either order is `(r + 1) × h`, but a winner, unhandled exception, or caller
+  cancellation stops the outer strategy from multiplying more work.
+
+Timeout position follows the same rule. `Timeout(t).Hedge(h)` is one total budget around every
+fork. `Hedge(h).Timeout(t)` gives each fork an independent budget. Cancelling hedge losers does
+not count as their timeout and does not invoke their `OnTimeout` callback.
+
 ## Merging independent shields
 
 Use `Wrap` to put one shield around another, or `Compose` to stack several:

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -55,7 +55,7 @@ internal sealed class HedgingStrategy : Strategy
 
         if (!_judge.ShouldHandle(in outcome))
         {
-            return new ValueTask<Outcome<T>>(outcome);
+            return new ValueTask<Outcome<T>>(NormalizeCancellation(outcome, context));
         }
 
         return ExecuteCoreAsync(next, context, initial: null, launched: 1, outcome);
@@ -115,7 +115,7 @@ internal sealed class HedgingStrategy : Strategy
                         : await WhenAnyAttempt(pending).ConfigureAwait(false);
                 }
 
-                var outcome = await completed.ConfigureAwait(false);
+                var outcome = NormalizeCancellation(await completed.ConfigureAwait(false), context);
                 Remove(pending, completed);
 
                 if (!_judge.ShouldHandle(in outcome))
@@ -225,6 +225,21 @@ internal sealed class HedgingStrategy : Strategy
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
+    }
+
+    private static Outcome<T> NormalizeCancellation<T>(Outcome<T> outcome, KevlarContext context)
+    {
+        if (!context.CancellationToken.IsCancellationRequested
+            || outcome.Exception is not OperationCanceledException cancellation
+            || cancellation.CancellationToken == context.CancellationToken)
+        {
+            return outcome;
+        }
+
+        return Outcome<T>.FromException(new OperationCanceledException(
+            cancellation.Message,
+            cancellation,
+            context.CancellationToken));
     }
 
     private readonly struct HedgeAttempt<T>

--- a/tests/Kevlar.Tests/RetryHedgeTimeoutCompositionTests.cs
+++ b/tests/Kevlar.Tests/RetryHedgeTimeoutCompositionTests.cs
@@ -1,0 +1,260 @@
+namespace Kevlar.Tests;
+
+public class RetryHedgeTimeoutCompositionTests
+{
+    [Test]
+    public async Task Retry_Outside_Hedge_Starts_A_New_Group_After_Group_Exhaustion()
+    {
+        var events = new List<string>();
+        var invocations = 0;
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = _ => events.Add("retry-group");
+            })
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 3;
+                options.Delay = System.Threading.Timeout.InfiniteTimeSpan;
+                options.OnHedge = hedge => events.Add($"hedge-{hedge.Attempt}");
+            });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            events.Add($"action-{++invocations}");
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(events).IsEquivalentTo(
+            [
+                "action-1", "hedge-2", "action-2", "hedge-3", "action-3",
+                "retry-group",
+                "action-4", "hedge-2", "action-5", "hedge-3", "action-6",
+            ],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Hedge_Outside_Retry_Gives_Each_Attempt_Its_Own_Retry_Loop()
+    {
+        var events = new List<string>();
+        var invocations = 0;
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 3;
+                options.Delay = System.Threading.Timeout.InfiniteTimeSpan;
+                options.OnHedge = hedge => events.Add($"hedge-{hedge.Attempt}");
+            })
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = _ => events.Add("attempt-retry");
+            });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            events.Add($"action-{++invocations}");
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(events).IsEquivalentTo(
+            [
+                "action-1", "attempt-retry", "action-2",
+                "hedge-2", "action-3", "attempt-retry", "action-4",
+                "hedge-3", "action-5", "attempt-retry", "action-6",
+            ],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Retry_And_Hedge_Multiply_Handled_Result_Attempts()
+    {
+        var invocations = 0;
+        var shield = Shield.For<int>()
+            .WhenResult(-1)
+            .Retry(1, Backoff.None)
+            .Hedge(3, System.Threading.Timeout.InfiniteTimeSpan);
+
+        var result = await shield.ExecuteAsync(_ =>
+            new ValueTask<int>(Interlocked.Increment(ref invocations) == 6 ? 42 : -1));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(invocations).IsEqualTo(6);
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Winner_Stops_Outer_Retries_And_Loser_Retry_Loops(bool retryOutside)
+    {
+        var invocations = 0;
+        var retryEvents = 0;
+        var loserCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = CreateRetryHedge(retryOutside, () => retryEvents++);
+
+        var result = await shield.ExecuteAsync<int>(async token =>
+        {
+            if (Interlocked.Increment(ref invocations) == 2)
+            {
+                return 42;
+            }
+
+            try
+            {
+                await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+                return -1;
+            }
+            catch (OperationCanceledException)
+            {
+                loserCancelled.TrySetResult();
+                throw;
+            }
+        });
+
+        await loserCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(invocations).IsEqualTo(2);
+        await Assert.That(retryEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Unhandled_Exception_And_Caller_Cancellation_Do_Not_Multiply_Work()
+    {
+        var invocations = 0;
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .Retry(2, Backoff.None)
+            .Hedge(3, System.Threading.Timeout.InfiniteTimeSpan);
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            Interlocked.Increment(ref invocations);
+            throw new ArgumentException("unhandled");
+        })).Throws<ArgumentException>();
+        await Assert.That(invocations).IsEqualTo(1);
+
+        using var cancellation = new CancellationTokenSource();
+        invocations = 0;
+        var cancelled = await shield.ExecuteOutcomeAsync<int>(token =>
+        {
+            Interlocked.Increment(ref invocations);
+            cancellation.Cancel();
+            throw new OperationCanceledException(token);
+        }, cancellation.Token);
+
+        await Assert.That(cancelled.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)cancelled.Exception!).CancellationToken == cancellation.Token)
+            .IsTrue();
+        await Assert.That(invocations).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Total_Timeout_Outside_Hedge_Cancels_All_Forks_And_Prevents_Launches()
+    {
+        var timeProvider = new ControlledTimeProvider();
+        var attempts = new AsyncCounter("outer-timeout hedge attempts");
+        var hedgeEvents = 0;
+        var timeoutEvents = 0;
+        var shield = Shield
+            .Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeout = _ => timeoutEvents++;
+            })
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 3;
+                options.Delay = TimeSpan.FromSeconds(10);
+                options.OnHedge = _ => hedgeEvents++;
+            })
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            attempts.Signal();
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 42;
+        }).AsTask();
+
+        await attempts.WaitForAsync(1);
+        await timeProvider.WaitForTimersAsync(2);
+        timeProvider.FireTimer(0);
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<TimeoutExceededException>();
+        await Assert.That(attempts.Count).IsEqualTo(1);
+        await Assert.That(hedgeEvents).IsEqualTo(0);
+        await Assert.That(timeoutEvents).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Timeout_Inside_Hedge_Gives_Attempts_Independent_Budgets()
+    {
+        var timeProvider = new ControlledTimeProvider();
+        var attempts = new AsyncCounter("per-attempt timeout hedge attempts");
+        var secondRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutEvents = new AsyncCounter("per-attempt timeout events");
+        var attemptNumber = 0;
+        var shield = Shield
+            .When<TimeoutExceededException>()
+            .Hedge(2, TimeSpan.Zero)
+            .Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeout = _ => timeoutEvents.Signal();
+            })
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync<int>(async token =>
+        {
+            var current = Interlocked.Increment(ref attemptNumber);
+            attempts.Signal();
+            if (current == 1)
+            {
+                await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+                return -1;
+            }
+
+            await secondRelease.Task;
+            return 42;
+        }).AsTask();
+
+        await attempts.WaitForAsync(2);
+        await timeProvider.WaitForTimersAsync(2);
+        timeProvider.FireTimer(0);
+        await timeoutEvents.WaitForAsync(1);
+        secondRelease.TrySetResult();
+
+        await Assert.That(await execution.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(42);
+        await Assert.That(timeoutEvents.Count).IsEqualTo(1);
+        await Assert.That(timeProvider.IsTimerDisposed(1)).IsTrue();
+    }
+
+    private static Shield CreateRetryHedge(bool retryOutside, Action onRetry)
+    {
+        var shield = Shield.When<InvalidOperationException>();
+        return retryOutside
+            ? shield
+                .Retry(options =>
+                {
+                    options.MaxRetries = 2;
+                    options.Backoff = Backoff.None;
+                    options.OnRetry = _ => onRetry();
+                })
+                .Hedge(2, TimeSpan.Zero)
+            : shield
+                .Hedge(2, TimeSpan.Zero)
+                .Retry(options =>
+                {
+                    options.MaxRetries = 2;
+                    options.Backoff = Backoff.None;
+                    options.OnRetry = _ => onRetry();
+                });
+    }
+}


### PR DESCRIPTION
## Summary

- define exact retry × hedge attempt scopes and maximum multiplication in both strategy orders
- distinguish total timeout outside hedging from independent per-fork timeouts inside hedging
- preserve the parent cancellation token when hedge-fork cleanup would otherwise surface a disposed linked token
- document winner, unhandled failure, caller cancellation, and loser-timeout semantics

Closes #21

## Validation

- `dotnet build Kevlar.slnx -c Release --no-incremental`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (365 passed; 21 consecutive runs)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `npm --prefix docs run build`