### PR TITLE
feat(analyzers): diagnose pipeline hazards

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ One clause up top decides what "failure" means for every strategy below it — e
 - **Intuitive first.** `Shield.When<TimeoutException>().Retry(3)` reads like what it does. No context pooling ceremony, no predicate-builder classes, no options objects for the simple cases — and full options objects when you want them.
 - **Fast.** Outcomes flow between pipeline layers as structs instead of thrown exceptions; contexts are pooled internally; state-passing overloads eliminate closures; `ValueTask` end to end.
 - **Production defaults.** `Shield.Retry(3)` gives you exponential backoff *with jitter* capped at 30s — the thing you'd have configured anyway.
-- **Hard to hold wrong.** Impossible chain orders throw at build time with the fix in the message, and the `Kevlar.Analyzers` package flags delegates that ignore their `CancellationToken` at compile time.
+- **Hard to hold wrong.** Impossible chain orders throw at build time with the fix in the message, and the `Kevlar.Analyzers` package flags cancellation and pipeline hazards at compile time.
 - **Observable out of the box.** `shield.ToString()` prints the whole pipeline; every shield publishes metrics through a built-in `Meter` — no telemetry package, no setup.
 - **Composable.** Shields merge with `Wrap` and `Compose`, chain fluently, and stateful strategies (breakers, limiters) intentionally share their state wherever the same shield instance is reused.
 - **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net10.0` targets.
@@ -275,7 +275,7 @@ services.AddHttpClient("api")
 
 On .NET 8+ every shield publishes metrics through a `Meter` named `"Kevlar"` with zero configuration — executions, retries, timeouts, hedges, fallbacks, rejections and circuit transitions, tagged with the shield's `WithName` name. Subscribe with `AddMeter(KevlarDiagnostics.MeterName)`.
 
-And `dotnet add package Kevlar.Analyzers` adds compile-time checks — starting with KEV001: an execution delegate that ignores the `CancellationToken` it is handed (the most common way to defeat a timeout).
+And `dotnet add package Kevlar.Analyzers` adds compile-time checks for ignored execution cancellation, synchronous hedging, and unreachable reactive strategies. See the [analyzer rule reference](docs/docs/analyzers.md).
 
 ## Custom strategies
 

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 12
+---
+
+# Analyzers
+
+Install the optional analyzer package in each project that builds Kevlar pipelines:
+
+```bash
+dotnet add package Kevlar.Analyzers
+```
+
+The analyzers report only hazards that are provable from the current expression or a stable local
+initializer. They do not guess what a factory method returns or follow a local that is reassigned.
+Generated code is ignored.
+
+| Rule | Severity | Hazard |
+|---|---|---|
+| `KEV001` | Warning | execution delegate ignores its `CancellationToken` |
+| `KEV002` | Warning | hedging pipeline is passed to synchronous `Execute` |
+| `KEV003` | Warning | inner fallback makes retry, hedging, or circuit breaker unreachable |
+
+## KEV001: ignored execution cancellation
+
+Kevlar cancels the token passed to an execution delegate when the caller cancels, a timeout expires,
+or a hedge loses. Work that ignores the token can continue after the shield has returned.
+
+```csharp
+await shield.ExecuteAsync(ct => client.GetAsync(url));        // KEV001
+await shield.ExecuteAsync(ct => client.GetAsync(url, ct));    // clean
+```
+
+Pass the token to cancellable work. Name it `_` only when the operation is truly synchronous or
+uncancellable and ignoring cancellation is deliberate.
+
+## KEV002: synchronous hedging
+
+Hedging races concurrent attempts and therefore supports only asynchronous execution. Synchronous
+`Execute` always throws for a shield containing hedging, so use `ExecuteAsync` or remove hedging:
+
+```csharp
+var hedged = Shield.Hedge(2, TimeSpan.FromMilliseconds(50));
+
+var value = await hedged.ExecuteAsync(ct => LoadAsync(ct));   // clean
+```
+
+The rule recognizes direct fluent chains and stable local aliases, including typed shields and
+extension-method syntax. It deliberately skips opaque factory results and reassigned locals.
+
+## KEV003: unreachable reactive strategy
+
+A fallback placed inside retry, hedging, or circuit breaker under the same handling clause consumes
+every handled failure before the outer strategy sees it. Kevlar rejects that pipeline at construction
+time. Put fallback first so it wraps the reactive strategy:
+
+```csharp
+var shield = Shield.For<int>()
+    .Fallback(-1)
+    .Retry(3);
+```
+
+Alternatively, start a new, narrower handling clause before the inner fallback when layered recovery
+is intentional:
+
+```csharp
+var shield = Shield.For<int>()
+    .Retry(3)
+    .When<TimeoutExceededException>()
+    .Fallback(-1);
+```
+
+No automatic code fix is supplied for `KEV002` or `KEV003`: changing sync control flow or strategy
+order can change application semantics.
+
+## Suppression
+
+Suppress one reviewed site with ordinary C# warning pragmas and record why the analyzer cannot see
+the wider invariant:
+
+```csharp
+#pragma warning disable KEV002 // Execution is unreachable in the synchronous deployment mode.
+var value = shield.Execute(_ => 1);
+#pragma warning restore KEV002
+```
+
+To suppress a rule project-wide, append its ID to `NoWarn`:
+
+```xml
+<NoWarn>$(NoWarn);KEV002</NoWarn>
+```
+
+Prefer a narrow pragma. Project-wide suppression can hide newly introduced unsafe call sites.

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -17,7 +17,7 @@ Generated code is ignored.
 | Rule | Severity | Hazard |
 |---|---|---|
 | `KEV001` | Warning | execution delegate ignores its `CancellationToken` |
-| `KEV002` | Warning | hedging pipeline is passed to synchronous `Execute` |
+| `KEV002` | Warning | known multi-attempt hedging pipeline is passed to synchronous `Execute` |
 | `KEV003` | Warning | inner fallback makes retry, hedging, or circuit breaker unreachable |
 
 ## KEV001: ignored execution cancellation
@@ -35,8 +35,9 @@ uncancellable and ignoring cancellation is deliberate.
 
 ## KEV002: synchronous hedging
 
-Hedging races concurrent attempts and therefore supports only asynchronous execution. Synchronous
-`Execute` always throws for a shield containing hedging, so use `ExecuteAsync` or remove hedging:
+Multi-attempt hedging races concurrent attempts and therefore supports only asynchronous execution.
+Synchronous `Execute` throws for a shield containing a hedge with a known `MaxAttempts` greater than
+one, so use `ExecuteAsync` or remove hedging:
 
 ```csharp
 var hedged = Shield.Hedge(2, TimeSpan.FromMilliseconds(50));
@@ -44,8 +45,9 @@ var hedged = Shield.Hedge(2, TimeSpan.FromMilliseconds(50));
 var value = await hedged.ExecuteAsync(ct => LoadAsync(ct));   // clean
 ```
 
-The rule recognizes direct fluent chains and stable local aliases, including typed shields and
-extension-method syntax. It deliberately skips opaque factory results and reassigned locals.
+The rule recognizes direct fluent chains, composed shields, and stable local aliases, including typed
+shields and extension-method syntax. It deliberately skips opaque factory results, reassigned locals,
+and hedging whose configured attempt count is not a compile-time constant.
 
 ## KEV003: unreachable reactive strategy
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -25,7 +25,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 - **Intuitive first.** `Shield.When<TimeoutException>().Retry(3)` reads like what it does. No context pooling ceremony, no predicate-builder classes, no options objects for the simple cases — and full options objects when you want them.
 - **Fast.** Outcomes flow between pipeline layers as structs instead of thrown exceptions; contexts are pooled internally; state-passing overloads eliminate closures; `ValueTask` end to end.
 - **Production defaults.** `Shield.Retry(3)` gives you exponential backoff *with jitter* capped at 30s — the thing you'd have configured anyway.
-- **Hard to hold wrong.** `Task` and `ValueTask` delegates both flow straight in; impossible chain orders throw at build time with a fix in the message; the `Kevlar.Analyzers` package flags delegates that ignore their `CancellationToken` at compile time.
+- **Hard to hold wrong.** `Task` and `ValueTask` delegates both flow straight in; impossible chain orders throw at build time with a fix in the message; the `Kevlar.Analyzers` package flags cancellation and pipeline hazards at compile time.
 - **Observable out of the box.** Every shield describes itself (`shield.ToString()` prints the whole pipeline) and publishes metrics through a built-in `Meter` — no telemetry package, no setup.
 - **Composable.** Shields merge with `Wrap` and `Compose`, chain fluently, and stateful strategies (breakers, limiters) intentionally share their state wherever the same shield instance is reused.
 - **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net10.0` targets.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -57,7 +57,7 @@ dotnet add package Kevlar.Analyzers
 | Rule | Severity | Catches |
 |---|---|---|
 | `KEV001` | Warning | An execution delegate that never uses the `CancellationToken` it is handed — the most common way to defeat a [timeout](strategies/timeout.md). |
