### PR TITLE
feat(circuit-breaker): add dynamic break hooks

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/CircuitBreakerBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/CircuitBreakerBenchmarks.cs
@@ -15,6 +15,16 @@ namespace Kevlar.Benchmarks;
 public class CircuitBreakerBenchmarks
 {
     private static readonly Shield KevlarBreaker = Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));
+    private static readonly Shield KevlarDynamicDurationBreaker = Shield.CircuitBreaker(options =>
+    {
+        options.ConsecutiveFailures = 5;
+        options.BreakDurationGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(30));
+    });
+    private static readonly Shield KevlarAsyncCallbackBreaker = Shield.CircuitBreaker(options =>
+    {
+        options.ConsecutiveFailures = 5;
+        options.OnStateChangedAsync = static _ => default;
+    });
     private static readonly Shield KevlarOpenBreaker = Shield.CircuitBreaker(1, TimeSpan.FromDays(1));
 
     private static readonly ResiliencePipeline PollyBreaker = new ResiliencePipelineBuilder()
@@ -46,6 +56,14 @@ public class CircuitBreakerBenchmarks
 
     [BenchmarkCategory("ClosedHappyPath"), Benchmark]
     public ValueTask<int> Polly_ClosedHappyPath() => PollyBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("ClosedHappyPath"), Benchmark]
+    public ValueTask<int> Kevlar_DynamicDurationConfigured() =>
+        KevlarDynamicDurationBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("ClosedHappyPath"), Benchmark]
+    public ValueTask<int> Kevlar_AsyncCallbackConfigured() =>
+        KevlarAsyncCallbackBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     [BenchmarkCategory("OpenFastFail"), Benchmark(Baseline = true)]
     public async ValueTask<bool> Kevlar_OpenFastFail()

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -100,4 +100,4 @@ and suppression guidance.
 
 ## Callbacks
 
-Every reactive strategy also raises in-process events for logging — `OnRetry`, `OnTimeout`, `OnStateChanged`, `OnHedge`, `onFallback` — documented on each [strategy page](/docs/category/strategies). Metrics tell you *how much*; callbacks give you the *which request* detail.
+Every reactive strategy also raises in-process events for logging — including synchronous and asynchronous retry, timeout, and circuit-transition callbacks — documented on each [strategy page](/docs/category/strategies). Metrics tell you *how much*; callbacks give you the *which request* detail.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -100,4 +100,4 @@ and suppression guidance.
 
 ## Callbacks
 
-Strategy callbacks provide request-level logging where configured. Retry and circuit breaker expose synchronous and asynchronous callbacks. Timeout, hedging, and result-aware fallback expose synchronous callbacks only. Concurrency limit and rate limit expose no callback APIs. Each callback is documented on its [strategy page](/docs/category/strategies). Metrics tell you *how much*; callbacks give you the *which request* detail.
+Strategy callbacks provide request-level logging where configured. Retry, circuit breaker, timeout, and result-aware fallback expose synchronous and asynchronous callbacks. Hedging exposes a synchronous callback only. Concurrency limit and rate limit expose no callback APIs. Each callback is documented on its [strategy page](/docs/category/strategies). Metrics tell you *how much*; callbacks give you the *which request* detail.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -100,4 +100,4 @@ and suppression guidance.
 
 ## Callbacks
 
-Every reactive strategy also raises in-process events for logging — including synchronous and asynchronous retry, timeout, and circuit-transition callbacks — documented on each [strategy page](/docs/category/strategies). Metrics tell you *how much*; callbacks give you the *which request* detail.
+Strategy callbacks provide request-level logging where configured. Retry and circuit breaker expose synchronous and asynchronous callbacks. Timeout, hedging, and result-aware fallback expose synchronous callbacks only. Concurrency limit and rate limit expose no callback APIs. Each callback is documented on its [strategy page](/docs/category/strategies). Metrics tell you *how much*; callbacks give you the *which request* detail.

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -33,8 +33,31 @@ Configure either `ConsecutiveFailures` *or* `FailureRatio` — not both. When ne
 | `MinimumThroughput` | `10` | Sampling mode: don't judge until at least this many calls landed in the window |
 | `SamplingWindow` | `30s` | Rolling window over which the ratio is measured (tracked in 10 buckets) |
 | `BreakDuration` | `15s` | How long the circuit stays open before allowing a probe |
+| `BreakDurationGenerator` | — | Awaited outcome/context-aware duration; overrides `BreakDuration` for each trip |
 | `Monitor` | — | A `CircuitBreakerMonitor` for observing + manual control |
 | `OnStateChanged` | — | Callback on every transition: `e.From`, `e.To`, `e.LastException` |
+| `OnStateChangedAsync` | — | Awaited callback on every transition, after `OnStateChanged` |
+
+### Dynamic break duration
+
+Use `BreakDurationGenerator` when the dependency supplies a recovery hint or different failures need different cooling periods:
+
+```csharp
+var breaker = Shield.CircuitBreaker(o =>
+{
+    o.ConsecutiveFailures = 3;
+    o.BreakDurationGenerator = async trip =>
+    {
+        await Task.Yield(); // for example, fetch a dependency recovery hint
+        trip.Context.CancellationToken.ThrowIfCancellationRequested();
+        return trip.Exception is TimeoutException
+            ? TimeSpan.FromMinutes(1)
+            : TimeSpan.FromSeconds(30);
+    };
+});
+```
+
+The generator runs after the handled outcome crosses the threshold and before the circuit changes to `Open`. It is awaited outside the circuit lock. Its duration must be positive; its exception or cancellation propagates unchanged and leaves the circuit available for a later trip. `Result` carries a boxed handled result when a typed shield trips without an exception. `Context` is pooled and must not be retained after the callback completes. A dynamic breaker describes itself as `break dynamic` without running the generator.
 
 ## The state machine
 
@@ -63,17 +86,24 @@ var shield = Shield.CircuitBreaker(o =>
     o.FailureRatio = 0.5;
     o.Monitor = monitor;
     o.OnStateChanged = c => logger.LogWarning("Circuit {From} -> {To}", c.From, c.To);
+    o.OnStateChangedAsync = async c =>
+    {
+        await Task.Yield();
+        logger.LogInformation("Recorded circuit transition to {State}", c.To);
+    };
 });
 
 _ = monitor.State;      // Closed / Open / HalfOpen / Isolated
 monitor.StateChanged += e => metrics.Record(e.To);
 monitor.Isolate();      // force open (maintenance switch)
 monitor.Reset();        // close and clear metrics
