### PR TITLE
fix(metrics): follow OTel conventions

### DIFF
--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -31,19 +31,19 @@ On .NET 8+ every shield publishes metrics through a `System.Diagnostics.Metrics.
 services.AddOpenTelemetry().WithMetrics(metrics => metrics.AddMeter(KevlarDiagnostics.MeterName));
 ```
 
-| Instrument | Counts | Tags |
-|---|---|---|
-| `kevlar.executions` | completed public execution calls, including empty shields and pre-cancelled calls | `shield.name`, `outcome` (`success`/`failure`) |
-| `kevlar.retries` | retry attempts | `shield.name` |
-| `kevlar.timeouts` | executions cancelled by a timeout strategy | `shield.name` |
-| `kevlar.hedges` | extra hedged attempts launched | `shield.name` |
-| `kevlar.fallbacks` | outcomes replaced by a fallback | `shield.name` |
-| `kevlar.rejections` | fail-fast rejections | `shield.name`, `kind` (`circuit_open`/`rate_limit`/`concurrency_limit`) |
-| `kevlar.circuit_breaker.transitions` | circuit state changes | `from`, `to` |
+| Instrument | Unit | Counts | Attributes |
+|---|---|---|---|
+| `kevlar.executions` | `{execution}` | completed public execution calls, including empty shields and pre-cancelled calls | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
+| `kevlar.retries` | `{retry}` | retry attempts | `kevlar.shield.name` |
+| `kevlar.timeouts` | `{timeout}` | executions cancelled by a timeout strategy | `kevlar.shield.name` |
+| `kevlar.hedges` | `{hedge}` | extra hedged attempts launched | `kevlar.shield.name` |
+| `kevlar.fallbacks` | `{fallback}` | outcomes replaced by a fallback | `kevlar.shield.name` |
+| `kevlar.rejections` | `{rejection}` | fail-fast rejections | `kevlar.shield.name`, `kevlar.rejection.type` (`circuit_open`/`rate_limit`/`concurrency_limit`) |
+| `kevlar.circuit_breaker.transitions` | `{transition}` | circuit state changes | `kevlar.circuit_breaker.state.from`, `kevlar.circuit_breaker.state.to` (`closed`/`open`/`half_open`/`isolated`) |
 
 Each public execution call records exactly one `kevlar.executions` measurement after its final outcome: recovery through fallback is `success`; exceptions, caller cancellation, timeout, and strategy rejection are `failure`. Retry and hedge attempts do not add execution measurements of their own.
 