-| `KEV002` | Warning | A statically known hedging pipeline passed to synchronous `Execute`. |
+| `KEV002` | Warning | A statically known multi-attempt hedging pipeline passed to synchronous `Execute`. |
 | `KEV003` | Warning | An inner fallback that makes retry, hedging, or circuit breaker unreachable under the same handling clause. |
 
 ```csharp

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -57,11 +57,16 @@ dotnet add package Kevlar.Analyzers
 | Rule | Severity | Catches |
 |---|---|---|
 | `KEV001` | Warning | An execution delegate that never uses the `CancellationToken` it is handed — the most common way to defeat a [timeout](strategies/timeout.md). |
+| `KEV002` | Warning | A statically known hedging pipeline passed to synchronous `Execute`. |
+| `KEV003` | Warning | An inner fallback that makes retry, hedging, or circuit breaker unreachable under the same handling clause. |
 
 ```csharp
 await shield.ExecuteAsync(ct => client.GetAsync(url));        // KEV001: token ignored
 await shield.ExecuteAsync(ct => client.GetAsync(url, ct));    // clean
 ```
+
+See [Analyzer rules](analyzers.md) for rationale, safe alternatives, conservative analysis limits,
+and suppression guidance.
 
 ## Callbacks
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
     'http',
     'custom-strategies',
     'library-authors',
+    'analyzers',
     'observability',
     'testing',
     'performance',

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,5 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 KEV001 | Reliability | Warning | Execution delegate ignores its CancellationToken
+KEV002 | Reliability | Warning | Hedging requires asynchronous execution
+KEV003 | Configuration | Warning | Fallback makes a reactive strategy unreachable

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,5 +6,5 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 KEV001 | Reliability | Warning | Execution delegate ignores its CancellationToken
-KEV002 | Reliability | Warning | Hedging requires asynchronous execution
+KEV002 | Reliability | Warning | Statically known multi-attempt hedging requires asynchronous execution
 KEV003 | Configuration | Warning | Fallback makes a reactive strategy unreachable

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -122,7 +122,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
             if (!visitedLocals.Add(localReference.Local)
-                || !TryGetStableInitializer(localReference.Local, context, out var initializer))
+                || !TryGetStableInitializer(localReference, context, out var initializer))
             {
                 matchedMethod = null;
                 return false;
@@ -239,10 +239,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool TryGetStableInitializer(
-        ILocalSymbol local,
+        ILocalReferenceOperation localReference,
         OperationAnalysisContext context,
         out IOperation? initializer)
     {
+        var local = localReference.Local;
         var declarations = local.DeclaringSyntaxReferences;
         if (declarations.Length != 1
             || declarations[0].GetSyntax(context.CancellationToken) is not VariableDeclaratorSyntax
@@ -270,7 +271,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol,
                     local)
-                && IsWritten(identifier))
+                && (IsWritten(identifier)
+                    || local.Type is IArrayTypeSymbol
+                        && IsEscapingArrayReference(identifier, localReference.Syntax)))
             {
                 initializer = null;
                 return false;
@@ -279,6 +282,35 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         initializer = semanticModel.GetOperation(initializerSyntax, context.CancellationToken);
         return initializer is not null;
+    }
+
+    private static bool IsEscapingArrayReference(
+        IdentifierNameSyntax identifier,
+        SyntaxNode permittedReference)
+    {
+        if (identifier.SyntaxTree == permittedReference.SyntaxTree
+            && identifier.Span == permittedReference.Span)
+        {
+            return false;
+        }
+
+        foreach (var ancestor in identifier.Ancestors())
+        {
+            switch (ancestor)
+            {
+                case ArgumentSyntax:
+                case EqualsValueClauseSyntax:
+                case ReturnStatementSyntax:
+                case YieldStatementSyntax:
+                    return true;
+                case AssignmentExpressionSyntax assignment when assignment.Right.Span.Contains(identifier.Span):
+                    return true;
+                case StatementSyntax:
+                    return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool IsWritten(IdentifierNameSyntax identifier)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -299,6 +299,41 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        if (TryGetAmbientClause(inner, context, knownTypes, visitedLocals, out var innerAmbient)
+            && TryGetAmbientClause(outer, context, knownTypes, visitedLocals, out var outerAmbient))
+        {
+            var resultAmbient = innerAmbient ?? outerAmbient;
+            if (SameAmbient(innerAmbient, resultAmbient)
+                && FindInPipeline(
+                    inner,
+                    context,
+                    predicate,
+                    knownTypes,
+                    stopAtHandlingClause,
+                    stopAtCompositionBoundary,
+                    visitedLocals,
+                    out matchedMethod))
+            {
+                return true;
+            }
+
+            if (SameAmbient(outerAmbient, resultAmbient))
+            {
+                return FindInPipeline(
+                    outer,
+                    context,
+                    predicate,
+                    knownTypes,
+                    stopAtHandlingClause,
+                    stopAtCompositionBoundary,
+                    visitedLocals,
+                    out matchedMethod);
+            }
+
+            matchedMethod = null;
+            return false;
+        }
+
         if (!IsKnownClauseFree(inner, context, knownTypes, visitedLocals))
         {
             return FindInPipeline(
@@ -351,6 +386,55 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         foreach (var argument in invocation.Arguments)
         {
             CollectCompositionOperands(argument.Value, context, operands, visitedLocals);
+        }
+
+        var ambientClauses = new SyntaxNode?[operands.Count];
+        var allKnown = true;
+        for (var index = 0; index < operands.Count; index++)
+        {
+            if (!TryGetAmbientClause(
+                operands[index],
+                context,
+                knownTypes,
+                visitedLocals,
+                out ambientClauses[index]))
+            {
+                allKnown = false;
+                break;
+            }
+        }
+
+        if (allKnown)
+        {
+            SyntaxNode? resultAmbient = null;
+            for (var index = ambientClauses.Length - 1; index >= 0; index--)
+            {
+                if (ambientClauses[index] is not null)
+                {
+                    resultAmbient = ambientClauses[index];
+                    break;
+                }
+            }
+
+            for (var index = 0; index < operands.Count; index++)
+            {
+                if (SameAmbient(ambientClauses[index], resultAmbient)
+                    && FindInPipeline(
+                        operands[index],
+                        context,
+                        predicate,
+                        knownTypes,
+                        stopAtHandlingClause,
+                        stopAtCompositionBoundary,
+                        visitedLocals,
+                        out matchedMethod))
+                {
+                    return true;
+                }
+            }
+
+            matchedMethod = null;
+            return false;
         }
 
         for (var index = operands.Count - 1; index >= 0; index--)
@@ -451,6 +535,140 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    private static bool TryGetAmbientClause(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals,
+        out SyntaxNode? ambientClause)
+    {
+        operation = Unwrap(operation);
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedLocals.Add(localReference.Local)
+                || !TryGetStableInitializer(localReference, context, out var initializer))
+            {
+                ambientClause = null;
+                return false;
+            }
+
+            var found = TryGetAmbientClause(
+                initializer,
+                context,
+                knownTypes,
+                visitedLocals,
+                out ambientClause);
+            visitedLocals.Remove(localReference.Local);
+            return found;
+        }
+
+        if (operation is IConditionalAccessOperation conditionalAccess)
+        {
+            return TryGetAmbientClause(
+                conditionalAccess.Operation,
+                context,
+                knownTypes,
+                visitedLocals,
+                out ambientClause);
+        }
+
+        if (operation is IPropertyReferenceOperation propertyReference)
+        {
+            ambientClause = null;
+            return propertyReference.Property.Name == "Empty"
+                && knownTypes.IsShield(propertyReference.Property.ContainingType);
+        }
+
+        if (operation is not IInvocationOperation invocation)
+        {
+            ambientClause = null;
+            return false;
+        }
+
+        var method = Normalize(invocation.TargetMethod);
+        if (StartsHandlingClause(method, knownTypes))
+        {
+            ambientClause = invocation.Syntax;
+            return true;
+        }
+
+        if (!IsKevlarFluentMethod(method, knownTypes))
+        {
+            ambientClause = null;
+            return false;
+        }
+
+        if (method.Name == "Wrap")
+        {
+            var inner = GetArgument(invocation, "inner");
+            if (!TryGetAmbientClause(inner, context, knownTypes, visitedLocals, out ambientClause))
+            {
+                return false;
+            }
+
+            return ambientClause is not null
+                || TryGetAmbientClause(
+                    GetReceiver(invocation),
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out ambientClause);
+        }
+
+        if (method.Name == "Compose")
+        {
+            var operands = new List<IOperation>();
+            foreach (var argument in invocation.Arguments)
+            {
+                CollectCompositionOperands(argument.Value, context, operands, visitedLocals);
+            }
+
+            ambientClause = null;
+            foreach (var operand in operands)
+            {
+                if (!TryGetAmbientClause(
+                    operand,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out var operandAmbient))
+                {
+                    ambientClause = null;
+                    return false;
+                }
+
+                ambientClause = operandAmbient ?? ambientClause;
+            }
+
+            return true;
+        }
+
+        var receiver = GetReceiver(invocation);
+        if (receiver is not null)
+        {
+            return TryGetAmbientClause(
+                receiver,
+                context,
+                knownTypes,
+                visitedLocals,
+                out ambientClause);
+        }
+
+        ambientClause = null;
+        return knownTypes.IsShield(method.ContainingType);
+    }
+
+    private static bool SameAmbient(SyntaxNode? left, SyntaxNode? right)
+    {
+        if (left is null || right is null)
+        {
+            return left is null && right is null;
+        }
+
+        return left.SyntaxTree == right.SyntaxTree && left.Span == right.Span;
     }
 
     private static bool WrapPreservesAmbient(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -176,6 +176,28 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        if (operation?.Syntax is CollectionExpressionSyntax)
+        {
+            foreach (var child in operation.ChildOperations)
+            {
+                if (FindInPipeline(
+                    child,
+                    context,
+                    predicate,
+                    knownTypes,
+                    stopAtHandlingClause,
+                    stopAtCompositionBoundary,
+                    visitedLocals,
+                    out matchedMethod))
+                {
+                    return true;
+                }
+            }
+
+            matchedMethod = null;
+            return false;
+        }
+
         if (operation is not IInvocationOperation invocation)
         {
             matchedMethod = null;
@@ -198,6 +220,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         var isCompositionBoundary = IsCompositionBoundary(method, knownTypes);
         if (stopAtCompositionBoundary && isCompositionBoundary)
         {
+            if (method.Name == "Wrap"
+                && WrapPreservesAmbient(invocation, context, knownTypes, visitedLocals))
+            {
+                return FindInPipeline(
+                    GetReceiver(invocation),
+                    context,
+                    predicate,
+                    knownTypes,
+                    stopAtHandlingClause,
+                    stopAtCompositionBoundary,
+                    visitedLocals,
+                    out matchedMethod);
+            }
+
             matchedMethod = null;
             return false;
         }
@@ -236,6 +272,79 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             stopAtCompositionBoundary,
             visitedLocals,
             out matchedMethod);
+    }
+
+    private static bool WrapPreservesAmbient(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Name == "inner")
+            {
+                return IsKnownClauseFree(argument.Value, context, knownTypes, visitedLocals);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsKnownClauseFree(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        operation = Unwrap(operation);
+
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedLocals.Add(localReference.Local)
+                || !TryGetStableInitializer(localReference, context, out var initializer))
+            {
+                return false;
+            }
+
+            var isClauseFree = IsKnownClauseFree(initializer, context, knownTypes, visitedLocals);
+            visitedLocals.Remove(localReference.Local);
+            return isClauseFree;
+        }
+
+        if (operation is IPropertyReferenceOperation propertyReference)
+        {
+            return propertyReference.Property.Name == "Empty"
+                && knownTypes.IsShield(propertyReference.Property.ContainingType);
+        }
+
+        if (operation is not IInvocationOperation invocation)
+        {
+            return false;
+        }
+
+        var method = Normalize(invocation.TargetMethod);
+        if (StartsHandlingClause(method, knownTypes) || !IsKevlarFluentMethod(method, knownTypes))
+        {
+            return false;
+        }
+
+        if (method.Name == "Wrap")
+        {
+            return IsKnownClauseFree(GetReceiver(invocation), context, knownTypes, visitedLocals)
+                && WrapPreservesAmbient(invocation, context, knownTypes, visitedLocals);
+        }
+
+        if (method.Name == "Compose")
+        {
+            return false;
+        }
+
+        var receiver = GetReceiver(invocation);
+        return receiver is null
+            ? knownTypes.IsShield(method.ContainingType)
+            : IsKnownClauseFree(receiver, context, knownTypes, visitedLocals);
     }
 
     private static bool TryGetStableInitializer(
@@ -428,7 +537,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static bool StartsHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
         (method.Name is "When" or "WhenResult" or "WhenDefault")
-        && (knownTypes.IsShield(method.ContainingType) || knownTypes.IsShieldExtensions(method.ContainingType));
+        && (knownTypes.IsShield(method.ContainingType)
+            || knownTypes.IsShieldBuilder(method.ContainingType)
+            || knownTypes.IsShieldExtensions(method.ContainingType));
 
     private static bool IsCompositionBoundary(IMethodSymbol method, KnownTypes knownTypes) =>
         (method.Name is "Wrap" or "Compose") && IsKevlarFluentMethod(method, knownTypes);

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -86,6 +86,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 invocation.Syntax.GetLocation(),
                 reactiveStrategy));
         }
+
+        if (IsCompositionBoundary(Normalize(invocation.TargetMethod), knownTypes)
+            && FindCompositionHazard(invocation, context, knownTypes, out reactiveStrategy))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                UnreachableReactiveStrategyRule,
+                invocation.Syntax.GetLocation(),
+                reactiveStrategy));
+        }
     }
 
     private static bool FindInPipeline(
@@ -176,7 +185,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (operation?.Syntax is CollectionExpressionSyntax)
+        if (operation?.Syntax is CollectionExpressionSyntax or SpreadElementSyntax)
         {
             foreach (var child in operation.ChildOperations)
             {
@@ -265,6 +274,85 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             stopAtCompositionBoundary,
             visitedLocals,
             out matchedMethod);
+    }
+
+    private static bool FindCompositionHazard(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        out string? matchedMethod)
+    {
+        var operands = new List<IOperation>();
+        var method = Normalize(invocation.TargetMethod);
+        if (method.Name == "Wrap")
+        {
+            var outer = GetReceiver(invocation);
+            var inner = GetArgument(invocation, "inner");
+            if (outer is null || inner is null)
+            {
+                matchedMethod = null;
+                return false;
+            }
+
+            operands.Add(outer);
+            operands.Add(inner);
+        }
+        else
+        {
+            foreach (var argument in invocation.Arguments)
+            {
+                CollectCompositionOperands(argument.Value, context, operands, visitedLocals: null);
+            }
+        }
+
+        var ambientClauses = new SyntaxNode?[operands.Count];
+        for (var index = 0; index < operands.Count; index++)
+        {
+            if (!TryGetAmbientClause(
+                operands[index],
+                context,
+                knownTypes,
+                visitedLocals: null,
+                out ambientClauses[index]))
+            {
+                matchedMethod = null;
+                return false;
+            }
+        }
+
+        for (var fallbackIndex = 1; fallbackIndex < operands.Count; fallbackIndex++)
+        {
+            if (!FindInPipeline(
+                operands[fallbackIndex],
+                context,
+                candidate => IsKevlarFluentMethod(candidate.TargetMethod, knownTypes, "Fallback"),
+                knownTypes,
+                stopAtHandlingClause: true,
+                stopAtCompositionBoundary: true,
+                out _))
+            {
+                continue;
+            }
+
+            for (var reactiveIndex = 0; reactiveIndex < fallbackIndex; reactiveIndex++)
+            {
+                if (SameAmbient(ambientClauses[reactiveIndex], ambientClauses[fallbackIndex])
+                    && FindInPipeline(
+                        operands[reactiveIndex],
+                        context,
+                        candidate => IsReactiveStrategy(Normalize(candidate.TargetMethod), knownTypes),
+                        knownTypes,
+                        stopAtHandlingClause: true,
+                        stopAtCompositionBoundary: true,
+                        out matchedMethod))
+                {
+                    return true;
+                }
+            }
+        }
+
+        matchedMethod = null;
+        return false;
     }
 
     private static bool FindAtCompositionBoundary(
@@ -508,7 +596,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (operation?.Syntax is CollectionExpressionSyntax)
+        if (operation?.Syntax is CollectionExpressionSyntax or SpreadElementSyntax)
         {
             foreach (var child in operation.ChildOperations)
             {
@@ -601,6 +689,19 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        if (knownTypes.IsShieldBuilder(method.ContainingType)
+            && method.ReturnType is INamedTypeSymbol returnType
+            && knownTypes.IsShield(returnType)
+            && BuilderCreatesHandlingClause(
+                GetReceiver(invocation),
+                context,
+                knownTypes,
+                visitedLocals))
+        {
+            ambientClause = invocation.Syntax;
+            return true;
+        }
+
         if (method.Name == "Wrap")
         {
             var inner = GetArgument(invocation, "inner");
@@ -659,6 +760,46 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         ambientClause = null;
         return knownTypes.IsShield(method.ContainingType);
+    }
+
+    private static bool BuilderCreatesHandlingClause(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        operation = Unwrap(operation);
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedLocals.Add(localReference.Local)
+                || !TryGetStableInitializer(localReference, context, out var initializer))
+            {
+                return false;
+            }
+
+            var createsClause = BuilderCreatesHandlingClause(
+                initializer,
+                context,
+                knownTypes,
+                visitedLocals);
+            visitedLocals.Remove(localReference.Local);
+            return createsClause;
+        }
+
+        if (operation is not IInvocationOperation invocation)
+        {
+            return false;
+        }
+
+        var method = Normalize(invocation.TargetMethod);
+        return StartsHandlingClause(method, knownTypes)
+            || knownTypes.IsShieldBuilder(method.ContainingType)
+                && BuilderCreatesHandlingClause(
+                    GetReceiver(invocation),
+                    context,
+                    knownTypes,
+                    visitedLocals);
     }
 
     private static bool SameAmbient(SyntaxNode? left, SyntaxNode? right)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Kevlar.Analyzers;
 
 /// <summary>
-/// Diagnoses statically provable Kevlar pipeline hazards: synchronous hedging and reactive
+/// Diagnoses statically provable Kevlar pipeline hazards: synchronous multi-attempt hedging and reactive
 /// strategies made unreachable by an inner fallback using the same handling clause.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -17,12 +17,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     /// <summary>The KEV002 rule.</summary>
     public static readonly DiagnosticDescriptor SynchronousHedgingRule = new(
         id: "KEV002",
-        title: "Hedging requires asynchronous execution",
-        messageFormat: "This shield contains hedging, which cannot run through synchronous 'Execute'. Use 'ExecuteAsync' or remove hedging.",
+        title: "Multi-attempt hedging requires asynchronous execution",
+        messageFormat: "This shield contains multi-attempt hedging, which cannot run through synchronous 'Execute'. Use 'ExecuteAsync' or remove hedging.",
         category: "Reliability",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Hedging races concurrent attempts and is only supported by Kevlar's asynchronous execution boundary. Synchronous Execute always fails for a pipeline containing hedging.");
+        description: "Multi-attempt hedging races concurrent attempts and is only supported by Kevlar's asynchronous execution boundary. Synchronous Execute fails for a pipeline containing statically known multi-attempt hedging.");
 
     /// <summary>The KEV003 rule.</summary>
     public static readonly DiagnosticDescriptor UnreachableReactiveStrategyRule = new(
@@ -57,10 +57,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         var invocation = (IInvocationOperation)context.Operation;
 
         if (IsSynchronousExecute(invocation.TargetMethod, knownTypes)
-            && FindInReceiverChain(
+            && FindInPipeline(
                 GetReceiver(invocation),
                 context,
-                method => IsKevlarFluentMethod(method, knownTypes, "Hedge"),
+                candidate => IsKnownMultiAttemptHedge(candidate, knownTypes),
                 knownTypes,
                 stopAtHandlingClause: false,
                 stopAtCompositionBoundary: false,
@@ -72,10 +72,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         if (IsKevlarFluentMethod(invocation.TargetMethod, knownTypes, "Fallback")
-            && FindInReceiverChain(
+            && FindInPipeline(
                 GetReceiver(invocation),
                 context,
-                method => IsReactiveStrategy(method, knownTypes),
+                candidate => IsReactiveStrategy(Normalize(candidate.TargetMethod), knownTypes),
                 knownTypes,
                 stopAtHandlingClause: true,
                 stopAtCompositionBoundary: true,
@@ -88,15 +88,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool FindInReceiverChain(
+    private static bool FindInPipeline(
         IOperation? operation,
         OperationAnalysisContext context,
-        Func<IMethodSymbol, bool> predicate,
+        Func<IInvocationOperation, bool> predicate,
         KnownTypes knownTypes,
         bool stopAtHandlingClause,
         bool stopAtCompositionBoundary,
         out string? matchedMethod)
-        => FindInReceiverChain(
+        => FindInPipeline(
             operation,
             context,
             predicate,
@@ -106,10 +106,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             visitedLocals: null,
             out matchedMethod);
 
-    private static bool FindInReceiverChain(
+    private static bool FindInPipeline(
         IOperation? operation,
         OperationAnalysisContext context,
-        Func<IMethodSymbol, bool> predicate,
+        Func<IInvocationOperation, bool> predicate,
         KnownTypes knownTypes,
         bool stopAtHandlingClause,
         bool stopAtCompositionBoundary,
@@ -128,8 +128,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 return false;
             }
 
-            return FindInReceiverChain(
+            var found = FindInPipeline(
                 initializer,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
+            visitedLocals.Remove(localReference.Local);
+            return found;
+        }
+
+        if (operation is IConditionalAccessOperation conditionalAccess)
+        {
+            return FindInPipeline(
+                conditionalAccess.Operation,
                 context,
                 predicate,
                 knownTypes,
@@ -139,17 +154,26 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 out matchedMethod);
         }
 
-        if (operation is IConditionalAccessOperation conditionalAccess)
+        if (operation is IArrayCreationOperation { Initializer: { } arrayInitializer })
         {
-            return FindInReceiverChain(
-                conditionalAccess.Operation,
-                context,
-                predicate,
-                knownTypes,
-                stopAtHandlingClause,
-                stopAtCompositionBoundary,
-                visitedLocals,
-                out matchedMethod);
+            foreach (var element in arrayInitializer.ElementValues)
+            {
+                if (FindInPipeline(
+                    element,
+                    context,
+                    predicate,
+                    knownTypes,
+                    stopAtHandlingClause,
+                    stopAtCompositionBoundary,
+                    visitedLocals,
+                    out matchedMethod))
+                {
+                    return true;
+                }
+            }
+
+            matchedMethod = null;
+            return false;
         }
 
         if (operation is not IInvocationOperation invocation)
@@ -165,13 +189,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (predicate(method))
+        if (predicate(invocation))
         {
             matchedMethod = method.Name;
             return true;
         }
 
-        if (stopAtCompositionBoundary && IsCompositionBoundary(method, knownTypes))
+        var isCompositionBoundary = IsCompositionBoundary(method, knownTypes);
+        if (stopAtCompositionBoundary && isCompositionBoundary)
         {
             matchedMethod = null;
             return false;
@@ -183,7 +208,26 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        return FindInReceiverChain(
+        if (isCompositionBoundary)
+        {
+            foreach (var argument in invocation.Arguments)
+            {
+                if (FindInPipeline(
+                    argument.Value,
+                    context,
+                    predicate,
+                    knownTypes,
+                    stopAtHandlingClause,
+                    stopAtCompositionBoundary,
+                    visitedLocals,
+                    out matchedMethod))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return FindInPipeline(
             GetReceiver(invocation),
             context,
             predicate,
@@ -328,6 +372,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsReactiveStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
         (method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker")
         && IsKevlarFluentMethod(method, knownTypes);
+
+    private static bool IsKnownMultiAttemptHedge(
+        IInvocationOperation invocation,
+        KnownTypes knownTypes)
+    {
+        if (!IsKevlarFluentMethod(invocation.TargetMethod, knownTypes, "Hedge"))
+        {
+            return false;
+        }
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Name == "maxAttempts"
+                && argument.Value.ConstantValue is { HasValue: true, Value: int maxAttempts })
+            {
+                return maxAttempts > 1;
+            }
+        }
+
+        return false;
+    }
 
     private static bool StartsHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
         (method.Name is "When" or "WhenResult" or "WhenDefault")

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1,0 +1,380 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Kevlar.Analyzers;
+
+/// <summary>
+/// Diagnoses statically provable Kevlar pipeline hazards: synchronous hedging and reactive
+/// strategies made unreachable by an inner fallback using the same handling clause.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The KEV002 rule.</summary>
+    public static readonly DiagnosticDescriptor SynchronousHedgingRule = new(
+        id: "KEV002",
+        title: "Hedging requires asynchronous execution",
+        messageFormat: "This shield contains hedging, which cannot run through synchronous 'Execute'. Use 'ExecuteAsync' or remove hedging.",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Hedging races concurrent attempts and is only supported by Kevlar's asynchronous execution boundary. Synchronous Execute always fails for a pipeline containing hedging.");
+
+    /// <summary>The KEV003 rule.</summary>
+    public static readonly DiagnosticDescriptor UnreachableReactiveStrategyRule = new(
+        id: "KEV003",
+        title: "Fallback makes a reactive strategy unreachable",
+        messageFormat: "Fallback is inside '{0}' with the same handling clause, so '{0}' cannot observe a handled failure. Chain Fallback first or give it a narrower handling clause.",
+        category: "Configuration",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A fallback inside retry, hedging, or circuit breaker under the same handling clause recovers every handled failure before the outer strategy can observe it. Kevlar rejects this pipeline at construction time.");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(SynchronousHedgingRule, UnreachableReactiveStrategyRule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static compilationContext =>
+        {
+            var knownTypes = new KnownTypes(compilationContext.Compilation);
+            compilationContext.RegisterOperationAction(
+                context => AnalyzeInvocation(context, knownTypes),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, KnownTypes knownTypes)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+
+        if (IsSynchronousExecute(invocation.TargetMethod, knownTypes)
+            && FindInReceiverChain(
+                GetReceiver(invocation),
+                context,
+                method => IsKevlarFluentMethod(method, knownTypes, "Hedge"),
+                knownTypes,
+                stopAtHandlingClause: false,
+                stopAtCompositionBoundary: false,
+                out _))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                SynchronousHedgingRule,
+                invocation.Syntax.GetLocation()));
+        }
+
+        if (IsKevlarFluentMethod(invocation.TargetMethod, knownTypes, "Fallback")
+            && FindInReceiverChain(
+                GetReceiver(invocation),
+                context,
+                method => IsReactiveStrategy(method, knownTypes),
+                knownTypes,
+                stopAtHandlingClause: true,
+                stopAtCompositionBoundary: true,
+                out var reactiveStrategy))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                UnreachableReactiveStrategyRule,
+                invocation.Syntax.GetLocation(),
+                reactiveStrategy));
+        }
+    }
+
+    private static bool FindInReceiverChain(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        Func<IMethodSymbol, bool> predicate,
+        KnownTypes knownTypes,
+        bool stopAtHandlingClause,
+        bool stopAtCompositionBoundary,
+        out string? matchedMethod)
+        => FindInReceiverChain(
+            operation,
+            context,
+            predicate,
+            knownTypes,
+            stopAtHandlingClause,
+            stopAtCompositionBoundary,
+            visitedLocals: null,
+            out matchedMethod);
+
+    private static bool FindInReceiverChain(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        Func<IMethodSymbol, bool> predicate,
+        KnownTypes knownTypes,
+        bool stopAtHandlingClause,
+        bool stopAtCompositionBoundary,
+        HashSet<ISymbol>? visitedLocals,
+        out string? matchedMethod)
+    {
+        operation = Unwrap(operation);
+
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedLocals.Add(localReference.Local)
+                || !TryGetStableInitializer(localReference.Local, context, out var initializer))
+            {
+                matchedMethod = null;
+                return false;
+            }
+
+            return FindInReceiverChain(
+                initializer,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
+        }
+
+        if (operation is IConditionalAccessOperation conditionalAccess)
+        {
+            return FindInReceiverChain(
+                conditionalAccess.Operation,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
+        }
+
+        if (operation is not IInvocationOperation invocation)
+        {
+            matchedMethod = null;
+            return false;
+        }
+
+        var method = Normalize(invocation.TargetMethod);
+        if (stopAtHandlingClause && StartsHandlingClause(method, knownTypes))
+        {
+            matchedMethod = null;
+            return false;
+        }
+
+        if (predicate(method))
+        {
+            matchedMethod = method.Name;
+            return true;
+        }
+
+        if (stopAtCompositionBoundary && IsCompositionBoundary(method, knownTypes))
+        {
+            matchedMethod = null;
+            return false;
+        }
+
+        if (!IsKevlarFluentMethod(method, knownTypes))
+        {
+            matchedMethod = null;
+            return false;
+        }
+
+        return FindInReceiverChain(
+            GetReceiver(invocation),
+            context,
+            predicate,
+            knownTypes,
+            stopAtHandlingClause,
+            stopAtCompositionBoundary,
+            visitedLocals,
+            out matchedMethod);
+    }
+
+    private static bool TryGetStableInitializer(
+        ILocalSymbol local,
+        OperationAnalysisContext context,
+        out IOperation? initializer)
+    {
+        var declarations = local.DeclaringSyntaxReferences;
+        if (declarations.Length != 1
+            || declarations[0].GetSyntax(context.CancellationToken) is not VariableDeclaratorSyntax
+            {
+                Initializer.Value: { } initializerSyntax,
+            } declarator)
+        {
+            initializer = null;
+            return false;
+        }
+
+        var semanticModel = context.Operation.SemanticModel;
+        if (semanticModel is null || semanticModel.SyntaxTree != declarator.SyntaxTree)
+        {
+            initializer = null;
+            return false;
+        }
+
+        var scope = (SyntaxNode?)declarator.FirstAncestorOrSelf<BlockSyntax>()
+            ?? declarator.SyntaxTree.GetRoot(context.CancellationToken);
+
+        foreach (var identifier in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText == local.Name
+                && SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol,
+                    local)
+                && IsWritten(identifier))
+            {
+                initializer = null;
+                return false;
+            }
+        }
+
+        initializer = semanticModel.GetOperation(initializerSyntax, context.CancellationToken);
+        return initializer is not null;
+    }
+
+    private static bool IsWritten(IdentifierNameSyntax identifier)
+    {
+        foreach (var ancestor in identifier.Ancestors())
+        {
+            switch (ancestor)
+            {
+                case AssignmentExpressionSyntax assignment when assignment.Left.Span.Contains(identifier.Span):
+                    return true;
+                case PrefixUnaryExpressionSyntax prefix
+                    when prefix.IsKind(SyntaxKind.PreIncrementExpression)
+                        || prefix.IsKind(SyntaxKind.PreDecrementExpression):
+                    return true;
+                case PostfixUnaryExpressionSyntax postfix
+                    when postfix.IsKind(SyntaxKind.PostIncrementExpression)
+                        || postfix.IsKind(SyntaxKind.PostDecrementExpression):
+                    return true;
+                case ArgumentSyntax argument when !argument.RefKindKeyword.IsKind(SyntaxKind.None):
+                    return true;
+                case StatementSyntax:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static IOperation? GetReceiver(IInvocationOperation invocation)
+    {
+        var instance = Unwrap(invocation.Instance);
+        if (instance is IConditionalAccessInstanceOperation)
+        {
+            for (var parent = invocation.Parent; parent is not null; parent = parent.Parent)
+            {
+                if (parent is IConditionalAccessOperation conditionalAccess)
+                {
+                    return conditionalAccess.Operation;
+                }
+            }
+        }
+        else if (instance is not null)
+        {
+            return instance;
+        }
+
+        var method = Normalize(invocation.TargetMethod);
+        if (!method.IsExtensionMethod)
+        {
+            return null;
+        }
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Ordinal == 0)
+            {
+                return argument.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static IOperation? Unwrap(IOperation? operation)
+    {
+        while (true)
+        {
+            switch (operation)
+            {
+                case IConversionOperation conversion:
+                    operation = conversion.Operand;
+                    continue;
+                case IParenthesizedOperation parenthesized:
+                    operation = parenthesized.Operand;
+                    continue;
+                default:
+                    return operation;
+            }
+        }
+    }
+
+    private static IMethodSymbol Normalize(IMethodSymbol method) =>
+        (method.ReducedFrom ?? method).OriginalDefinition;
+
+    private static bool IsSynchronousExecute(IMethodSymbol method, KnownTypes knownTypes)
+    {
+        method = Normalize(method);
+        return method.Name == "Execute" && knownTypes.IsShield(method.ContainingType);
+    }
+
+    private static bool IsReactiveStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
+        (method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker")
+        && IsKevlarFluentMethod(method, knownTypes);
+
+    private static bool StartsHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
+        (method.Name is "When" or "WhenResult" or "WhenDefault")
+        && (knownTypes.IsShield(method.ContainingType) || knownTypes.IsShieldExtensions(method.ContainingType));
+
+    private static bool IsCompositionBoundary(IMethodSymbol method, KnownTypes knownTypes) =>
+        (method.Name is "Wrap" or "Compose") && IsKevlarFluentMethod(method, knownTypes);
+
+    private static bool IsKevlarFluentMethod(
+        IMethodSymbol method,
+        KnownTypes knownTypes,
+        string? expectedName = null)
+    {
+        method = Normalize(method);
+        return (expectedName is null || method.Name == expectedName)
+            && (knownTypes.IsShield(method.ContainingType)
+                || knownTypes.IsShieldBuilder(method.ContainingType)
+                || knownTypes.IsShieldExtensions(method.ContainingType));
+    }
+
+    private sealed class KnownTypes
+    {
+        private readonly INamedTypeSymbol? _shield;
+        private readonly INamedTypeSymbol? _shieldOfT;
+        private readonly INamedTypeSymbol? _shieldBuilder;
+        private readonly INamedTypeSymbol? _shieldBuilderOfT;
+        private readonly INamedTypeSymbol? _shieldExtensions;
+
+        internal KnownTypes(Compilation compilation)
+        {
+            _shield = compilation.GetTypeByMetadataName("Kevlar.Shield");
+            _shieldOfT = compilation.GetTypeByMetadataName("Kevlar.Shield`1");
+            _shieldBuilder = compilation.GetTypeByMetadataName("Kevlar.ShieldBuilder");
+            _shieldBuilderOfT = compilation.GetTypeByMetadataName("Kevlar.ShieldBuilder`1");
+            _shieldExtensions = compilation.GetTypeByMetadataName("Kevlar.ShieldExtensions");
+        }
+
+        internal bool IsShield(INamedTypeSymbol type) =>
+            Is(type, _shield) || Is(type, _shieldOfT);
+
+        internal bool IsShieldBuilder(INamedTypeSymbol type) =>
+            Is(type, _shieldBuilder) || Is(type, _shieldBuilderOfT);
+
+        internal bool IsShieldExtensions(INamedTypeSymbol type) => Is(type, _shieldExtensions);
+
+        private static bool Is(INamedTypeSymbol type, INamedTypeSymbol? expected) =>
+            expected is not null
+            && SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, expected);
+    }
+}

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -220,22 +220,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         var isCompositionBoundary = IsCompositionBoundary(method, knownTypes);
         if (stopAtCompositionBoundary && isCompositionBoundary)
         {
-            if (method.Name == "Wrap"
-                && WrapPreservesAmbient(invocation, context, knownTypes, visitedLocals))
-            {
-                return FindInPipeline(
-                    GetReceiver(invocation),
-                    context,
-                    predicate,
-                    knownTypes,
-                    stopAtHandlingClause,
-                    stopAtCompositionBoundary,
-                    visitedLocals,
-                    out matchedMethod);
-            }
-
-            matchedMethod = null;
-            return false;
+            return FindAtCompositionBoundary(
+                invocation,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
         }
 
         if (!IsKevlarFluentMethod(method, knownTypes))
@@ -272,6 +265,192 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             stopAtCompositionBoundary,
             visitedLocals,
             out matchedMethod);
