### PR TITLE
feat(di): support atomic config reload

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <!-- Satellites -->
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
 
     <!-- Analyzers -->

--- a/benchmarks/Kevlar.Benchmarks/Kevlar.Benchmarks.csproj
+++ b/benchmarks/Kevlar.Benchmarks/Kevlar.Benchmarks.csproj
@@ -9,12 +9,15 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Polly.RateLimiting" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\..\src\Kevlar.Extensions.DependencyInjection\Kevlar.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Kevlar.Benchmarks/ReloadingShieldProviderBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/ReloadingShieldProviderBenchmarks.cs
@@ -1,0 +1,41 @@
+using BenchmarkDotNet.Attributes;
+using Kevlar.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>Measures the atomic current-snapshot read against a direct shield reference.</summary>
+[MemoryDiagnoser]
+public class ReloadingShieldProviderBenchmarks
+{
+    private ServiceProvider _services = null!;
+    private IShieldProvider _provider = null!;
+    private Shield _snapshot = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Retry:MaxRetries"] = "1",
+                ["Retry:Backoff"] = "None",
+            })
+            .Build();
+        _services = new ServiceCollection()
+            .AddReloadingShield("benchmark", configuration)
+            .BuildServiceProvider();
+        _provider = _services.GetRequiredKeyedService<IShieldProvider>("benchmark");
+        _snapshot = _provider.Current;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Shield DirectSnapshot() => _snapshot;
+
+    [Benchmark]
+    public Shield ReloadAwareCurrent() => _provider.Current;
+
+    [GlobalCleanup]
+    public void Cleanup() => _services.Dispose();
+}

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -49,7 +49,7 @@ Registry semantics worth knowing:
 
 - Shields are keyed by **name + result type** — an untyped `"api"` shield and a `Shield<HttpResponseMessage>` named `"api"` coexist independently.
 - Last registration for a given name wins, matching standard DI override behaviour.
-- Factory registrations run lazily on first resolve and the result is cached — so every consumer shares one instance (and its strategy state), exactly like instance registrations.
+- Ordinary factory registrations run lazily on first resolve and the result is cached — so every consumer shares one instance (and its strategy state), exactly like instance registrations.
 - `AddShield` registers the `IKevlarRegistry` for you (`AddKevlar()` exists if you ever need just the registry).
 
 ## Binding shields from configuration