-The `shield.name` tag appears only for shields named via `WithName` — name the shields you dashboard. `WithName("")` emits the tag with an empty value; an unnamed shield omits it. On `netstandard2.0` targets the instruments are inert because the metrics API isn't in-box there.
+The `kevlar.shield.name` attribute appears only for shields named via `WithName` — name the shields you dashboard. `WithName("")` emits the attribute with an empty value; an unnamed shield omits it. Instrument and attribute names use the product-specific `kevlar` namespace; count units use singular UCUM annotations. On `netstandard2.0` targets the instruments are inert because the metrics API isn't in-box there.
 
 ## Compile-time checks
 

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -16,13 +16,34 @@ internal static class KevlarMetrics
 {
 #if NET8_0_OR_GREATER
     private static readonly Meter Meter = new(KevlarDiagnostics.MeterName, "1.0");
-    private static readonly Counter<long> Executions = Meter.CreateCounter<long>("kevlar.executions");
-    private static readonly Counter<long> Retries = Meter.CreateCounter<long>("kevlar.retries");
-    private static readonly Counter<long> Timeouts = Meter.CreateCounter<long>("kevlar.timeouts");
-    private static readonly Counter<long> Hedges = Meter.CreateCounter<long>("kevlar.hedges");
-    private static readonly Counter<long> Fallbacks = Meter.CreateCounter<long>("kevlar.fallbacks");
-    private static readonly Counter<long> Rejections = Meter.CreateCounter<long>("kevlar.rejections");
-    private static readonly Counter<long> CircuitTransitions = Meter.CreateCounter<long>("kevlar.circuit_breaker.transitions");
+    private static readonly Counter<long> Executions = Meter.CreateCounter<long>(
+        "kevlar.executions",
+        "{execution}",
+        "Completed public shield executions.");
+    private static readonly Counter<long> Retries = Meter.CreateCounter<long>(
+        "kevlar.retries",
+        "{retry}",
+        "Retry attempts started after the initial attempt.");
+    private static readonly Counter<long> Timeouts = Meter.CreateCounter<long>(
+        "kevlar.timeouts",
+        "{timeout}",
+        "Executions cancelled by a timeout strategy.");
+    private static readonly Counter<long> Hedges = Meter.CreateCounter<long>(
+        "kevlar.hedges",
+        "{hedge}",
+        "Additional hedged attempts started.");
+    private static readonly Counter<long> Fallbacks = Meter.CreateCounter<long>(
+        "kevlar.fallbacks",
+        "{fallback}",
+        "Outcomes replaced by a fallback.");
+    private static readonly Counter<long> Rejections = Meter.CreateCounter<long>(
+        "kevlar.rejections",
+        "{rejection}",
+        "Executions rejected before the user delegate starts.");
+    private static readonly Counter<long> CircuitTransitions = Meter.CreateCounter<long>(
+        "kevlar.circuit_breaker.transitions",
+        "{transition}",
+        "Circuit-breaker state transitions.");
 #endif
 
 #if NET8_0_OR_GREATER
@@ -37,7 +58,7 @@ internal static class KevlarMetrics
         if (Executions.Enabled)
         {
             var tags = NameTags(shieldName);
-            tags.Add("outcome", success ? "success" : "failure");
+            tags.Add("kevlar.execution.outcome", success ? "success" : "failure");
             Executions.Add(1, tags);
         }
 #endif
@@ -89,7 +110,7 @@ internal static class KevlarMetrics
         if (Rejections.Enabled)
         {
             var tags = NameTags(shieldName);
-            tags.Add("kind", kind);
+            tags.Add("kevlar.rejection.type", kind);
             Rejections.Add(1, tags);
         }
 #endif
@@ -102,8 +123,8 @@ internal static class KevlarMetrics
         {
             CircuitTransitions.Add(1, new TagList
             {
-                { "from", from.ToString() },
-                { "to", to.ToString() },
+                { "kevlar.circuit_breaker.state.from", StateName(from) },
+                { "kevlar.circuit_breaker.state.to", StateName(to) },
             });
         }
 #endif
@@ -115,10 +136,19 @@ internal static class KevlarMetrics
         var tags = default(TagList);
         if (shieldName is not null)
         {
-            tags.Add("shield.name", shieldName);
+            tags.Add("kevlar.shield.name", shieldName);
         }
 
         return tags;
     }
+
+    private static string StateName(CircuitState state) => state switch
+    {
+        CircuitState.Closed => "closed",
+        CircuitState.Open => "open",
+        CircuitState.HalfOpen => "half_open",
+        CircuitState.Isolated => "isolated",
+        _ => throw new ArgumentOutOfRangeException(nameof(state)),
+    };
 #endif
 }

--- a/src/Kevlar/KevlarDiagnostics.cs
+++ b/src/Kevlar/KevlarDiagnostics.cs
@@ -10,15 +10,15 @@ namespace Kevlar;
 /// The meter version is <c>1.0</c>. Instruments (all <c>Counter&lt;long&gt;</c>):
 /// <list type="bullet">
 /// <item><c>kevlar.executions</c> — completed public execution calls, including empty shields and
-/// pre-cancelled calls; tags <c>shield.name</c>, <c>outcome</c> (<c>success</c>/<c>failure</c>)</item>
-/// <item><c>kevlar.retries</c> — retry attempts; tag <c>shield.name</c></item>
-/// <item><c>kevlar.timeouts</c> — executions cancelled by a timeout strategy; tag <c>shield.name</c></item>
-/// <item><c>kevlar.hedges</c> — extra hedged attempts launched; tag <c>shield.name</c></item>
-/// <item><c>kevlar.fallbacks</c> — outcomes replaced by a fallback; tag <c>shield.name</c></item>
-/// <item><c>kevlar.rejections</c> — fail-fast rejections; tags <c>shield.name</c>, <c>kind</c> (<c>circuit_open</c>/<c>rate_limit</c>/<c>concurrency_limit</c>)</item>
-/// <item><c>kevlar.circuit_breaker.transitions</c> — circuit state changes; tags <c>from</c>, <c>to</c></item>
+/// pre-cancelled calls; attributes <c>kevlar.shield.name</c>, <c>kevlar.execution.outcome</c> (<c>success</c>/<c>failure</c>)</item>
+/// <item><c>kevlar.retries</c> — retry attempts; attribute <c>kevlar.shield.name</c></item>
+/// <item><c>kevlar.timeouts</c> — executions cancelled by a timeout strategy; attribute <c>kevlar.shield.name</c></item>
+/// <item><c>kevlar.hedges</c> — extra hedged attempts launched; attribute <c>kevlar.shield.name</c></item>
+/// <item><c>kevlar.fallbacks</c> — outcomes replaced by a fallback; attribute <c>kevlar.shield.name</c></item>
+/// <item><c>kevlar.rejections</c> — fail-fast rejections; attributes <c>kevlar.shield.name</c>, <c>kevlar.rejection.type</c> (<c>circuit_open</c>/<c>rate_limit</c>/<c>concurrency_limit</c>)</item>
+/// <item><c>kevlar.circuit_breaker.transitions</c> — circuit state changes; attributes <c>kevlar.circuit_breaker.state.from</c>, <c>kevlar.circuit_breaker.state.to</c></item>
 /// </list>
