### PR TITLE
feat(timeout): add dynamic duration hooks

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/TimeoutBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/TimeoutBenchmarks.cs
@@ -16,6 +16,19 @@ public class TimeoutBenchmarks
 {
     private static readonly Shield KevlarTimeout = Shield.Timeout(TimeSpan.FromSeconds(10));
 
+    private static readonly Shield KevlarGeneratedTimeout = Shield.Timeout(options =>
+        options.TimeoutGenerator = static _ =>
+            new ValueTask<TimeSpan>(TimeSpan.FromSeconds(10)));
+
+    private static readonly Shield KevlarAsyncGeneratedTimeout = Shield.Timeout(options =>
+        options.TimeoutGenerator = GenerateTimeoutAsync);
+
+    private static readonly Shield KevlarAsyncHookConfigured = Shield.Timeout(options =>
+    {
+        options.Timeout = TimeSpan.FromSeconds(10);
+        options.OnTimeoutAsync = static _ => ValueTask.CompletedTask;
+    });
+
     private static readonly ResiliencePipeline PollyTimeout = new ResiliencePipelineBuilder()
         .AddTimeout(new TimeoutStrategyOptions { Timeout = TimeSpan.FromSeconds(10) })
         .Build();
@@ -25,4 +38,22 @@ public class TimeoutBenchmarks
 
     [BenchmarkCategory("HappyPath"), Benchmark]
     public ValueTask<int> Polly_HappyPath() => PollyTimeout.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("HappyPath"), Benchmark]
+    public ValueTask<int> Kevlar_SynchronousGenerator_HappyPath() =>
+        KevlarGeneratedTimeout.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("HappyPath"), Benchmark]
+    public ValueTask<int> Kevlar_AsynchronousGenerator_HappyPath() =>
+        KevlarAsyncGeneratedTimeout.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("HappyPath"), Benchmark]
+    public ValueTask<int> Kevlar_AsyncHookConfigured_HappyPath() =>
+        KevlarAsyncHookConfigured.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    private static async ValueTask<TimeSpan> GenerateTimeoutAsync(KevlarContext _)
+    {
+        await Task.Yield();
+        return TimeSpan.FromSeconds(10);
+    }
 }