@@ -75,6 +75,48 @@ services.AddShield("github", builder.Configuration.GetSection("Resilience:GitHub
 ```
 
 The schema is `ShieldDefinition`: optional `Timeout`, `Retry`, `CircuitBreaker`, `RateLimit`, `ConcurrencyLimit` and `AttemptTimeout` sections, chained in that fixed order (outermost first). Only the sections you declare are added, and the defaults inside each section match the fluent API's.
+
+### Reloading configuration atomically
+
+`AddShield(name, IConfiguration)` intentionally binds once, when first resolved. Use
+`AddReloadingShield` when future configuration reloads must affect new operations:
+
+```csharp
+services.AddReloadingShield(
+    "github",
+    builder.Configuration.GetSection("Resilience:GitHub"),
+    error => logger.LogError(error, "Rejected GitHub shield configuration"));
+```
+
+Consume the keyed provider and read `Current` once per operation:
+
+<!-- doc-test-ignore: Application client type requires the host's FetchUserAsync implementation. -->
+```csharp
+public sealed class GitHubClient(
+    [FromKeyedServices("github")] IShieldProvider provider)
+{
+    public Task<User> GetUserAsync(string id, CancellationToken ct)
+    {
+        Shield snapshot = provider.Current;
+        return snapshot.ExecuteAsync(
+            ct2 => FetchUserAsync(id, ct2),
+            ct).AsTask();
+    }
+}
+```
+
+Registry consumers can call `registry.GetShield("github")` once per operation to obtain the
+current snapshot. A keyed `Shield` resolved from DI is also one immutable snapshot; it does not
+change after a reload. Every ordinary `AddShield` registration exposes an `IShieldProvider` too,
+but its `Current` snapshot remains fixed.
+
+On a valid change, Kevlar builds the entire replacement before one atomic publish. Operations
+already using the prior snapshot finish on it. Invalid configuration keeps the last known-good
+snapshot and invokes the optional failure callback; callback exceptions are contained so later
+reloads remain active. Each successful replacement starts with fresh circuit-breaker,
+rate-limiter, and concurrency-limiter state. The provider performs no binding, locking, or
+allocation while reading `Current`; all rebuild work occurs on configuration change. Disposing
+the service provider removes the change-token subscription.
 
 ## Consuming as a keyed service
 

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -98,8 +98,8 @@ $expectedDependencies = @{
         '.NETStandard2.0' = @('Microsoft.Bcl.TimeProvider', 'Reservoir', 'System.Threading.Tasks.Extensions')
     }
     'Kevlar.Extensions.DependencyInjection' = @{
-        'net10.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions')
-        '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions')
+        'net10.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Primitives')
+        '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Primitives')
     }
     'Kevlar.Extensions.Http' = @{
         'net10.0' = @('Kevlar', 'Microsoft.Extensions.Http')

--- a/src/Kevlar.Extensions.DependencyInjection/FixedShieldProvider.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/FixedShieldProvider.cs
@@ -1,0 +1,6 @@
+namespace Kevlar.Extensions.DependencyInjection;
+
+internal sealed class FixedShieldProvider(Shield shield) : IShieldProvider
+{
+    public Shield Current { get; } = shield;
+}

--- a/src/Kevlar.Extensions.DependencyInjection/IKevlarRegistry.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/IKevlarRegistry.cs
@@ -4,9 +4,9 @@ namespace Kevlar.Extensions.DependencyInjection;
 
 /// <summary>Resolves named shields registered via <c>AddShield</c>.</summary>
 /// <remarks>
-/// Each registered factory runs at most once. Its shield or exception is cached and returned or
-/// rethrown by every registry, <c>TryGet</c>, and keyed-service path for that registration.
-/// Names are case-sensitive; an empty name is valid.
+/// Each registration factory runs at most once. Ordinary shields and factory exceptions are
+/// cached. Reload-aware registrations cache their provider; <see cref="GetShield(string)"/>
+/// returns that provider's current snapshot. Names are case-sensitive; an empty name is valid.
 /// </remarks>
 public interface IKevlarRegistry
 {

--- a/src/Kevlar.Extensions.DependencyInjection/IShieldProvider.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/IShieldProvider.cs
@@ -1,0 +1,13 @@
+namespace Kevlar.Extensions.DependencyInjection;
+
+/// <summary>Provides the current immutable snapshot of a named shield.</summary>
+/// <remarks>
+/// Read <see cref="Current"/> once for each operation, then execute that snapshot. The read is
+/// atomic and allocation-free. Providers registered by <c>AddReloadingShield</c> may publish a
+/// replacement; ordinary shield providers always return their original snapshot.
+/// </remarks>
+public interface IShieldProvider
+{
+    /// <summary>Gets the current last known-good shield snapshot.</summary>
+    Shield Current { get; }
+}

--- a/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
+++ b/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarRegistry.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarRegistry.cs
@@ -50,9 +50,16 @@ internal sealed class KevlarRegistry : IKevlarRegistry
 
     public bool TryGetShield(string name, [NotNullWhen(true)] out Shield? shield)
     {
-        if (Resolve(name, null) is Shield resolved)
+        var value = Resolve(name, null);
+        if (value is Shield resolved)
         {
             shield = resolved;
+            return true;
+        }
+
+        if (value is IShieldProvider provider)
+        {
+            shield = provider.Current;
             return true;
         }
 
@@ -94,4 +101,5 @@ internal sealed class KevlarRegistry : IKevlarRegistry
                 () => registration.Factory(_serviceProvider),
                 LazyThreadSafetyMode.ExecutionAndPublication)).Value;
     }
+
 }

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -33,6 +33,9 @@ public static class KevlarServiceCollectionExtensions
         services.AddKevlar();
         services.AddSingleton(new ShieldRegistration(name, null, factory));
         services.AddKeyedSingleton(name, (sp, _) => sp.GetRequiredService<IKevlarRegistry>().GetShield(name));
+        services.AddKeyedSingleton<IShieldProvider>(
+            name,
+            (sp, _) => new FixedShieldProvider(sp.GetRequiredService<IKevlarRegistry>().GetShield(name)));
         return services;
     }
 
@@ -51,6 +54,45 @@ public static class KevlarServiceCollectionExtensions
             var definition = BindDefinition(configuration);
             return definition.Build().WithName(name);
         });
+    }
+
+    /// <summary>
+    /// Registers a named, reload-aware shield bound from <paramref name="configuration"/>.
+    /// A complete replacement is built on each change and atomically published through
+    /// <see cref="IShieldProvider.Current"/>. Invalid replacements retain the last known-good
+    /// snapshot and are reported to <paramref name="onReloadFailure"/> when supplied.
+    /// </summary>
+    /// <remarks>
+    /// Each successful replacement has fresh circuit-breaker, rate-limiter, and concurrency-
+    /// limiter state. Resolve the keyed <see cref="IShieldProvider"/> to observe future replacements,
+    /// or call <see cref="IKevlarRegistry.GetShield(string)"/> once per operation.
+    /// A keyed <see cref="Shield"/> is an immutable snapshot and does not update after resolution.
+    /// Exceptions thrown by <paramref name="onReloadFailure"/> are suppressed so future reloads
+    /// remain active.
+    /// </remarks>
+    public static IServiceCollection AddReloadingShield(
+        this IServiceCollection services,
+        string name,
+        IConfiguration configuration,
+        Action<Exception>? onReloadFailure = null)
+    {
+        if (services is null) { throw new ArgumentNullException(nameof(services)); }
+        if (name is null) { throw new ArgumentNullException(nameof(name)); }
+        if (configuration is null) { throw new ArgumentNullException(nameof(configuration)); }
+
+        services.AddKevlar();
+        services.AddKeyedSingleton<IShieldProvider>(
+            name,
+            (_, _) => new ReloadingShieldProvider(
+                () => BindDefinition(configuration).Build().WithName(name),
+                configuration.GetReloadToken,
+                onReloadFailure));
+        services.AddSingleton(new ShieldRegistration(
+            name,
+            null,
+            sp => sp.GetRequiredKeyedService<IShieldProvider>(name)));
+        services.AddKeyedSingleton(name, (sp, _) => sp.GetRequiredService<IKevlarRegistry>().GetShield(name));
+        return services;
     }
 
     /// <summary>Registers a named result-aware shield, resolvable via <see cref="IKevlarRegistry.GetShield{TResult}(string)"/> or as a keyed <see cref="Shield{TResult}"/> service.</summary>

--- a/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Kevlar.Extensions.DependencyInjection.IShieldProvider
+Kevlar.Extensions.DependencyInjection.IShieldProvider.Current.get -> Kevlar.Shield!
+static Kevlar.Extensions.DependencyInjection.KevlarServiceCollectionExtensions.AddReloadingShield(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! name, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Kevlar.Extensions.DependencyInjection/ReloadingShieldProvider.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/ReloadingShieldProvider.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.Primitives;
+
+namespace Kevlar.Extensions.DependencyInjection;
+
+internal sealed class ReloadingShieldProvider : IShieldProvider, IDisposable
+{
+    private readonly object _reloadLock = new();
+    private readonly Func<Shield> _factory;
+    private readonly Action<Exception>? _onReloadFailure;
+    private readonly IDisposable _subscription;
+    private Shield _current;
+    private bool _disposed;
+
+    public ReloadingShieldProvider(
+        Func<Shield> factory,
+        Func<IChangeToken> reloadTokenFactory,
+        Action<Exception>? onReloadFailure)
+    {
+        _factory = factory;
+        _onReloadFailure = onReloadFailure;
+        _subscription = ChangeToken.OnChange(reloadTokenFactory, Reload);
+
+        try
+        {
+            lock (_reloadLock)
+            {
+                _current = factory();
+            }
+        }
+        catch
+        {
+            _subscription.Dispose();
+            throw;
+        }
+    }
+
+    public Shield Current => Volatile.Read(ref _current);
+
+    public void Dispose()
+    {
+        lock (_reloadLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+        }
+
+        _subscription.Dispose();
+    }
+
+    private void Reload()
+    {
+        Exception? failure = null;
+
+        lock (_reloadLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            try
+            {
+                var replacement = _factory();
+                Volatile.Write(ref _current, replacement);
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+        }
+
+        if (failure is not null && _onReloadFailure is not null)
+        {
+            try
+            {
+                _onReloadFailure(failure);
+            }
+            catch
+            {
+                // A reporting failure must not disable future configuration reloads.
+            }
+        }
+    }
+}

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -125,6 +125,18 @@ public class DependencyInjectionContractTests
     }
 
     [Test]
+    public async Task Ordinary_Shield_Exposes_A_Fixed_Keyed_Provider()
+    {
+        using var services = new ServiceCollection()
+            .AddShield("static", Shield.Empty)
+            .BuildServiceProvider();
+        var registry = services.GetRequiredService<IKevlarRegistry>();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("static");
+
+        await Assert.That(ReferenceEquals(shieldProvider.Current, registry.GetShield("static"))).IsTrue();
+    }
+
+    [Test]
     public async Task Missing_Typed_Registration_Reports_Name_And_Result_Type()
     {
         using var provider = new ServiceCollection().AddKevlar().BuildServiceProvider();

--- a/tests/Kevlar.Tests/ReloadingShieldTests.cs
+++ b/tests/Kevlar.Tests/ReloadingShieldTests.cs
@@ -1,0 +1,300 @@
+using Kevlar.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kevlar.Tests;
+
+public class ReloadingShieldTests
+{
+    [Test]
+    public async Task Registration_Null_Guards_Report_Exact_Parameters()
+    {
+        var configuration = BuildConfiguration();
+        IServiceCollection? missingServices = null;
+
+        var servicesError = await Assert.That(() => missingServices!.AddReloadingShield("dynamic", configuration))
+            .Throws<ArgumentNullException>();
+        var nameError = await Assert.That(() => new ServiceCollection().AddReloadingShield(null!, configuration))
+            .Throws<ArgumentNullException>();
+        var configurationError = await Assert.That(() => new ServiceCollection().AddReloadingShield("dynamic", null!))
+            .Throws<ArgumentNullException>();
+
+        await Assert.That(servicesError!.ParamName).IsEqualTo("services");
+        await Assert.That(nameError!.ParamName).IsEqualTo("name");
+        await Assert.That(configurationError!.ParamName).IsEqualTo("configuration");
+    }
+
+    [Test]
+    public async Task Valid_Reload_Atomically_Publishes_A_Fresh_Snapshot()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration)
+            .BuildServiceProvider();
+        var registry = services.GetRequiredService<IKevlarRegistry>();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var first = shieldProvider.Current;
+
+        configuration["Retry:MaxRetries"] = "4";
+        configuration.Reload();
+
+        var second = shieldProvider.Current;
+        await Assert.That(ReferenceEquals(first, second)).IsFalse();
+        await Assert.That(first.ToString()).IsEqualTo("dynamic: Retry(1, no delay)");
+        await Assert.That(second.ToString()).IsEqualTo("dynamic: Retry(4, no delay)");
+        await Assert.That(ReferenceEquals(registry.GetShield("dynamic"), second)).IsTrue();
+    }
+
+    [Test]
+    public async Task Keyed_Provider_Is_Live_But_Injected_Shield_Remains_Its_Resolved_Snapshot()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration)
+            .BuildServiceProvider();
+        var live = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var injectedSnapshot = services.GetRequiredKeyedService<Shield>("dynamic");
+
+        configuration["Retry:MaxRetries"] = "2";
+        configuration.Reload();
+
+        await Assert.That(live.Current.ToString()).IsEqualTo("dynamic: Retry(2, no delay)");
+        await Assert.That(injectedSnapshot.ToString()).IsEqualTo("dynamic: Retry(1, no delay)");
+    }
+
+    [Test]
+    public async Task Last_Mixed_Registration_Wins_For_Registry_And_Provider()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        var fixedShield = Shield.Timeout(TimeSpan.FromSeconds(1));
+        using var fixedLast = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration)
+            .AddShield("dynamic", fixedShield)
+            .BuildServiceProvider();
+        using var reloadingLast = new ServiceCollection()
+            .AddShield("dynamic", fixedShield)
+            .AddReloadingShield("dynamic", configuration)
+            .BuildServiceProvider();
+
+        var fixedRegistry = fixedLast.GetRequiredService<IKevlarRegistry>();
+        var fixedProvider = fixedLast.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var reloadingRegistry = reloadingLast.GetRequiredService<IKevlarRegistry>();
+        var reloadingProvider = reloadingLast.GetRequiredKeyedService<IShieldProvider>("dynamic");
+
+        await Assert.That(ReferenceEquals(fixedRegistry.GetShield("dynamic"), fixedShield)).IsTrue();
+        await Assert.That(ReferenceEquals(fixedProvider.Current, fixedShield)).IsTrue();
+        await Assert.That(reloadingRegistry.GetShield("dynamic").ToString())
+            .IsEqualTo("dynamic: Retry(1, no delay)");
+        await Assert.That(reloadingProvider.Current.ToString())
+            .IsEqualTo("dynamic: Retry(1, no delay)");
+    }
+
+    [Test]
+    public async Task Invalid_Reload_Keeps_Last_Good_And_Reports_The_Full_Key()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        Exception? reported = null;
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration, error => reported = error)
+            .BuildServiceProvider();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var lastGood = shieldProvider.Current;
+
+        configuration["Retry:MaxRetries"] = "invalid";
+        configuration.Reload();
+
+        await Assert.That(ReferenceEquals(shieldProvider.Current, lastGood)).IsTrue();
+        await Assert.That(reported).IsTypeOf<InvalidOperationException>();
+        await Assert.That(reported!.Message)
+            .IsEqualTo("Configuration value 'invalid' for 'Retry:MaxRetries' is not an integer.");
+    }
+
+    [Test]
+    public async Task Callback_Failure_Does_Not_Stop_Subsequent_Reloads()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration, _ => throw new InvalidOperationException("callback"))
+            .BuildServiceProvider();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        _ = shieldProvider.Current;
+
+        configuration["Retry:MaxRetries"] = "invalid";
+        configuration.Reload();
+        configuration["Retry:MaxRetries"] = "3";
+        configuration.Reload();
+
+        await Assert.That(shieldProvider.Current.ToString()).IsEqualTo("dynamic: Retry(3, no delay)");
+    }
+
+    [Test]
+    public async Task Repeated_Reloads_Publish_Complete_Snapshots_Under_Concurrent_Reads()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "0"), ("Retry:Backoff", "None"));
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration)
+            .BuildServiceProvider();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var unexpected = new List<string>();
+        using var stop = new CancellationTokenSource();
+        var readers = Enumerable.Range(0, Environment.ProcessorCount)
+            .Select(_ => Task.Run(() =>
+            {
+                while (!stop.IsCancellationRequested)
+                {
+                    var description = shieldProvider.Current.ToString();
+                    if (description is not "dynamic: Retry(0, no delay)" and
+                        not "dynamic: Retry(1, no delay)" and
+                        not "dynamic: Retry(2, no delay)")
+                    {
+                        lock (unexpected)
+                        {
+                            unexpected.Add(description);
+                        }
+                    }
+                }
+            }))
+            .ToArray();
+
+        for (var reload = 0; reload < 30; reload++)
+        {
+            configuration["Retry:MaxRetries"] = (reload % 3).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            configuration.Reload();
+        }
+
+        stop.Cancel();
+        await Task.WhenAll(readers);
+
+        await Assert.That(unexpected).IsEmpty();
+    }
+
+    [Test]
+    public async Task Concurrent_First_Resolve_And_Reload_Cannot_Miss_The_Change()
+    {
+        for (var iteration = 0; iteration < 100; iteration++)
+        {
+            var configuration = BuildConfiguration(("Retry:MaxRetries", "0"), ("Retry:Backoff", "None"));
+            using var services = new ServiceCollection()
+                .AddReloadingShield("dynamic", configuration)
+                .BuildServiceProvider();
+            var resolve = Task.Run(() => services.GetRequiredKeyedService<IShieldProvider>("dynamic"));
+
+            configuration["Retry:MaxRetries"] = "1";
+            configuration.Reload();
+            var shieldProvider = await resolve;
+
+            await Assert.That(shieldProvider.Current.ToString())
+                .IsEqualTo("dynamic: Retry(1, no delay)");
+        }
+    }
+
+    [Test]
+    public async Task In_Flight_Execution_Finishes_On_The_Snapshot_It_Started_With()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration)
+            .BuildServiceProvider();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var oldSnapshot = shieldProvider.Current;
+        var attempts = 0;
+        var firstAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var execution = oldSnapshot.ExecuteAsync(async _ =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                firstAttempt.SetResult();
+                await continueAttempt.Task;
+            }
+
+            throw new InvalidOperationException("retry");
+        }).AsTask();
+
+        await firstAttempt.Task;
+        configuration["Retry:MaxRetries"] = "4";
+        configuration.Reload();
+        continueAttempt.SetResult();
+
+        await Assert.That(async () => await execution).Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(ReferenceEquals(shieldProvider.Current, oldSnapshot)).IsFalse();
+    }
+
+    [Test]
+    public async Task Successful_Reload_Starts_With_Fresh_Strategy_State()
+    {
+        var configuration = BuildConfiguration(
+            ("CircuitBreaker:ConsecutiveFailures", "1"),
+            ("CircuitBreaker:BreakDuration", "01:00:00"));
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration)
+            .BuildServiceProvider();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var attempts = 0;
+
+        await Assert.That(async () => await shieldProvider.Current.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException("failure");
+        })).Throws<InvalidOperationException>();
+        await Assert.That(async () => await shieldProvider.Current.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return ValueTask.CompletedTask;
+        })).Throws<CircuitOpenException>();
+
+        configuration.Reload();
+
+        await Assert.That(async () => await shieldProvider.Current.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException("failure");
+        })).Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Disposal_Unsubscribes_From_Configuration_Changes()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        var failures = 0;
+        var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration, _ => Interlocked.Increment(ref failures))
+            .BuildServiceProvider();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        var snapshot = shieldProvider.Current;
+
+        services.Dispose();
+        configuration["Retry:MaxRetries"] = "invalid";
+        configuration.Reload();
+
+        await Assert.That(failures).IsEqualTo(0);
+        await Assert.That(ReferenceEquals(shieldProvider.Current, snapshot)).IsTrue();
+    }
+
+    [Test]
+    public async Task Provider_Current_Read_Does_Not_Allocate()
+    {
+        var configuration = BuildConfiguration(("Retry:MaxRetries", "1"), ("Retry:Backoff", "None"));
+        using var services = new ServiceCollection()
+            .AddReloadingShield("dynamic", configuration)
+            .BuildServiceProvider();
+        var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
+        _ = shieldProvider.Current;
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var iteration = 0; iteration < 10_000; iteration++)
+        {
+            _ = shieldProvider.Current;
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    private static IConfigurationRoot BuildConfiguration(params (string Key, string Value)[] values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values.Select(pair => new KeyValuePair<string, string?>(pair.Key, pair.Value)))
+            .Build();
+}


### PR DESCRIPTION
## Summary
- add opt-in AddReloadingShield registration with atomic IShieldProvider snapshots
- retain the last known-good snapshot on invalid configuration and contain failure-callback exceptions
- keep in-flight executions on their original immutable pipeline and reset strategy state after valid replacement
- expose fixed providers for ordinary named shields so mixed registrations preserve last-registration-wins semantics
- document registry/keyed snapshot behavior, disposal, state reset, and the zero-allocation current-snapshot fast path

## Validation
- dotnet build Kevlar.slnx -c Release
- unit tests: 542 passed
- integration tests: 16 passed
- analyzer tests: 19 passed
- allocation tests: 2 passed
- netstandard tests: 1 passed
- Docusaurus production build
- documentation snippets: 81 compiled; runtime examples passed
- package layout, metadata, consumer, analyzer, trimmed and single-file checks passed (NativeAOT remains Linux CI-only)
- BenchmarkDotNet: direct snapshot 0.604 ns / 0 B; reload-aware Current 0.592 ns / 0 B

Closes #73