### PR TITLE
feat(retry): add async delay generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Shield.Retry(o =>
     o.MaxDelay = TimeSpan.FromSeconds(10);   // absolute cap — even over DelayGenerator output
     o.OnRetry = e => logger.LogWarning(e.Exception, "Retry {Attempt} after {Delay}", e.Attempt, e.Delay);
     o.DelayGenerator = e => /* return a TimeSpan to override the computed delay, or null */ null;
+    o.DelayGeneratorAsync = e => new ValueTask<TimeSpan?>(TimeSpan.Zero); // awaited override
 });
 ```
 

--- a/benchmarks/Kevlar.Benchmarks/RetryDelayGeneratorBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/RetryDelayGeneratorBenchmarks.cs
@@ -1,0 +1,64 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>Measures retry delay-generation modes when one retry is required.</summary>
+[MemoryDiagnoser]
+public class RetryDelayGeneratorBenchmarks
+{
+    private static readonly InvalidOperationException RecoverableError = new("transient");
+
+    private static readonly Shield FixedDelay = CreateShield();
+    private static readonly Shield SynchronousGenerator = CreateShield(options =>
+        options.DelayGenerator = static _ => TimeSpan.Zero);
+    private static readonly Shield CompletedAsyncGenerator = CreateShield(options =>
+        options.DelayGeneratorAsync = static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero));
+    private static readonly Shield YieldingAsyncGenerator = CreateShield(options =>
+        options.DelayGeneratorAsync = YieldAsync);
+
+    private readonly Counter _fixedCounter = new();
+    private readonly Counter _synchronousCounter = new();
+    private readonly Counter _completedAsyncCounter = new();
+    private readonly Counter _yieldingAsyncCounter = new();
+
+    [Benchmark(Baseline = true)]
+    public ValueTask<int> Fixed() => ExecuteAsync(FixedDelay, _fixedCounter);
+
+    [Benchmark]
+    public ValueTask<int> Synchronous() => ExecuteAsync(SynchronousGenerator, _synchronousCounter);
+
+    [Benchmark]
+    public ValueTask<int> AsyncCompleted() => ExecuteAsync(CompletedAsyncGenerator, _completedAsyncCounter);
+
+    [Benchmark]
+    public ValueTask<int> AsyncYielding() => ExecuteAsync(YieldingAsyncGenerator, _yieldingAsyncCounter);
+
+    private static Shield CreateShield(Action<RetryOptions>? configure = null) => Shield.Retry(options =>
+    {
+        options.MaxRetries = 1;
+        options.Backoff = Backoff.None;
+        configure?.Invoke(options);
+    });
+
+    private static ValueTask<int> ExecuteAsync(Shield shield, Counter counter) =>
+        shield.ExecuteAsync(counter, static (state, _) =>
+        {
+            if (++state.Value % 2 != 0)
+            {
+                throw RecoverableError;
+            }
+
+            return new ValueTask<int>(42);
+        });
+
+    private static async ValueTask<TimeSpan?> YieldAsync(RetryEvent _)
+    {
+        await Task.Yield();
+        return TimeSpan.Zero;
+    }
+
+    private sealed class Counter
+    {
+        public int Value;
+    }
+}

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -49,6 +49,7 @@ Shield.Retry(o =>
     o.OnRetry = e => logger.LogWarning(e.Exception,
         "Retry {Attempt} after {Delay}", e.Attempt, e.Delay);
     o.DelayGenerator = e => /* return a TimeSpan to override the computed delay, or null */ null;
+    o.DelayGeneratorAsync = e => new ValueTask<TimeSpan?>(TimeSpan.Zero);
 });
 ```
 
