### PR TITLE
fix(circuit-breaker): serialize transitions

### DIFF
--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -71,7 +71,9 @@ monitor.Isolate();      // force open (maintenance switch)
 monitor.Reset();        // close and clear metrics
 ```
 
-A monitor binds to exactly **one** breaker: assign it to `CircuitBreakerOptions.Monitor` when building the shield, and keep your reference. Binding it twice throws, as does using it before binding. Both `OnStateChanged` and `monitor.StateChanged` fire for the same transition (callback first).
+A monitor binds to exactly **one** breaker: assign it to `CircuitBreakerOptions.Monitor` when building the shield, and keep your reference. Binding it twice throws, as does using it before binding.
+
+Transitions are delivered serially in state-change order, first to `OnStateChanged` and then to `monitor.StateChanged`. Callbacks run outside the circuit lock, so they can read `State` or call `Reset()` / `Isolate()`; a reentrant transition is queued behind the transition currently being delivered. If either observer throws, the other still runs and the circuit keeps its new, usable state. One callback failure is rethrown unchanged after delivery; failures from both observers are combined in an `AggregateException`.
 
 ## Share the circuit deliberately
 

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -24,6 +25,7 @@ internal sealed class CircuitBreakerCore
     private readonly double _breakDurationTimestampUnits;
     private readonly Action<CircuitStateChangedEvent>? _onStateChanged;
     private readonly CircuitBreakerMonitor? _monitor;
+    private readonly Queue<TransitionPublication> _pendingTransitions = new();
 
     private readonly long[] _bucketFailures = new long[BucketCount];
     private readonly long[] _bucketSuccesses = new long[BucketCount];
@@ -36,6 +38,8 @@ internal sealed class CircuitBreakerCore
     private int _consecutiveFailures;
     private bool _probeInFlight;
     private Exception? _lastException;
+    private bool _isPublishing;
+    private int _publishingThreadId;
 
     public CircuitBreakerCore(CircuitBreakerOptions options)
     {
@@ -85,7 +89,7 @@ internal sealed class CircuitBreakerCore
     /// </summary>
     public bool TryEnter(TimeProvider timeProvider, out CircuitOpenException? rejection)
     {
-        CircuitStateChangedEvent? transition = null;
+        TransitionPublication? transition = null;
         bool allowed;
         rejection = null;
 
@@ -138,13 +142,26 @@ internal sealed class CircuitBreakerCore
             }
         }
 
-        Publish(transition);
+        try
+        {
+            Publish(transition);
+        }
+        catch
+        {
+            if (transition?.StateChange.To == CircuitState.HalfOpen)
+            {
+                AbandonProbe();
+            }
+
+            throw;
+        }
+
         return allowed;
     }
 
     public void RecordSuccess(TimeProvider timeProvider)
     {
-        CircuitStateChangedEvent? transition = null;
+        TransitionPublication? transition = null;
 
         lock (_gate)
         {
@@ -169,7 +186,7 @@ internal sealed class CircuitBreakerCore
 
     public void RecordFailure(TimeProvider timeProvider, Exception? exception)
     {
-        CircuitStateChangedEvent? transition = null;
+        TransitionPublication? transition = null;
 
         lock (_gate)
         {
@@ -217,7 +234,7 @@ internal sealed class CircuitBreakerCore
 
     public void Isolate()
     {
-        CircuitStateChangedEvent? transition = null;
+        TransitionPublication? transition = null;
 
         lock (_gate)
         {
@@ -232,7 +249,7 @@ internal sealed class CircuitBreakerCore
 
     public void Reset()
     {
-        CircuitStateChangedEvent? transition = null;
+        TransitionPublication? transition = null;
 
         lock (_gate)
         {
@@ -361,20 +378,141 @@ internal sealed class CircuitBreakerCore
         public double TimestampScale { get; }
     }
 
-    private CircuitStateChangedEvent ChangeState(CircuitState next)
+    private TransitionPublication ChangeState(CircuitState next)
     {
         var transition = new CircuitStateChangedEvent(_state, next, _lastException);
         _state = next;
-        return transition;
+        var publication = new TransitionPublication(transition);
+        _pendingTransitions.Enqueue(publication);
+        if (!_isPublishing)
+        {
+            _isPublishing = true;
+            publication.StartsDrain = true;
+        }
+
+        return publication;
     }
 
-    private void Publish(CircuitStateChangedEvent? transition)
+    private void Publish(TransitionPublication? publication)
     {
-        if (transition is { } stateChange)
+        if (publication is null)
         {
-            KevlarMetrics.CircuitTransition(stateChange.From, stateChange.To);
+            return;
+        }
+
+        if (publication.StartsDrain)
+        {
+            var reentrantFailures = DrainPublications();
+            publication.ThrowIfFailed(reentrantFailures);
+        }
+        else if (Volatile.Read(ref _publishingThreadId) == Environment.CurrentManagedThreadId)
+        {
+            publication.IsReentrant = true;
+        }
+        else
+        {
+            publication.Completion.Task.GetAwaiter().GetResult();
+            publication.ThrowIfFailed();
+        }
+    }
+
+    private List<Exception>? DrainPublications()
+    {
+        lock (_gate)
+        {
+            Volatile.Write(ref _publishingThreadId, Environment.CurrentManagedThreadId);
+        }
+
+        List<Exception>? reentrantFailures = null;
+        while (true)
+        {
+            TransitionPublication publication;
+            lock (_gate)
+            {
+                if (_pendingTransitions.Count == 0)
+                {
+                    Volatile.Write(ref _publishingThreadId, 0);
+                    _isPublishing = false;
+                    return reentrantFailures;
+                }
+
+                publication = _pendingTransitions.Dequeue();
+            }
+
+            publication.Failure = PublishObservers(publication.StateChange);
+            if (publication.IsReentrant && publication.Failure is { } reentrantFailure)
+            {
+                (reentrantFailures ??= []).Add(reentrantFailure);
+            }
+
+            publication.Completion.TrySetResult(true);
+        }
+    }
+
+    private Exception? PublishObservers(CircuitStateChangedEvent stateChange)
+    {
+        KevlarMetrics.CircuitTransition(stateChange.From, stateChange.To);
+
+        Exception? optionFailure = null;
+        try
+        {
             _onStateChanged?.Invoke(stateChange);
+        }
+        catch (Exception exception)
+        {
+            optionFailure = exception;
+        }
+
+        try
+        {
             _monitor?.Raise(in stateChange);
+        }
+        catch (Exception monitorFailure)
+        {
+            return optionFailure is null
+                ? monitorFailure
+                : new AggregateException(optionFailure, monitorFailure);
+        }
+
+        return optionFailure;
+    }
+
+    private sealed class TransitionPublication(CircuitStateChangedEvent stateChange)
+    {
+        public CircuitStateChangedEvent StateChange { get; } = stateChange;
+
+        public TaskCompletionSource<bool> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool StartsDrain { get; set; }
+
+        public bool IsReentrant { get; set; }
+
+        public Exception? Failure { get; set; }
+
+        public void ThrowIfFailed(List<Exception>? additionalFailures = null)
+        {
+            if (additionalFailures is null or { Count: 0 })
+            {
+                if (Failure is { } failure)
+                {
+                    ExceptionDispatchInfo.Capture(failure).Throw();
+                }
+
+                return;
+            }
+
+            if (Failure is { } publicationFailure)
+            {
+                additionalFailures.Insert(0, publicationFailure);
+            }
+
+            if (additionalFailures.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(additionalFailures[0]).Throw();
+            }
+
+            throw new AggregateException(additionalFailures).Flatten();
         }
     }
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -37,6 +37,8 @@ internal sealed class CircuitBreakerCore
     private double _openUntilTimestamp;
     private int _consecutiveFailures;
     private bool _probeInFlight;
+    private long _probeGeneration;
+    private long _activeProbeGeneration;
     private Exception? _lastException;
     private bool _isPublishing;
     private int _publishingThreadId;
@@ -85,11 +87,12 @@ internal sealed class CircuitBreakerCore
     /// <summary>
     /// Gates an execution. Returns <see langword="false"/> with a rejection when the circuit
     /// refuses it; a <see langword="true"/> return during half-open marks a probe in flight,
-    /// so the caller must report back via Record* or <see cref="AbandonProbe"/>.
+    /// so the caller must report back via Record* or <see cref="AbandonProbe()"/>.
     /// </summary>
     public bool TryEnter(TimeProvider timeProvider, out CircuitOpenException? rejection)
     {
         TransitionPublication? transition = null;
+        long admittedProbeGeneration = 0;
         bool allowed;
         rejection = null;
 
@@ -113,6 +116,7 @@ internal sealed class CircuitBreakerCore
                     {
                         transition = ChangeState(CircuitState.HalfOpen);
                         _probeInFlight = true;
+                        admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
                         allowed = true;
                     }
                     else
@@ -135,6 +139,7 @@ internal sealed class CircuitBreakerCore
                     else
                     {
                         _probeInFlight = true;
+                        admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
                         allowed = true;
                     }
 
@@ -150,7 +155,7 @@ internal sealed class CircuitBreakerCore
         {
             if (transition?.StateChange.To == CircuitState.HalfOpen)
             {
-                AbandonProbe();
+                AbandonProbe(admittedProbeGeneration);
             }
 
             throw;
@@ -226,6 +231,17 @@ internal sealed class CircuitBreakerCore
         lock (_gate)
         {
             if (_state == CircuitState.HalfOpen)
+            {
+                _probeInFlight = false;
+            }
+        }
+    }
+
+    private void AbandonProbe(long probeGeneration)
+    {
+        lock (_gate)
+        {
+            if (_state == CircuitState.HalfOpen && _activeProbeGeneration == probeGeneration)
             {
                 _probeInFlight = false;
             }
@@ -424,29 +440,74 @@ internal sealed class CircuitBreakerCore
         }
 
         List<Exception>? reentrantFailures = null;
-        while (true)
+        TransitionPublication? activePublication = null;
+        Exception? drainFailure = null;
+        var completed = false;
+        try
         {
-            TransitionPublication publication;
-            lock (_gate)
+            while (true)
             {
-                if (_pendingTransitions.Count == 0)
+                lock (_gate)
+                {
+                    if (_pendingTransitions.Count == 0)
+                    {
+                        Volatile.Write(ref _publishingThreadId, 0);
+                        _isPublishing = false;
+                        completed = true;
+                        return reentrantFailures;
+                    }
+
+                    activePublication = _pendingTransitions.Dequeue();
+                }
+
+                activePublication.Failure = PublishObservers(activePublication.StateChange);
+                if (activePublication.IsReentrant && activePublication.Failure is { } reentrantFailure)
+                {
+                    (reentrantFailures ??= []).Add(reentrantFailure);
+                }
+
+                activePublication.Completion.TrySetResult(true);
+                activePublication = null;
+            }
+        }
+        catch (Exception exception)
+        {
+            drainFailure = exception;
+            throw;
+        }
+        finally
+        {
+            if (!completed)
+            {
+                lock (_gate)
                 {
                     Volatile.Write(ref _publishingThreadId, 0);
                     _isPublishing = false;
-                    return reentrantFailures;
+                    FailPublication(activePublication, drainFailure);
+                    while (_pendingTransitions.TryDequeue(out var publication))
+                    {
+                        FailPublication(publication, drainFailure);
+                    }
                 }
-
-                publication = _pendingTransitions.Dequeue();
             }
-
-            publication.Failure = PublishObservers(publication.StateChange);
-            if (publication.IsReentrant && publication.Failure is { } reentrantFailure)
-            {
-                (reentrantFailures ??= []).Add(reentrantFailure);
-            }
-
-            publication.Completion.TrySetResult(true);
         }
+    }
+
+    private static void FailPublication(TransitionPublication? publication, Exception? failure)
+    {
+        if (publication is null)
+        {
+            return;
+        }
+
+        if (failure is not null)
+        {
+            var publicationFailure = publication.Failure;
+            AddFailure(ref publicationFailure, failure);
+            publication.Failure = publicationFailure;
+        }
+
+        publication.Completion.TrySetResult(true);
     }
 
     private Exception? PublishObservers(CircuitStateChangedEvent stateChange)

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -42,6 +42,7 @@ internal sealed class CircuitBreakerCore
     private Exception? _lastException;
     private bool _isPublishing;
     private int _publishingThreadId;
+    private TransitionPublication? _activePublication;
 
     public CircuitBreakerCore(CircuitBreakerOptions options)
     {
@@ -418,12 +419,13 @@ internal sealed class CircuitBreakerCore
 
         if (publication.StartsDrain)
         {
-            var reentrantFailures = DrainPublications();
-            publication.ThrowIfFailed(reentrantFailures);
+            DrainPublications();
+            publication.ThrowIfFailed();
         }
         else if (Volatile.Read(ref _publishingThreadId) == Environment.CurrentManagedThreadId)
         {
-            publication.IsReentrant = true;
+            publication.Parent = _activePublication;
+            _activePublication!.PendingChildren++;
         }
         else
         {
@@ -432,14 +434,13 @@ internal sealed class CircuitBreakerCore
         }
     }
 
-    private List<Exception>? DrainPublications()
+    private void DrainPublications()
     {
         lock (_gate)
         {
             Volatile.Write(ref _publishingThreadId, Environment.CurrentManagedThreadId);
         }
 
-        List<Exception>? reentrantFailures = null;
         TransitionPublication? activePublication = null;
         Exception? drainFailure = null;
         var completed = false;
@@ -454,19 +455,17 @@ internal sealed class CircuitBreakerCore
                         Volatile.Write(ref _publishingThreadId, 0);
                         _isPublishing = false;
                         completed = true;
-                        return reentrantFailures;
+                        return;
                     }
 
                     activePublication = _pendingTransitions.Dequeue();
                 }
 
+                _activePublication = activePublication;
                 activePublication.Failure = PublishObservers(activePublication.StateChange);
-                if (activePublication.IsReentrant && activePublication.Failure is { } reentrantFailure)
-                {
-                    (reentrantFailures ??= []).Add(reentrantFailure);
-                }
-
-                activePublication.Completion.TrySetResult(true);
+                _activePublication = null;
+                activePublication.ObserversCompleted = true;
+                CompletePublication(activePublication);
                 activePublication = null;
             }
         }
@@ -481,6 +480,7 @@ internal sealed class CircuitBreakerCore
             {
                 lock (_gate)
                 {
+                    _activePublication = null;
                     Volatile.Write(ref _publishingThreadId, 0);
                     _isPublishing = false;
                     FailPublication(activePublication, drainFailure);
@@ -491,6 +491,30 @@ internal sealed class CircuitBreakerCore
                 }
             }
         }
+    }
+
+    private static void CompletePublication(TransitionPublication publication)
+    {
+        if (!publication.ObserversCompleted || publication.PendingChildren != 0)
+        {
+            return;
+        }
+
+        publication.Completion.TrySetResult(true);
+        if (publication.Parent is not { } parent)
+        {
+            return;
+        }
+
+        if (publication.Failure is { } failure)
+        {
+            var parentFailure = parent.Failure;
+            AddFailure(ref parentFailure, failure);
+            parent.Failure = parentFailure;
+        }
+
+        parent.PendingChildren--;
+        CompletePublication(parent);
     }
 
     private static void FailPublication(TransitionPublication? publication, Exception? failure)
@@ -507,7 +531,8 @@ internal sealed class CircuitBreakerCore
             publication.Failure = publicationFailure;
         }
 
-        publication.Completion.TrySetResult(true);
+        publication.ObserversCompleted = true;
+        CompletePublication(publication);
     }
 
     private Exception? PublishObservers(CircuitStateChangedEvent stateChange)
@@ -562,33 +587,20 @@ internal sealed class CircuitBreakerCore
 
         public bool StartsDrain { get; set; }
 
-        public bool IsReentrant { get; set; }
+        public TransitionPublication? Parent { get; set; }
+
+        public int PendingChildren { get; set; }
+
+        public bool ObserversCompleted { get; set; }
 
         public Exception? Failure { get; set; }
 
-        public void ThrowIfFailed(List<Exception>? additionalFailures = null)
+        public void ThrowIfFailed()
         {
-            if (additionalFailures is null or { Count: 0 })
+            if (Failure is { } failure)
             {
-                if (Failure is { } failure)
-                {
-                    ExceptionDispatchInfo.Capture(failure).Throw();
-                }
-
-                return;
+                ExceptionDispatchInfo.Capture(failure).Throw();
             }
-
-            if (Failure is { } publicationFailure)
-            {
-                additionalFailures.Insert(0, publicationFailure);
-            }
-
-            if (additionalFailures.Count == 1)
-            {
-                ExceptionDispatchInfo.Capture(additionalFailures[0]).Throw();
-            }
-
-            throw new AggregateException(additionalFailures).Flatten();
         }
     }
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -451,16 +451,23 @@ internal sealed class CircuitBreakerCore
 
     private Exception? PublishObservers(CircuitStateChangedEvent stateChange)
     {
-        KevlarMetrics.CircuitTransition(stateChange.From, stateChange.To);
+        Exception? failure = null;
+        try
+        {
+            KevlarMetrics.CircuitTransition(stateChange.From, stateChange.To);
+        }
+        catch (Exception exception)
+        {
+            AddFailure(ref failure, exception);
+        }
 
-        Exception? optionFailure = null;
         try
         {
             _onStateChanged?.Invoke(stateChange);
         }
         catch (Exception exception)
         {
-            optionFailure = exception;
+            AddFailure(ref failure, exception);
         }
 
         try
@@ -469,12 +476,20 @@ internal sealed class CircuitBreakerCore
         }
         catch (Exception monitorFailure)
         {
-            return optionFailure is null
-                ? monitorFailure
-                : new AggregateException(optionFailure, monitorFailure);
+            AddFailure(ref failure, monitorFailure);
         }
 
-        return optionFailure;
+        return failure;
+    }
+
+    private static void AddFailure(ref Exception? failure, Exception next)
+    {
+        failure = failure switch
+        {
+            null => next,
+            AggregateException aggregate => new AggregateException([.. aggregate.InnerExceptions, next]),
+            _ => new AggregateException(failure, next),
+        };
     }
 
     private sealed class TransitionPublication(CircuitStateChangedEvent stateChange)

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -13,7 +13,12 @@ public sealed class CircuitBreakerMonitor
     /// <summary>The current state of the bound circuit.</summary>
     public CircuitState State => BoundCore().State;
 
-    /// <summary>Raised on every state transition of the bound circuit.</summary>
+    /// <summary>
+    /// Raised on every state transition of the bound circuit, after
+    /// <see cref="CircuitBreakerOptions.OnStateChanged"/>. Transitions are delivered serially
+    /// outside the circuit lock, so handlers may read state or call <see cref="Reset"/> or
+    /// <see cref="Isolate"/> without deadlocking.
+    /// </summary>
     public event Action<CircuitStateChangedEvent>? StateChanged;
 
     /// <summary>Forces the circuit open. Executions are rejected until <see cref="Reset"/> is called.</summary>

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -17,7 +17,9 @@ public sealed class CircuitBreakerMonitor
     /// Raised on every state transition of the bound circuit, after
     /// <see cref="CircuitBreakerOptions.OnStateChanged"/>. Transitions are delivered serially
     /// outside the circuit lock, so handlers may read state or call <see cref="Reset"/> or
-    /// <see cref="Isolate"/> without deadlocking.
+    /// <see cref="Isolate"/> without deadlocking. Handlers run synchronously and block later
+    /// transition publishers, so they should not perform I/O, wait on external work, or otherwise
+    /// run for a long time.
     /// </summary>
     public event Action<CircuitStateChangedEvent>? StateChanged;
 

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -33,6 +33,10 @@ public sealed class CircuitBreakerOptions
     /// </summary>
     public CircuitBreakerMonitor? Monitor { get; set; }
 
-    /// <summary>Invoked on every state transition.</summary>
+    /// <summary>
+    /// Invoked on every state transition, before <see cref="CircuitBreakerMonitor.StateChanged"/>.
+    /// Transitions are delivered serially outside the circuit lock. Exceptions propagate after
+    /// the monitor observer is invoked; failures from both observers are aggregated.
+    /// </summary>
     public Action<CircuitStateChangedEvent>? OnStateChanged { get; set; }
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -36,7 +36,9 @@ public sealed class CircuitBreakerOptions
     /// <summary>
     /// Invoked on every state transition, before <see cref="CircuitBreakerMonitor.StateChanged"/>.
     /// Transitions are delivered serially outside the circuit lock. Exceptions propagate after
-    /// the monitor observer is invoked; failures from both observers are aggregated.
+    /// the monitor observer is invoked; failures from both observers are aggregated. The handler
+    /// runs synchronously and blocks later transition publishers, so it should not perform I/O,
+    /// wait on external work, or otherwise run for a long time.
     /// </summary>
     public Action<CircuitStateChangedEvent>? OnStateChanged { get; set; }
 }

--- a/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
@@ -178,7 +178,7 @@ public class CircuitBreakerTransitionOrderingTests
             {
                 foreach (var tag in tags)
                 {
-                    if (tag is { Key: "to", Value: "Isolated" })
+                    if (tag is { Key: "kevlar.circuit_breaker.state.to", Value: "isolated" })
                     {
                         throw metricsFailure;
                     }

--- a/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
@@ -149,6 +150,50 @@ public class CircuitBreakerTransitionOrderingTests
         await Assert.That(ReferenceEquals(thrown.InnerExceptions[0], optionFailure)).IsTrue();
         await Assert.That(ReferenceEquals(thrown.InnerExceptions[1], monitorFailure)).IsTrue();
         await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Throwing_Metrics_Listener_Does_Not_Stall_Later_Transitions()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var metricsFailure = new InvalidOperationException("metrics callback");
+        var observed = new List<CircuitState>();
+        _ = Shield.CircuitBreaker(options =>
+        {
+            options.Monitor = monitor;
+            options.OnStateChanged = change => observed.Add(change.To);
+        });
+
+        using (var listener = new MeterListener())
+        {
+            listener.InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument is Counter<long> { Name: "kevlar.circuit_breaker.transitions" })
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+            {
+                foreach (var tag in tags)
+                {
+                    if (tag is { Key: "to", Value: "Isolated" })
+                    {
+                        throw metricsFailure;
+                    }
+                }
+            });
+            listener.Start();
+
+            var thrown = await Assert.That(() => monitor.Isolate()).Throws<InvalidOperationException>();
+            await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
+        }
+
+        await Task.Run(monitor.Reset).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(observed.SequenceEqual([CircuitState.Isolated, CircuitState.Closed])).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
@@ -1,0 +1,264 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class CircuitBreakerTransitionOrderingTests
+{
+    [Test]
+    public async Task Concurrent_Control_Publishes_One_Ordered_NonConcurrent_Stream()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var optionTransitions = new ConcurrentQueue<(CircuitState From, CircuitState To)>();
+        var monitorTransitions = new ConcurrentQueue<(CircuitState From, CircuitState To)>();
+        var openingEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOpening = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackGate = new object();
+        var activeCallbacks = 0;
+        var maximumConcurrentCallbacks = 0;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = change =>
+            {
+                var active = Interlocked.Increment(ref activeCallbacks);
+                lock (callbackGate)
+                {
+                    maximumConcurrentCallbacks = Math.Max(maximumConcurrentCallbacks, active);
+                }
+
+                try
+                {
+                    optionTransitions.Enqueue((change.From, change.To));
+                    if (change is { From: CircuitState.Closed, To: CircuitState.Open })
+                    {
+                        openingEntered.TrySetResult();
+                        releaseOpening.Task.GetAwaiter().GetResult();
+                    }
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref activeCallbacks);
+                }
+            };
+        });
+        monitor.StateChanged += change => monitorTransitions.Enqueue((change.From, change.To));
+
+        var opening = Task.Run(async () =>
+            await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException()));
+        await openingEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var reset = Task.Run(monitor.Reset);
+        await WaitForStateAsync(monitor, CircuitState.Closed);
+        var isolate = Task.Run(monitor.Isolate);
+        await WaitForStateAsync(monitor, CircuitState.Isolated);
+
+        releaseOpening.TrySetResult();
+        await Task.WhenAll(opening, reset, isolate).WaitAsync(TimeSpan.FromSeconds(5));
+
+        (CircuitState From, CircuitState To)[] expected =
+        [
+            (CircuitState.Closed, CircuitState.Open),
+            (CircuitState.Open, CircuitState.Closed),
+            (CircuitState.Closed, CircuitState.Isolated),
+        ];
+        await Assert.That(optionTransitions.SequenceEqual(expected)).IsTrue();
+        await Assert.That(monitorTransitions.SequenceEqual(expected)).IsTrue();
+        await Assert.That(maximumConcurrentCallbacks).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Throwing_Option_Callback_Does_Not_Skip_Monitor_Observer()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var callbackFailure = new InvalidOperationException("option callback");
+        CircuitStateChangedEvent? observed = null;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = _ => throw callbackFailure;
+        });
+        monitor.StateChanged += change => observed = change;
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException("operation")))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(thrown, callbackFailure)).IsTrue();
+        await Assert.That(observed?.To).IsEqualTo(CircuitState.Open);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Throwing_Monitor_Observer_Leaves_The_Circuit_Usable()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var monitorFailure = new InvalidOperationException("monitor callback");
+        var optionObserved = false;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = change => optionObserved |= change.To == CircuitState.Open;
+        });
+        monitor.StateChanged += change =>
+        {
+            if (change.To == CircuitState.Open)
+            {
+                throw monitorFailure;
+            }
+        };
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException("operation")))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(thrown, monitorFailure)).IsTrue();
+        await Assert.That(optionObserved).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+
+        monitor.Reset();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Failures_From_Both_Observers_Are_Aggregated()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var optionFailure = new InvalidOperationException("option callback");
+        var monitorFailure = new InvalidOperationException("monitor callback");
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = _ => throw optionFailure;
+        });
+        monitor.StateChanged += _ => throw monitorFailure;
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException("operation")))
+            .Throws<AggregateException>();
+
+        await Assert.That(thrown!.InnerExceptions.Count).IsEqualTo(2);
+        await Assert.That(ReferenceEquals(thrown.InnerExceptions[0], optionFailure)).IsTrue();
+        await Assert.That(ReferenceEquals(thrown.InnerExceptions[1], monitorFailure)).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task HalfOpen_Observer_Failure_Releases_The_Probe_Slot()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var callbackFailure = new InvalidOperationException("half-open callback");
+        var failHalfOpenCallback = true;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromSeconds(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = change =>
+            {
+                if (change.To == CircuitState.HalfOpen && failHalfOpenCallback)
+                {
+                    failHalfOpenCallback = false;
+                    throw callbackFailure;
+                }
+            };
+        }).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("operation"));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(ReferenceEquals(thrown, callbackFailure)).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Reentrant_Control_Is_Queued_After_The_Current_Transition()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var optionTransitions = new List<(CircuitState From, CircuitState To)>();
+        var monitorTransitions = new List<(CircuitState From, CircuitState To)>();
+        var statesReadFromCallback = new List<CircuitState>();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = change =>
+            {
+                optionTransitions.Add((change.From, change.To));
+                statesReadFromCallback.Add(monitor.State);
+                if (change.To == CircuitState.Open)
+                {
+                    monitor.Reset();
+                }
+            };
+        });
+        monitor.StateChanged += change => monitorTransitions.Add((change.From, change.To));
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        (CircuitState From, CircuitState To)[] expected =
+        [
+            (CircuitState.Closed, CircuitState.Open),
+            (CircuitState.Open, CircuitState.Closed),
+        ];
+        await Assert.That(optionTransitions.SequenceEqual(expected)).IsTrue();
+        await Assert.That(monitorTransitions.SequenceEqual(expected)).IsTrue();
+        await Assert.That(statesReadFromCallback.SequenceEqual(
+            [CircuitState.Open, CircuitState.Closed])).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Repeated_Failure_Storms_Produce_One_Opening_Transition()
+    {
+        for (var iteration = 0; iteration < 25; iteration++)
+        {
+            var openingTransitions = 0;
+            var shield = Shield.CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 3;
+                options.BreakDuration = TimeSpan.FromMinutes(1);
+                options.OnStateChanged = change =>
+                {
+                    if (change.To == CircuitState.Open)
+                    {
+                        Interlocked.Increment(ref openingTransitions);
+                    }
+                };
+            });
+
+            await Task.WhenAll(Enumerable.Range(0, 32).Select(_ =>
+                shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException()).AsTask()));
+
+            await Assert.That(openingTransitions).IsEqualTo(1);
+        }
+    }
+
+    private static async Task WaitForStateAsync(CircuitBreakerMonitor monitor, CircuitState expected)
+    {
+        var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (monitor.State != expected && DateTime.UtcNow < timeout)
+        {
+            await Task.Yield();
+        }
+
+        await Assert.That(monitor.State).IsEqualTo(expected);
+    }
+}

--- a/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
@@ -324,6 +324,53 @@ public class CircuitBreakerTransitionOrderingTests
     }
 
     [Test]
+    public async Task Reentrant_Failure_Is_Attributed_To_Its_Concurrent_Parent()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var nestedFailure = new InvalidOperationException("nested observer");
+        var firstObserverEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstObserver = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blockFirstIsolation = true;
+        _ = Shield.CircuitBreaker(options =>
+        {
+            options.Monitor = monitor;
+            options.OnStateChanged = change =>
+            {
+                if (change is { From: CircuitState.Closed, To: CircuitState.Isolated })
+                {
+                    if (blockFirstIsolation)
+                    {
+                        blockFirstIsolation = false;
+                        firstObserverEntered.TrySetResult();
+                        releaseFirstObserver.Task.GetAwaiter().GetResult();
+                        return;
+                    }
+
+                    throw nestedFailure;
+                }
+
+                if (change.To == CircuitState.Closed)
+                {
+                    monitor.Isolate();
+                }
+            };
+        });
+
+        var first = Task.Run(monitor.Isolate);
+        await firstObserverEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var second = Task.Run(monitor.Reset);
+        await WaitForStateAsync(monitor, CircuitState.Closed);
+
+        releaseFirstObserver.TrySetResult();
+        await first.WaitAsync(TimeSpan.FromSeconds(5));
+        var thrown = await Assert.That(async () => await second.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(thrown, nestedFailure)).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Isolated);
+    }
+
+    [Test]
     public async Task Repeated_Failure_Storms_Produce_One_Opening_Transition()
     {
         for (var iteration = 0; iteration < 25; iteration++)

--- a/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
@@ -233,6 +233,59 @@ public class CircuitBreakerTransitionOrderingTests
     }
 
     [Test]
+    public async Task HalfOpen_Observer_Failure_Does_Not_Release_A_Newer_Probe()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var callbackFailure = new InvalidOperationException("half-open callback");
+        var releaseNewProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<int>? newProbe = null;
+        var arrangeReentrantProbe = true;
+        Shield? shield = null;
+        shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromSeconds(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = change =>
+            {
+                if (change.To != CircuitState.HalfOpen || !arrangeReentrantProbe)
+                {
+                    return;
+                }
+
+                arrangeReentrantProbe = false;
+                monitor.Reset();
+                shield!.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("reopen"))
+                    .AsTask().GetAwaiter().GetResult();
+                timeProvider.Advance(TimeSpan.FromSeconds(1));
+                newProbe = shield.ExecuteAsync(async _ =>
+                {
+                    await releaseNewProbe.Task;
+                    return 42;
+                }).AsTask();
+                throw callbackFailure;
+            };
+        }).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("open"));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(ReferenceEquals(thrown, callbackFailure)).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+
+        var rejected = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(2));
+        await Assert.That(rejected.Exception).IsTypeOf<CircuitOpenException>();
+
+        releaseNewProbe.TrySetResult();
+        await Assert.That(await newProbe!).IsEqualTo(42);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
     public async Task Reentrant_Control_Is_Queued_After_The_Current_Transition()
     {
         var monitor = new CircuitBreakerMonitor();


### PR DESCRIPTION
## Summary
- serialize circuit-breaker transition publication in mutation order without invoking observers under the core lock
- preserve both option and monitor observer delivery, aggregate dual failures, and keep reentrant control calls deadlock-free
- release failed half-open probe admission and document observer ordering/failure semantics
- add deterministic concurrent, failure, reentrancy, and repeated-storm regressions

Closes #24

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (433 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `npm run build` (docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circuit-breaker transition handling during concurrent failures and recoveries.
  * Ensured transitions are delivered in order and safely support reentrant callbacks.
  * Preserved circuit usability when monitoring or state-change callbacks fail.
  * Improved exception reporting when multiple callbacks fail.

* **Documentation**
  * Clarified callback timing, serialization, locking behavior, and exception propagation for circuit-breaker state changes.

* **Tests**
  * Added coverage for transition ordering, callback failures, recovery scenarios, reentrant controls, and duplicate transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->