-/// The <c>shield.name</c> tag is present only for shields named via <c>WithName</c>; an explicitly
+/// The <c>kevlar.shield.name</c> attribute is present only for shields named via <c>WithName</c>; an explicitly
 /// empty name is emitted as an empty tag value.
 /// </remarks>
 public static class KevlarDiagnostics

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -43,7 +43,7 @@ public class MetricsTests
         public long Total(string instrument, string? shieldName = null, params (string Key, string Value)[] tags) =>
             _measurements
                 .Where(m => m.Instrument == instrument)
-                .Where(m => shieldName is null || (m.Tags.TryGetValue("shield.name", out var name) && Equals(name, shieldName)))
+                .Where(m => shieldName is null || (m.Tags.TryGetValue("kevlar.shield.name", out var name) && Equals(name, shieldName)))
                 .Where(m => tags.All(tag => m.Tags.TryGetValue(tag.Key, out var value) && Equals(value, tag.Value)))
                 .Sum(m => m.Value);
 
@@ -56,8 +56,8 @@ public class MetricsTests
             _measurements
                 .Where(measurement => measurement.Instrument == instrument)
                 .Where(measurement => requireName
-                    ? measurement.Tags.TryGetValue("shield.name", out var name) && Equals(name, shieldName)
-                    : !measurement.Tags.ContainsKey("shield.name"))
+                    ? measurement.Tags.TryGetValue("kevlar.shield.name", out var name) && Equals(name, shieldName)
+                    : !measurement.Tags.ContainsKey("kevlar.shield.name"))
                 .Select(measurement => measurement.Tags)
                 .ToArray();
 
@@ -74,8 +74,8 @@ public class MetricsTests
         await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
             .Throws<InvalidOperationException>();
 
-        await Assert.That(listener.Total("kevlar.executions", "metrics-executions", ("outcome", "success"))).IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.executions", "metrics-executions", ("outcome", "failure"))).IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-executions", ("kevlar.execution.outcome", "success"))).IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", "metrics-executions", ("kevlar.execution.outcome", "failure"))).IsEqualTo(1);
     }
 
     [Test]
@@ -86,7 +86,7 @@ public class MetricsTests
 
         await shield.ExecuteAsync(_ => new ValueTask<int>(42));
 
-        await Assert.That(listener.Total("kevlar.executions", "metrics-empty", ("outcome", "success")))
+        await Assert.That(listener.Total("kevlar.executions", "metrics-empty", ("kevlar.execution.outcome", "success")))
             .IsEqualTo(1);
     }
 
@@ -115,7 +115,7 @@ public class MetricsTests
         _ = await typed.ExecuteOutcomeAsync(taskResult);
         _ = typed.Execute(_ => 42);
 
-        await Assert.That(listener.Total("kevlar.executions", name, ("outcome", "success")))
+        await Assert.That(listener.Total("kevlar.executions", name, ("kevlar.execution.outcome", "success")))
             .IsEqualTo(13);
     }
 
@@ -147,7 +147,7 @@ public class MetricsTests
 
         await Assert.That(invoked).IsFalse();
         await Assert.That(outcome.IsSuccess).IsFalse();
-        await Assert.That(listener.Total("kevlar.executions", name, ("outcome", "failure")))
+        await Assert.That(listener.Total("kevlar.executions", name, ("kevlar.execution.outcome", "failure")))
             .IsEqualTo(3);
     }
 
@@ -158,22 +158,27 @@ public class MetricsTests
         await Shield.Empty.WithName("metrics-schema")
             .ExecuteAsync(_ => new ValueTask<int>(42));
 
