### PR TITLE
test(packaging): verify publish compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: dotnet pack Kevlar.slnx -c Release --no-build -p:Version=${{ steps.gitversion.outputs.semVer }}
 
+      - name: Install NativeAOT prerequisites
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install --yes clang zlib1g-dev
+
       - name: Verify packages
         if: matrix.os == 'ubuntu-latest'
         shell: pwsh

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="Polyfill" Version="11.2.0" />
 
     <!-- Satellites -->
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
 
     <!-- Analyzers -->

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -132,6 +132,12 @@ local platforms explicitly.
 
 Run the complete package check after packing a local version:
 
+On Linux, install the NativeAOT prerequisites first:
+
+```bash
+sudo apt-get update && sudo apt-get install --yes clang zlib1g-dev
+```
+
 ```powershell
 dotnet pack Kevlar.slnx -c Release -p:Version=0.0.0-local
 ./scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -120,3 +120,19 @@ var result = await shield.ExecuteAsync(ct =>
 ```
 
 For assertion-friendly, no-throw checks, use [`ExecuteOutcomeAsync`](executing.md#no-throw-execution) and inspect the `Outcome<T>` instead of catching.
+
+## Publish compatibility
+
+Package verification publishes and runs clean package-consuming applications through
+trimmed, single-file, and NativeAOT configurations. The matrix covers all Kevlar
+strategies, typed and untyped execution, configuration-bound dependency injection,
+and HTTP integration on .NET 10. A trimmed .NET 8 application provides the
+compatibility baseline. NativeAOT runs on Linux CI; the script reports unsupported
+local platforms explicitly.
+
+Run the complete package check after packing a local version:
+
+```powershell
+dotnet pack Kevlar.slnx -c Release -p:Version=0.0.0-local
+./scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local
+```

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -83,6 +83,15 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($expectedRepositoryComm
     throw 'Unable to determine the expected repository commit.'
 }
 
+$centralPackagesPath = Join-Path $PSScriptRoot '..\Directory.Packages.props'
+[xml]$centralPackages = Get-Content -LiteralPath $centralPackagesPath -Raw
+$configurationVersion = Get-NodeText $centralPackages "/Project/ItemGroup/PackageVersion[@Include='Microsoft.Extensions.Configuration']/@Version"
+$dependencyInjectionVersion = Get-NodeText $centralPackages "/Project/ItemGroup/PackageVersion[@Include='Microsoft.Extensions.DependencyInjection']/@Version"
+if ($null -eq $configurationVersion -or $null -eq $dependencyInjectionVersion)
+{
+    throw 'Could not resolve Microsoft.Extensions package versions from Directory.Packages.props.'
+}
+
 $expectedDependencies = @{
     'Kevlar' = @{
         'net10.0' = @('Reservoir')
@@ -281,7 +290,8 @@ Console.WriteLine("Kevlar package consumer passed.");
     & (Join-Path $PSScriptRoot 'Verify-PublishCompatibility.ps1') `
         -PackagesPath $packageDirectory `
         -Version $Version `
-        -NuGetConfigPath $nugetConfigPath
+        -ConfigurationVersion $configurationVersion `
+        -DependencyInjectionVersion $dependencyInjectionVersion
 
     $analyzerDirectory = Join-Path $temporaryRoot 'analyzer'
     $analyzerProject = @"

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -89,8 +89,8 @@ $expectedDependencies = @{
         '.NETStandard2.0' = @('Microsoft.Bcl.TimeProvider', 'Reservoir', 'System.Threading.Tasks.Extensions')
     }
     'Kevlar.Extensions.DependencyInjection' = @{
-        'net10.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Binder', 'Microsoft.Extensions.DependencyInjection.Abstractions')
-        '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Binder', 'Microsoft.Extensions.DependencyInjection.Abstractions')
+        'net10.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions')
+        '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions')
     }
     'Kevlar.Extensions.Http' = @{
         'net10.0' = @('Kevlar', 'Microsoft.Extensions.Http')
@@ -277,6 +277,11 @@ Console.WriteLine("Kevlar package consumer passed.");
         Invoke-DotNet @('restore', $projectPath, '--configfile', $nugetConfigPath, '--no-cache', '--force-evaluate')
         Invoke-DotNet @('run', '--project', $projectPath, '-c', 'Release', '--no-restore')
     }