+await monitor.IsolateAsync(); // async equivalents await transition callbacks
+await monitor.ResetAsync();
 ```
 
 A monitor binds to exactly **one** breaker: assign it to `CircuitBreakerOptions.Monitor` when building the shield, and keep your reference. Binding it twice throws, as does using it before binding.
 
-Transitions are delivered serially in state-change order, first to `OnStateChanged` and then to `monitor.StateChanged`. Callbacks run outside the circuit lock, so they can read `State` or call `Reset()` / `Isolate()`; a reentrant transition is queued behind the transition currently being delivered. If either observer throws, the other still runs and the circuit keeps its new, usable state. One callback failure is rethrown unchanged after delivery; failures from both observers are combined in an `AggregateException`.
+Transitions are delivered serially in state-change order: `OnStateChanged`, awaited `OnStateChangedAsync`, then `monitor.StateChanged`. Callbacks run outside the circuit lock, so they can read `State` or call the synchronous or asynchronous monitor controls; a reentrant transition is queued behind the transition currently being delivered. Use `ResetAsync()` and `IsolateAsync()` when asynchronous transition callbacks are configured so the calling thread is not blocked. If an observer throws, later observers still run and the circuit keeps its new, usable state. One callback failure is rethrown unchanged after delivery; multiple failures are combined in an `AggregateException`.
 
 ## Share the circuit deliberately
 

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,3 +1,14 @@
+Kevlar.CircuitBreakerBreakDurationEvent
+Kevlar.CircuitBreakerBreakDurationEvent.CircuitBreakerBreakDurationEvent() -> void
+Kevlar.CircuitBreakerBreakDurationEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.CircuitBreakerBreakDurationEvent.Exception.get -> System.Exception?
+Kevlar.CircuitBreakerBreakDurationEvent.Result.get -> object?
+Kevlar.CircuitBreakerMonitor.IsolateAsync() -> System.Threading.Tasks.ValueTask
+Kevlar.CircuitBreakerMonitor.ResetAsync() -> System.Threading.Tasks.ValueTask
+Kevlar.CircuitBreakerOptions.BreakDurationGenerator.get -> System.Func<Kevlar.CircuitBreakerBreakDurationEvent, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Kevlar.CircuitBreakerOptions.BreakDurationGenerator.set -> void
+Kevlar.CircuitBreakerOptions.OnStateChangedAsync.get -> System.Func<Kevlar.CircuitStateChangedEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.CircuitBreakerOptions.OnStateChangedAsync.set -> void
 Kevlar.Shield.ExecuteOutcomeAsync<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
 Kevlar.Shield<TResult>.ExecuteOutcomeAsync<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<TResult>>
 Kevlar.TimeoutOptions.OnTimeoutAsync.get -> System.Func<Kevlar.TimeoutEvent, System.Threading.Tasks.ValueTask>?

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationEvent.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationEvent.cs
@@ -1,0 +1,27 @@
+namespace Kevlar;
+
+/// <summary>Describes the handled outcome that is about to open a circuit.</summary>
+public readonly struct CircuitBreakerBreakDurationEvent
+{
+    internal CircuitBreakerBreakDurationEvent(
+        Exception? exception,
+        object? result,
+        KevlarContext context)
+    {
+        Exception = exception;
+        Result = result;
+        Context = context;
+    }
+
+    /// <summary>The handled exception, or <see langword="null"/> when a result was handled.</summary>
+    public Exception? Exception { get; }
+
+    /// <summary>The handled result (boxed), or <see langword="null"/> when an exception occurred.</summary>
+    public object? Result { get; }
+
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it or its property bag after
+    /// the callback completes.
+    /// </summary>
+    public KevlarContext Context { get; }
+}

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationEvent.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationEvent.cs
@@ -3,6 +3,8 @@ namespace Kevlar;
 /// <summary>Describes the handled outcome that is about to open a circuit.</summary>
 public readonly struct CircuitBreakerBreakDurationEvent
 {
+    private readonly KevlarContext? _context;
+
     internal CircuitBreakerBreakDurationEvent(
         Exception? exception,
         object? result,
@@ -10,7 +12,7 @@ public readonly struct CircuitBreakerBreakDurationEvent
     {
         Exception = exception;
         Result = result;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The handled exception, or <see langword="null"/> when a result was handled.</summary>
@@ -23,5 +25,6 @@ public readonly struct CircuitBreakerBreakDurationEvent
     /// The ambient execution context. It is pooled; do not retain it or its property bag after
     /// the callback completes.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => _context
+        ?? throw new InvalidOperationException("A default break-duration event has no execution context.");
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -24,9 +24,12 @@ internal sealed class CircuitBreakerCore
     private readonly TimeSpan _breakDuration;
     private readonly double _breakDurationTimestampUnits;
     private readonly Action<CircuitState> _recordState;
+    private readonly Func<CircuitBreakerBreakDurationEvent, ValueTask<TimeSpan>>? _breakDurationGenerator;
     private readonly Action<CircuitStateChangedEvent>? _onStateChanged;
+    private readonly Func<CircuitStateChangedEvent, ValueTask>? _onStateChangedAsync;
     private readonly CircuitBreakerMonitor? _monitor;
     private readonly Queue<TransitionPublication> _pendingTransitions = new();
+    private readonly AsyncLocal<TransitionPublication?>? _ambientPublication;
 
     private readonly long[] _bucketFailures = new long[BucketCount];
     private readonly long[] _bucketSuccesses = new long[BucketCount];
@@ -41,6 +44,8 @@ internal sealed class CircuitBreakerCore
     private long _probeGeneration;
     private long _activeProbeGeneration;
     private Exception? _lastException;
+    private long _openingGeneration;
+    private bool _openingPending;
     private bool _isPublishing;
     private int _publishingThreadId;
     private TransitionPublication? _activePublication;
@@ -65,16 +70,27 @@ internal sealed class CircuitBreakerCore
         _breakDuration = options.BreakDuration;
         _breakDurationTimestampUnits = options.BreakDuration.TotalSeconds * Stopwatch.Frequency;
         _recordState = recordState;
+        _breakDurationGenerator = options.BreakDurationGenerator;
         _onStateChanged = options.OnStateChanged;
+        _onStateChangedAsync = options.OnStateChangedAsync;
+        _ambientPublication = options.OnStateChangedAsync is null
+            ? null
+            : new AsyncLocal<TransitionPublication?>();
         _monitor = options.Monitor;
         _monitor?.Bind(this);
     }
 
     public string Describe() =>
         _consecutiveFailureLimit is { } limit
-            ? $"CircuitBreaker({limit} consecutive, break {DescribeHelper.Time(_breakDuration)})"
+            ? $"CircuitBreaker({limit} consecutive, break {DescribeBreakDuration()})"
             : FormattableString.Invariant(
-                $"CircuitBreaker({_failureRatio!.Value * 100:0.#}% over {DescribeHelper.Time(_samplingWindow)}, min {_minimumThroughput}, break {DescribeHelper.Time(_breakDuration)})");
+                $"CircuitBreaker({_failureRatio!.Value * 100:0.#}% over {DescribeHelper.Time(_samplingWindow)}, min {_minimumThroughput}, break {DescribeBreakDuration()})");
+
+    public bool RequiresAsyncExecution => _breakDurationGenerator is not null || _onStateChangedAsync is not null;
+
+    private string DescribeBreakDuration() => _breakDurationGenerator is null
+        ? DescribeHelper.Time(_breakDuration)
+        : "dynamic";
 
     public CircuitState State
     {
@@ -97,61 +113,7 @@ internal sealed class CircuitBreakerCore
         out CircuitOpenException? rejection,
         out long admittedProbeGeneration)
     {
-        TransitionPublication? transition = null;
-        admittedProbeGeneration = 0;
-        bool allowed;
-        rejection = null;
-
-        lock (_gate)
-        {
-            var now = _state == CircuitState.Open ? timeProvider.GetUtcNow() : default;
-            switch (_state)
-            {
-                case CircuitState.Closed:
-                    allowed = true;
-                    break;
-
-                case CircuitState.Isolated:
-                    rejection = new CircuitOpenException(null, isIsolated: true, _lastException);
-                    allowed = false;
-                    break;
-
-                case CircuitState.Open:
-                    var timestamp = GetCurrentTimestamp(timeProvider);
-                    if (timestamp >= _openUntilTimestamp)
-                    {
-                        transition = ChangeState(CircuitState.HalfOpen);
-                        _probeInFlight = true;
-                        admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
-                        allowed = true;
-                    }
-                    else
-                    {
-                        rejection = new CircuitOpenException(
-                            GetElapsedTime(_openUntilTimestamp - timestamp),
-                            isIsolated: false,
-                            _lastException);
-                        allowed = false;
-                    }
-
-                    break;
-
-                default: // HalfOpen
-                    if (_probeInFlight)
-                    {
-                        rejection = new CircuitOpenException(null, isIsolated: false, _lastException);
-                        allowed = false;
-                    }
-                    else
-                    {
-                        _probeInFlight = true;
-                        admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
-                        allowed = true;
-                    }
-
-                    break;
-            }
-        }
+        var allowed = TryEnterCore(timeProvider, out rejection, out var transition, out admittedProbeGeneration);
 
         try
         {
@@ -170,19 +132,142 @@ internal sealed class CircuitBreakerCore
         return allowed;
     }
 
+    public ValueTask<EntryResult> TryEnterAsync(TimeProvider timeProvider)
+    {
+        var allowed = TryEnterCore(
+            timeProvider,
+            out var rejection,
+            out var transition,
+            out var admittedProbeGeneration);
+        ValueTask publication;
+        try
+        {
+            publication = PublishAsync(transition);
+        }
+        catch
+        {
+            if (transition?.StateChange.To == CircuitState.HalfOpen)
+            {
+                AbandonProbe(admittedProbeGeneration);
+            }
+
+            throw;
+        }
+
+        if (publication.IsCompletedSuccessfully)
+        {
+            publication.GetAwaiter().GetResult();
+            return new ValueTask<EntryResult>(new EntryResult(allowed, rejection, admittedProbeGeneration));
+        }
+
+        return AwaitEntryPublicationAsync(
+            publication,
+            allowed,
+            rejection,
+            transition,
+            admittedProbeGeneration);
+    }
+
+    private bool TryEnterCore(
+        TimeProvider timeProvider,
+        out CircuitOpenException? rejection,
+        out TransitionPublication? transition,
+        out long admittedProbeGeneration)
+    {
+        transition = null;
+        admittedProbeGeneration = 0;
+        rejection = null;
+
+        lock (_gate)
+        {
+            switch (_state)
+            {
+                case CircuitState.Closed:
+                    return true;
+
+                case CircuitState.Isolated:
+                    rejection = new CircuitOpenException(null, isIsolated: true, _lastException);
+                    return false;
+
+                case CircuitState.Open:
+                    var timestamp = GetCurrentTimestamp(timeProvider);
+                    if (timestamp < _openUntilTimestamp)
+                    {
+                        rejection = new CircuitOpenException(
+                            GetElapsedTime(_openUntilTimestamp - timestamp),
+                            isIsolated: false,
+                            _lastException);
+                        return false;
+                    }
+
+                    transition = ChangeState(CircuitState.HalfOpen);
+                    _probeInFlight = true;
+                    admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
+                    return true;
+
+                default: // HalfOpen
+                    if (_probeInFlight)
+                    {
+                        rejection = new CircuitOpenException(null, isIsolated: false, _lastException);
+                        return false;
+                    }
+
+                    _probeInFlight = true;
+                    admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
+                    return true;
+            }
+        }
+    }
+
+    private async ValueTask<EntryResult> AwaitEntryPublicationAsync(
+        ValueTask publication,
+        bool allowed,
+        CircuitOpenException? rejection,
+        TransitionPublication? transition,
+        long admittedProbeGeneration)
+    {
+        try
+        {
+            await publication.ConfigureAwait(false);
+            return new EntryResult(allowed, rejection, admittedProbeGeneration);
+        }
+        catch
+        {
+            if (transition?.StateChange.To == CircuitState.HalfOpen)
+            {
+                AbandonProbe(admittedProbeGeneration);
+            }
+
+            throw;
+        }
+    }
+
+    public readonly record struct EntryResult(
+        bool Allowed,
+        CircuitOpenException? Rejection,
+        long AdmittedProbeGeneration);
+
     public void RecordSuccess(TimeProvider timeProvider)
     {
-        TransitionPublication? transition = null;
+        Publish(RecordSuccessCore(timeProvider));
+    }
 
+    public ValueTask RecordSuccessAsync(TimeProvider timeProvider) =>
+        PublishAsync(RecordSuccessCore(timeProvider));
+
+    private TransitionPublication? RecordSuccessCore(TimeProvider timeProvider)
+    {
         lock (_gate)
         {
             if (_state == CircuitState.HalfOpen)
             {
                 _probeInFlight = false;
+                CancelPendingOpening();
                 ResetMetrics();
-                transition = ChangeState(CircuitState.Closed);
+                return ChangeState(CircuitState.Closed);
             }
-            else if (_state == CircuitState.Closed)
+
+            if (_state == CircuitState.Closed)
             {
                 _consecutiveFailures = 0;
                 if (_failureRatio is not null)
@@ -190,15 +275,68 @@ internal sealed class CircuitBreakerCore
                     _bucketSuccesses[AdvanceBucket(timeProvider)]++;
                 }
             }
-        }
 
-        Publish(transition);
+            return null;
+        }
     }
 
     public void RecordFailure(TimeProvider timeProvider, Exception? exception)
     {
-        TransitionPublication? transition = null;
+        Publish(RecordFailureCore(timeProvider, exception));
+    }
 
+    public ValueTask RecordFailureAsync<T>(
+        TimeProvider timeProvider,
+        in Outcome<T> outcome,
+        KevlarContext context)
+    {
+        if (_breakDurationGenerator is null)
+        {
+            return PublishAsync(RecordFailureCore(timeProvider, outcome.Exception));
+        }
+
+        if (!TryReserveDynamicOpening(timeProvider, outcome.Exception, out var reservation))
+        {
+            return default;
+        }
+
+        ValueTask<TimeSpan> generation;
+        try
+        {
+            var item = new CircuitBreakerBreakDurationEvent(
+                outcome.Exception,
+                outcome.Exception is null ? outcome.Result : null,
+                context);
+            generation = _breakDurationGenerator(item);
+        }
+        catch
+        {
+            CancelPendingOpening(reservation);
+            throw;
+        }
+
+        if (!generation.IsCompletedSuccessfully)
+        {
+            return AwaitBreakDurationAsync(generation, reservation, timeProvider);
+        }
+
+        TimeSpan duration;
+        try
+        {
+            duration = generation.Result;
+            ValidateGeneratedBreakDuration(duration);
+        }
+        catch
+        {
+            CancelPendingOpening(reservation);
+            throw;
+        }
+
+        return PublishAsync(CommitDynamicOpening(reservation, timeProvider, duration));
+    }
+
+    private TransitionPublication? RecordFailureCore(TimeProvider timeProvider, Exception? exception)
+    {
         lock (_gate)
         {
             _lastException = exception;
@@ -207,9 +345,10 @@ internal sealed class CircuitBreakerCore
             {
                 _probeInFlight = false;
                 _openUntilTimestamp = GetCurrentTimestamp(timeProvider) + _breakDurationTimestampUnits;
-                transition = ChangeState(CircuitState.Open);
+                return ChangeState(CircuitState.Open);
             }
-            else if (_state == CircuitState.Closed)
+
+            if (_state == CircuitState.Closed)
             {
                 var timestamp = _failureRatio is null
                     ? 0
@@ -223,13 +362,120 @@ internal sealed class CircuitBreakerCore
                     }
 
                     _openUntilTimestamp = timestamp + _breakDurationTimestampUnits;
-                    transition = ChangeState(CircuitState.Open);
+                    return ChangeState(CircuitState.Open);
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private bool TryReserveDynamicOpening(
+        TimeProvider timeProvider,
+        Exception? exception,
+        out OpeningReservation reservation)
+    {
+        lock (_gate)
+        {
+            reservation = default;
+            if (_openingPending)
+            {
+                return false;
+            }
+
+            var shouldOpen = _state switch
+            {
+                CircuitState.HalfOpen => true,
+                CircuitState.Closed => IsTripped(
+                    _failureRatio is null ? 0 : GetCurrentTimestamp(timeProvider)),
+                _ => false,
+            };
+            if (!shouldOpen)
+            {
+                _lastException = exception;
+                return false;
+            }
+
+            _openingPending = true;
+            reservation = new OpeningReservation(++_openingGeneration, _state, exception);
+            return true;
+        }
+    }
+
+    private async ValueTask AwaitBreakDurationAsync(
+        ValueTask<TimeSpan> generation,
+        OpeningReservation reservation,
+        TimeProvider timeProvider)
+    {
+        TimeSpan duration;
+        try
+        {
+            duration = await generation.ConfigureAwait(false);
+            ValidateGeneratedBreakDuration(duration);
+        }
+        catch
+        {
+            CancelPendingOpening(reservation);
+            throw;
+        }
+
+        await PublishAsync(CommitDynamicOpening(reservation, timeProvider, duration)).ConfigureAwait(false);
+    }
+
+    private TransitionPublication? CommitDynamicOpening(
+        OpeningReservation reservation,
+        TimeProvider timeProvider,
+        TimeSpan duration)
+    {
+        lock (_gate)
+        {
+            if (!_openingPending
+                || _openingGeneration != reservation.Generation
+                || _state != reservation.ExpectedState)
+            {
+                return null;
+            }
+
+            _openingPending = false;
+            _probeInFlight = false;
+            _lastException = reservation.Exception;
+            _openUntilTimestamp = GetCurrentTimestamp(timeProvider)
+                + (duration.TotalSeconds * Stopwatch.Frequency);
+            return ChangeState(CircuitState.Open);
+        }
+    }
+
+    private void CancelPendingOpening(OpeningReservation reservation)
+    {
+        lock (_gate)
+        {
+            if (_openingPending && _openingGeneration == reservation.Generation)
+            {
+                CancelPendingOpening();
+                if (_state == CircuitState.HalfOpen)
+                {
+                    _probeInFlight = false;
                 }
             }
         }
-
-        Publish(transition);
     }
+
+    private void CancelPendingOpening()
+    {
+        _openingPending = false;
+        _openingGeneration++;
+    }
+
+    private static void ValidateGeneratedBreakDuration(TimeSpan duration) =>
+        Throw.IfOutOfRange(
+            duration <= TimeSpan.Zero,
+            nameof(duration),
+            "Generated break duration must be positive.");
+
+    private readonly record struct OpeningReservation(
+        long Generation,
+        CircuitState ExpectedState,
+        Exception? Exception);
 
     /// <summary>Releases a half-open probe slot without recording an outcome (e.g. the probe was cancelled).</summary>
     public void AbandonProbe(long probeGeneration)
@@ -245,34 +491,41 @@ internal sealed class CircuitBreakerCore
 
     public void Isolate()
     {
-        TransitionPublication? transition = null;
+        Publish(IsolateCore());
+    }
 
+    public ValueTask IsolateAsync() => PublishAsync(IsolateCore());
+
+    private TransitionPublication? IsolateCore()
+    {
         lock (_gate)
         {
-            if (_state != CircuitState.Isolated)
-            {
-                transition = ChangeState(CircuitState.Isolated);
-            }
+            CancelPendingOpening();
+            _probeInFlight = false;
+            return _state == CircuitState.Isolated
+                ? null
+                : ChangeState(CircuitState.Isolated);
         }
-
-        Publish(transition);
     }
 
     public void Reset()
     {
-        TransitionPublication? transition = null;
+        Publish(ResetCore());
+    }
 
+    public ValueTask ResetAsync() => PublishAsync(ResetCore());
+
+    private TransitionPublication? ResetCore()
+    {
         lock (_gate)
         {
+            CancelPendingOpening();
             ResetMetrics();
             _probeInFlight = false;
-            if (_state != CircuitState.Closed)
-            {
-                transition = ChangeState(CircuitState.Closed);
-            }
+            return _state == CircuitState.Closed
+                ? null
+                : ChangeState(CircuitState.Closed);
         }
-
-        Publish(transition);
     }
 
     private bool IsTripped(double timestamp)
@@ -406,6 +659,52 @@ internal sealed class CircuitBreakerCore
 
     private void Publish(TransitionPublication? publication)
     {
+        if (_onStateChangedAsync is null)
+        {
+            PublishSynchronously(publication);
+            return;
+        }
+
+        PublishAsync(publication).AsTask().GetAwaiter().GetResult();
+    }
+
+    private ValueTask PublishAsync(TransitionPublication? publication)
+    {
+        if (publication is null)
+        {
+            return default;
+        }
+
+        if (_onStateChangedAsync is null)
+        {
+            PublishSynchronously(publication);
+            return default;
+        }
+
+        if (publication.StartsDrain)
+        {
+            return DrainPublicationsAsync(publication);
+        }
+
+        var parent = _ambientPublication!.Value;
+        if (parent is not null)
+        {
+            lock (_gate)
+            {
+                if (!parent.ObserversCompleted)
+                {
+                    publication.Parent = parent;
+                    parent.PendingChildren++;
+                    return default;
+                }
+            }
+        }
+
+        return WaitForPublicationAsync(publication);
+    }
+
+    private void PublishSynchronously(TransitionPublication? publication)
+    {
         if (publication is null)
         {
             return;
@@ -426,6 +725,12 @@ internal sealed class CircuitBreakerCore
             publication.Completion.Task.GetAwaiter().GetResult();
             publication.ThrowIfFailed();
         }
+    }
+
+    private async ValueTask WaitForPublicationAsync(TransitionPublication publication)
+    {
+        await publication.Completion.Task.ConfigureAwait(false);
+        publication.ThrowIfFailed();
     }
 
     private void DrainPublications()
@@ -485,6 +790,72 @@ internal sealed class CircuitBreakerCore
                 }
             }
         }
+    }
+
+    private async ValueTask DrainPublicationsAsync(TransitionPublication starter)
+    {
+        TransitionPublication? activePublication = null;
+        Exception? drainFailure = null;
+        var completed = false;
+        try
+        {
+            while (true)
+            {
+                lock (_gate)
+                {
+                    if (_pendingTransitions.Count == 0)
+                    {
+                        _isPublishing = false;
+                        completed = true;
+                        break;
+                    }
+
+                    activePublication = _pendingTransitions.Dequeue();
+                }
+
+                var previousPublication = _ambientPublication!.Value;
+                _ambientPublication.Value = activePublication;
+                try
+                {
+                    activePublication.Failure = await PublishObserversAsync(
+                        activePublication.StateChange).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _ambientPublication.Value = previousPublication;
+                }
+
+                lock (_gate)
+                {
+                    activePublication.ObserversCompleted = true;
+                    CompletePublication(activePublication);
+                }
+
+                activePublication = null;
+            }
+        }
+        catch (Exception exception)
+        {
+            drainFailure = exception;
+            throw;
+        }
+        finally
+        {
+            if (!completed)
+            {
+                lock (_gate)
+                {
+                    _isPublishing = false;
+                    FailPublication(activePublication, drainFailure);
+                    while (_pendingTransitions.TryDequeue(out var publication))
+                    {
+                        FailPublication(publication, drainFailure);
+                    }
+                }
+            }
+        }
+
+        starter.ThrowIfFailed();
     }
 
     private static void CompletePublication(TransitionPublication publication)
@@ -553,6 +924,65 @@ internal sealed class CircuitBreakerCore
         try
         {
             _onStateChanged?.Invoke(stateChange);
+        }
+        catch (Exception exception)
+        {
+            AddFailure(ref failure, exception);
+        }
+
+        try
+        {
+            _monitor?.Raise(in stateChange);
+        }
+        catch (Exception monitorFailure)
+        {
+            AddFailure(ref failure, monitorFailure);
+        }
+
+        return failure;
+    }
+
+    private async ValueTask<Exception?> PublishObserversAsync(CircuitStateChangedEvent stateChange)
+    {
+        Exception? failure = null;
+        try
+        {
+            KevlarMetrics.CircuitTransition(stateChange.From, stateChange.To);
+        }
+        catch (Exception exception)
+        {
+            AddFailure(ref failure, exception);
+        }
+
+        try
+        {
+            _recordState(stateChange.To);
+        }
+        catch (Exception exception)
+        {
+            AddFailure(ref failure, exception);
+        }
+
+        try
+        {
+            _onStateChanged?.Invoke(stateChange);
+        }
+        catch (Exception exception)
+        {
+            AddFailure(ref failure, exception);
+        }
+
+        try
+        {
+            var notification = _onStateChangedAsync!(stateChange);
+            if (!notification.IsCompletedSuccessfully)
+            {
+                await notification.ConfigureAwait(false);
+            }
+            else
+            {
+                notification.GetAwaiter().GetResult();
+            }
         }
         catch (Exception exception)
         {

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -378,8 +378,14 @@ internal sealed class CircuitBreakerCore
         lock (_gate)
         {
             reservation = default;
+            _lastException = exception;
             if (_openingPending)
             {
+                if (_state == CircuitState.Closed)
+                {
+                    _ = IsTripped(_failureRatio is null ? 0 : GetCurrentTimestamp(timeProvider));
+                }
+
                 return false;
             }
 
@@ -392,7 +398,6 @@ internal sealed class CircuitBreakerCore
             };
             if (!shouldOpen)
             {
-                _lastException = exception;
                 return false;
             }
 

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -15,9 +15,10 @@ public sealed class CircuitBreakerMonitor
 
     /// <summary>
     /// Raised on every state transition of the bound circuit, after
-    /// <see cref="CircuitBreakerOptions.OnStateChanged"/>. Transitions are delivered serially
-    /// outside the circuit lock, so handlers may read state or call <see cref="Reset"/> or
-    /// <see cref="Isolate"/> without deadlocking. Handlers run synchronously and block later
+    /// <see cref="CircuitBreakerOptions.OnStateChanged"/> and
+    /// <see cref="CircuitBreakerOptions.OnStateChangedAsync"/>. Transitions are delivered
+    /// serially outside the circuit lock, so handlers may read state or call <see cref="Reset"/>
+    /// or <see cref="Isolate"/> without deadlocking. Handlers run synchronously and block later
     /// transition publishers, so they should not perform I/O, wait on external work, or otherwise
     /// run for a long time.
     /// </summary>
@@ -26,8 +27,17 @@ public sealed class CircuitBreakerMonitor
     /// <summary>Forces the circuit open. Executions are rejected until <see cref="Reset"/> is called.</summary>
     public void Isolate() => BoundCore().Isolate();
 
+    /// <summary>
+    /// Forces the circuit open and asynchronously waits for configured transition observers.
+    /// Executions are rejected until <see cref="ResetAsync"/> is called.
+    /// </summary>
+    public ValueTask IsolateAsync() => BoundCore().IsolateAsync();
+
     /// <summary>Closes the circuit and clears all failure metrics.</summary>
     public void Reset() => BoundCore().Reset();
+
+    /// <summary>Closes the circuit, clears all failure metrics, and asynchronously waits for configured transition observers.</summary>
+    public ValueTask ResetAsync() => BoundCore().ResetAsync();
 
     internal void Bind(CircuitBreakerCore core)
     {

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -29,6 +29,9 @@ public sealed class CircuitBreakerMonitor
 
     /// <summary>
     /// Forces the circuit open and asynchronously waits for configured transition observers.
+    /// A reentrant call from a transition callback queues its transition behind the active
+    /// publication and returns before that queued transition reaches observers; do not use the
+    /// returned task to order reentrant transition work.
     /// Executions are rejected until <see cref="ResetAsync"/> is called.
     /// </summary>
     public ValueTask IsolateAsync() => BoundCore().IsolateAsync();
@@ -36,7 +39,12 @@ public sealed class CircuitBreakerMonitor
     /// <summary>Closes the circuit and clears all failure metrics.</summary>
     public void Reset() => BoundCore().Reset();
 
-    /// <summary>Closes the circuit, clears all failure metrics, and asynchronously waits for configured transition observers.</summary>
+    /// <summary>
+    /// Closes the circuit, clears all failure metrics, and asynchronously waits for configured
+    /// transition observers. A reentrant call from a transition callback queues its transition
+    /// behind the active publication and returns before that queued transition reaches observers;
+    /// do not use the returned task to order reentrant transition work.
+    /// </summary>
     public ValueTask ResetAsync() => BoundCore().ResetAsync();
 
     internal void Bind(CircuitBreakerCore core)

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -27,6 +27,13 @@ public sealed class CircuitBreakerOptions
     public TimeSpan BreakDuration { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
+    /// Produces and awaits the break duration when a handled outcome trips or re-opens the
+    /// circuit. The returned value must be positive. The event context is valid only until the
+    /// callback completes. When configured, this value overrides <see cref="BreakDuration"/>.
+    /// </summary>
+    public Func<CircuitBreakerBreakDurationEvent, ValueTask<TimeSpan>>? BreakDurationGenerator { get; set; }
+
+    /// <summary>
     /// An optional monitor giving external code visibility of the circuit state plus manual
     /// <see cref="CircuitBreakerMonitor.Isolate"/> / <see cref="CircuitBreakerMonitor.Reset"/> control.
     /// A monitor can be bound to only one circuit breaker.
@@ -34,11 +41,18 @@ public sealed class CircuitBreakerOptions
     public CircuitBreakerMonitor? Monitor { get; set; }
 
     /// <summary>
-    /// Invoked on every state transition, before <see cref="CircuitBreakerMonitor.StateChanged"/>.
-    /// Transitions are delivered serially outside the circuit lock. Exceptions propagate after
-    /// the monitor observer is invoked; failures from both observers are aggregated. The handler
-    /// runs synchronously and blocks later transition publishers, so it should not perform I/O,
-    /// wait on external work, or otherwise run for a long time.
+    /// Invoked on every state transition, before <see cref="OnStateChangedAsync"/> and
+    /// <see cref="CircuitBreakerMonitor.StateChanged"/>. Transitions are delivered serially
+    /// outside the circuit lock. Exceptions propagate after all observers run; multiple failures
+    /// are aggregated. The handler runs synchronously and blocks later transition publishers, so
+    /// it should not perform I/O, wait on external work, or otherwise run for a long time.
     /// </summary>
     public Action<CircuitStateChangedEvent>? OnStateChanged { get; set; }
+
+    /// <summary>
+    /// Invoked and awaited on every state transition, after <see cref="OnStateChanged"/> and
+    /// before <see cref="CircuitBreakerMonitor.StateChanged"/>. Transitions are delivered
+    /// serially outside the circuit lock.
+    /// </summary>
+    public Func<CircuitStateChangedEvent, ValueTask>? OnStateChangedAsync { get; set; }
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -26,6 +26,11 @@ internal sealed class CircuitBreakerStrategy : Strategy
     {
         var alias = new StrategyMetricAlias(context.ShieldName, context.StrategyIndex);
         var recordState = RegisterMetricsAlias(alias);
+        if (_core.RequiresAsyncExecution)
+        {
+            return await ExecuteConfiguredAsync(next, context, alias, recordState).ConfigureAwait(false);
+        }
+
         if (!_core.TryEnter(context.TimeProvider, out var rejection, out var admittedProbeGeneration))
         {
             if (recordState)
@@ -154,5 +159,59 @@ internal sealed class CircuitBreakerStrategy : Strategy
         {
             throw new AggregateException(failures).Flatten();
         }
+    }
+
+    private async ValueTask<Outcome<T>> ExecuteConfiguredAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        StrategyMetricAlias alias,
+        bool recordState)
+    {
+        var entry = await _core.TryEnterAsync(context.TimeProvider).ConfigureAwait(false);
+        if (!entry.Allowed)
+        {
+            if (recordState)
+            {
+                RecordState(alias);
+            }
+
+            KevlarMetrics.Rejection(context.ShieldName, "circuit_open");
+            return Outcome<T>.FromException(entry.Rejection!);
+        }
+
+        if (recordState)
+        {
+            try
+            {
+                RecordState(alias);
+            }
+            catch
+            {
+                _core.AbandonProbe(entry.AdmittedProbeGeneration);
+                throw;
+            }
+        }
+
+        var outcome = await next.InvokeAsync(context).ConfigureAwait(false);
+
+        if (_judge.ShouldHandle(in outcome))
+        {
+            await _core.RecordFailureAsync(context.TimeProvider, in outcome, context).ConfigureAwait(false);
+        }
+        else if (outcome.Exception is OperationCanceledException && context.CancellationToken.IsCancellationRequested)
+        {
+            _core.AbandonProbe(entry.AdmittedProbeGeneration);
+        }
+        else
+        {
+            await _core.RecordSuccessAsync(context.TimeProvider).ConfigureAwait(false);
+        }
+
+        if (recordState)
+        {
+            RecordState(alias);
+        }
+
+        return outcome;
     }
 }

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -21,6 +21,16 @@ public class AllocationBudgetTests
         options.DelayGeneratorAsync = static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero);
     });
     private readonly Shield _breaker = Shield.CircuitBreaker(5, TimeSpan.FromMinutes(1));
+    private readonly Shield _dynamicBreaker = Shield.CircuitBreaker(options =>
+    {
+        options.ConsecutiveFailures = 5;
+        options.BreakDurationGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+    });
+    private readonly Shield _asyncTransitionBreaker = Shield.CircuitBreaker(options =>
+    {
+        options.ConsecutiveFailures = 5;
+        options.OnStateChangedAsync = static _ => default;
+    });
     private readonly Shield _timeout = Shield.Timeout(TimeSpan.FromMinutes(1));
     private readonly Shield<int> _fallback = Shield.For<int>()
         .When<InvalidOperationException>()
@@ -102,6 +112,10 @@ public class AllocationBudgetTests
             test._asyncDelayRetry.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("circuit closed", this, static test =>
             test._breaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("dynamic circuit closed", this, static test =>
+            test._dynamicBreaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("async transition circuit closed", this, static test =>
+            test._asyncTransitionBreaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("timeout happy path", this, static test =>
             test._timeout.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("fallback pass-through", this, static test =>

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -1,0 +1,347 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class CircuitBreakerDynamicOptionsTests
+{
+    [Test]
+    public async Task BreakDurationGenerator_Receives_Handled_Outcome_And_Context()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var durations = new Queue<TimeSpan>([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)]);
+        var observed = new List<(object? Result, Exception? Exception, string? ShieldName)>();
+        var shield = Shield.For<int>()
+            .WhenResult(result => result < 0)
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.BreakDurationGenerator = item =>
+                {
+                    observed.Add((item.Result, item.Exception, item.Context.ShieldName));
+                    return new ValueTask<TimeSpan>(durations.Dequeue());
+                };
+            })
+            .WithName("dynamic-breaker")
+            .WithTimeProvider(timeProvider);
+
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(-1))).IsEqualTo(-1);
+        var firstRejection = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+        await Assert.That(firstRejection.Exception).IsTypeOf<CircuitOpenException>();
+        await Assert.That(((CircuitOpenException)firstRejection.Exception!).RetryAfter).IsEqualTo(TimeSpan.FromSeconds(1));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(-2))).IsEqualTo(-2);
+        var secondRejection = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+        await Assert.That(((CircuitOpenException)secondRejection.Exception!).RetryAfter).IsEqualTo(TimeSpan.FromSeconds(3));
+
+        await Assert.That(observed.Count).IsEqualTo(2);
+        await Assert.That(observed[0].Result).IsEqualTo(-1);
+        await Assert.That(observed[0].Exception).IsNull();
+        await Assert.That(observed[0].ShieldName).IsEqualTo("dynamic-breaker");
+        await Assert.That(observed[1].Result).IsEqualTo(-2);
+    }
+
+    [Test]
+    public async Task BreakDurationGenerator_Runs_Outside_Lock_And_Discards_Stale_Result()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var generatorEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseGenerator = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.Monitor = monitor;
+            options.BreakDurationGenerator = async _ =>
+            {
+                generatorEntered.SetResult();
+                monitor.Isolate();
+                await releaseGenerator.Task;
+                return TimeSpan.FromMinutes(1);
+            };
+        });
+
+        var execution = shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException()).AsTask();
+        await generatorEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Isolated);
+
+        releaseGenerator.SetResult();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(outcome.Exception).IsTypeOf<InvalidOperationException>();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Isolated);
+    }
+
+    [Test]
+    public async Task BreakDurationGenerator_Failure_Propagates_Exactly_And_Allows_Another_Trip()
+    {
+        var generatorFailure = new InvalidOperationException("generator");
+        var calls = 0;
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.Monitor = monitor;
+            options.BreakDurationGenerator = _ => ++calls == 1
+                ? ValueTask.FromException<TimeSpan>(generatorFailure)
+                : new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+        });
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new ApplicationException("operation")))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(thrown, generatorFailure)).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ApplicationException("operation"));
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Generated_BreakDuration_Must_Be_Positive()
+    {
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDurationGenerator = _ => new ValueTask<TimeSpan>(TimeSpan.Zero);
+        });
+
+        await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_During_BreakDurationGenerator_Propagates_Exactly()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var generatorEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseGenerator = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.Monitor = monitor;
+            options.BreakDurationGenerator = async item =>
+            {
+                generatorEntered.SetResult();
+                await releaseGenerator.Task;
+                item.Context.CancellationToken.ThrowIfCancellationRequested();
+                return TimeSpan.FromMinutes(1);
+            };
+        });
+
+        var execution = shield.ExecuteAsync<int>(
+            _ => throw new InvalidOperationException("operation"),
+            cancellation.Token).AsTask();
+        await generatorEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        releaseGenerator.SetResult();
+
+        var thrown = await Assert.That(async () => await execution).Throws<OperationCanceledException>();
+        await Assert.That(thrown!.CancellationToken).IsEqualTo(cancellation.Token);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Concurrent_Trip_Invokes_One_BreakDurationGenerator()
+    {
+        var generatorEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseGenerator = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.Monitor = monitor;
+            options.BreakDurationGenerator = async _ =>
+            {
+                Interlocked.Increment(ref calls);
+                generatorEntered.SetResult();
+                await releaseGenerator.Task;
+                return TimeSpan.FromMinutes(1);
+            };
+        });
+
+        var executions = Enumerable.Range(0, 32)
+            .Select(_ => shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException()).AsTask())
+            .ToArray();
+        await generatorEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Yield();
+        await Assert.That(calls).IsEqualTo(1);
+
+        releaseGenerator.SetResult();
+        await Task.WhenAll(executions).WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Async_State_Callback_Is_Awaited_Before_Monitor_And_Serializes_Transitions()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var callbackEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var events = new ConcurrentQueue<string>();
+        var activeCallbacks = 0;
+        var maximumConcurrentCallbacks = 0;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = change => events.Enqueue($"sync:{change.To}");
+            options.OnStateChangedAsync = async change =>
+            {
+                var active = Interlocked.Increment(ref activeCallbacks);
+                InterlockedExtensions.Max(ref maximumConcurrentCallbacks, active);
+                events.Enqueue($"async:{change.To}:start");
+                if (change.To == CircuitState.Open)
+                {
+                    callbackEntered.SetResult();
+                    await releaseCallback.Task;
+                }
+
+                events.Enqueue($"async:{change.To}:end");
+                Interlocked.Decrement(ref activeCallbacks);
+            };
+        });
+        monitor.StateChanged += change => events.Enqueue($"monitor:{change.To}");
+
+        var opening = shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException()).AsTask();
+        await callbackEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(opening.IsCompleted).IsFalse();
+
+        var reset = monitor.ResetAsync().AsTask();
+        await Assert.That(reset.IsCompleted).IsFalse();
+        releaseCallback.SetResult();
+        await Task.WhenAll(opening, reset).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(events.SequenceEqual(
+        [
+            "sync:Open",
+            "async:Open:start",
+            "async:Open:end",
+            "monitor:Open",
+            "sync:Closed",
+            "async:Closed:start",
+            "async:Closed:end",
+            "monitor:Closed",
+        ])).IsTrue();
+        await Assert.That(maximumConcurrentCallbacks).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Async_State_Callback_Can_Await_Reentrant_Control()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var observed = new ConcurrentQueue<CircuitState>();
+        _ = Shield.CircuitBreaker(options =>
+        {
+            options.Monitor = monitor;
+            options.OnStateChangedAsync = async change =>
+            {
+                observed.Enqueue(change.To);
+                if (change.To == CircuitState.Isolated)
+                {
+                    await monitor.ResetAsync();
+                }
+            };
+        });
+
+        await monitor.IsolateAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(observed.SequenceEqual([CircuitState.Isolated, CircuitState.Closed])).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Async_State_Callback_Failure_Does_Not_Skip_Monitor_And_Preserves_Instance()
+    {
+        var callbackFailure = new InvalidOperationException("async callback");
+        var monitor = new CircuitBreakerMonitor();
+        CircuitState? observed = null;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.Monitor = monitor;
+            options.OnStateChangedAsync = _ => ValueTask.FromException(callbackFailure);
+        });
+        monitor.StateChanged += change => observed = change.To;
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new ApplicationException("operation")))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(thrown, callbackFailure)).IsTrue();
+        await Assert.That(observed).IsEqualTo(CircuitState.Open);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Dynamic_Breaker_Releases_Probe_When_Synchronous_HalfOpen_Callback_Fails()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var callbackFailure = new InvalidOperationException("half-open callback");
+        var failCallback = true;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDurationGenerator = static _ =>
+                new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
+            options.OnStateChanged = change =>
+            {
+                if (change.To == CircuitState.HalfOpen && failCallback)
+                {
+                    failCallback = false;
+                    throw callbackFailure;
+                }
+            };
+        }).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ApplicationException("open"));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(ReferenceEquals(thrown, callbackFailure)).IsTrue();
+
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(42))).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Dynamic_Breaker_Description_Does_Not_Execute_Generator()
+    {
+        var calls = 0;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 2;
+            options.BreakDurationGenerator = _ =>
+            {
+                calls++;
+                return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
+            };
+        });
+
+        await Assert.That(shield.ToString()).IsEqualTo("CircuitBreaker(2 consecutive, break dynamic)");
+        await Assert.That(calls).IsEqualTo(0);
+    }
+}
+
+file static class InterlockedExtensions
+{
+    public static void Max(ref int target, int value)
+    {
+        var current = Volatile.Read(ref target);
+        while (current < value)
+        {
+            var observed = Interlocked.CompareExchange(ref target, value, current);
+            if (observed == current)
+            {
+                return;
+            }
+
+            current = observed;
+        }
+    }
+}

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -6,6 +6,14 @@ namespace Kevlar.Tests;
 public class CircuitBreakerDynamicOptionsTests
 {
     [Test]
+    public async Task Default_BreakDuration_Event_Rejects_Missing_Context()
+    {
+        var item = default(CircuitBreakerBreakDurationEvent);
+
+        await Assert.That(() => item.Context).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task BreakDurationGenerator_Receives_Handled_Outcome_And_Context()
     {
         var timeProvider = new FakeTimeProvider();
@@ -225,6 +233,55 @@ public class CircuitBreakerDynamicOptionsTests
 
         releaseGenerator.SetResult();
         await Task.WhenAll(executions).WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Failure_During_Pending_Generator_Remains_In_Ratio_Window()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var generatorEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseGenerator = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var generatorFailure = new InvalidOperationException("generator");
+        var generatorCalls = 0;
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.FailureRatio = 0.5;
+            options.MinimumThroughput = 2;
+            options.SamplingWindow = TimeSpan.FromSeconds(10);
+            options.Monitor = monitor;
+            options.BreakDurationGenerator = async _ =>
+            {
+                if (Interlocked.Increment(ref generatorCalls) > 1)
+                {
+                    return TimeSpan.FromMinutes(1);
+                }
+
+                generatorEntered.SetResult();
+                await releaseGenerator.Task;
+                throw generatorFailure;
+            };
+        }).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
+        var opening = shield.ExecuteOutcomeAsync<int>(
+            _ => ValueTask.FromException<int>(new ApplicationException("first"))).AsTask();
+        await generatorEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(9));
+        await shield.ExecuteOutcomeAsync<int>(
+            _ => ValueTask.FromException<int>(new ApplicationException("pending")));
+        releaseGenerator.SetResult();
+        var openingOutcome = await opening;
+        await Assert.That(ReferenceEquals(openingOutcome.Exception, generatorFailure)).IsTrue();
+
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
+        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
+        await shield.ExecuteOutcomeAsync<int>(
+            _ => ValueTask.FromException<int>(new ApplicationException("latest")));
+
         await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
     }
 

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -98,6 +98,38 @@ public class CircuitBreakerDynamicOptionsTests
     }
 
     [Test]
+    public async Task Synchronous_BreakDurationGenerator_Failure_Releases_The_Opening_Reservation()
+    {
+        var expected = new InvalidOperationException("synchronous generator");
+        var calls = 0;
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.Monitor = monitor;
+            options.BreakDurationGenerator = _ =>
+            {
+                if (++calls == 1)
+                {
+                    throw expected;
+                }
+
+                return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+            };
+        });
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new ApplicationException("operation")))
+            .Throws<InvalidOperationException>();
+        await Assert.That(ReferenceEquals(thrown, expected)).IsTrue();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ApplicationException("operation"));
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
     public async Task Generated_BreakDuration_Must_Be_Positive()
     {
         var shield = Shield.CircuitBreaker(options =>
@@ -109,6 +141,27 @@ public class CircuitBreakerDynamicOptionsTests
         await Assert.That(async () =>
                 await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
             .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Asynchronously_Generated_BreakDuration_Must_Be_Positive()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.Monitor = monitor;
+            options.BreakDurationGenerator = async _ =>
+            {
+                await Task.Yield();
+                return TimeSpan.Zero;
+            };
+        });
+
+        _ = await Assert.That(async () =>
+                await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
     }
 
     [Test]
@@ -306,6 +359,39 @@ public class CircuitBreakerDynamicOptionsTests
             .Throws<InvalidOperationException>();
         await Assert.That(ReferenceEquals(thrown, callbackFailure)).IsTrue();
 
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(42))).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Dynamic_Breaker_Releases_Probe_When_Async_HalfOpen_Callback_Fails()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var expected = new InvalidOperationException("async half-open callback");
+        var failCallback = true;
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDurationGenerator = static _ =>
+                new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
+            options.OnStateChangedAsync = change =>
+            {
+                if (change.To == CircuitState.HalfOpen && failCallback)
+                {
+                    failCallback = false;
+                    return ValueTask.FromException(expected);
+                }
+
+                return ValueTask.CompletedTask;
+            };
+        }).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ApplicationException("open"));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var thrown = await Assert.That(async () =>
+                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(ReferenceEquals(thrown, expected)).IsTrue();
         await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(42))).IsEqualTo(42);
     }
 


### PR DESCRIPTION
Closes #87.

## Summary
- add outcome/context-aware `BreakDurationGenerator`, invoked and awaited outside the circuit lock before Open mutation
- add serialized awaited `OnStateChangedAsync` delivery plus `ResetAsync` / `IsolateAsync` monitor controls
- preserve fixed/synchronous fast paths, stale-trip arbitration, exception identity, cancellation, and reentrant transition ordering
- document APIs; add public API baseline, regressions, allocation gates, and benchmarks

## Ordering and safety
- break duration generation: handled outcome -> awaited generator -> validate -> Open mutation -> transition metrics/observers
- transition observers: metrics -> `OnStateChanged` -> awaited `OnStateChangedAsync` -> monitor `StateChanged`
- generators and observers never execute under the breaker gate
- one dynamic generator owns each concurrent trip; manual state changes invalidate stale generated durations

## Validation
- `dotnet build Kevlar.slnx -c Release` (0 warnings/errors)
- unit: 553 passed
- allocation: 2 passed; fixed, dynamic-configured, and async-hook-configured closed paths all 0 B/op
- integration: 16 passed
- analyzer: 19 passed
- netstandard2.0: 1 passed
- docs production build passed
- package layout/consumer/analyzer checks passed
- 83 documentation snippets compiled and runtime snippets passed
- trimmed/single-file .NET 8/.NET 10 publish compatibility passed on Windows (NativeAOT remains Linux CI)

## Benchmark (.NET 10, BDN short job)
- fixed closed happy path: 104.0 ns, 0 B
- dynamic-duration configured happy path: 124.0 ns, 0 B
- async-transition configured happy path: 124.8 ns, 0 B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic circuit-breaker durations based on results, exceptions, and execution context.
  * Added asynchronous state-change callbacks with ordered transition notifications.
  * Added asynchronous controls for isolating and resetting circuits.

* **Bug Fixes**
  * Improved validation, cancellation, concurrent-trip handling, callback failures, and half-open probe recovery.
  * Improved circuit-state metrics and failure tracking during asynchronous operations.

* **Documentation**
  * Updated circuit-breaker and observability guides with configuration details and callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->