+    }
+
+    private static bool FindAtCompositionBoundary(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        Func<IInvocationOperation, bool> predicate,
+        KnownTypes knownTypes,
+        bool stopAtHandlingClause,
+        bool stopAtCompositionBoundary,
+        HashSet<ISymbol>? visitedLocals,
+        out string? matchedMethod)
+    {
+        var method = Normalize(invocation.TargetMethod);
+        if (method.Name == "Compose")
+        {
+            return FindInComposeAmbient(
+                invocation,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
+        }
+
+        var outer = GetReceiver(invocation);
+        var inner = GetArgument(invocation, "inner");
+        if (inner is null)
+        {
+            matchedMethod = null;
+            return false;
+        }
+
+        if (!IsKnownClauseFree(inner, context, knownTypes, visitedLocals))
+        {
+            return FindInPipeline(
+                inner,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
+        }
+
+        if (FindInPipeline(
+            outer,
+            context,
+            predicate,
+            knownTypes,
+            stopAtHandlingClause,
+            stopAtCompositionBoundary,
+            visitedLocals,
+            out matchedMethod))
+        {
+            return true;
+        }
+
+        return IsKnownClauseFree(outer, context, knownTypes, visitedLocals)
+            && FindInPipeline(
+                inner,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
+    }
+
+    private static bool FindInComposeAmbient(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        Func<IInvocationOperation, bool> predicate,
+        KnownTypes knownTypes,
+        bool stopAtHandlingClause,
+        bool stopAtCompositionBoundary,
+        HashSet<ISymbol>? visitedLocals,
+        out string? matchedMethod)
+    {
+        var operands = new List<IOperation>();
+        foreach (var argument in invocation.Arguments)
+        {
+            CollectCompositionOperands(argument.Value, context, operands, visitedLocals);
+        }
+
+        for (var index = operands.Count - 1; index >= 0; index--)
+        {
+            if (IsKnownClauseFree(operands[index], context, knownTypes, visitedLocals))
+            {
+                continue;
+            }
+
+            return FindInPipeline(
+                operands[index],
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod);
+        }
+
+        foreach (var operand in operands)
+        {
+            if (FindInPipeline(
+                operand,
+                context,
+                predicate,
+                knownTypes,
+                stopAtHandlingClause,
+                stopAtCompositionBoundary,
+                visitedLocals,
+                out matchedMethod))
+            {
+                return true;
+            }
+        }
+
+        matchedMethod = null;
+        return false;
+    }
+
+    private static void CollectCompositionOperands(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        List<IOperation> operands,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        operation = Unwrap(operation);
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (visitedLocals.Add(localReference.Local))
+            {
+                if (TryGetStableInitializer(localReference, context, out var initializer))
+                {
+                    CollectCompositionOperands(initializer, context, operands, visitedLocals);
+                    visitedLocals.Remove(localReference.Local);
+                    return;
+                }
+
+                visitedLocals.Remove(localReference.Local);
+            }
+        }
+
+        if (operation is IArrayCreationOperation { Initializer: { } arrayInitializer })
+        {
+            foreach (var element in arrayInitializer.ElementValues)
+            {
+                CollectCompositionOperands(element, context, operands, visitedLocals);
+            }
+
+            return;
+        }
+
+        if (operation?.Syntax is CollectionExpressionSyntax)
+        {
+            foreach (var child in operation.ChildOperations)
+            {
+                CollectCompositionOperands(child, context, operands, visitedLocals);
+            }
+
+            return;
+        }
+
+        if (operation is not null)
+        {
+            operands.Add(operation);
+        }
+    }
+
+    private static IOperation? GetArgument(IInvocationOperation invocation, string parameterName)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Name == parameterName)
+            {
+                return argument.Value;
+            }
+        }
+
+        return null;
     }
 
     private static bool WrapPreservesAmbient(

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Kevlar.Analyzers.PipelineHazardAnalyzer
+Kevlar.Analyzers.PipelineHazardAnalyzer.PipelineHazardAnalyzer() -> void
+override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
+override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.UnreachableReactiveStrategyRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -102,6 +102,12 @@ public class PipelineHazardAnalyzerTests
             "_ = ShieldExtensions.Fallback(ShieldExtensions.Retry(Shield.Empty, 1), static _ => ValueTask.CompletedTask);",
             "_ = Shield.For<int>().Retry(1).Wrap(Shield.Empty).Fallback(0);",
             "_ = Shield.For<int>().Retry(1).Wrap(Shield.Timeout(TimeSpan.FromSeconds(1))).Fallback(0);",
+            "_ = Shield<int>.Empty.Wrap(Shield.Retry(1)).Fallback(0);",
+            "_ = Shield.Compose(Shield.Retry(1)).For<int>().Fallback(0);",
+            "_ = Shield.Compose(Shield.Timeout(TimeSpan.FromSeconds(1)), Shield.Retry(1)).For<int>().Fallback(0);",
+            "_ = Shield.Compose([Shield.Retry(1)]).For<int>().Fallback(0);",
+            "var parts = new[] { Shield.Retry(1) }; _ = Shield.Compose(parts).For<int>().Fallback(0);",
+            "_ = Shield.Compose(Shield.When<InvalidOperationException>().Retry(1), Shield.Empty).For<int>().Fallback(0);",
         };
 
         await AssertEachAsync(cases, "KEV003");