--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -13,6 +13,7 @@ Shield.Timeout(o =>
 {
     o.Timeout = TimeSpan.FromSeconds(10);          // default 30s
     o.OnTimeout = e => logger.LogWarning("Timed out after {Timeout}", e.Timeout);
+    o.OnTimeoutAsync = e => ValueTask.CompletedTask;
 });
 ```
 
@@ -43,6 +44,36 @@ When cancellation signals overlap, the outcome is decided after the delegate com
 3. An `OperationCanceledException` for any other token is preserved unchanged.
 
 This token-identity rule also applies to nested timeouts. A cancelled outer timeout is treated as the inner timeout's caller, so only the winning scope reports `OnTimeout`. The strategy restores the prior context token and completes timer cleanup before invoking `OnTimeout`; if the callback throws, that exception is surfaced without contaminating later executions.
+
+## Dynamic timeouts and asynchronous notifications
+
+Use `TimeoutGenerator` when the budget depends on the current execution context. The generator runs
+and is awaited before the timer is armed or the executed delegate starts. Its result overrides the
+fixed `Timeout` for that execution and must be positive and within the runtime timer limit:
+
+```csharp
+var shield = Shield.Timeout(o =>
+{
+    o.TimeoutGenerator = context => new ValueTask<TimeSpan>(
+        context.ShieldName == "interactive"
+            ? TimeSpan.FromSeconds(2)
+            : TimeSpan.FromSeconds(30));
+
+    o.OnTimeout = timeout => Console.WriteLine(timeout.Timeout);
+    o.OnTimeoutAsync = timeout => ValueTask.CompletedTask;
+});
+```
+
+The generator receives the caller's current `CancellationToken` through `KevlarContext`. Observe it
+in asynchronous work. If caller cancellation wins while generation runs, the executed delegate is
+not started. The context is pooled: inspect it only during the generator or callback and never retain
+it.
+
+After a timeout wins, Kevlar records timeout metrics, restores the caller token, disposes timer state,
+then invokes `OnTimeout` followed by awaited `OnTimeoutAsync`. A callback exception or cancellation
+is surfaced unchanged instead of `TimeoutExceededException`. Hooks may run concurrently when a shield
+is reused, so callbacks must be thread-safe and must not assume serialization. Truly asynchronous
+generators and hooks block the calling thread when used through synchronous `Execute`.
 
 ## Total vs per-attempt
 

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 Kevlar.Shield.ExecuteOutcomeAsync<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
 Kevlar.Shield<TResult>.ExecuteOutcomeAsync<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<TResult>>
+Kevlar.TimeoutOptions.OnTimeoutAsync.get -> System.Func<Kevlar.TimeoutEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.TimeoutOptions.OnTimeoutAsync.set -> void
+Kevlar.TimeoutOptions.TimeoutGenerator.get -> System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Kevlar.TimeoutOptions.TimeoutGenerator.set -> void
 static Kevlar.ShieldTaskExtensions.ExecuteOutcomeAsync<T, TState>(this Kevlar.Shield! shield, TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
 static Kevlar.ShieldTaskExtensions.ExecuteOutcomeAsync<TResult, TState>(this Kevlar.Shield<TResult>! shield, TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<TResult>>
 virtual Kevlar.Strategy.IsDuplicateReferenceUnsafe.get -> bool

--- a/src/Kevlar/Strategies/Timeout/TimeoutOptions.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutOptions.cs
@@ -1,13 +1,31 @@
 namespace Kevlar;
 
 /// <summary>Configuration for a timeout strategy.</summary>
+/// <remarks>
+/// <see cref="TimeoutGenerator"/> runs before the timeout timer is armed and overrides
+/// <see cref="Timeout"/> for that execution. When a timeout wins, callbacks run in this order:
+/// <see cref="OnTimeout"/>, then <see cref="OnTimeoutAsync"/>. Both callbacks run after timer
+/// cleanup and restoration of the caller's cancellation token.
+/// </remarks>
 public sealed class TimeoutOptions
 {
     /// <summary>The maximum time an execution may take. The default is 30 seconds.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// Produces and awaits the timeout for each execution. The returned value must be positive and
+    /// no greater than the runtime timer limit. The context is valid only until the callback completes.
+    /// </summary>
+    public Func<KevlarContext, ValueTask<TimeSpan>>? TimeoutGenerator { get; set; }
+
     /// <summary>Invoked when an execution is cancelled because it exceeded the timeout.</summary>
     public Action<TimeoutEvent>? OnTimeout { get; set; }
+
+    /// <summary>
+    /// Invoked and awaited after <see cref="OnTimeout"/> when an execution exceeds its timeout.
+    /// The event context is valid only until the callback completes.
+    /// </summary>
+    public Func<TimeoutEvent, ValueTask>? OnTimeoutAsync { get; set; }
 }
 
 /// <summary>Describes an execution that exceeded its timeout.</summary>

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -11,19 +11,67 @@ namespace Kevlar.Strategies;
 internal sealed class TimeoutStrategy : Strategy
 {
     private readonly TimeSpan _timeout;
+    private readonly Func<KevlarContext, ValueTask<TimeSpan>>? _timeoutGenerator;
     private readonly Action<TimeoutEvent>? _onTimeout;
+    private readonly Func<TimeoutEvent, ValueTask>? _onTimeoutAsync;
 
     public TimeoutStrategy(TimeoutOptions options)
     {
         Throw.IfOutOfRange(options.Timeout <= TimeSpan.Zero, nameof(options), "Timeout must be positive.");
         Throw.IfOutOfRange(options.Timeout > DelayHelper.MaximumDelay, nameof(options.Timeout), "Timeout exceeds the runtime timer limit.");
         _timeout = options.Timeout;
+        _timeoutGenerator = options.TimeoutGenerator;
         _onTimeout = options.OnTimeout;
+        _onTimeoutAsync = options.OnTimeoutAsync;
     }
 
-    public override string Describe() => $"Timeout({DescribeHelper.Time(_timeout)})";
+    public override string Describe() => _timeoutGenerator is null
+        ? $"Timeout({DescribeHelper.Time(_timeout)})"
+        : "Timeout(dynamic)";
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    {
+        if (_timeoutGenerator is null)
+        {
+            return ExecuteWithTimeout(next, context, _timeout);
+        }
+
+        var generation = _timeoutGenerator(context);
+        if (!generation.IsCompletedSuccessfully)
+        {
+            return AwaitGenerationAsync(generation, next, context);
+        }
+
+        var timeout = generation.Result;
+        ValidateGeneratedTimeout(timeout);
+        if (context.CancellationToken.IsCancellationRequested)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(
+                new OperationCanceledException(context.CancellationToken)));
+        }
+
+        return ExecuteWithTimeout(next, context, timeout);
+    }
+
+    private async ValueTask<Outcome<T>> AwaitGenerationAsync<T, TState>(
+        ValueTask<TimeSpan> generation,
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        var timeout = await generation.ConfigureAwait(false);
+        ValidateGeneratedTimeout(timeout);
+        if (context.CancellationToken.IsCancellationRequested)
+        {
+            return Outcome<T>.FromException(new OperationCanceledException(context.CancellationToken));
+        }
+
+        return await ExecuteWithTimeout(next, context, timeout).ConfigureAwait(false);
+    }
+
+    private ValueTask<Outcome<T>> ExecuteWithTimeout<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        TimeSpan timeout)
     {
         var priorToken = context.CancellationToken;
         var usesSystemTime = ReferenceEquals(context.TimeProvider, TimeProvider.System);
@@ -37,7 +85,7 @@ internal sealed class TimeoutStrategy : Strategy
         {
             if (usesSystemTime)
             {
-                timeoutSource.CancelAfter(_timeout);
+                timeoutSource.CancelAfter(timeout);
             }
             else
             {
@@ -54,7 +102,7 @@ internal sealed class TimeoutStrategy : Strategy
                         }
                     },
                     timeoutSource,
-                    _timeout,
+                    timeout,
                     System.Threading.Timeout.InfiniteTimeSpan);
             }
 
@@ -69,7 +117,7 @@ internal sealed class TimeoutStrategy : Strategy
 
         if (!execution.IsCompletedSuccessfully)
         {
-            return AwaitAsync(execution, context, priorToken, timeoutSource, timer);
+            return AwaitAsync(execution, context, priorToken, timeoutSource, timer, timeout);
         }
 
         var outcome = execution.Result;
@@ -79,13 +127,14 @@ internal sealed class TimeoutStrategy : Strategy
             return new ValueTask<Outcome<T>>(outcome);
         }
 
-        return new ValueTask<Outcome<T>>(CompleteCancellation(
+        return CompleteCancellationAsync(
             outcome,
             cancellationException,
             context,
             priorToken,
             timeoutSource,
-            timer));
+            timer,
+            timeout);
     }
 
     private async ValueTask<Outcome<T>> AwaitAsync<T>(
@@ -93,7 +142,8 @@ internal sealed class TimeoutStrategy : Strategy
         KevlarContext context,
         CancellationToken priorToken,
         CancellationTokenSource timeoutSource,
-        ITimer? timer)
+        ITimer? timer,
+        TimeSpan timeout)
     {
         Outcome<T> outcome;
 
@@ -113,7 +163,14 @@ internal sealed class TimeoutStrategy : Strategy
             return outcome;
         }
 
-        return CompleteCancellation(outcome, cancellationException, context, priorToken, timeoutSource, timer);
+        return await CompleteCancellationAsync(
+            outcome,
+            cancellationException,
+            context,
+            priorToken,
+            timeoutSource,
+            timer,
+            timeout).ConfigureAwait(false);
     }
 
     private static void Cleanup(
@@ -127,13 +184,14 @@ internal sealed class TimeoutStrategy : Strategy
         timeoutSource.Dispose();
     }
 
-    private Outcome<T> CompleteCancellation<T>(
+    private ValueTask<Outcome<T>> CompleteCancellationAsync<T>(
         Outcome<T> outcome,
         OperationCanceledException cancellationException,
         KevlarContext context,
         CancellationToken priorToken,
         CancellationTokenSource timeoutSource,
-        ITimer? timer)
+        ITimer? timer,
+        TimeSpan timeout)
     {
         context.CancellationToken = priorToken;
         timer?.Dispose();
@@ -144,13 +202,13 @@ internal sealed class TimeoutStrategy : Strategy
 
             if (cancellationException.CancellationToken == priorToken)
             {
-                return outcome;
+                return new ValueTask<Outcome<T>>(outcome);
             }
 
-            return Outcome<T>.FromException(new OperationCanceledException(
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(new OperationCanceledException(
                 cancellationException.Message,
                 cancellationException,
-                priorToken));
+                priorToken)));
         }
 
         var timedOut = timeoutSource.IsCancellationRequested
@@ -160,10 +218,38 @@ internal sealed class TimeoutStrategy : Strategy
         if (timedOut)
         {
             KevlarMetrics.Timeout(context.ShieldName);
-            _onTimeout?.Invoke(new TimeoutEvent(_timeout, context));
-            return Outcome<T>.FromException(new TimeoutExceededException(_timeout));
+            var timeoutEvent = new TimeoutEvent(timeout, context);
+            _onTimeout?.Invoke(timeoutEvent);
+
+            if (_onTimeoutAsync is not null)
+            {
+                var notification = _onTimeoutAsync(timeoutEvent);
+                if (!notification.IsCompletedSuccessfully)
+                {
+                    return AwaitTimeoutNotificationAsync<T>(notification, timeout);
+                }
+
+                notification.GetAwaiter().GetResult();
+            }
+
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(
+                new TimeoutExceededException(timeout)));
         }
 
-        return outcome;
+        return new ValueTask<Outcome<T>>(outcome);
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitTimeoutNotificationAsync<T>(
+        ValueTask notification,
+        TimeSpan timeout)
+    {
+        await notification.ConfigureAwait(false);
+        return Outcome<T>.FromException(new TimeoutExceededException(timeout));
+    }
+
+    private static void ValidateGeneratedTimeout(TimeSpan timeout)
+    {
+        Throw.IfOutOfRange(timeout <= TimeSpan.Zero, nameof(timeout), "Generated timeout must be positive.");
+        Throw.IfOutOfRange(timeout > DelayHelper.MaximumDelay, nameof(timeout), "Generated timeout exceeds the runtime timer limit.");
     }
 }

--- a/tests/Kevlar.Tests/TimeoutDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/TimeoutDynamicOptionsTests.cs
@@ -1,0 +1,308 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class TimeoutDynamicOptionsTests
+{
+    [Test]
+    public async Task Generated_Timeout_Uses_The_Execution_Context()
+    {
+        var fakeTime = new FakeTimeProvider();
+        string? observedName = null;
+        var shield = Shield.Timeout(options =>
+            {
+                options.TimeoutGenerator = context =>
+                {
+                    observedName = context.ShieldName;
+                    return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(2));
+                };
+            })
+            .WithName("dynamic-timeout")
+            .WithTimeProvider(fakeTime);
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }).AsTask();
+
+        fakeTime.Advance(TimeSpan.FromSeconds(2));
+
+        var exception = await Assert.That(async () => await execution).Throws<TimeoutExceededException>();
+        await Assert.That(exception!.Timeout).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(observedName).IsEqualTo("dynamic-timeout");
+        await Assert.That(shield.ToString()).IsEqualTo("dynamic-timeout: Timeout(dynamic)");
+    }
+
+    [Test]
+    public async Task Generated_Timeout_Supports_Typed_Synchronous_Execution()
+    {
+        var sawSynchronousContext = false;
+        var shield = Shield<int>.Empty.Timeout(options =>
+        {
+            options.TimeoutGenerator = context =>
+            {
+                sawSynchronousContext = context.IsSynchronous;
+                return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+            };
+        });
+
+        var result = shield.Execute(_ => 42);
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(sawSynchronousContext).IsTrue();
+    }
+
+    [Test]
+    public async Task Async_Timeout_Generator_Is_Awaited_Before_Execution()
+    {
+        var generatorGate = new AsyncGate("timeout generator");
+        var actionStarted = false;
+        var shield = Shield.Timeout(options =>
+        {
+            options.TimeoutGenerator = async context =>
+            {
+                await generatorGate.EnterAsync(context.CancellationToken);
+                return TimeSpan.FromMinutes(1);
+            };
+        });
+
+        var execution = shield.ExecuteAsync(_ =>
+        {
+            actionStarted = true;
+            return new ValueTask<int>(42);
+        }).AsTask();
+
+        await generatorGate.WaitForEntryAsync();
+        await Assert.That(actionStarted).IsFalse();
+        await Assert.That(execution.IsCompleted).IsFalse();
+
+        generatorGate.Release();
+
+        await Assert.That(await execution).IsEqualTo(42);
+        await Assert.That(actionStarted).IsTrue();
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_During_Generation_Skips_Execution()
+    {
+        using var callerCancellation = new CancellationTokenSource();
+        var generatorStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionStarted = false;
+        var shield = Shield.Timeout(options =>
+        {
+            options.TimeoutGenerator = async context =>
+            {
+                generatorStarted.SetResult();
+                await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, context.CancellationToken);
+                return TimeSpan.FromMinutes(1);
+            };
+        });
+
+        var execution = shield.ExecuteOutcomeAsync(
+            _ =>
+            {
+                actionStarted = true;
+                return new ValueTask<int>(42);
+            },
+            callerCancellation.Token).AsTask();
+
+        await generatorStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        callerCancellation.Cancel();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(actionStarted).IsFalse();
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken)
+            .IsEqualTo(callerCancellation.Token);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task Invalid_Generated_Timeout_Fails_Before_Execution(int seconds)
+    {
+        var actionStarted = false;
+        var shield = Shield.Timeout(options =>
+        {
+            options.TimeoutGenerator = _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(seconds));
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync(_ =>
+        {
+            actionStarted = true;
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(actionStarted).IsFalse();
+        await Assert.That(outcome.Exception).IsTypeOf<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Async_Timeout_Hook_Is_Ordered_After_Synchronous_Hook_And_Awaited()
+    {
+        var fakeTime = new FakeTimeProvider();
+        using var callerCancellation = new CancellationTokenSource();
+        var hookGate = new AsyncGate("async timeout hook");
+        var observations = new List<string>();
+        CancellationToken callbackToken = default;
+        var shield = Shield.Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeout = _ => observations.Add("sync");
+                options.OnTimeoutAsync = async timeout =>
+                {
+                    callbackToken = timeout.Context.CancellationToken;
+                    observations.Add("async-start");
+                    await hookGate.EnterAsync();
+                    observations.Add("async-end");
+                };
+            })
+            .WithTimeProvider(fakeTime);
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, callerCancellation.Token).AsTask();
+
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await hookGate.WaitForEntryAsync();
+
+        await Assert.That(execution.IsCompleted).IsFalse();
+        await Assert.That(observations).IsEquivalentTo(["sync", "async-start"]);
+        await Assert.That(callbackToken).IsEqualTo(callerCancellation.Token);
+
+        hookGate.Release();
+
+        await Assert.That(async () => await execution).Throws<TimeoutExceededException>();
+        await Assert.That(observations).IsEquivalentTo(["sync", "async-start", "async-end"]);
+    }
+
+    [Test]
+    public async Task Async_Timeout_Hook_Failure_Surfaces_The_Exact_Exception()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var callbackFailure = new ApplicationException("async timeout callback failed");
+        var shield = Shield.Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeoutAsync = _ => ValueTask.FromException(callbackFailure);
+            })
+            .WithTimeProvider(fakeTime);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }).AsTask();
+
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        var outcome = await execution;
+
+        await Assert.That(ReferenceEquals(outcome.Exception, callbackFailure)).IsTrue();
+    }
+
+    [Test]
+    public async Task Synchronously_Completed_Async_Hook_Receives_Generated_Timeout()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var observed = TimeSpan.Zero;
+        var shield = Shield.Timeout(options =>
+            {
+                options.TimeoutGenerator = _ =>
+                    new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
+                options.OnTimeoutAsync = timeout =>
+                {
+                    observed = timeout.Timeout;
+                    return ValueTask.CompletedTask;
+                };
+            })
+            .WithTimeProvider(fakeTime);
+
+        var execution = StartTimedExecution(shield);
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+
+        await Assert.That(async () => await execution).Throws<TimeoutExceededException>();
+        await Assert.That(observed).IsEqualTo(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task Synchronous_Execution_Waits_For_The_Async_Timeout_Hook()
+    {
+        var hookCompleted = false;
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromMilliseconds(10);
+            options.OnTimeoutAsync = async _ =>
+            {
+                await Task.Yield();
+                hookCompleted = true;
+            };
+        });
+
+        await Assert.That(() => shield.Execute(token =>
+        {
+            token.WaitHandle.WaitOne();
+            token.ThrowIfCancellationRequested();
+            return 1;
+        })).Throws<TimeoutExceededException>();
+        await Assert.That(hookCompleted).IsTrue();
+    }
+
+    [Test]
+    public async Task Timeout_Generator_Failure_Surfaces_The_Exact_Exception()
+    {
+        var generatorFailure = new ApplicationException("timeout generator failed");
+        var actionStarted = false;
+        var shield = Shield.Timeout(options =>
+            options.TimeoutGenerator = _ => ValueTask.FromException<TimeSpan>(generatorFailure));
+
+        var outcome = await shield.ExecuteOutcomeAsync(_ =>
+        {
+            actionStarted = true;
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(actionStarted).IsFalse();
+        await Assert.That(ReferenceEquals(outcome.Exception, generatorFailure)).IsTrue();
+    }
+
+    [Test]
+    public async Task Async_Timeout_Hooks_May_Run_Concurrently()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var hooksStarted = new AsyncCounter("concurrent timeout hooks");
+        var releaseHooks = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(1);
+                options.OnTimeoutAsync = async _ =>
+                {
+                    hooksStarted.Signal();
+                    await releaseHooks.Task;
+                };
+            })
+            .WithTimeProvider(fakeTime);
+
+        var first = StartTimedExecution(shield);
+        var second = StartTimedExecution(shield);
+
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await hooksStarted.WaitForAsync(2);
+        await Assert.That(first.IsCompleted).IsFalse();
+        await Assert.That(second.IsCompleted).IsFalse();
+
+        releaseHooks.SetResult();
+
+        await Assert.That(async () => await first).Throws<TimeoutExceededException>();
+        await Assert.That(async () => await second).Throws<TimeoutExceededException>();
+    }
+
+    private static Task<int> StartTimedExecution(Shield shield) =>
+        shield.ExecuteAsync(async token =>
+        {
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }).AsTask();
+}


### PR DESCRIPTION
## Summary

- add context-aware awaited TimeoutGenerator with per-execution validation
- add ordered OnTimeoutAsync after cleanup and the synchronous notification
- preserve caller-cancellation arbitration, exception identity, typed/sync execution, and pooled-context lifetime
- document callback ordering, concurrency, cancellation, and synchronous blocking semantics
- add fixed, sync-generated, truly async-generated, and async-hook-configured benchmarks

Part of #75.

## Validation

- dotnet build Kevlar.slnx -c Release (0 warnings/errors)
- unit: 541 passed
- integration: 16 passed
- analyzers: 19 passed
- netstandard: 1 passed
- allocation: 2 passed
- npm run build
- Verify-Packages.ps1
- Verify-DocSnippets.ps1 (82 snippets)

## Benchmarks

BenchmarkDotNet ShortRun, .NET 10.0.11, x64:

- fixed timeout: 109.0 ns / 0 B before; 112.2 ns / 0 B after (+2.9%, overlapping confidence intervals)
- synchronous generator: 120.2 ns / 0 B
- async hook configured, happy path: 116.8 ns / 0 B
- truly asynchronous generator: 1.116 us / 687 B

Closes #86