### PR TITLE
fix(metrics): count every execution

### DIFF
--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -25,7 +25,7 @@ Log it once at startup and every incident review starts from the actual configur
 
 ## Metrics
 
-On .NET 8+ every shield publishes metrics through a `System.Diagnostics.Metrics.Meter` named `Kevlar` — zero configuration, and effectively free (a branch per event) until something listens. Subscribe with OpenTelemetry:
+On .NET 8+ every shield publishes metrics through a `System.Diagnostics.Metrics.Meter` named `Kevlar`, version `1.0` — zero configuration, and effectively free (a branch per event) until something listens. All instruments are `Counter<long>`. Subscribe with OpenTelemetry:
 
 ```csharp
 services.AddOpenTelemetry().WithMetrics(metrics => metrics.AddMeter(KevlarDiagnostics.MeterName));
@@ -33,7 +33,7 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics.AddMeter(KevlarDiagno
 
 | Instrument | Counts | Tags |
 |---|---|---|
-| `kevlar.executions` | completed executions | `shield.name`, `outcome` (`success`/`failure`) |
+| `kevlar.executions` | completed public execution calls, including empty shields and pre-cancelled calls | `shield.name`, `outcome` (`success`/`failure`) |
 | `kevlar.retries` | retry attempts | `shield.name` |
 | `kevlar.timeouts` | executions cancelled by a timeout strategy | `shield.name` |
 | `kevlar.hedges` | extra hedged attempts launched | `shield.name` |
@@ -41,7 +41,9 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics.AddMeter(KevlarDiagno
 | `kevlar.rejections` | fail-fast rejections | `shield.name`, `kind` (`circuit_open`/`rate_limit`/`concurrency_limit`) |
 | `kevlar.circuit_breaker.transitions` | circuit state changes | `from`, `to` |
 
-The `shield.name` tag appears only for shields named via `WithName` — name the shields you dashboard. On `netstandard2.0` targets the instruments are inert because the metrics API isn't in-box there.
+Each public execution call records exactly one `kevlar.executions` measurement after its final outcome: recovery through fallback is `success`; exceptions, caller cancellation, timeout, and strategy rejection are `failure`. Retry and hedge attempts do not add execution measurements of their own.
+
+The `shield.name` tag appears only for shields named via `WithName` — name the shields you dashboard. `WithName("")` emits the tag with an empty value; an unnamed shield omits it. On `netstandard2.0` targets the instruments are inert because the metrics API isn't in-box there.
 
 ## Compile-time checks
 

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -25,6 +25,12 @@ internal static class KevlarMetrics
     private static readonly Counter<long> CircuitTransitions = Meter.CreateCounter<long>("kevlar.circuit_breaker.transitions");
 #endif
 
+#if NET8_0_OR_GREATER
+    public static bool ExecutionEnabled => Executions.Enabled;
+#else
+    public static bool ExecutionEnabled => false;
+#endif
+
     public static void Execution(string? shieldName, bool success)
     {
 #if NET8_0_OR_GREATER

--- a/src/Kevlar/Internal/ShieldEngine.cs
+++ b/src/Kevlar/Internal/ShieldEngine.cs
@@ -13,13 +13,28 @@ internal static class ShieldEngine
     {
         if (cancellationToken.IsCancellationRequested)
         {
+            KevlarMetrics.Execution(shieldName, success: false);
             return Rethrow<T>(Outcome<T>.FromException(new OperationCanceledException(cancellationToken)));
         }
 
         if (head is null)
         {
-            // No strategies: skip the context and outcome machinery entirely.
-            return action(state, cancellationToken);
+            try
+            {
+                var execution = action(state, cancellationToken);
+                if (execution.IsCompletedSuccessfully)
+                {
+                    KevlarMetrics.Execution(shieldName, success: true);
+                    return execution;
+                }
+
+                return AwaitDirectAsync(execution, shieldName);
+            }
+            catch
+            {
+                KevlarMetrics.Execution(shieldName, success: false);
+                throw;
+            }
         }
 
         var context = KevlarContext.Rent(cancellationToken, isSynchronous: false, timeProvider, shieldName);
@@ -46,6 +61,7 @@ internal static class ShieldEngine
     {
         if (cancellationToken.IsCancellationRequested)
         {
+            KevlarMetrics.Execution(shieldName, success: false);
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(new OperationCanceledException(cancellationToken)));
         }
 
@@ -71,11 +87,25 @@ internal static class ShieldEngine
         Func<TState, CancellationToken, T> action,
         CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            KevlarMetrics.Execution(shieldName, success: false);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
 
         if (head is null)
         {
-            return action(state, cancellationToken);
+            try
+            {
+                var result = action(state, cancellationToken);
+                KevlarMetrics.Execution(shieldName, success: true);
+                return result;
+            }
+            catch
+            {
+                KevlarMetrics.Execution(shieldName, success: false);
+                throw;
+            }
         }
 
         var context = KevlarContext.Rent(cancellationToken, isSynchronous: true, timeProvider, shieldName);
@@ -157,6 +187,21 @@ internal static class ShieldEngine
         finally
         {
             KevlarContext.Return(context);
+        }
+    }
+
+    private static async ValueTask<T> AwaitDirectAsync<T>(ValueTask<T> execution, string? shieldName)
+    {
+        try
+        {
+            var result = await execution.ConfigureAwait(false);
+            KevlarMetrics.Execution(shieldName, success: true);
+            return result;
+        }
+        catch
+        {
+            KevlarMetrics.Execution(shieldName, success: false);
+            throw;
         }
     }
 

--- a/src/Kevlar/Internal/ShieldEngine.cs
+++ b/src/Kevlar/Internal/ShieldEngine.cs
@@ -19,6 +19,11 @@ internal static class ShieldEngine
 
         if (head is null)
         {
+            if (!KevlarMetrics.ExecutionEnabled)
+            {
+                return action(state, cancellationToken);
+            }
+
             try
             {
                 var execution = action(state, cancellationToken);

--- a/src/Kevlar/KevlarDiagnostics.cs
+++ b/src/Kevlar/KevlarDiagnostics.cs
@@ -7,9 +7,10 @@ namespace Kevlar;
 /// <c>MeterListener</c>. On <c>netstandard2.0</c> the instruments are inert.
 /// </summary>
 /// <remarks>
-/// Instruments (all counters):
+/// The meter version is <c>1.0</c>. Instruments (all <c>Counter&lt;long&gt;</c>):
 /// <list type="bullet">
-/// <item><c>kevlar.executions</c> — completed executions; tags <c>shield.name</c>, <c>outcome</c> (<c>success</c>/<c>failure</c>)</item>
+/// <item><c>kevlar.executions</c> — completed public execution calls, including empty shields and
+/// pre-cancelled calls; tags <c>shield.name</c>, <c>outcome</c> (<c>success</c>/<c>failure</c>)</item>
 /// <item><c>kevlar.retries</c> — retry attempts; tag <c>shield.name</c></item>
 /// <item><c>kevlar.timeouts</c> — executions cancelled by a timeout strategy; tag <c>shield.name</c></item>
 /// <item><c>kevlar.hedges</c> — extra hedged attempts launched; tag <c>shield.name</c></item>
@@ -17,7 +18,8 @@ namespace Kevlar;
 /// <item><c>kevlar.rejections</c> — fail-fast rejections; tags <c>shield.name</c>, <c>kind</c> (<c>circuit_open</c>/<c>rate_limit</c>/<c>concurrency_limit</c>)</item>
 /// <item><c>kevlar.circuit_breaker.transitions</c> — circuit state changes; tags <c>from</c>, <c>to</c></item>
 /// </list>
-/// The <c>shield.name</c> tag is present only for shields named via <c>WithName</c>.
+/// The <c>shield.name</c> tag is present only for shields named via <c>WithName</c>; an explicitly
+/// empty name is emitted as an empty tag value.
 /// </remarks>
 public static class KevlarDiagnostics
 {

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
 
@@ -13,6 +14,7 @@ public class MetricsTests
     private sealed class KevlarMeterListener : IDisposable
     {
         private readonly MeterListener _listener = new();
+        private readonly ConcurrentDictionary<string, Instrument> _instruments = new(StringComparer.Ordinal);
         private readonly ConcurrentBag<(string Instrument, long Value, Dictionary<string, object?> Tags)> _measurements = [];
 
         public KevlarMeterListener()
@@ -21,6 +23,7 @@ public class MetricsTests
             {
                 if (instrument.Meter.Name == KevlarDiagnostics.MeterName)
                 {
+                    _instruments[instrument.Name] = instrument;
                     listener.EnableMeasurementEvents(instrument);
                 }
             };
@@ -44,6 +47,20 @@ public class MetricsTests
                 .Where(m => tags.All(tag => m.Tags.TryGetValue(tag.Key, out var value) && Equals(value, tag.Value)))
                 .Sum(m => m.Value);
 
+        public IReadOnlyCollection<Instrument> Instruments => _instruments.Values.ToArray();
+
+        public IReadOnlyCollection<Dictionary<string, object?>> Measurements(
+            string instrument,
+            string? shieldName,
+            bool requireName = true) =>
+            _measurements
+                .Where(measurement => measurement.Instrument == instrument)
+                .Where(measurement => requireName
+                    ? measurement.Tags.TryGetValue("shield.name", out var name) && Equals(name, shieldName)
+                    : !measurement.Tags.ContainsKey("shield.name"))
+                .Select(measurement => measurement.Tags)
+                .ToArray();
+
         public void Dispose() => _listener.Dispose();
     }
 
@@ -59,6 +76,126 @@ public class MetricsTests
 
         await Assert.That(listener.Total("kevlar.executions", "metrics-executions", ("outcome", "success"))).IsEqualTo(1);
         await Assert.That(listener.Total("kevlar.executions", "metrics-executions", ("outcome", "failure"))).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Empty_Shield_Executions_Are_Counted()
+    {
+        using var listener = new KevlarMeterListener();
+        var shield = Shield.Empty.WithName("metrics-empty");
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(listener.Total("kevlar.executions", "metrics-empty", ("outcome", "success")))
+            .IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Every_Public_Execution_Shape_Is_Counted_Once()
+    {
+        using var listener = new KevlarMeterListener();
+        const string name = "metrics-shapes";
+        var untyped = Shield.Empty.WithName(name);
+        var typed = Shield<int>.Empty.WithName(name);
+        Func<CancellationToken, Task<int>> taskResult = _ => Task.FromResult(42);
+        Func<CancellationToken, Task> taskVoid = _ => Task.CompletedTask;
+
+        await untyped.ExecuteAsync(_ => new ValueTask<int>(42));
+        await untyped.ExecuteAsync(taskResult);
+        await untyped.ExecuteAsync(_ => ValueTask.CompletedTask);
+        await untyped.ExecuteAsync(taskVoid);
+        _ = await untyped.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+        _ = await untyped.ExecuteOutcomeAsync(taskResult);
+        _ = untyped.Execute(_ => 42);
+        untyped.Execute(_ => { });
+
+        await typed.ExecuteAsync(_ => new ValueTask<int>(42));
+        await typed.ExecuteAsync(taskResult);
+        _ = await typed.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+        _ = await typed.ExecuteOutcomeAsync(taskResult);
+        _ = typed.Execute(_ => 42);
+
+        await Assert.That(listener.Total("kevlar.executions", name, ("outcome", "success")))
+            .IsEqualTo(13);
+    }
+
+    [Test]
+    public async Task PreCancelled_Executions_Are_Failures_And_Skip_The_Delegate()
+    {
+        using var listener = new KevlarMeterListener();
+        using var cancellation = new CancellationTokenSource();
+        const string name = "metrics-pre-cancelled";
+        var shield = Shield.Empty.WithName(name);
+        var invoked = false;
+        cancellation.Cancel();
+
+        await Assert.That(async () => await shield.ExecuteAsync(_ =>
+        {
+            invoked = true;
+            return new ValueTask<int>(42);
+        }, cancellation.Token)).Throws<OperationCanceledException>();
+        var outcome = await shield.ExecuteOutcomeAsync(_ =>
+        {
+            invoked = true;
+            return new ValueTask<int>(42);
+        }, cancellation.Token);
+        await Assert.That(() => shield.Execute(_ =>
+        {
+            invoked = true;
+            return 42;
+        }, cancellation.Token)).Throws<OperationCanceledException>();
+
+        await Assert.That(invoked).IsFalse();
+        await Assert.That(outcome.IsSuccess).IsFalse();
+        await Assert.That(listener.Total("kevlar.executions", name, ("outcome", "failure")))
+            .IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Meter_And_Instrument_Schema_Is_Stable()
+    {
+        using var listener = new KevlarMeterListener();
+        await Shield.Empty.WithName("metrics-schema")
+            .ExecuteAsync(_ => new ValueTask<int>(42));
+
+        var expectedNames = new[]
+        {
+            "kevlar.executions",
+            "kevlar.retries",
+            "kevlar.timeouts",
+            "kevlar.hedges",
+            "kevlar.fallbacks",
+            "kevlar.rejections",
+            "kevlar.circuit_breaker.transitions",
+        };
+
+        await Assert.That(listener.Instruments.Select(instrument => instrument.Name))
+            .IsEquivalentTo(expectedNames);
+        await Assert.That(listener.Instruments.All(instrument => instrument is Counter<long>)).IsTrue();
+        await Assert.That(listener.Instruments.All(instrument => instrument.Meter.Name == "Kevlar")).IsTrue();
+        await Assert.That(listener.Instruments.All(instrument => instrument.Meter.Version == "1.0")).IsTrue();
+    }
+
+    [Test]
+    public async Task Name_And_Outcome_Tag_Schema_Is_Stable()
+    {
+        using var listener = new KevlarMeterListener();
+        var unnamed = Shield.Empty;
+        var emptyName = Shield.Empty.WithName(string.Empty);
+        var named = Shield.Empty.WithName("metrics-tags");
+
+        await unnamed.ExecuteAsync(_ => new ValueTask<int>(1));
+        await emptyName.ExecuteAsync(_ => new ValueTask<int>(2));
+        await named.ExecuteAsync(_ => new ValueTask<int>(3));
+
+        var unnamedTags = listener.Measurements("kevlar.executions", null, requireName: false);
+        var emptyTags = listener.Measurements("kevlar.executions", string.Empty).Single();
+        var namedTags = listener.Measurements("kevlar.executions", "metrics-tags").Single();
+        await Assert.That(unnamedTags.Any(tags => tags.Keys.SequenceEqual(["outcome"]))).IsTrue();
+        await Assert.That(emptyTags.Keys).IsEquivalentTo(["shield.name", "outcome"]);
+        await Assert.That(emptyTags["shield.name"]).IsEqualTo(string.Empty);
+        await Assert.That(namedTags.Keys).IsEquivalentTo(["shield.name", "outcome"]);
+        await Assert.That(namedTags["outcome"]).IsEqualTo("success");
     }
 
     [Test]
@@ -92,6 +229,8 @@ public class MetricsTests
             .Throws<TimeoutExceededException>();
 
         await Assert.That(listener.Total("kevlar.timeouts", "metrics-timeouts")).IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-timeouts", ("outcome", "failure")))
+            .IsEqualTo(1);
     }
 
     [Test]
@@ -105,6 +244,145 @@ public class MetricsTests
             .Throws<RateLimitExceededException>();
 
         await Assert.That(listener.Total("kevlar.rejections", "metrics-rate", ("kind", "rate_limit"))).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Every_Rejection_Kind_Is_Counted_Exactly_Once()
+    {
+        using var listener = new KevlarMeterListener();
+        var rateLimit = Shield.RateLimit(1, TimeSpan.FromHours(1)).WithName("metrics-reject-rate");
+        await rateLimit.ExecuteAsync(_ => new ValueTask<int>(1));
+        await Assert.That(async () => await rateLimit.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+
+        var circuit = Shield.CircuitBreaker(1, TimeSpan.FromHours(1)).WithName("metrics-reject-circuit");
+        _ = await circuit.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        await Assert.That(async () => await circuit.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var concurrency = Shield.ConcurrencyLimit(1).WithName("metrics-reject-concurrency");
+        var occupying = concurrency.ExecuteAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+            return 1;
+        }).AsTask();
+        await entered.Task;
+        try
+        {
+            await Assert.That(async () => await concurrency.ExecuteAsync(_ => new ValueTask<int>(2)))
+                .Throws<ConcurrencyLimitExceededException>();
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        _ = await occupying;
+
+        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-rate", ("kind", "rate_limit")))
+            .IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-circuit", ("kind", "circuit_open")))
+            .IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-concurrency", ("kind", "concurrency_limit")))
+            .IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-rate", ("outcome", "success")))
+            .IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-rate", ("outcome", "failure")))
+            .IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-circuit", ("outcome", "failure")))
+            .IsEqualTo(2);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-concurrency", ("outcome", "success")))
+            .IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-concurrency", ("outcome", "failure")))
+            .IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Nested_Strategies_Record_One_Execution_And_Exact_Events()
+    {
+        using var listener = new KevlarMeterListener();
+        const string name = "metrics-nested";
+        var attempts = 0;
+        var shield = Shield.For<int>()
+            .When<InvalidOperationException>()
+            .Fallback(42)
+            .Retry(2, Backoff.None)
+            .WithName(name);
+
+        var result = await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(3);
+        await Assert.That(listener.Total("kevlar.executions", name, ("outcome", "success"))).IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.retries", name)).IsEqualTo(2);
+        await Assert.That(listener.Total("kevlar.fallbacks", name)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Concurrent_Execution_Totals_Are_Exact_And_Isolated_By_Name()
+    {
+        using var listener = new KevlarMeterListener();
+        const int countPerShield = 250;
+        const string firstName = "metrics-concurrent-first";
+        const string secondName = "metrics-concurrent-second";
+        var first = Shield.Empty.WithName(firstName);
+        var second = Shield.Empty.WithName(secondName);
+
+        var executions = Enumerable.Range(0, countPerShield * 2)
+            .Select(async index =>
+            {
+                var shield = index % 2 == 0 ? first : second;
+                return await shield.ExecuteAsync(async _ =>
+                {
+                    await Task.Yield();
+                    return index;
+                });
+            });
+        _ = await Task.WhenAll(executions);
+
+        await Assert.That(listener.Total("kevlar.executions", firstName, ("outcome", "success")))
+            .IsEqualTo(countPerShield);
+        await Assert.That(listener.Total("kevlar.executions", secondName, ("outcome", "success")))
+            .IsEqualTo(countPerShield);
+    }
+
+    [Test]
+    public async Task Every_Circuit_Transition_Direction_Is_Emitted()
+    {
+        using var listener = new KevlarMeterListener();
+        var before = CircuitTransitionTotals(listener);
+
+        await EmitNaturalCircuitTransitions();
+        await EmitIsolationTransitions(CircuitState.Closed);
+        await EmitIsolationTransitions(CircuitState.Open);
+        await EmitIsolationTransitions(CircuitState.HalfOpen);
+        await EmitOpenResetTransition();
+
+        var after = CircuitTransitionTotals(listener);
+        var expectedDirections = new[]
+        {
+            (CircuitState.Closed, CircuitState.Open),
+            (CircuitState.Open, CircuitState.HalfOpen),
+            (CircuitState.HalfOpen, CircuitState.Closed),
+            (CircuitState.HalfOpen, CircuitState.Open),
+            (CircuitState.Closed, CircuitState.Isolated),
+            (CircuitState.Open, CircuitState.Isolated),
+            (CircuitState.HalfOpen, CircuitState.Isolated),
+            (CircuitState.Open, CircuitState.Closed),
+            (CircuitState.Isolated, CircuitState.Closed),
+        };
+
+        foreach (var direction in expectedDirections)
+        {
+            await Assert.That(after[direction] > before[direction]).IsTrue();
+        }
     }
 
     [Test]
@@ -161,5 +439,91 @@ public class MetricsTests
 
         await Assert.That(attempts).IsEqualTo(1);
         await Assert.That(listener.Total("kevlar.hedges", "metrics-suppressed-hedge")).IsEqualTo(0);
+    }
+
+    private static Dictionary<(CircuitState From, CircuitState To), long> CircuitTransitionTotals(
+        KevlarMeterListener listener) =>
+        (from source in Enum.GetValues<CircuitState>()
+         from target in Enum.GetValues<CircuitState>()
+         select (source, target)).ToDictionary(
+            direction => direction,
+            direction => listener.Total(
+                "kevlar.circuit_breaker.transitions",
+                null,
+                ("from", direction.source.ToString()),
+                ("to", direction.target.ToString())));
+
+    private static async Task EmitNaturalCircuitTransitions()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var shield = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(1)).WithTimeProvider(timeProvider);
+
+        _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        _ = await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+    }
+
+    private static async Task EmitIsolationTransitions(CircuitState state)
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromSeconds(1);
+            options.Monitor = monitor;
+        }).WithTimeProvider(timeProvider);
+
+        if (state is CircuitState.Open or CircuitState.HalfOpen)
+        {
+            _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        }
+
+        if (state == CircuitState.HalfOpen)
+        {
+            var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            timeProvider.Advance(TimeSpan.FromSeconds(1));
+            var probe = shield.ExecuteAsync(async _ =>
+            {
+                entered.SetResult();
+                await release.Task;
+                return 1;
+            }).AsTask();
+            await entered.Task;
+            try
+            {
+                monitor.Isolate();
+            }
+            finally
+            {
+                release.TrySetResult();
+            }
+
+            _ = await probe;
+        }
+        else
+        {
+            monitor.Isolate();
+        }
+
+        monitor.Reset();
+    }
+
+    private static async Task EmitOpenResetTransition()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+        });
+
+        _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        monitor.Reset();
     }
 }


### PR DESCRIPTION
## Summary
- emit exactly one execution counter for empty and pre-cancelled public calls
- lock the meter version, counter types, tag schema, outcomes, rejection kinds, and circuit transitions
- verify nested and high-concurrency totals remain exact and name-isolated
- document execution, naming, and recovery semantics

Closes #28

## Validation
- dotnet build Kevlar.slnx -c Release
- dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m
- npm ci (docs)
- npm run build (docs)