@@ -140,6 +146,9 @@ public class PipelineHazardAnalyzerTests
             "var shield = CreateShield(); _ = shield.Fallback(0);",
             "var shield = Shield.For<int>().Retry(1); shield = Shield<int>.Empty; _ = shield.Fallback(0);",
             "_ = Shield.For<int>().Retry(1).Wrap(Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1))).Fallback(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Wrap(Shield.Retry(1)).Fallback(0);",
+            "_ = Shield.Compose(Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)), Shield.Retry(1)).For<int>().Fallback(0);",
+            "var parts = new[] { Shield.Retry(1) }; parts[0] = Shield.Empty; _ = Shield.Compose(parts).For<int>().Fallback(0);",
         };
 
         foreach (var body in cases)

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -21,6 +21,7 @@ public class PipelineHazardAnalyzerTests
             "var shield = ShieldExtensions.Hedge(Shield.Empty, 2, TimeSpan.Zero); _ = shield.Execute(_ => 1);",
             "_ = Shield.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
             "_ = Shield.Compose(Shield.Empty, Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
+            "var parts = new[] { Shield.Hedge(2, TimeSpan.Zero) }; _ = Shield.Compose(parts).Execute(_ => 1);",
             "_ = Shield<int>.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
         };
 
@@ -66,6 +67,22 @@ public class PipelineHazardAnalyzerTests
         foreach (var body in cases)
         {
             var diagnostics = await AnalyzeBodyAsync(body, "private static Shield CreateShield() => Shield.Hedge(2, TimeSpan.Zero);");
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV002_Skips_Aliased_And_Mutated_Shield_Arrays()
+    {
+        var cases = new[]
+        {
+            "var parts = new[] { Shield.Hedge(2, TimeSpan.Zero) }; parts[0] = Shield.Empty; _ = Shield.Compose(parts).Execute(_ => 1);",
+            "var parts = new[] { Shield.Hedge(2, TimeSpan.Zero) }; var alias = parts; alias[0] = Shield.Empty; _ = Shield.Compose(parts).Execute(_ => 1);",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body);
             await Assert.That(diagnostics).IsEmpty();
         }
     }

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1,0 +1,214 @@
+using System.Collections.Immutable;
+using Kevlar.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Kevlar.Analyzers.Tests;
+
+public class PipelineHazardAnalyzerTests
+{
+    [Test]
+    public async Task KEV002_Flags_Known_Hedging_Shields_Used_Synchronously()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.Hedge(2, TimeSpan.Zero).Execute(_ => 1);",
+            "Shield.Empty.Hedge(2, TimeSpan.Zero).Execute(_ => { });",
+            "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero).Execute(_ => 1);",
+            "var shield = Shield.Hedge(2, TimeSpan.Zero); var alias = shield; _ = alias.Execute(_ => 1);",
+            "Shield? shield = Shield.Hedge(2, TimeSpan.Zero); _ = shield?.Execute(_ => 1);",
+            "var shield = ShieldExtensions.Hedge(Shield.Empty, 2, TimeSpan.Zero); _ = shield.Execute(_ => 1);",
+        };
+
+        await AssertEachAsync(cases, "KEV002");
+    }
+
+    [Test]
+    public async Task KEV002_Supports_Type_Aliases_And_Generic_Result_Shields()
+    {
+        var aliasDiagnostics = await AnalyzeSourceAsync("""
+            using KShield = Kevlar.Shield;
+
+            public class TestSubject
+            {
+                public int Run() => KShield.Hedge(2, TimeSpan.Zero).Execute(_ => 1);
+            }
+            """);
+        var genericDiagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public T Run<T>() => Shield.For<T>().Hedge(2, TimeSpan.Zero).Execute(_ => default!);
+            }
+            """);
+
+        await AssertRuleAsync(aliasDiagnostics, "KEV002");
+        await AssertRuleAsync(genericDiagnostics, "KEV002");
+    }
+
+    [Test]
+    public async Task KEV002_Skips_Async_Unknown_And_Reassigned_Shields()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.Hedge(2, TimeSpan.Zero).ExecuteAsync(_ => new ValueTask<int>(1));",
+            "var shield = CreateShield(); _ = shield.Execute(_ => 1);",
+            "var shield = Shield.Hedge(2, TimeSpan.Zero); shield = Shield.Empty; _ = shield.Execute(_ => 1);",
+            "_ = Shield.Empty.Execute(_ => 1);",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body, "private static Shield CreateShield() => Shield.Hedge(2, TimeSpan.Zero);");
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV003_Flags_Unreachable_Reactive_Strategies()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.For<int>().Retry(1).Fallback(0);",
+            "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero).Fallback(0);",
+            "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Fallback(0);",
+            "_ = Shield.For<int>().WhenResult(0).Retry(1).Fallback(0);",
+            "var shield = Shield.For<int>().Retry(1); var alias = shield; _ = alias.Fallback(0);",
+            "Shield<int>? shield = Shield.For<int>().Retry(1); _ = shield?.Fallback(0);",
+            "_ = ShieldExtensions.Fallback(ShieldExtensions.Retry(Shield.Empty, 1), static _ => ValueTask.CompletedTask);",
+        };
+
+        await AssertEachAsync(cases, "KEV003");
+    }
+
+    [Test]
+    public async Task KEV003_Supports_Type_Aliases_And_Generic_Result_Shields()
+    {
+        var aliasDiagnostics = await AnalyzeSourceAsync("""
+            using KShield = Kevlar.Shield;
+
+            public class TestSubject
+            {
+                public Shield<int> Build() => KShield.For<int>().Retry(1).Fallback(0);
+            }
+            """);
+        var genericDiagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public Shield<T> Build<T>() => Shield.For<T>().Retry(1).Fallback((T)default!);
+            }
+            """);
+
+        await AssertRuleAsync(aliasDiagnostics, "KEV003");
+        await AssertRuleAsync(genericDiagnostics, "KEV003");
+    }
+
+    [Test]
+    public async Task KEV003_Skips_Valid_Or_Unknown_Compositions()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.For<int>().Fallback(0).Retry(1);",
+            "_ = Shield.For<int>().Retry(1).When<InvalidOperationException>().Fallback(0);",
+            "_ = Shield.For<int>().Timeout(TimeSpan.FromSeconds(1)).Fallback(0);",
+            "var shield = CreateShield(); _ = shield.Fallback(0);",
+            "var shield = Shield.For<int>().Retry(1); shield = Shield<int>.Empty; _ = shield.Fallback(0);",
+            "_ = Shield.For<int>().Retry(1).Wrap(Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1))).Fallback(0);",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body, "private static Shield<int> CreateShield() => Shield.For<int>().Retry(1);");
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task Non_Kevlar_Methods_And_Generated_Code_Are_Ignored()
+    {
+        var unrelated = await AnalyzeSourceAsync("""
+            public sealed class OtherShield
+            {
+                public OtherShield Hedge() => this;
+                public OtherShield Retry() => this;
+                public OtherShield Fallback() => this;
+                public int Execute(Func<CancellationToken, int> action) => action(default);
+            }
+
+            public class TestSubject
+            {
+                public int Run() => new OtherShield().Hedge().Retry().Fallback().Execute(_ => 1);
+            }
+            """);
+        var generated = await AnalyzeBodyAsync(
+            "_ = Shield.Hedge(2, TimeSpan.Zero).Execute(_ => 1); _ = Shield.For<int>().Retry(1).Fallback(0);",
+            isGenerated: true);
+
+        await Assert.That(unrelated).IsEmpty();
+        await Assert.That(generated).IsEmpty();
+    }
+
+    private static async Task AssertEachAsync(IEnumerable<string> cases, string expectedRule)
+    {
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body);
+            await AssertRuleAsync(diagnostics, expectedRule);
+        }
+    }
+
+    private static async Task AssertRuleAsync(ImmutableArray<Diagnostic> diagnostics, string expectedRule)
+    {
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Id).IsEqualTo(expectedRule);
+        await Assert.That(diagnostics[0].Severity).IsEqualTo(DiagnosticSeverity.Warning);
+    }
+
+    private static Task<ImmutableArray<Diagnostic>> AnalyzeBodyAsync(
+        string body,
+        string members = "",
+        bool isGenerated = false) =>
+        AnalyzeSourceAsync($$"""
+            public class TestSubject
+            {
+                {{members}}
+
+                public void Run()
+                {
+                    {{body}}
+                }
+            }
+            """, isGenerated);
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeSourceAsync(
+        string declarations,
+        bool isGenerated = false)
+    {
+        var source = (isGenerated ? "// <auto-generated/>\n" : string.Empty) + $$"""
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Kevlar;
+
+            {{declarations}}
+            """;
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Append(MetadataReference.CreateFromFile(typeof(Shield).Assembly.Location));
+        var compilation = CSharpCompilation.Create(
+            "PipelineHazardAnalyzerTestSubject",
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var errors = compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        if (errors.Length > 0)
+        {
+            throw new InvalidOperationException("Test source does not compile: " + string.Join("; ", errors.Select(static error => error.ToString())));
+        }
+
+        return await compilation
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new PipelineHazardAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync();
+    }
+}

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -21,6 +21,7 @@ public class PipelineHazardAnalyzerTests
             "var shield = ShieldExtensions.Hedge(Shield.Empty, 2, TimeSpan.Zero); _ = shield.Execute(_ => 1);",
             "_ = Shield.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
             "_ = Shield.Compose(Shield.Empty, Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
