### PR TITLE
test(perf): enforce allocation budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,10 @@ jobs:
           retention-days: 14
 
   # Only reachable from a manual run with the "Upload package to NuGet"
-  # checkbox ticked, and only after both OS legs are green.
+  # checkbox ticked, and only after tests, coverage, and allocation gates are green.
   publish:
     name: Publish NuGet
-    needs: [build-and-test, coverage]
+    needs: [allocation-gates, build-and-test, coverage]
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nuget == true
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,14 @@ jobs:
     name: Allocation gates (.NET 10, Ubuntu)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0  # Required for GitVersion
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,26 @@ on:
         default: false
 
 jobs:
+  allocation-gates:
+    name: Allocation gates (.NET 10, Ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0  # Required for GitVersion
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run allocation gates
+        run: >-
+          dotnet run --project tests/Kevlar.AllocationTests -c Release --
+          --timeout 5m --minimum-expected-tests 2 --zero-tests-policy strict
+
   build-and-test:
     strategy:
       fail-fast: false

--- a/Kevlar.slnx
+++ b/Kevlar.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/Kevlar.Analyzers/Kevlar.Analyzers.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Kevlar.AllocationTests/Kevlar.AllocationTests.csproj" />
     <Project Path="tests/Kevlar.IntegrationTests/Kevlar.IntegrationTests.csproj" />
     <Project Path="tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj" />
     <Project Path="tests/Kevlar.Tests/Kevlar.Tests.csproj" />

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -23,3 +23,15 @@ dotnet run -c Release --project benchmarks/Kevlar.Benchmarks -- --filter '*'
 ```
 
 As always with microbenchmarks: measure your own workload before optimizing around these numbers. The differences matter in tight loops and high-throughput services; they don't matter around a 50ms network call.
+
+## Allocation regression gates
+
+BenchmarkDotNet remains the trend and comparison tool. Pull requests also run a smaller deterministic allocation suite on Ubuntu with .NET 10. Each scenario is warmed up before measurement, then sampled five times over 10,000 operations with `GC.GetAllocatedBytesForCurrentThread()` so JIT, static initialization, pool seeding, test-runner work, and allocations on unrelated threads stay outside the per-operation count.
+
+Documented synchronous-completion hot paths have a strict `0 B/op` budget. Paths that inherently create failures or parallel hedge attempts have explicit bounded budgets; those gates catch meaningful recurring regressions without pretending the failure path can be allocation-free. The allocation project is intentionally separate from coverage collection, which instruments assemblies and would contaminate the counts.
+
+Run the same gates locally with:
+
+```bash
+dotnet run -c Release --project tests/Kevlar.AllocationTests -- --timeout 5m
+```

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -26,7 +26,7 @@ As always with microbenchmarks: measure your own workload before optimizing arou
 
 ## Allocation regression gates
 
-BenchmarkDotNet remains the trend and comparison tool. Pull requests also run a smaller deterministic allocation suite on Ubuntu with .NET 10. Each scenario is warmed up before measurement, then sampled five times over 10,000 operations with `GC.GetAllocatedBytesForCurrentThread()` so JIT, static initialization, pool seeding, test-runner work, and allocations on unrelated threads stay outside the per-operation count.
+BenchmarkDotNet remains the trend and comparison tool. Pull requests also run a smaller deterministic allocation suite on Ubuntu with .NET 10. Each scenario is warmed up before measurement, then sampled five times over 10,000 operations. Synchronous-completion paths use `GC.GetAllocatedBytesForCurrentThread()` so test-runner work and unrelated threads stay outside the count. The parallel-hedge path waits for every canceled loser and uses `GC.GetTotalAllocatedBytes(precise: true)` so its asynchronous continuation and cleanup allocations are included regardless of which thread runs them.
 
 Documented synchronous-completion hot paths have a strict `0 B/op` budget. Paths that inherently create failures or parallel hedge attempts have explicit bounded budgets; those gates catch meaningful recurring regressions without pretending the failure path can be allocation-free. The allocation project is intentionally separate from coverage collection, which instruments assemblies and would contaminate the counts.
 

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -1,5 +1,6 @@
 namespace Kevlar.AllocationTests;
 
+/// <summary>Guards documented allocation budgets for representative shield execution paths.</summary>
 [NotInParallel]
 public class AllocationBudgetTests
 {
@@ -39,6 +40,7 @@ public class AllocationBudgetTests
     private readonly Counter _retryCounter = new();
     private readonly ParallelHedgeState _parallelHedgeState = new();
 
+    /// <summary>Verifies that documented synchronous-completion hot paths allocate no managed memory.</summary>
     [Test]
     public void Documented_Hot_Paths_Allocate_Zero_Bytes_Per_Operation()
     {
@@ -69,6 +71,7 @@ public class AllocationBudgetTests
             test._primaryWinsHedge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
     }
 
+    /// <summary>Verifies bounded allocations for failure and parallel execution paths.</summary>
     [Test]
     public void Allocating_Paths_Stay_Within_Per_Operation_Budgets()
     {
@@ -96,11 +99,14 @@ public class AllocationBudgetTests
             {
             }
         });
-        AssertBudget("hedge launches second attempt", 2_048, this, static test =>
+        AssertBudget("hedge launches second attempt", 3_072, this, static test =>
+        {
             test._parallelHedge.ExecuteAsync(
                 test._parallelHedgeState,
                 static (state, cancellationToken) => state.ExecuteAsync(cancellationToken))
-            .GetAwaiter().GetResult());
+                .GetAwaiter().GetResult();
+            test._parallelHedgeState.WaitForLoserCompletion();
+        }, AllocationScope.AllThreads);
     }
 
     private static void AssertZero<TState>(string scenario, TState state, Action<TState> operation) =>
@@ -110,7 +116,8 @@ public class AllocationBudgetTests
         string scenario,
         long maximumBytesPerOperation,
         TState state,
-        Action<TState> operation)
+        Action<TState> operation,
+        AllocationScope scope = AllocationScope.CurrentThread)
     {
         for (var operationIndex = 0; operationIndex < WarmupOperations; operationIndex++)
         {
@@ -120,13 +127,13 @@ public class AllocationBudgetTests
         var maximumObserved = 0L;
         for (var sample = 0; sample < Samples; sample++)
         {
-            var before = GC.GetAllocatedBytesForCurrentThread();
+            var before = GetAllocatedBytes(scope);
             for (var operationIndex = 0; operationIndex < MeasuredOperations; operationIndex++)
             {
                 operation(state);
             }
 
-            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            var allocated = GetAllocatedBytes(scope) - before;
             maximumObserved = Math.Max(maximumObserved, allocated);
         }
 
@@ -150,6 +157,7 @@ public class AllocationBudgetTests
 
     private sealed class ParallelHedgeState
     {
+        private readonly SemaphoreSlim _loserCompleted = new(initialCount: 0, maxCount: 1);
         private int _attempt;
 
         public ValueTask<int> ExecuteAsync(CancellationToken cancellationToken) =>
@@ -157,10 +165,36 @@ public class AllocationBudgetTests
                 ? new ValueTask<int>(42)
                 : WaitForCancellationAsync(cancellationToken);
 
-        private static async ValueTask<int> WaitForCancellationAsync(CancellationToken cancellationToken)
+        public void WaitForLoserCompletion()
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-            return 0;
+            if (!_loserCompleted.Wait(TimeSpan.FromSeconds(5)))
+            {
+                throw new TimeoutException("The canceled hedge attempt did not complete.");
+            }
         }
+
+        private async ValueTask<int> WaitForCancellationAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 0;
+            }
+            finally
+            {
+                _loserCompleted.Release();
+            }
+        }
+    }
+
+    private static long GetAllocatedBytes(AllocationScope scope) =>
+        scope == AllocationScope.AllThreads
+            ? GC.GetTotalAllocatedBytes(precise: true)
+            : GC.GetAllocatedBytesForCurrentThread();
+
+    private enum AllocationScope
+    {
+        CurrentThread,
+        AllThreads,
     }
 }

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -37,7 +37,7 @@ public class AllocationBudgetTests
         .Fallback(7);
     private readonly Shield _parallelHedge = Shield.Hedge(2, TimeSpan.Zero);
     private readonly Counter _retryCounter = new();
-    private readonly Counter _hedgeCounter = new();
+    private readonly ParallelHedgeState _parallelHedgeState = new();
 
     [Test]
     public void Documented_Hot_Paths_Allocate_Zero_Bytes_Per_Operation()
@@ -97,15 +97,10 @@ public class AllocationBudgetTests
             }
         });
         AssertBudget("hedge launches second attempt", 2_048, this, static test =>
-            test._parallelHedge.ExecuteAsync(test._hedgeCounter, static (counter, _) =>
-            {
-                if (++counter.Value % 2 != 0)
-                {
-                    throw RecoverableFailure;
-                }
-
-                return new ValueTask<int>(42);
-            }).GetAwaiter().GetResult());
+            test._parallelHedge.ExecuteAsync(
+                test._parallelHedgeState,
+                static (state, cancellationToken) => state.ExecuteAsync(cancellationToken))
+            .GetAwaiter().GetResult());
     }
 
     private static void AssertZero<TState>(string scenario, TState state, Action<TState> operation) =>
@@ -151,5 +146,21 @@ public class AllocationBudgetTests
     private sealed class Counter
     {
         public int Value;
+    }
+
+    private sealed class ParallelHedgeState
+    {
+        private int _attempt;
+
+        public ValueTask<int> ExecuteAsync(CancellationToken cancellationToken) =>
+            ++_attempt % 2 == 0
+                ? new ValueTask<int>(42)
+                : WaitForCancellationAsync(cancellationToken);
+
+        private static async ValueTask<int> WaitForCancellationAsync(CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
     }
 }

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -1,0 +1,155 @@
+namespace Kevlar.AllocationTests;
+
+[NotInParallel]
+public class AllocationBudgetTests
+{
+    private const int WarmupOperations = 10_000;
+    private const int MeasuredOperations = 10_000;
+    private const int Samples = 5;
+
+    private static readonly InvalidOperationException RecoverableFailure = new("recoverable");
+
+    private readonly Shield _empty = Shield.Empty;
+    private readonly Shield _retry = Shield.Retry(3, Backoff.None);
+    private readonly Shield _breaker = Shield.CircuitBreaker(5, TimeSpan.FromMinutes(1));
+    private readonly Shield _timeout = Shield.Timeout(TimeSpan.FromMinutes(1));
+    private readonly Shield<int> _fallback = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .Fallback(7);
+    private readonly Shield _rateLimit = Shield.RateLimit(1_000_000_000, TimeSpan.FromSeconds(1));
+    private readonly Shield _concurrencyLimit = Shield.ConcurrencyLimit(1024);
+    private readonly Shield<int> _typedJudge = Shield.For<int>()
+        .WhenResult(-1)
+        .Retry(3, Backoff.None);
+    private readonly Shield _composed = Shield
+        .RateLimit(1_000_000_000, TimeSpan.FromSeconds(1))
+        .Timeout(TimeSpan.FromMinutes(1))
+        .Retry(3, Backoff.None)
+        .CircuitBreaker(5, TimeSpan.FromMinutes(1))
+        .ConcurrencyLimit(1024);
+    private readonly Shield<int> _primaryWinsHedge = Shield.For<int>()
+        .Hedge(2, TimeSpan.FromMinutes(1));
+
+    private readonly Shield _recoveryRetry = Shield.Retry(3, Backoff.None);
+    private readonly Shield _openBreaker = Shield.CircuitBreaker(1, TimeSpan.FromDays(1));
+    private readonly Shield<int> _triggeredFallback = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .Fallback(7);
+    private readonly Shield _parallelHedge = Shield.Hedge(2, TimeSpan.Zero);
+    private readonly Counter _retryCounter = new();
+    private readonly Counter _hedgeCounter = new();
+
+    [Test]
+    public void Documented_Hot_Paths_Allocate_Zero_Bytes_Per_Operation()
+    {
+        AssertZero("empty sync", this, static test => test._empty.Execute(static _ => 42));
+        AssertZero("empty async", this, static test =>
+            test._empty.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("empty async state", this, static test =>
+            test._empty.ExecuteAsync(42, static (state, _) => new ValueTask<int>(state)).GetAwaiter().GetResult());
+        AssertZero("retry sync happy path", this, static test =>
+            test._retry.Execute(static _ => 42));
+        AssertZero("retry async happy path", this, static test =>
+            test._retry.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("circuit closed", this, static test =>
+            test._breaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("timeout happy path", this, static test =>
+            test._timeout.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("fallback pass-through", this, static test =>
+            test._fallback.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("rate limit uncontended", this, static test =>
+            test._rateLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("concurrency limit uncontended", this, static test =>
+            test._concurrencyLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("typed result judging", this, static test =>
+            test._typedJudge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("composed pipeline", this, static test =>
+            test._composed.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("hedge primary wins", this, static test =>
+            test._primaryWinsHedge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+    }
+
+    [Test]
+    public void Allocating_Paths_Stay_Within_Per_Operation_Budgets()
+    {
+        _openBreaker.ExecuteOutcomeAsync<int>(static _ => throw RecoverableFailure).GetAwaiter().GetResult();
+
+        AssertBudget("retry recovers after two failures", 512, this, static test =>
+            test._recoveryRetry.ExecuteAsync(test._retryCounter, static (counter, _) =>
+            {
+                if (++counter.Value % 3 != 0)
+                {
+                    throw RecoverableFailure;
+                }
+
+                return new ValueTask<int>(42);
+            }).GetAwaiter().GetResult());
+        AssertBudget("fallback triggered", 512, this, static test =>
+            test._triggeredFallback.ExecuteAsync(static _ => throw RecoverableFailure).GetAwaiter().GetResult());
+        AssertBudget("open circuit rejection", 2_048, this, static test =>
+        {
+            try
+            {
+                test._openBreaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult();
+            }
+            catch (CircuitOpenException)
+            {
+            }
+        });
+        AssertBudget("hedge launches second attempt", 2_048, this, static test =>
+            test._parallelHedge.ExecuteAsync(test._hedgeCounter, static (counter, _) =>
+            {
+                if (++counter.Value % 2 != 0)
+                {
+                    throw RecoverableFailure;
+                }
+
+                return new ValueTask<int>(42);
+            }).GetAwaiter().GetResult());
+    }
+
+    private static void AssertZero<TState>(string scenario, TState state, Action<TState> operation) =>
+        AssertBudget(scenario, 0, state, operation);
+
+    private static void AssertBudget<TState>(
+        string scenario,
+        long maximumBytesPerOperation,
+        TState state,
+        Action<TState> operation)
+    {
+        for (var operationIndex = 0; operationIndex < WarmupOperations; operationIndex++)
+        {
+            operation(state);
+        }
+
+        var maximumObserved = 0L;
+        for (var sample = 0; sample < Samples; sample++)
+        {
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var operationIndex = 0; operationIndex < MeasuredOperations; operationIndex++)
+            {
+                operation(state);
+            }
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            maximumObserved = Math.Max(maximumObserved, allocated);
+        }
+
+        var maximumAllowed = maximumBytesPerOperation * MeasuredOperations;
+        Console.WriteLine(
+            $"{scenario}: {maximumObserved / (double)MeasuredOperations:F2} B/op " +
+            $"(budget {maximumBytesPerOperation} B/op)");
+
+        if (maximumObserved > maximumAllowed)
+        {
+            throw new InvalidOperationException(
+                $"{scenario} allocated {maximumObserved / (double)MeasuredOperations:F2} B/op; " +
+                $"budget is {maximumBytesPerOperation} B/op.");
+        }
+    }
+
+    private sealed class Counter
+    {
+        public int Value;
+    }
+}

--- a/tests/Kevlar.AllocationTests/Kevlar.AllocationTests.csproj
+++ b/tests/Kevlar.AllocationTests/Kevlar.AllocationTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kevlar\Kevlar.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #33.

Adds deterministic per-thread allocation regression gates for documented zero-allocation hot paths and bounded failure/hedge paths. Runs the focused suite on Ubuntu/.NET 10 in CI and documents its relationship to BenchmarkDotNet.

Validation:
- dotnet build Kevlar.slnx -c Release --no-incremental
- dotnet run --project tests/Kevlar.AllocationTests -c Release -- --timeout 5m --minimum-expected-tests 2 --zero-tests-policy strict (plus 10 repeated runs)
- dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m
- npm run build (docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated performance checks to verify key operations remain within documented memory-allocation limits.
  * Added coverage for failure recovery, circuit breaking, fallback, and hedging scenarios.

* **Documentation**
  * Documented allocation budgets, measurement methodology, and instructions for running performance checks locally.

* **Chores**
  * Updated the solution and continuous integration workflow to include allocation checks before package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->