@@ -60,8 +61,15 @@ Shield.Retry(o =>
 | `OnRetry` | — | Called synchronously before each retry sleeps — attempt number, final delay, failure |
 | `OnRetryAsync` | — | Awaited before each retry sleeps |
 | `DelayGenerator` | — | Per-retry override: return a `TimeSpan` to replace the computed delay, or `null` to keep it. This is how [`Retry-After` support](../http.md) works |
+| `DelayGeneratorAsync` | — | Awaited per-retry override for asynchronous delay sources; return a `TimeSpan` to replace the current delay, or `null` to keep it |
 
-Order per retry: backoff computes the delay → `MaxDelay` clamps it → `DelayGenerator` may override it (non-null, non-negative returns only) → `MaxDelay` clamps the override too → `OnRetry`/`OnRetryAsync` see the final delay → sleep.
+Order per retry: retry metrics are recorded → backoff computes the delay → `MaxDelay` clamps it → `DelayGenerator` may override it → the awaited `DelayGeneratorAsync` may override that result → `OnRetry`/`OnRetryAsync` see the final delay → sleep. Both generators ignore `null` and negative results, and `MaxDelay` clamps each override.
+
+Async generators receive the caller token through `e.Context.CancellationToken`. If cancellation
+arrives while a generator is awaiting, notification hooks still run after it completes, then the
+next attempt is suppressed and caller cancellation surfaces. A generator exception surfaces with
+its original identity and skips later hooks. `RetryEvent.Context` is pooled execution state: use it
+only before the returned `ValueTask` completes; never retain it or its property bag.
 
 On an untyped `Shield`, the `RetryEvent` callbacks receive: `Attempt` (1-based retry number), `Delay`, `Exception` (null when a handled *result* triggered the retry), `Result` (the handled result, boxed as `object?`) and `Context`. On a typed `Shield<T>`, the events are `RetryEvent<T>` instead: same `Attempt`/`Delay`/`Context`, plus the handled failure as a typed `Outcome<T>` — `e.Outcome.Result` is your `T`, no casting.
 

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -3,3 +3,7 @@ Kevlar.Shield<TResult>.ExecuteOutcomeAsync<TState>(TState state, System.Func<TSt
 static Kevlar.ShieldTaskExtensions.ExecuteOutcomeAsync<T, TState>(this Kevlar.Shield! shield, TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
 static Kevlar.ShieldTaskExtensions.ExecuteOutcomeAsync<TResult, TState>(this Kevlar.Shield<TResult>! shield, TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<TResult>>
 virtual Kevlar.Strategy.IsDuplicateReferenceUnsafe.get -> bool
+Kevlar.RetryOptions.DelayGeneratorAsync.get -> System.Func<Kevlar.RetryEvent, System.Threading.Tasks.ValueTask<System.TimeSpan?>>?
+Kevlar.RetryOptions.DelayGeneratorAsync.set -> void
+Kevlar.RetryOptions<TResult>.DelayGeneratorAsync.get -> System.Func<Kevlar.RetryEvent<TResult>, System.Threading.Tasks.ValueTask<System.TimeSpan?>>?
+Kevlar.RetryOptions<TResult>.DelayGeneratorAsync.set -> void

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -74,8 +74,9 @@ public sealed class Shield<TResult>
 
     /// <summary>
     /// Adds a retry strategy configured via <paramref name="configure"/>. The options expose
-    /// result-typed events: <c>OnRetry</c>, <c>OnRetryAsync</c> and <c>DelayGenerator</c> receive
-    /// a <see cref="RetryEvent{TResult}"/> carrying the handled <see cref="Outcome{TResult}"/>.
+    /// result-typed events: <c>OnRetry</c>, <c>OnRetryAsync</c>, <c>DelayGenerator</c>, and
+    /// <c>DelayGeneratorAsync</c> receive a <see cref="RetryEvent{TResult}"/> carrying the handled
+    /// <see cref="Outcome{TResult}"/>.
     /// </summary>
     public Shield<TResult> Retry(Action<RetryOptions<TResult>> configure)
     {

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -3,8 +3,9 @@ namespace Kevlar;
 /// <summary>Configuration for a retry strategy.</summary>
 /// <remarks>
 /// Before each retry, callbacks run in this order: <see cref="DelayGenerator"/>,
-/// <see cref="OnRetry"/>, then <see cref="OnRetryAsync"/>. If the caller's cancellation token is
-/// cancelled by the time the callbacks complete, the retry stops and surfaces caller cancellation.
+/// <see cref="DelayGeneratorAsync"/>, <see cref="OnRetry"/>, then <see cref="OnRetryAsync"/>.
+/// If the caller's cancellation token is cancelled by the time the callbacks complete, the retry
+/// stops and surfaces caller cancellation.
 /// </remarks>
 public class RetryOptions
 {
@@ -35,6 +36,15 @@ public class RetryOptions
     /// HTTP <c>Retry-After</c> header). <see cref="MaxDelay"/> still caps the returned value.
     /// </summary>
     public Func<RetryEvent, TimeSpan?>? DelayGenerator { get; set; }
+
+    /// <summary>
+    /// Asynchronously overrides the delay for a specific retry. Receives the delay after
+    /// <see cref="DelayGenerator"/> and <see cref="MaxDelay"/> have been applied; return a
+    /// non-null value to replace it. <see cref="MaxDelay"/> still caps the returned value.
+    /// The callback is awaited before retry notifications run. Do not retain its pooled
+    /// <see cref="RetryEvent.Context"/> after the returned task completes.
+    /// </summary>
+    public Func<RetryEvent, ValueTask<TimeSpan?>>? DelayGeneratorAsync { get; set; }
 }
 
 /// <summary>
@@ -46,6 +56,7 @@ public sealed class RetryOptions<TResult> : RetryOptions
     private Action<RetryEvent<TResult>>? _onRetry;
     private Func<RetryEvent<TResult>, ValueTask>? _onRetryAsync;
     private Func<RetryEvent<TResult>, TimeSpan?>? _delayGenerator;
+    private Func<RetryEvent<TResult>, ValueTask<TimeSpan?>>? _delayGeneratorAsync;
 
     /// <summary>Invoked synchronously before each retry sleeps, with the typed handled outcome.</summary>
     public new Action<RetryEvent<TResult>>? OnRetry
@@ -83,6 +94,23 @@ public sealed class RetryOptions<TResult> : RetryOptions
             base.DelayGenerator = value is null ? null : untyped => value(new RetryEvent<TResult>(untyped));
         }
     }
+
+    /// <summary>
+    /// Asynchronously overrides the delay for a specific retry, with the typed handled outcome.
+    /// Receives the delay after the synchronous generator and <see cref="RetryOptions.MaxDelay"/>
+    /// have been applied. Return a non-null value to replace it; the maximum still applies.
+    /// </summary>
+    public new Func<RetryEvent<TResult>, ValueTask<TimeSpan?>>? DelayGeneratorAsync
+    {
+        get => _delayGeneratorAsync;
+        set
+        {
+            _delayGeneratorAsync = value;
+            base.DelayGeneratorAsync = value is null
+                ? null
+                : untyped => value(new RetryEvent<TResult>(untyped));
+        }
+    }
 }
 
 /// <summary>Describes a retry that is about to happen.</summary>
@@ -109,7 +137,10 @@ public readonly struct RetryEvent
     /// <summary>The handled result from the failed attempt (boxed), or <see langword="null"/> when an exception occurred.</summary>
     public object? Result { get; }
 
-    /// <summary>The ambient execution context.</summary>
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it or its property bag after
+    /// the callback (including an asynchronous callback) completes.
+    /// </summary>
     public KevlarContext Context { get; }
 }
 
@@ -132,6 +163,9 @@ public readonly struct RetryEvent<TResult>
             ? Outcome<TResult>.FromException(exception)
             : Outcome<TResult>.FromResult((TResult)_inner.Result!);
 
-    /// <summary>The ambient execution context.</summary>
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it or its property bag after
+    /// the callback (including an asynchronous callback) completes.
+    /// </summary>
     public KevlarContext Context => _inner.Context;
 }

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -11,6 +11,7 @@ internal sealed class RetryStrategy : Strategy
     private readonly Action<RetryEvent>? _onRetry;
     private readonly Func<RetryEvent, ValueTask>? _onRetryAsync;
     private readonly Func<RetryEvent, TimeSpan?>? _delayGenerator;