+            "_ = Shield.Compose([Shield.Hedge(2, TimeSpan.Zero)]).Execute(_ => 1);",
             "var parts = new[] { Shield.Hedge(2, TimeSpan.Zero) }; _ = Shield.Compose(parts).Execute(_ => 1);",
             "_ = Shield<int>.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
         };
@@ -99,6 +100,8 @@ public class PipelineHazardAnalyzerTests
             "var shield = Shield.For<int>().Retry(1); var alias = shield; _ = alias.Fallback(0);",
             "Shield<int>? shield = Shield.For<int>().Retry(1); _ = shield?.Fallback(0);",
             "_ = ShieldExtensions.Fallback(ShieldExtensions.Retry(Shield.Empty, 1), static _ => ValueTask.CompletedTask);",
+            "_ = Shield.For<int>().Retry(1).Wrap(Shield.Empty).Fallback(0);",
+            "_ = Shield.For<int>().Retry(1).Wrap(Shield.Timeout(TimeSpan.FromSeconds(1))).Fallback(0);",
         };
 
         await AssertEachAsync(cases, "KEV003");

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -108,6 +108,8 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Compose([Shield.Retry(1)]).For<int>().Fallback(0);",
             "var parts = new[] { Shield.Retry(1) }; _ = Shield.Compose(parts).For<int>().Fallback(0);",
             "_ = Shield.Compose(Shield.When<InvalidOperationException>().Retry(1), Shield.Empty).For<int>().Fallback(0);",