+
+    & (Join-Path $PSScriptRoot 'Verify-PublishCompatibility.ps1') `
+        -PackagesPath $packageDirectory `
+        -Version $Version `
+        -NuGetConfigPath $nugetConfigPath
 
     $analyzerDirectory = Join-Path $temporaryRoot 'analyzer'
     $analyzerProject = @"

--- a/scripts/Verify-PublishCompatibility.ps1
+++ b/scripts/Verify-PublishCompatibility.ps1
@@ -80,6 +80,15 @@ try
     <add key="local" value="$escapedPackageDirectory" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="local">
+      <package pattern="Kevlar" />
+      <package pattern="Kevlar.*" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>
 "@
 

--- a/scripts/Verify-PublishCompatibility.ps1
+++ b/scripts/Verify-PublishCompatibility.ps1
@@ -7,7 +7,10 @@ param(
     [string]$Version,
 
     [Parameter(Mandatory)]
-    [string]$NuGetConfigPath
+    [string]$ConfigurationVersion,
+
+    [Parameter(Mandatory)]
+    [string]$DependencyInjectionVersion
 )
 
 $ErrorActionPreference = 'Stop'
@@ -57,17 +60,29 @@ function Get-RuntimeIdentifier
 }
 
 $packageDirectory = (Resolve-Path -LiteralPath $PackagesPath).Path
-$nugetConfig = (Resolve-Path -LiteralPath $NuGetConfigPath).Path
 $runtimeIdentifier = Get-RuntimeIdentifier
 $platformName = $runtimeIdentifier.Split('-')[0]
 $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "kevlar-publish-consumer-$([guid]::NewGuid().ToString('N'))"
 $consumerDirectory = Join-Path $temporaryRoot 'consumer'
 $projectPath = Join-Path $consumerDirectory 'PublishConsumer.csproj'
+$nugetConfigPath = Join-Path $temporaryRoot 'NuGet.Config'
 $previousPackagesPath = $env:NUGET_PACKAGES
 $env:NUGET_PACKAGES = Join-Path $temporaryRoot '.packages'
 
 try
 {
+    $escapedPackageDirectory = [System.Security.SecurityElement]::Escape($packageDirectory)
+    Write-TextFile $nugetConfigPath @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$escapedPackageDirectory" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@
+
     $project = @"
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
@@ -87,8 +102,8 @@ try
     <PackageReference Include="Kevlar" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$ConfigurationVersion" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$DependencyInjectionVersion" />
   </ItemGroup>
 </Project>
 "@
@@ -196,7 +211,7 @@ file sealed class StubHandler : HttpMessageHandler
             '-f', $entry.Framework,
             '-r', $runtimeIdentifier,
             '--self-contained', 'true',
-            '--configfile', $nugetConfig,
+            '--configfile', $nugetConfigPath,
             '--no-cache',
             '-o', $outputDirectory
         ) + $entry.Properties

--- a/scripts/Verify-PublishCompatibility.ps1
+++ b/scripts/Verify-PublishCompatibility.ps1
@@ -1,0 +1,232 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$PackagesPath,
+
+    [Parameter(Mandatory)]
+    [string]$Version,
+
+    [Parameter(Mandatory)]
+    [string]$NuGetConfigPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Write-TextFile([string]$Path, [string]$Contents)
+{
+    [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($Path)) | Out-Null
+    [System.IO.File]::WriteAllText($Path, $Contents, [System.Text.UTF8Encoding]::new($false))
+}
+
+function Invoke-DotNet([string[]]$Arguments)
+{
+    & dotnet @Arguments
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "dotnet $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Get-RuntimeIdentifier
+{
+    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    $architectureName = switch ($architecture)
+    {
+        ([System.Runtime.InteropServices.Architecture]::X64) { 'x64' }
+        ([System.Runtime.InteropServices.Architecture]::Arm64) { 'arm64' }
+        default { throw "Publish compatibility does not support architecture '$architecture'." }
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows))
+    {
+        return "win-$architectureName"
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux))
+    {
+        return "linux-$architectureName"
+    }
+
+    if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX))
+    {
+        return "osx-$architectureName"
+    }
+
+    throw 'Publish compatibility does not support this operating system.'
+}
+
+$packageDirectory = (Resolve-Path -LiteralPath $PackagesPath).Path
+$nugetConfig = (Resolve-Path -LiteralPath $NuGetConfigPath).Path
+$runtimeIdentifier = Get-RuntimeIdentifier
+$platformName = $runtimeIdentifier.Split('-')[0]
+$temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "kevlar-publish-consumer-$([guid]::NewGuid().ToString('N'))"
+$consumerDirectory = Join-Path $temporaryRoot 'consumer'
+$projectPath = Join-Path $consumerDirectory 'PublishConsumer.csproj'
+$previousPackagesPath = $env:NUGET_PACKAGES
+$env:NUGET_PACKAGES = Join-Path $temporaryRoot '.packages'
+
+try
+{
+    $project = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Kevlar" Version="$Version" />
+    <PackageReference Include="Kevlar.Extensions.DependencyInjection" Version="$Version" />
+    <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+  </ItemGroup>
+</Project>
+"@
+    Write-TextFile $projectPath $project
+    Write-TextFile (Join-Path $consumerDirectory 'Program.cs') @'
+using System.Net;
+using Kevlar;
+using Kevlar.Extensions.DependencyInjection;
+using Kevlar.Extensions.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+var untyped = Shield.Empty;
+if (untyped.Execute(static _ => 42) != 42
+    || await untyped.ExecuteAsync(static _ => new ValueTask<int>(42)) != 42
+    || !(await untyped.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42))).IsSuccess)
+{
+    throw new InvalidOperationException("Untyped execution failed.");
+}
+
+var typed = Shield<int>.Empty;
+if (typed.Execute(static _ => 42) != 42
+    || await typed.ExecuteAsync(static _ => new ValueTask<int>(42)) != 42)
+{
+    throw new InvalidOperationException("Typed execution failed.");
+}
+
+var retryAttempts = 0;
+var retried = await Shield.Retry(1, Backoff.None).ExecuteAsync(_ =>
+    ++retryAttempts == 1 ? throw new InvalidOperationException() : new ValueTask<int>(42));
+var timed = await Shield.Timeout(TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
+var broken = await Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
+var limited = await Shield.RateLimit(1, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
+var isolated = await Shield.ConcurrencyLimit(1).ExecuteAsync(static _ => new ValueTask<int>(42));
+var hedged = await Shield.Hedge(2, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
+var fallback = await Shield.For<int>().When<InvalidOperationException>().Fallback(42)
+    .ExecuteAsync<int>(static _ => throw new InvalidOperationException());
+if (retried + timed + broken + limited + isolated + hedged + fallback != 294)
+{
+    throw new InvalidOperationException("Built-in strategy execution failed.");
+}
+
+var settings = new Dictionary<string, string?>
+{
+    ["Retry:MaxRetries"] = "1",
+    ["Retry:Backoff"] = "None",
+    ["CircuitBreaker:ConsecutiveFailures"] = "2",
+    ["CircuitBreaker:BreakDuration"] = "00:00:01",
+    ["RateLimit:Permits"] = "10",
+    ["RateLimit:Window"] = "00:00:01",
+    ["ConcurrencyLimit:MaxConcurrency"] = "2",
+};
+var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+var services = new ServiceCollection();
+services.AddShield("configured", configuration);
+services.AddShield<int>("typed", typed);
+services.AddHttpClient("http")
+    .ConfigurePrimaryHttpMessageHandler(static () => new StubHandler())
+    .AddShield(HttpShield.WhenTransient().Retry(1, Backoff.None));
+using var provider = services.BuildServiceProvider();
+var registry = provider.GetRequiredService<IKevlarRegistry>();
+if (await registry.GetShield("configured").ExecuteAsync(static _ => new ValueTask<int>(42)) != 42
+    || await registry.GetShield<int>("typed").ExecuteAsync(static _ => new ValueTask<int>(42)) != 42)
+{
+    throw new InvalidOperationException("Dependency-injection registration failed.");
+}
+
+using var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("http");
+using var response = await client.GetAsync("http://localhost/smoke");
+if (response.StatusCode != HttpStatusCode.OK)
+{
+    throw new InvalidOperationException("HTTP handler wiring failed.");
+}
+
+Console.WriteLine("Kevlar publish compatibility passed.");
+
+file sealed class StubHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+}
+'@
+
+    $publishMatrix = @(
+        @{ Name = 'net10-trimmed'; Framework = 'net10.0'; Platforms = @('win', 'linux', 'osx'); Properties = @('-p:PublishTrimmed=true', '-p:TrimMode=full') },
+        @{ Name = 'net10-single-file'; Framework = 'net10.0'; Platforms = @('win', 'linux', 'osx'); Properties = @('-p:PublishSingleFile=true') },
+        @{ Name = 'net10-native-aot'; Framework = 'net10.0'; Platforms = @('linux'); Properties = @('-p:PublishAot=true') },
+        @{ Name = 'net8-compat-trimmed'; Framework = 'net8.0'; Platforms = @('win', 'linux', 'osx'); Properties = @('-p:PublishTrimmed=true', '-p:TrimMode=full') }
+    )
+
+    foreach ($entry in $publishMatrix)
+    {
+        if ($entry.Platforms -notcontains $platformName)
+        {
+            Write-Host "$($entry.Name): explicitly unsupported on $platformName; NativeAOT package verification runs on Linux CI."
+            continue
+        }
+
+        $outputDirectory = Join-Path $temporaryRoot $entry.Name
+        $arguments = @(
+            'publish', $projectPath,
+            '-c', 'Release',
+            '-f', $entry.Framework,
+            '-r', $runtimeIdentifier,
+            '--self-contained', 'true',
+            '--configfile', $nugetConfig,
+            '--no-cache',
+            '-o', $outputDirectory
+        ) + $entry.Properties
+        Invoke-DotNet $arguments
+
+        $executableName = if ($runtimeIdentifier.StartsWith('win-', [StringComparison]::Ordinal))
+        {
+            'PublishConsumer.exe'
+        }
+        else
+        {
+            'PublishConsumer'
+        }
+        $executable = Join-Path $outputDirectory $executableName
+        if (-not (Test-Path -LiteralPath $executable -PathType Leaf))
+        {
+            throw "$($entry.Name) did not produce '$executableName'."
+        }
+
+        & $executable
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "$($entry.Name) executable failed with exit code $LASTEXITCODE."
+        }
+    }
+
+    Write-Host "All publish compatibility checks passed for $runtimeIdentifier."
+}
+finally
+{
+    $env:NUGET_PACKAGES = $previousPackagesPath
+    Remove-Item -LiteralPath $temporaryRoot -Recurse -Force
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,10 @@
     <NoWarn>$(NoWarn);RS0026</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />

--- a/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
+++ b/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -84,50 +84,92 @@ public static class KevlarServiceCollectionExtensions
         var retry = configuration.GetSection(nameof(ShieldDefinition.Retry));
         if (HasValues(retry))
         {
-            definition.Retry = new RetryDefinition
+            var retryDefinition = new RetryDefinition
             {
-                MaxRetries = ReadInt(retry, nameof(RetryDefinition.MaxRetries), 3),
-                Backoff = ReadEnum(retry, nameof(RetryDefinition.Backoff), BackoffKind.Exponential),
                 BaseDelay = ReadTimeSpan(retry, nameof(RetryDefinition.BaseDelay)),
-                Factor = ReadDouble(retry, nameof(RetryDefinition.Factor), 2),
-                Jitter = ReadBool(retry, nameof(RetryDefinition.Jitter), fallback: true),
                 MaxDelay = ReadTimeSpan(retry, nameof(RetryDefinition.MaxDelay)),
             };
+            if (ReadNullableInt(retry, nameof(RetryDefinition.MaxRetries)) is { } maxRetries)
+            {
+                retryDefinition.MaxRetries = maxRetries;
+            }
+            if (ReadNullableEnum<BackoffKind>(retry, nameof(RetryDefinition.Backoff)) is { } backoff)
+            {
+                retryDefinition.Backoff = backoff;
+            }
+            if (ReadNullableDouble(retry, nameof(RetryDefinition.Factor)) is { } factor)
+            {
+                retryDefinition.Factor = factor;
+            }
+            if (ReadNullableBool(retry, nameof(RetryDefinition.Jitter)) is { } jitter)
+            {
+                retryDefinition.Jitter = jitter;
+            }
+
+            definition.Retry = retryDefinition;
         }
 
         var breaker = configuration.GetSection(nameof(ShieldDefinition.CircuitBreaker));
         if (HasValues(breaker))
         {
-            definition.CircuitBreaker = new CircuitBreakerDefinition
+            var breakerDefinition = new CircuitBreakerDefinition
             {
                 ConsecutiveFailures = ReadNullableInt(breaker, nameof(CircuitBreakerDefinition.ConsecutiveFailures)),
                 FailureRatio = ReadNullableDouble(breaker, nameof(CircuitBreakerDefinition.FailureRatio)),
-                MinimumThroughput = ReadInt(breaker, nameof(CircuitBreakerDefinition.MinimumThroughput), 10),
-                SamplingWindow = ReadTimeSpan(breaker, nameof(CircuitBreakerDefinition.SamplingWindow)) ?? TimeSpan.FromSeconds(30),
-                BreakDuration = ReadTimeSpan(breaker, nameof(CircuitBreakerDefinition.BreakDuration)) ?? TimeSpan.FromSeconds(15),
             };
+            if (ReadNullableInt(breaker, nameof(CircuitBreakerDefinition.MinimumThroughput)) is { } minimumThroughput)
+            {
+                breakerDefinition.MinimumThroughput = minimumThroughput;
+            }
+            if (ReadTimeSpan(breaker, nameof(CircuitBreakerDefinition.SamplingWindow)) is { } samplingWindow)
+            {
+                breakerDefinition.SamplingWindow = samplingWindow;
+            }
+            if (ReadTimeSpan(breaker, nameof(CircuitBreakerDefinition.BreakDuration)) is { } breakDuration)
+            {
+                breakerDefinition.BreakDuration = breakDuration;
+            }
+
+            definition.CircuitBreaker = breakerDefinition;
         }
 
         var rateLimit = configuration.GetSection(nameof(ShieldDefinition.RateLimit));
         if (HasValues(rateLimit))
         {
-            definition.RateLimit = new RateLimitDefinition
+            var rateLimitDefinition = new RateLimitDefinition
             {
-                Permits = ReadInt(rateLimit, nameof(RateLimitDefinition.Permits), 100),
-                Window = ReadTimeSpan(rateLimit, nameof(RateLimitDefinition.Window)) ?? TimeSpan.FromSeconds(1),
                 Burst = ReadNullableInt(rateLimit, nameof(RateLimitDefinition.Burst)),
-                QueueLimit = ReadInt(rateLimit, nameof(RateLimitDefinition.QueueLimit), 0),
             };
+            if (ReadNullableInt(rateLimit, nameof(RateLimitDefinition.Permits)) is { } permits)
+            {
+                rateLimitDefinition.Permits = permits;
+            }
+            if (ReadTimeSpan(rateLimit, nameof(RateLimitDefinition.Window)) is { } window)
+            {
+                rateLimitDefinition.Window = window;
+            }
+            if (ReadNullableInt(rateLimit, nameof(RateLimitDefinition.QueueLimit)) is { } queueLimit)
+            {
+                rateLimitDefinition.QueueLimit = queueLimit;
+            }
+
+            definition.RateLimit = rateLimitDefinition;
         }
 
         var concurrency = configuration.GetSection(nameof(ShieldDefinition.ConcurrencyLimit));
         if (HasValues(concurrency))
         {
-            definition.ConcurrencyLimit = new ConcurrencyLimitDefinition
+            var concurrencyDefinition = new ConcurrencyLimitDefinition();
+            if (ReadNullableInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxConcurrency)) is { } maxConcurrency)
             {
-                MaxConcurrency = ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxConcurrency), 10),
-                MaxQueue = ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxQueue), 0),
-            };
+                concurrencyDefinition.MaxConcurrency = maxConcurrency;
+            }
+            if (ReadNullableInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxQueue)) is { } maxQueue)
+            {
+                concurrencyDefinition.MaxQueue = maxQueue;
+            }
+
+            definition.ConcurrencyLimit = concurrencyDefinition;
         }
 
         return definition;
@@ -139,37 +181,66 @@ public static class KevlarServiceCollectionExtensions
     private static string? Read(IConfiguration configuration, string key) =>
         configuration[key] is { Length: > 0 } value ? value : null;
 
-    private static int ReadInt(IConfiguration configuration, string key, int fallback) =>
-        Read(configuration, key) is { } value
-            ? int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture)
-            : fallback;
-
     private static int? ReadNullableInt(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value
-            ? int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture)
+            ? ParseInt(configuration, key, value)
             : null;
-
-    private static double ReadDouble(IConfiguration configuration, string key, double fallback) =>
-        Read(configuration, key) is { } value
-            ? double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture)
-            : fallback;
 
     private static double? ReadNullableDouble(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value
-            ? double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture)
+            ? ParseDouble(configuration, key, value)
             : null;
 
-    private static bool ReadBool(IConfiguration configuration, string key, bool fallback) =>
-        Read(configuration, key) is { } value ? bool.Parse(value) : fallback;
+    private static bool? ReadNullableBool(IConfiguration configuration, string key) =>
+        Read(configuration, key) is { } value ? ParseBool(configuration, key, value) : null;
 
     private static TimeSpan? ReadTimeSpan(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value
-            ? TimeSpan.Parse(value, CultureInfo.InvariantCulture)
+            ? ParseTimeSpan(configuration, key, value)
             : null;
 
-    private static TEnum ReadEnum<TEnum>(IConfiguration configuration, string key, TEnum fallback)
+    private static TEnum? ReadNullableEnum<TEnum>(IConfiguration configuration, string key)
         where TEnum : struct, Enum =>
         Read(configuration, key) is { } value
-            ? Enum.Parse<TEnum>(value, ignoreCase: true)
-            : fallback;
+            ? ParseEnum<TEnum>(configuration, key, value)
+            : null;
+
+    private static int ParseInt(IConfiguration configuration, string key, string value) =>
+        int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : throw InvalidValue(configuration, key, value, "an integer");
+
+    private static double ParseDouble(IConfiguration configuration, string key, string value) =>
+        double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : throw InvalidValue(configuration, key, value, "a number");
+
+    private static bool ParseBool(IConfiguration configuration, string key, string value) =>
+        bool.TryParse(value, out var parsed)
+            ? parsed
+            : throw InvalidValue(configuration, key, value, "a Boolean");
+
+    private static TimeSpan ParseTimeSpan(IConfiguration configuration, string key, string value) =>
+        TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : throw InvalidValue(configuration, key, value, "a TimeSpan");
+
+    private static TEnum ParseEnum<TEnum>(IConfiguration configuration, string key, string value)
+        where TEnum : struct, Enum =>
+        Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed)
+            ? parsed
+            : throw InvalidValue(configuration, key, value, $"a {typeof(TEnum).Name}");
+
+    private static InvalidOperationException InvalidValue(
+        IConfiguration configuration,
+        string key,
+        string value,
+        string expected)
+    {
+        var path = configuration is IConfigurationSection { Path.Length: > 0 } section
+            ? ConfigurationPath.Combine(section.Path, key)
+            : key;
+        return new InvalidOperationException(
+            $"Configuration value '{value}' for '{path}' is not {expected}.");
+    }
 }

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -77,31 +77,31 @@ public static class KevlarServiceCollectionExtensions
     {
         var definition = new ShieldDefinition
         {
-            Timeout = ReadTimeSpan(configuration, nameof(ShieldDefinition.Timeout)),
-            AttemptTimeout = ReadTimeSpan(configuration, nameof(ShieldDefinition.AttemptTimeout)),
+            Timeout = ReadNullableTimeSpan(configuration, nameof(ShieldDefinition.Timeout)),
+            AttemptTimeout = ReadNullableTimeSpan(configuration, nameof(ShieldDefinition.AttemptTimeout)),
         };
 
         var retry = configuration.GetSection(nameof(ShieldDefinition.Retry));
-        if (HasValues(retry))
+        if (HasChildren(retry))
         {
             var retryDefinition = new RetryDefinition
             {
-                BaseDelay = ReadTimeSpan(retry, nameof(RetryDefinition.BaseDelay)),
-                MaxDelay = ReadTimeSpan(retry, nameof(RetryDefinition.MaxDelay)),
+                BaseDelay = ReadNullableTimeSpan(retry, nameof(RetryDefinition.BaseDelay)),
+                MaxDelay = ReadNullableTimeSpan(retry, nameof(RetryDefinition.MaxDelay)),
             };
-            if (ReadNullableInt(retry, nameof(RetryDefinition.MaxRetries)) is { } maxRetries)
+            if (ReadInt(retry, nameof(RetryDefinition.MaxRetries)) is { } maxRetries)
             {
                 retryDefinition.MaxRetries = maxRetries;
             }
-            if (ReadNullableEnum<BackoffKind>(retry, nameof(RetryDefinition.Backoff)) is { } backoff)
+            if (ReadEnum<BackoffKind>(retry, nameof(RetryDefinition.Backoff)) is { } backoff)
             {
                 retryDefinition.Backoff = backoff;
             }
-            if (ReadNullableDouble(retry, nameof(RetryDefinition.Factor)) is { } factor)
+            if (ReadDouble(retry, nameof(RetryDefinition.Factor)) is { } factor)
             {
                 retryDefinition.Factor = factor;
             }
-            if (ReadNullableBool(retry, nameof(RetryDefinition.Jitter)) is { } jitter)
+            if (ReadBool(retry, nameof(RetryDefinition.Jitter)) is { } jitter)
             {
                 retryDefinition.Jitter = jitter;
             }
@@ -110,14 +110,14 @@ public static class KevlarServiceCollectionExtensions
         }
 
         var breaker = configuration.GetSection(nameof(ShieldDefinition.CircuitBreaker));
-        if (HasValues(breaker))
+        if (HasChildren(breaker))
         {
             var breakerDefinition = new CircuitBreakerDefinition
             {
                 ConsecutiveFailures = ReadNullableInt(breaker, nameof(CircuitBreakerDefinition.ConsecutiveFailures)),
                 FailureRatio = ReadNullableDouble(breaker, nameof(CircuitBreakerDefinition.FailureRatio)),
             };
-            if (ReadNullableInt(breaker, nameof(CircuitBreakerDefinition.MinimumThroughput)) is { } minimumThroughput)
+            if (ReadInt(breaker, nameof(CircuitBreakerDefinition.MinimumThroughput)) is { } minimumThroughput)
             {
                 breakerDefinition.MinimumThroughput = minimumThroughput;
             }
@@ -134,13 +134,13 @@ public static class KevlarServiceCollectionExtensions
         }
 
         var rateLimit = configuration.GetSection(nameof(ShieldDefinition.RateLimit));
-        if (HasValues(rateLimit))
+        if (HasChildren(rateLimit))
         {
             var rateLimitDefinition = new RateLimitDefinition
             {
                 Burst = ReadNullableInt(rateLimit, nameof(RateLimitDefinition.Burst)),
             };
-            if (ReadNullableInt(rateLimit, nameof(RateLimitDefinition.Permits)) is { } permits)
+            if (ReadInt(rateLimit, nameof(RateLimitDefinition.Permits)) is { } permits)
             {
                 rateLimitDefinition.Permits = permits;
             }
@@ -148,7 +148,7 @@ public static class KevlarServiceCollectionExtensions
             {
                 rateLimitDefinition.Window = window;
             }
-            if (ReadNullableInt(rateLimit, nameof(RateLimitDefinition.QueueLimit)) is { } queueLimit)
+            if (ReadInt(rateLimit, nameof(RateLimitDefinition.QueueLimit)) is { } queueLimit)
             {
                 rateLimitDefinition.QueueLimit = queueLimit;
             }
@@ -157,14 +157,14 @@ public static class KevlarServiceCollectionExtensions
         }
 
         var concurrency = configuration.GetSection(nameof(ShieldDefinition.ConcurrencyLimit));
-        if (HasValues(concurrency))
+        if (HasChildren(concurrency))
         {
             var concurrencyDefinition = new ConcurrencyLimitDefinition();
-            if (ReadNullableInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxConcurrency)) is { } maxConcurrency)
+            if (ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxConcurrency)) is { } maxConcurrency)
             {
                 concurrencyDefinition.MaxConcurrency = maxConcurrency;
             }
-            if (ReadNullableInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxQueue)) is { } maxQueue)
+            if (ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxQueue)) is { } maxQueue)
             {
                 concurrencyDefinition.MaxQueue = maxQueue;
             }
@@ -175,23 +175,32 @@ public static class KevlarServiceCollectionExtensions
         return definition;
     }
 
-    private static bool HasValues(IConfigurationSection section) =>
-        section.Value is not null || section.GetChildren().Any();
+    private static bool HasChildren(IConfigurationSection section) => section.GetChildren().Any();
 
     private static string? Read(IConfiguration configuration, string key) =>
         configuration[key];
 
-    private static int? ReadNullableInt(IConfiguration configuration, string key) =>
+    private static int? ReadInt(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value
             ? ParseInt(configuration, key, value)
             : null;
 
-    private static double? ReadNullableDouble(IConfiguration configuration, string key) =>
+    private static int? ReadNullableInt(IConfiguration configuration, string key) =>
+        ReadNullable(configuration, key) is { } value
+            ? ParseInt(configuration, key, value)
+            : null;
+
+    private static double? ReadDouble(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value
             ? ParseDouble(configuration, key, value)
             : null;
 
-    private static bool? ReadNullableBool(IConfiguration configuration, string key) =>
+    private static double? ReadNullableDouble(IConfiguration configuration, string key) =>
+        ReadNullable(configuration, key) is { } value
+            ? ParseDouble(configuration, key, value)
+            : null;
+
+    private static bool? ReadBool(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value ? ParseBool(configuration, key, value) : null;
 
     private static TimeSpan? ReadTimeSpan(IConfiguration configuration, string key) =>
@@ -199,11 +208,22 @@ public static class KevlarServiceCollectionExtensions
             ? ParseTimeSpan(configuration, key, value)
             : null;
 
-    private static TEnum? ReadNullableEnum<TEnum>(IConfiguration configuration, string key)
+    private static TimeSpan? ReadNullableTimeSpan(IConfiguration configuration, string key) =>
+        ReadNullable(configuration, key) is { } value
+            ? ParseTimeSpan(configuration, key, value)
+            : null;
+
+    private static TEnum? ReadEnum<TEnum>(IConfiguration configuration, string key)
         where TEnum : struct, Enum =>
         Read(configuration, key) is { } value
             ? ParseEnum<TEnum>(configuration, key, value)
             : null;
+
+    private static string? ReadNullable(IConfiguration configuration, string key)
+    {
+        var value = Read(configuration, key);
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
 
     private static int ParseInt(IConfiguration configuration, string key, string value) =>
         int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -47,7 +48,7 @@ public static class KevlarServiceCollectionExtensions
 
         return services.AddShield(name, _ =>
         {
-            var definition = configuration.Get<ShieldDefinition>() ?? new ShieldDefinition();
+            var definition = BindDefinition(configuration);
             return definition.Build().WithName(name);
         });
     }
@@ -71,4 +72,104 @@ public static class KevlarServiceCollectionExtensions
         services.AddKeyedSingleton(name, (sp, _) => sp.GetRequiredService<IKevlarRegistry>().GetShield<TResult>(name));
         return services;
     }
+
+    private static ShieldDefinition BindDefinition(IConfiguration configuration)
+    {
+        var definition = new ShieldDefinition
+        {
+            Timeout = ReadTimeSpan(configuration, nameof(ShieldDefinition.Timeout)),
+            AttemptTimeout = ReadTimeSpan(configuration, nameof(ShieldDefinition.AttemptTimeout)),
+        };
+
+        var retry = configuration.GetSection(nameof(ShieldDefinition.Retry));
+        if (HasValues(retry))
+        {
+            definition.Retry = new RetryDefinition
+            {
+                MaxRetries = ReadInt(retry, nameof(RetryDefinition.MaxRetries), 3),
+                Backoff = ReadEnum(retry, nameof(RetryDefinition.Backoff), BackoffKind.Exponential),
+                BaseDelay = ReadTimeSpan(retry, nameof(RetryDefinition.BaseDelay)),
+                Factor = ReadDouble(retry, nameof(RetryDefinition.Factor), 2),
+                Jitter = ReadBool(retry, nameof(RetryDefinition.Jitter), fallback: true),
+                MaxDelay = ReadTimeSpan(retry, nameof(RetryDefinition.MaxDelay)),
+            };
+        }
+
+        var breaker = configuration.GetSection(nameof(ShieldDefinition.CircuitBreaker));
+        if (HasValues(breaker))
+        {
+            definition.CircuitBreaker = new CircuitBreakerDefinition
+            {
+                ConsecutiveFailures = ReadNullableInt(breaker, nameof(CircuitBreakerDefinition.ConsecutiveFailures)),
+                FailureRatio = ReadNullableDouble(breaker, nameof(CircuitBreakerDefinition.FailureRatio)),
+                MinimumThroughput = ReadInt(breaker, nameof(CircuitBreakerDefinition.MinimumThroughput), 10),
+                SamplingWindow = ReadTimeSpan(breaker, nameof(CircuitBreakerDefinition.SamplingWindow)) ?? TimeSpan.FromSeconds(30),
+                BreakDuration = ReadTimeSpan(breaker, nameof(CircuitBreakerDefinition.BreakDuration)) ?? TimeSpan.FromSeconds(15),
+            };
+        }
+
+        var rateLimit = configuration.GetSection(nameof(ShieldDefinition.RateLimit));
+        if (HasValues(rateLimit))
+        {
+            definition.RateLimit = new RateLimitDefinition
+            {
+                Permits = ReadInt(rateLimit, nameof(RateLimitDefinition.Permits), 100),
+                Window = ReadTimeSpan(rateLimit, nameof(RateLimitDefinition.Window)) ?? TimeSpan.FromSeconds(1),
+                Burst = ReadNullableInt(rateLimit, nameof(RateLimitDefinition.Burst)),
+                QueueLimit = ReadInt(rateLimit, nameof(RateLimitDefinition.QueueLimit), 0),
+            };
+        }
+
+        var concurrency = configuration.GetSection(nameof(ShieldDefinition.ConcurrencyLimit));
+        if (HasValues(concurrency))
+        {
+            definition.ConcurrencyLimit = new ConcurrencyLimitDefinition
+            {
+                MaxConcurrency = ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxConcurrency), 10),
+                MaxQueue = ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxQueue), 0),
+            };
+        }
+
+        return definition;
+    }
+
+    private static bool HasValues(IConfigurationSection section) =>
+        section.Value is not null || section.GetChildren().Any();
+
+    private static string? Read(IConfiguration configuration, string key) =>
+        configuration[key] is { Length: > 0 } value ? value : null;
+
+    private static int ReadInt(IConfiguration configuration, string key, int fallback) =>
+        Read(configuration, key) is { } value
+            ? int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture)
+            : fallback;
+
+    private static int? ReadNullableInt(IConfiguration configuration, string key) =>
+        Read(configuration, key) is { } value
+            ? int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture)
+            : null;
+
+    private static double ReadDouble(IConfiguration configuration, string key, double fallback) =>
+        Read(configuration, key) is { } value
+            ? double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture)
+            : fallback;
+
+    private static double? ReadNullableDouble(IConfiguration configuration, string key) =>
+        Read(configuration, key) is { } value
+            ? double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture)
+            : null;
+
+    private static bool ReadBool(IConfiguration configuration, string key, bool fallback) =>
+        Read(configuration, key) is { } value ? bool.Parse(value) : fallback;
+
+    private static TimeSpan? ReadTimeSpan(IConfiguration configuration, string key) =>
+        Read(configuration, key) is { } value
+            ? TimeSpan.Parse(value, CultureInfo.InvariantCulture)
+            : null;
+
+    private static TEnum ReadEnum<TEnum>(IConfiguration configuration, string key, TEnum fallback)
+        where TEnum : struct, Enum =>
+        Read(configuration, key) is { } value
+            ? Enum.Parse<TEnum>(value, ignoreCase: true)
+            : fallback;
 }

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -179,7 +179,7 @@ public static class KevlarServiceCollectionExtensions
         section.Value is not null || section.GetChildren().Any();
 
     private static string? Read(IConfiguration configuration, string key) =>
-        configuration[key] is { Length: > 0 } value ? value : null;
+        configuration[key];
 
     private static int? ReadNullableInt(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Kevlar.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -130,5 +131,60 @@ public class ConfigurationBindingTests
 
         await Assert.That(shield.ToString()).IsEqualTo(
             "complete: Timeout(20s) → Retry(2, exponential 100ms ×3 ≤2s) → CircuitBreaker(25% over 8s, min 4, break 5s) → RateLimit(5/10s, burst 7, queue 2) → ConcurrencyLimit(3, queue 4) → Timeout(1s)");
+    }
+
+    [Test]
+    public async Task Configuration_Preserves_Definition_Defaults_For_Absent_Keys()
+    {
+        var configuration = BuildConfiguration(
+            ("Retry:MaxRetries", "3"),
+            ("CircuitBreaker:FailureRatio", "0.5"),
+            ("RateLimit:Burst", "100"),
+            ("ConcurrencyLimit:MaxQueue", "0"));
+        var services = new ServiceCollection();
+        services.AddShield("defaults", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("defaults");
+
+        await Assert.That(shield.ToString()).IsEqualTo(
+            "defaults: Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → RateLimit(100/1s) → ConcurrencyLimit(10)");
+    }
+
+    [Test]
+    public async Task Configuration_Parses_Numbers_Using_Invariant_Culture()
+    {
+        var configuration = BuildConfiguration(("CircuitBreaker:FailureRatio", "0.25"));
+        var services = new ServiceCollection();
+        services.AddShield("invariant", configuration);
+        using var provider = services.BuildServiceProvider();
+        var previousCulture = CultureInfo.CurrentCulture;
+        Shield shield;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("invariant");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+
+        await Assert.That(shield.ToString())
+            .IsEqualTo("invariant: CircuitBreaker(25% over 30s, min 10, break 15s)");
+    }
+
+    [Test]
+    public async Task Configuration_Invalid_Value_Identifies_The_Full_Key()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "abc"));
+        var services = new ServiceCollection();
+        services.AddShield("invalid", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<InvalidOperationException>()
+            .WithMessage("Configuration value 'abc' for 'Retry:MaxRetries' is not an integer.");
     }
 }

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -200,4 +200,60 @@ public class ConfigurationBindingTests
             .Throws<InvalidOperationException>()
             .WithMessage("Configuration value '' for 'Retry:MaxRetries' is not an integer.");
     }
+
+    [Test]
+    public async Task Configuration_Treats_Empty_Nullable_Values_As_Null()
+    {
+        var configuration = BuildConfiguration(
+            ("Timeout", ""),
+            ("AttemptTimeout", ""),
+            ("Retry:MaxRetries", "0"),
+            ("Retry:BaseDelay", ""),
+            ("Retry:MaxDelay", ""),
+            ("CircuitBreaker:ConsecutiveFailures", ""),
+            ("CircuitBreaker:FailureRatio", "0.5"),
+            ("RateLimit:Permits", "5"),
+            ("RateLimit:Burst", ""));
+        var services = new ServiceCollection();
+        services.AddShield("nullable", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("nullable");
+
+        await Assert.That(shield.ToString()).IsEqualTo(
+            "nullable: Retry(0, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → RateLimit(5/1s)");
+    }
+
+    [Test]
+    public async Task Configuration_Ignores_Scalar_Strategy_Sections()
+    {
+        var configuration = BuildConfiguration(
+            ("Retry", ""),
+            ("CircuitBreaker", "invalid"),
+            ("RateLimit", "invalid"),
+            ("ConcurrencyLimit", "invalid"));
+        var services = new ServiceCollection();
+        services.AddShield("scalar", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("scalar");
+
+        await Assert.That(shield.ToString()).IsEqualTo("scalar: (empty)");
+    }
+
+    [Test]
+    public async Task Configuration_Treats_Empty_Failure_Ratio_As_Null()
+    {
+        var configuration = BuildConfiguration(
+            ("CircuitBreaker:ConsecutiveFailures", "2"),
+            ("CircuitBreaker:FailureRatio", ""));
+        var services = new ServiceCollection();
+        services.AddShield("nullable-ratio", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("nullable-ratio");
+
+        await Assert.That(shield.ToString())
+            .IsEqualTo("nullable-ratio: CircuitBreaker(2 consecutive, break 15s)");
+    }
 }

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -187,4 +187,17 @@ public class ConfigurationBindingTests
             .Throws<InvalidOperationException>()
             .WithMessage("Configuration value 'abc' for 'Retry:MaxRetries' is not an integer.");
     }
+
+    [Test]
+    public async Task Configuration_Rejects_Explicit_Empty_Value()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", ""));
+        var services = new ServiceCollection();
+        services.AddShield("empty", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("empty"))
+            .Throws<InvalidOperationException>()
+            .WithMessage("Configuration value '' for 'Retry:MaxRetries' is not an integer.");
+    }
 }

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -99,4 +99,36 @@ public class ConfigurationBindingTests
         await Assert.That(definition.Build().ToString())
             .IsEqualTo("Retry(3, exponential 250ms ×2 +jitter ≤30s)");
     }
+
+    [Test]
+    public async Task Configuration_Binds_Every_Strategy_Option_Without_Reflection()
+    {
+        var configuration = BuildConfiguration(
+            ("Timeout", "00:00:20"),
+            ("Retry:MaxRetries", "2"),
+            ("Retry:Backoff", "exponential"),
+            ("Retry:BaseDelay", "00:00:00.100"),
+            ("Retry:Factor", "3"),
+            ("Retry:Jitter", "false"),
+            ("Retry:MaxDelay", "00:00:02"),
+            ("CircuitBreaker:FailureRatio", "0.25"),
+            ("CircuitBreaker:MinimumThroughput", "4"),
+            ("CircuitBreaker:SamplingWindow", "00:00:08"),
+            ("CircuitBreaker:BreakDuration", "00:00:05"),
+            ("RateLimit:Permits", "5"),
+            ("RateLimit:Window", "00:00:10"),
+            ("RateLimit:Burst", "7"),
+            ("RateLimit:QueueLimit", "2"),
+            ("ConcurrencyLimit:MaxConcurrency", "3"),
+            ("ConcurrencyLimit:MaxQueue", "4"),
+            ("AttemptTimeout", "00:00:01"));
+        var services = new ServiceCollection();
+        services.AddShield("complete", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("complete");
+
+        await Assert.That(shield.ToString()).IsEqualTo(
+            "complete: Timeout(20s) → Retry(2, exponential 100ms ×3 ≤2s) → CircuitBreaker(25% over 8s, min 4, break 5s) → RateLimit(5/10s, burst 7, queue 2) → ConcurrencyLimit(3, queue 4) → Timeout(1s)");
+    }
 }


### PR DESCRIPTION
## Summary
- publish and execute clean package consumers for trimmed, single-file, and NativeAOT configurations
- make configuration-bound DI AOT-safe without reflection and mark .NET 10 packages AOT compatible
- document the matrix and provision Linux NativeAOT prerequisites in CI

Closes #32

## Validation
- dotnet build Kevlar.slnx -c Release -p:Version=0.0.0-local
- dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m
- dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m
- dotnet pack Kevlar.slnx -c Release --no-build -p:Version=0.0.0-local
- pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local
- npm ci && npm run build (docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configuration-based shield settings now parse consistently across cultures, including timeouts, retries, rate limits, concurrency, and circuit breakers.
  - Added broader package publishing compatibility checks for trimmed, single-file, NativeAOT, and .NET 8 scenarios.

- **Bug Fixes**
  - Improved reliability when reading numeric, Boolean, enum, and duration-based configuration values.

- **Documentation**
  - Added guidance for validating package compatibility and running local package verification.

- **Tests**
  - Expanded coverage for all supported configuration and shield strategy options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->