+    private readonly Func<RetryEvent, ValueTask<TimeSpan?>>? _delayGeneratorAsync;
 
     public RetryStrategy(RetryOptions options, OutcomeJudge judge)
     {
@@ -26,6 +27,7 @@ internal sealed class RetryStrategy : Strategy
         _onRetry = options.OnRetry;
         _onRetryAsync = options.OnRetryAsync;
         _delayGenerator = options.DelayGenerator;
+        _delayGeneratorAsync = options.DelayGeneratorAsync;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
@@ -60,19 +62,26 @@ internal sealed class RetryStrategy : Strategy
                 delay = cap;
             }
 
-            if (_delayGenerator is not null || _onRetry is not null || _onRetryAsync is not null)
+            if (_delayGenerator is not null
+                || _delayGeneratorAsync is not null
+                || _onRetry is not null
+                || _onRetryAsync is not null)
             {
                 var result = outcome.Exception is null ? (object?)outcome.Result : null;
 
-                if (_delayGenerator is not null
-                    && _delayGenerator(new RetryEvent(attempt, delay, outcome.Exception, result, context)) is { } custom
-                    && custom >= TimeSpan.Zero)
+                if (_delayGenerator is not null)
                 {
-                    // MaxDelay is an absolute bound: it also caps generator-supplied delays
-                    // such as a server's Retry-After suggestion.
-                    delay = _maxDelay is { } absolute && custom > absolute
-                        ? absolute
-                        : DelayHelper.Clamp(custom);
+                    var generated = _delayGenerator(
+                        new RetryEvent(attempt, delay, outcome.Exception, result, context));
+                    delay = ApplyGeneratedDelay(delay, generated);
+                }
+
+                if (_delayGeneratorAsync is not null)
+                {
+                    var generated = await _delayGeneratorAsync(
+                        new RetryEvent(attempt, delay, outcome.Exception, result, context))
+                        .ConfigureAwait(false);
+                    delay = ApplyGeneratedDelay(delay, generated);
                 }
 
                 if (_onRetry is not null || _onRetryAsync is not null)
@@ -99,5 +108,19 @@ internal sealed class RetryStrategy : Strategy
                 }
             }
         }