-        var expectedNames = new[]
+        var expectedInstruments = new Dictionary<string, string>
         {
-            "kevlar.executions",
-            "kevlar.retries",
-            "kevlar.timeouts",
-            "kevlar.hedges",
-            "kevlar.fallbacks",
-            "kevlar.rejections",
-            "kevlar.circuit_breaker.transitions",
+            ["kevlar.executions"] = "{execution}",
+            ["kevlar.retries"] = "{retry}",
+            ["kevlar.timeouts"] = "{timeout}",
+            ["kevlar.hedges"] = "{hedge}",
+            ["kevlar.fallbacks"] = "{fallback}",
+            ["kevlar.rejections"] = "{rejection}",
+            ["kevlar.circuit_breaker.transitions"] = "{transition}",
         };
 
         await Assert.That(listener.Instruments.Select(instrument => instrument.Name))
-            .IsEquivalentTo(expectedNames);
+            .IsEquivalentTo(expectedInstruments.Keys);
         await Assert.That(listener.Instruments.All(instrument => instrument is Counter<long>)).IsTrue();
         await Assert.That(listener.Instruments.All(instrument => instrument.Meter.Name == "Kevlar")).IsTrue();
         await Assert.That(listener.Instruments.All(instrument => instrument.Meter.Version == "1.0")).IsTrue();
+        await Assert.That(listener.Instruments.All(instrument =>
+            expectedInstruments.TryGetValue(instrument.Name, out var unit) && instrument.Unit == unit))
+            .IsTrue();
+        await Assert.That(listener.Instruments.All(instrument => !string.IsNullOrWhiteSpace(instrument.Description)))
+            .IsTrue();
     }
 
     [Test]
@@ -191,11 +196,11 @@ public class MetricsTests
         var unnamedTags = listener.Measurements("kevlar.executions", null, requireName: false);
         var emptyTags = listener.Measurements("kevlar.executions", string.Empty).Single();
         var namedTags = listener.Measurements("kevlar.executions", "metrics-tags").Single();
-        await Assert.That(unnamedTags.Any(tags => tags.Keys.SequenceEqual(["outcome"]))).IsTrue();
-        await Assert.That(emptyTags.Keys).IsEquivalentTo(["shield.name", "outcome"]);
-        await Assert.That(emptyTags["shield.name"]).IsEqualTo(string.Empty);
-        await Assert.That(namedTags.Keys).IsEquivalentTo(["shield.name", "outcome"]);
-        await Assert.That(namedTags["outcome"]).IsEqualTo("success");
+        await Assert.That(unnamedTags.Any(tags => tags.Keys.SequenceEqual(["kevlar.execution.outcome"]))).IsTrue();
+        await Assert.That(emptyTags.Keys).IsEquivalentTo(["kevlar.shield.name", "kevlar.execution.outcome"]);
+        await Assert.That(emptyTags["kevlar.shield.name"]).IsEqualTo(string.Empty);
+        await Assert.That(namedTags.Keys).IsEquivalentTo(["kevlar.shield.name", "kevlar.execution.outcome"]);
+        await Assert.That(namedTags["kevlar.execution.outcome"]).IsEqualTo("success");
     }
 
     [Test]
@@ -229,7 +234,7 @@ public class MetricsTests
             .Throws<TimeoutExceededException>();
 
         await Assert.That(listener.Total("kevlar.timeouts", "metrics-timeouts")).IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.executions", "metrics-timeouts", ("outcome", "failure")))
+        await Assert.That(listener.Total("kevlar.executions", "metrics-timeouts", ("kevlar.execution.outcome", "failure")))
             .IsEqualTo(1);
     }
 
@@ -243,7 +248,7 @@ public class MetricsTests
         await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(2)))
             .Throws<RateLimitExceededException>();
 
-        await Assert.That(listener.Total("kevlar.rejections", "metrics-rate", ("kind", "rate_limit"))).IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.rejections", "metrics-rate", ("kevlar.rejection.type", "rate_limit"))).IsEqualTo(1);
     }
 
     [Test]
@@ -282,21 +287,21 @@ public class MetricsTests
 
         _ = await occupying;
 
-        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-rate", ("kind", "rate_limit")))
+        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-rate", ("kevlar.rejection.type", "rate_limit")))
             .IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-circuit", ("kind", "circuit_open")))
+        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-circuit", ("kevlar.rejection.type", "circuit_open")))
             .IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-concurrency", ("kind", "concurrency_limit")))
