### PR TITLE
build: enable reproducible package metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+    <DeterministicSourcePaths Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</DeterministicSourcePaths>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
   </PropertyGroup>

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -58,7 +58,31 @@ function Invoke-DotNet([string[]]$Arguments)
     }
 }
 
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$buildPropertiesJson = & dotnet msbuild `
+    (Join-Path $repositoryRoot 'src/Kevlar/Kevlar.csproj') `
+    -nologo `
+    -p:CI=true `
+    -getProperty:Deterministic,ContinuousIntegrationBuild,DeterministicSourcePaths,PublishRepositoryUrl,EmbedUntrackedSources
+if ($LASTEXITCODE -ne 0)
+{
+    throw 'Unable to inspect deterministic build properties.'
+}
+
+$buildProperties = ($buildPropertiesJson | Out-String | ConvertFrom-Json).Properties
+Assert-Equal 'Deterministic' $buildProperties.Deterministic 'true'
+Assert-Equal 'ContinuousIntegrationBuild' $buildProperties.ContinuousIntegrationBuild 'true'
+Assert-Equal 'DeterministicSourcePaths' $buildProperties.DeterministicSourcePaths 'true'
+Assert-Equal 'PublishRepositoryUrl' $buildProperties.PublishRepositoryUrl 'true'
+Assert-Equal 'EmbedUntrackedSources' $buildProperties.EmbedUntrackedSources 'true'
+
 $packageDirectory = (Resolve-Path -LiteralPath $PackagesPath).Path
+$expectedRepositoryCommit = (& git rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($expectedRepositoryCommit))
+{
+    throw 'Unable to determine the expected repository commit.'
+}
+
 $expectedDependencies = @{
     'Kevlar' = @{
         'net10.0' = @('Reservoir')
@@ -117,6 +141,7 @@ foreach ($packageId in $expectedDependencies.Keys)
         Assert-Equal "$packageId README metadata" (Get-NodeText $metadata "*[local-name()='readme']") 'README.md'
         Assert-Equal "$packageId repository URL" (Get-NodeText $metadata "*[local-name()='repository']/@url") 'https://github.com/thomhurst/Kevlar'
         Assert-Equal "$packageId repository type" (Get-NodeText $metadata "*[local-name()='repository']/@type") 'git'
+        Assert-Equal "$packageId repository commit" (Get-NodeText $metadata "*[local-name()='repository']/@commit") $expectedRepositoryCommit
 
         if ($entries -notcontains 'README.md')
         {


### PR DESCRIPTION
## Summary
- enable `ContinuousIntegrationBuild` and deterministic source-path mapping when `CI=true`
- publish repository metadata and embed source files unavailable through source control
- verify all reproducibility properties and exact repository commit metadata during package validation
- confirm CI-built DLL, PDB, and XML outputs are byte-identical from two different checkout paths

Closes #45

## Validation
- `dotnet build Kevlar.slnx -c Release -p:CI=true -p:Version=0.0.0-determinism`
- `dotnet pack Kevlar.slnx -c Release --no-build -p:CI=true -p:Version=0.0.0-determinism`
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-determinism`
- 426 unit, 16 integration, 19 analyzer, and 1 netstandard tests passed
- SHA-256 equality across two checkout paths for Kevlar DLL/PDB/XML on net10.0 and netstandard2.0