+    }
+
+    private TimeSpan ApplyGeneratedDelay(TimeSpan current, TimeSpan? generated)
+    {
+        if (generated is not { } custom || custom < TimeSpan.Zero)
+        {
+            return current;
+        }
+
+        // MaxDelay is an absolute bound: it also caps generator-supplied delays
+        // such as a server's Retry-After suggestion.
+        return _maxDelay is { } absolute && custom > absolute
+            ? absolute
+            : DelayHelper.Clamp(custom);
     }
 }

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -12,6 +12,12 @@ public class AllocationBudgetTests
 
     private readonly Shield _empty = Shield.Empty;
     private readonly Shield _retry = Shield.Retry(3, Backoff.None);
+    private readonly Shield _asyncDelayRetry = Shield.Retry(options =>
+    {
+        options.MaxRetries = 3;
+        options.Backoff = Backoff.None;
+        options.DelayGeneratorAsync = static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero);
+    });
     private readonly Shield _breaker = Shield.CircuitBreaker(5, TimeSpan.FromMinutes(1));
     private readonly Shield _timeout = Shield.Timeout(TimeSpan.FromMinutes(1));
     private readonly Shield<int> _fallback = Shield.For<int>()
@@ -32,12 +38,19 @@ public class AllocationBudgetTests
         .Hedge(2, TimeSpan.FromMinutes(1));
 
     private readonly Shield _recoveryRetry = Shield.Retry(3, Backoff.None);