+        await Assert.That(listener.Total("kevlar.rejections", "metrics-reject-concurrency", ("kevlar.rejection.type", "concurrency_limit")))
             .IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-rate", ("outcome", "success")))
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-rate", ("kevlar.execution.outcome", "success")))
             .IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-rate", ("outcome", "failure")))
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-rate", ("kevlar.execution.outcome", "failure")))
             .IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-circuit", ("outcome", "failure")))
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-circuit", ("kevlar.execution.outcome", "failure")))
             .IsEqualTo(2);
-        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-concurrency", ("outcome", "success")))
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-concurrency", ("kevlar.execution.outcome", "success")))
             .IsEqualTo(1);
-        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-concurrency", ("outcome", "failure")))
+        await Assert.That(listener.Total("kevlar.executions", "metrics-reject-concurrency", ("kevlar.execution.outcome", "failure")))
             .IsEqualTo(1);
     }
 
@@ -320,7 +325,7 @@ public class MetricsTests
 
         await Assert.That(result).IsEqualTo(42);
         await Assert.That(attempts).IsEqualTo(3);
-        await Assert.That(listener.Total("kevlar.executions", name, ("outcome", "success"))).IsEqualTo(1);
+        await Assert.That(listener.Total("kevlar.executions", name, ("kevlar.execution.outcome", "success"))).IsEqualTo(1);
         await Assert.That(listener.Total("kevlar.retries", name)).IsEqualTo(2);
         await Assert.That(listener.Total("kevlar.fallbacks", name)).IsEqualTo(1);
     }
@@ -347,9 +352,9 @@ public class MetricsTests
             });
         _ = await Task.WhenAll(executions);
 
-        await Assert.That(listener.Total("kevlar.executions", firstName, ("outcome", "success")))
+        await Assert.That(listener.Total("kevlar.executions", firstName, ("kevlar.execution.outcome", "success")))
             .IsEqualTo(countPerShield);
-        await Assert.That(listener.Total("kevlar.executions", secondName, ("outcome", "success")))
+        await Assert.That(listener.Total("kevlar.executions", secondName, ("kevlar.execution.outcome", "success")))
             .IsEqualTo(countPerShield);
     }
 
@@ -402,7 +407,11 @@ public class MetricsTests
 
         // The breaker tripped Closed -> Open; transitions carry no shield name, and other tests
         // may trip breakers concurrently, so assert at least ours was recorded.
-        var transitions = listener.Total("kevlar.circuit_breaker.transitions", null, ("from", "Closed"), ("to", "Open"));
+        var transitions = listener.Total(
+            "kevlar.circuit_breaker.transitions",
+            null,
+            ("kevlar.circuit_breaker.state.from", "closed"),
+            ("kevlar.circuit_breaker.state.to", "open"));
         await Assert.That(transitions >= 1).IsTrue();
     }
 
@@ -450,8 +459,17 @@ public class MetricsTests
             direction => listener.Total(
                 "kevlar.circuit_breaker.transitions",
                 null,
-                ("from", direction.source.ToString()),
-                ("to", direction.target.ToString())));
+                ("kevlar.circuit_breaker.state.from", StateName(direction.source)),
+                ("kevlar.circuit_breaker.state.to", StateName(direction.target))));
+
+    private static string StateName(CircuitState state) => state switch
+    {
+        CircuitState.Closed => "closed",
+        CircuitState.Open => "open",
+        CircuitState.HalfOpen => "half_open",
+        CircuitState.Isolated => "isolated",
+        _ => throw new ArgumentOutOfRangeException(nameof(state)),
+    };
 
     private static async Task EmitNaturalCircuitTransitions()
     {


### PR DESCRIPTION
## Summary
- add singular UCUM annotation units and descriptions to every counter
- namespace system-specific attributes under `kevlar.*`
- emit circuit state values as lowercase snake_case
- lock the updated instrument and attribute schema in tests and documentation

This follows OpenTelemetry's general metric and naming guidance: product-specific namespaces, dot-delimited object properties, lowercase snake_case components, and singular annotated units for discrete counts.

Closes #59

## Validation
- `dotnet build Kevlar.slnx -c Release`
- 483 unit, 16 integration, 19 analyzer, and 1 netstandard tests passed
- `npm ci && npm run build`

## References
- https://opentelemetry.io/docs/specs/semconv/general/naming/
- https://opentelemetry.io/docs/specs/semconv/general/metrics/