+            "var clause = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = outer.Wrap(clause).Fallback(0);",
+            "var clause = Shield.When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = Shield.Compose(outer, clause).For<int>().Fallback(0);",
         };
 
         await AssertEachAsync(cases, "KEV003");

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -19,6 +19,9 @@ public class PipelineHazardAnalyzerTests
             "var shield = Shield.Hedge(2, TimeSpan.Zero); var alias = shield; _ = alias.Execute(_ => 1);",
             "Shield? shield = Shield.Hedge(2, TimeSpan.Zero); _ = shield?.Execute(_ => 1);",
             "var shield = ShieldExtensions.Hedge(Shield.Empty, 2, TimeSpan.Zero); _ = shield.Execute(_ => 1);",
+            "_ = Shield.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
+            "_ = Shield.Compose(Shield.Empty, Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
+            "_ = Shield<int>.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
         };
 
         await AssertEachAsync(cases, "KEV002");
@@ -55,6 +58,9 @@ public class PipelineHazardAnalyzerTests
             "var shield = CreateShield(); _ = shield.Execute(_ => 1);",
             "var shield = Shield.Hedge(2, TimeSpan.Zero); shield = Shield.Empty; _ = shield.Execute(_ => 1);",
             "_ = Shield.Empty.Execute(_ => 1);",