+    private readonly Shield _recoveryAsyncDelayRetry = Shield.Retry(options =>
+    {
+        options.MaxRetries = 3;
+        options.Backoff = Backoff.None;
+        options.DelayGeneratorAsync = static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero);
+    });
     private readonly Shield _openBreaker = Shield.CircuitBreaker(1, TimeSpan.FromDays(1));
     private readonly Shield<int> _triggeredFallback = Shield.For<int>()
         .When<InvalidOperationException>()
         .Fallback(7);
     private readonly Shield _parallelHedge = Shield.Hedge(2, TimeSpan.Zero);
     private readonly Counter _retryCounter = new();
+    private readonly Counter _asyncDelayRetryCounter = new();
     private readonly ParallelHedgeState _parallelHedgeState = new();
 
     /// <summary>Verifies that documented synchronous-completion hot paths allocate no managed memory.</summary>
@@ -53,6 +66,8 @@ public class AllocationBudgetTests
             test._retry.Execute(static _ => 42));
         AssertZero("retry async happy path", this, static test =>
             test._retry.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("retry async delay generator happy path", this, static test =>
+            test._asyncDelayRetry.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("circuit closed", this, static test =>
             test._breaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("timeout happy path", this, static test =>
@@ -79,6 +94,16 @@ public class AllocationBudgetTests
 
         AssertBudget("retry recovers after two failures", 512, this, static test =>
             test._recoveryRetry.ExecuteAsync(test._retryCounter, static (counter, _) =>
+            {
+                if (++counter.Value % 3 != 0)
+                {
+                    throw RecoverableFailure;
+                }
+
+                return new ValueTask<int>(42);
+            }).GetAwaiter().GetResult());
+        AssertBudget("retry async delay generator recovers", 512, this, static test =>
+            test._recoveryAsyncDelayRetry.ExecuteAsync(test._asyncDelayRetryCounter, static (counter, _) =>
             {
                 if (++counter.Value % 3 != 0)
                 {

--- a/tests/Kevlar.Tests/AsyncRetryDelayGeneratorTests.cs
+++ b/tests/Kevlar.Tests/AsyncRetryDelayGeneratorTests.cs
@@ -1,0 +1,293 @@
+namespace Kevlar.Tests;
+
+public class AsyncRetryDelayGeneratorTests
+{
+    [Test]
+    public async Task Synchronously_Completed_Generator_Overrides_Delay_Before_Hooks()
+    {
+        var order = new List<string>();
+        var attempts = 0;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.Constant(TimeSpan.FromHours(1));
+            options.DelayGeneratorAsync = retry =>
+            {
+                order.Add($"generator:{retry.Delay.TotalHours}");
+                return new ValueTask<TimeSpan?>(TimeSpan.Zero);
+            };
+            options.OnRetry = retry => order.Add($"sync:{retry.Delay.TotalSeconds}");
+            options.OnRetryAsync = retry =>
+            {
+                order.Add($"async:{retry.Delay.TotalSeconds}");
+                return default;
+            };
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            order.Add($"attempt:{++attempts}");
+            return attempts == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException("retry"))
+                : new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(order).IsEquivalentTo(
+            ["attempt:1", "generator:1", "sync:0", "async:0", "attempt:2"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Typed_Truly_Asynchronous_Generator_Is_Awaited_And_Preserves_Outcome()
+    {
+        var gate = new AsyncGate("retry delay generator");
+        var order = new List<string>();
+        var seenResult = 0;
+        var attempts = 0;
+        var shield = Shield.For<int>()
+            .WhenResult(-1)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.DelayGeneratorAsync = async retry =>
+                {
+                    order.Add("generator-start");
+                    seenResult = retry.Outcome.Result;
+                    retry.Context.Properties.Set(ContextKey, "alive");
+                    await gate.EnterAsync();
+                    order.Add(retry.Context.Properties.TryGet(ContextKey, out var value) ? value : "missing");
+                    return TimeSpan.Zero;
+                };
+                options.OnRetry = _ => order.Add("hook");
+            });
+
+        var execution = shield.ExecuteAsync(_ =>
+        {
+            order.Add($"attempt-{++attempts}");
+            return new ValueTask<int>(attempts == 1 ? -1 : 42);
+        }).AsTask();
+
+        await gate.WaitForEntryAsync();
+        await Assert.That(order).IsEquivalentTo(
+            ["attempt-1", "generator-start"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        gate.Release();
+
+        await Assert.That(await execution).IsEqualTo(42);
+        await Assert.That(seenResult).IsEqualTo(-1);
+        await Assert.That(order).IsEquivalentTo(
+            ["attempt-1", "generator-start", "alive", "hook", "attempt-2"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Async_Generator_Runs_After_Sync_Generator_And_Absolute_Clamps_Apply()
+    {
+        var seenByAsync = TimeSpan.Zero;
+        var seenByHook = TimeSpan.Zero;
+        var attempts = 0;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.MaxDelay = TimeSpan.FromSeconds(5);
+            options.DelayGenerator = _ => TimeSpan.FromSeconds(9);
+            options.DelayGeneratorAsync = retry =>
+            {
+                seenByAsync = retry.Delay;
+                return new ValueTask<TimeSpan?>(TimeSpan.FromSeconds(8));
+            };
+            options.OnRetry = retry => seenByHook = retry.Delay;
+        });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(seenByAsync).IsEqualTo(TimeSpan.FromSeconds(5));
+        await Assert.That(seenByHook).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Invalid_Async_Generator_Result_Keeps_The_Previous_Delay()
+    {
+        var generated = new Queue<TimeSpan?>([null, TimeSpan.FromSeconds(-1)]);
+        var seen = new List<TimeSpan>();
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 2;
+            options.Backoff = Backoff.None;
+            options.DelayGeneratorAsync = _ => new ValueTask<TimeSpan?>(generated.Dequeue());
+            options.OnRetry = retry => seen.Add(retry.Delay);
+        });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(seen).IsEquivalentTo([TimeSpan.Zero, TimeSpan.Zero]);
+    }
+
+    [Test]
+    public async Task Async_Generator_Failure_Surfaces_Exact_Exception_And_Skips_Hooks()
+    {
+        var generatorFailure = new FormatException("generator failed");
+        var hooks = 0;
+        var attempts = 0;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 2;
+            options.Backoff = Backoff.None;
+            options.DelayGeneratorAsync = _ => ValueTask.FromException<TimeSpan?>(generatorFailure);
+            options.OnRetry = _ => hooks++;
+            options.OnRetryAsync = _ =>
+            {
+                hooks++;
+                return default;
+            };
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        });
+
+        await Assert.That(ReferenceEquals(outcome.Exception, generatorFailure)).IsTrue();
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(hooks).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_During_Generator_Runs_Hooks_Then_Stops_Retrying()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var gate = new AsyncGate("retry delay cancellation");
+        var hooks = 0;
+        var attempts = 0;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 2;
+            options.Backoff = Backoff.None;
+            options.DelayGeneratorAsync = async retry =>
+            {
+                await Assert.That(retry.Context.CancellationToken).IsEqualTo(cancellation.Token);
+                await gate.EnterAsync();
+                return TimeSpan.Zero;
+            };
+            options.OnRetry = _ => hooks++;
+        });
+
+        var execution = shield.ExecuteOutcomeAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        }, cancellation.Token).AsTask();
+
+        await gate.WaitForEntryAsync();
+        cancellation.Cancel();
+        gate.Release();
+        var outcome = await execution;
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken)
+            .IsEqualTo(cancellation.Token);
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(hooks).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Concurrent_Executions_Receive_Independent_Typed_Events()
+    {
+        const int executionCount = 32;
+        var events = new List<(int Attempt, int Result)>();
+        var shield = Shield.For<int>()
+            .WhenResult(-1)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.DelayGeneratorAsync = retry =>
+                {
+                    lock (events)
+                    {
+                        events.Add((retry.Attempt, retry.Outcome.Result));
+                    }
+
+                    return new ValueTask<TimeSpan?>(TimeSpan.Zero);
+                };
+            });
+
+        var executions = Enumerable.Range(0, executionCount)
+            .Select(_ =>
+            {
+                var attempt = 0;
+                return shield.ExecuteAsync(_ => new ValueTask<int>(attempt++ == 0 ? -1 : 42)).AsTask();
+            });
+
+        await Task.WhenAll(executions);
+
+        await Assert.That(events.Count).IsEqualTo(executionCount);
+        await Assert.That(events.All(retry => retry == (1, -1))).IsTrue();
+    }
+
+    [Test]
+    public async Task Generator_Can_Reenter_The_Same_Shield()
+    {
+        Shield? shield = null;
+        var attempts = 0;
+        var nestedResult = 0;
+        shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.DelayGeneratorAsync = async _ =>
+            {
+                nestedResult = await shield!.ExecuteAsync(static _ => new ValueTask<int>(42));
+                return TimeSpan.Zero;
+            };
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return attempts == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException())
+                : new ValueTask<int>(7);
+        });
+
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(nestedResult).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Truly_Async_Generator_Works_For_Synchronous_Execution()
+    {
+        var attempts = 0;
+        var sawSynchronousContext = false;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.DelayGeneratorAsync = async retry =>
+            {
+                sawSynchronousContext = retry.Context.IsSynchronous;
+                await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(false);
+                return TimeSpan.Zero;
+            };
+        });
+
+        var result = shield.Execute(_ => ++attempts == 1
+            ? throw new InvalidOperationException()
+            : 42);
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(sawSynchronousContext).IsTrue();
+    }
+
+    private static readonly KevlarKey<string> ContextKey = new("async-delay-lifetime");
+}


### PR DESCRIPTION
## Summary
- add typed and untyped DelayGeneratorAsync retry options using ValueTask<TimeSpan?>
- run async delay generation after the synchronous generator and before retry notifications, with MaxDelay applied to every override
- preserve exact callback exceptions, caller-cancellation behavior, reentrancy, concurrent event isolation, and pooled-context lifetime
- retain zero-allocation happy paths and fixed/synchronous recovery allocation profiles
- add docs, XML guidance, public API baselines, allocation gates, and four-mode benchmarks

## Validation
- dotnet build Kevlar.slnx -c Release
- unit tests: 538 passed
- integration tests: 16 passed
- analyzer tests: 19 passed
- allocation tests: 2 passed
- netstandard tests: 1 passed
- Docusaurus production build
- documentation snippets: 81 compiled; runtime examples passed
- package layout, metadata, consumer, analyzer, trimmed and single-file checks passed (NativeAOT remains Linux CI-only)
- BenchmarkDotNet, one recovery retry: fixed 1.125 us / 96 B; sync generator 1.099 us / 96 B; sync-completed async 1.125 us / 96 B; yielding async 2.281 us / 839 B

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for asynchronous retry delay generators.
  * Async generators can override retry delays, respect maximum-delay limits, and handle cancellation and failures.
  * Added support for asynchronous generators in both standard and result-based retry configurations.

* **Documentation**
  * Expanded retry documentation with configuration examples, execution order, validation, and context-lifetime guidance.

* **Tests**
  * Added coverage for asynchronous, concurrent, cancellation, error, clamping, and allocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->