+            "_ = Shield.Hedge(1, TimeSpan.Zero).Execute(_ => 1);",
+            "var attempts = DateTime.Now.Day; _ = Shield.Hedge(attempts, TimeSpan.Zero).Execute(_ => 1);",
+            "_ = Shield.Hedge(options => options.MaxAttempts = 2).Execute(_ => 1);",
         };
 
         foreach (var body in cases)

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -22,6 +22,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
             "_ = Shield.Compose(Shield.Empty, Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
             "_ = Shield.Compose([Shield.Hedge(2, TimeSpan.Zero)]).Execute(_ => 1);",
+            "_ = Shield.Compose([.. new[] { Shield.Hedge(2, TimeSpan.Zero) }]).Execute(_ => 1);",
             "var parts = new[] { Shield.Hedge(2, TimeSpan.Zero) }; _ = Shield.Compose(parts).Execute(_ => 1);",
             "_ = Shield<int>.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
         };
@@ -110,6 +111,8 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Compose(Shield.When<InvalidOperationException>().Retry(1), Shield.Empty).For<int>().Fallback(0);",
             "var clause = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = outer.Wrap(clause).Fallback(0);",
             "var clause = Shield.When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = Shield.Compose(outer, clause).For<int>().Fallback(0);",
+            "var retry = Shield.Retry(1); var fallback = Shield.For<int>().Fallback(0); _ = retry.Wrap(fallback);",
+            "var retry = Shield.Retry(1); var fallback = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); _ = Shield.Compose(retry, fallback);",
         };
 
         await AssertEachAsync(cases, "KEV003");
@@ -151,6 +154,10 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Wrap(Shield.Retry(1)).Fallback(0);",
             "_ = Shield.Compose(Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)), Shield.Retry(1)).For<int>().Fallback(0);",
             "var parts = new[] { Shield.Retry(1) }; parts[0] = Shield.Empty; _ = Shield.Compose(parts).For<int>().Fallback(0);",
+            "var builder = Shield.For<int>().When<InvalidOperationException>(); var retry = builder.Retry(1); _ = retry.Wrap(builder.Timeout(TimeSpan.Zero)).Fallback(0);",
+            "var fallback = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); var retry = Shield.Retry(1); _ = Shield.Compose(fallback, retry);",
+            "var retry = Shield.When<InvalidOperationException>().Retry(1); var fallback = Shield.For<int>().When<TimeoutException>().Fallback(0); _ = retry.Wrap(fallback);",
+            "var outer = Shield.Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero); var fallback = Shield.For<int>().When<InvalidOperationException>().Fallback(0); _ = outer.Wrap(fallback);",
         };
 
         foreach (var body in cases)


### PR DESCRIPTION
## Summary

- add KEV002 for synchronous execution of known hedging shields
- add KEV003 for fallback that masks an outer reactive strategy under the same handling clause
- support fluent chains, stable local aliases, extension/static calls, generics, aliases, and conditional access
- document severity, rationale, suppressions, safe alternatives, and conservative analysis limits

## Validation

- dotnet build Kevlar.slnx -c Release
- unit: 528 passed
- integration: 16 passed
- analyzers: 26 passed
- netstandard: 1 passed
- allocation: 2 passed
- npm run build
- Verify-Packages.ps1
- Verify-DocSnippets.ps1 (85 snippets)

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compile-time checks for synchronous execution of hedging pipelines.
  - Added detection of unreachable fallback strategies in reactive pipelines.
  - Expanded analyzer guidance for cancellation and pipeline hazards.
  - Added guidance for resolving, suppressing, and understanding analyzer warnings.

- **Documentation**
  - Documented analyzer installation, rules, examples, limitations, and remediation.
  - Updated navigation and compile-time safety references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->