### PR TITLE
feat(fallback): add asynchronous notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ Shield.When<MessagingException>()
     .Fallback((exception, ct) => deadLetter.PublishAsync(exception, ct));
 ```
 
+For awaited audit or telemetry work, use `FallbackWithNotifications` with
+`FallbackOptions<T>.OnFallbackAsync`. The hook completes before recovery runs; hook failures keep
+their exact exception identity and skip the recovery factory. Notification hooks may be concurrent
+and reentrant, and their pooled `FallbackEvent.Context` must not be retained after completion.
+
 Fallback belongs **before** the strategies it recovers from (first = outermost). Chain it after a retry with the same clause and Kevlar throws at build time — that order silently disables the retry, so it refuses to build it.
 
 ## Composition

--- a/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
@@ -21,6 +21,28 @@ public class FallbackBenchmarks
         .When<InvalidOperationException>()
         .Fallback(7);
 
+    private static readonly Shield<int> KevlarSyncNotification = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .Fallback(7, static _ => { });
+
+    private static readonly Shield<int> KevlarCompletedAsyncNotification = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .FallbackWithNotifications(
+            7,
+            new FallbackOptions<int>
+            {
+                OnFallbackAsync = static _ => ValueTask.CompletedTask,
+            });
+
+    private static readonly Shield<int> KevlarYieldingAsyncNotification = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .FallbackWithNotifications(
+            7,
+            new FallbackOptions<int>
+            {
+                OnFallbackAsync = static async _ => await Task.Yield(),
+            });
+
     private static readonly ResiliencePipeline<int> PollyFallback = new ResiliencePipelineBuilder<int>()
         .AddFallback(new FallbackStrategyOptions<int>
         {
@@ -40,4 +62,18 @@ public class FallbackBenchmarks
 
     [BenchmarkCategory("Triggered"), Benchmark]
     public ValueTask<int> Polly_Triggered() => PollyFallback.ExecuteAsync(static ValueTask<int> (_) => throw PrimaryError);
+
+    [BenchmarkCategory("Notifications"), Benchmark(Baseline = true)]
+    public ValueTask<int> Kevlar_NoNotification() => KevlarFallback.ExecuteAsync(static _ => throw PrimaryError);
+
+    [BenchmarkCategory("Notifications"), Benchmark]
+    public ValueTask<int> Kevlar_SyncNotification() => KevlarSyncNotification.ExecuteAsync(static _ => throw PrimaryError);
+
+    [BenchmarkCategory("Notifications"), Benchmark]
+    public ValueTask<int> Kevlar_CompletedAsyncNotification() =>
+        KevlarCompletedAsyncNotification.ExecuteAsync(static _ => throw PrimaryError);
+
+    [BenchmarkCategory("Notifications"), Benchmark]
+    public ValueTask<int> Kevlar_YieldingAsyncNotification() =>
+        KevlarYieldingAsyncNotification.ExecuteAsync(static _ => throw PrimaryError);
 }

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -58,6 +58,39 @@ The `FallbackEvent<T>` carries the failure that triggered it as a typed `Outcome
 exception becomes the pipeline outcome and the factory is not called. A later execution is
 unaffected. Async factory failures are likewise preserved as the pipeline outcome.
 
+## Awaited notifications
+
+Use `FallbackWithNotifications` when notification work must be awaited:
+
+<!-- doc-test-ignore: Illustrative logger and audit dependencies are application services. -->
+```csharp
+var shield = Shield.For<Config>()
+    .When<HttpRequestException>()
+    .FallbackWithNotifications(
+        Config.Default,
+        new FallbackOptions<Config>
+        {
+            OnFallback = e => logger.LogWarning(e.Outcome.Exception, "Using defaults"),
+            OnFallbackAsync = async e =>
+                await audit.RecordFallbackAsync(e.Outcome, e.Context.CancellationToken),
+        });
+```
+
+Kevlar records its fallback metric, invokes `OnFallback`, awaits `OnFallbackAsync`, then runs
+the fallback value or factory. A notification exception or cancellation is preserved as the exact
+pipeline outcome and skips recovery. Caller cancellation is exposed through `e.Context` and the
+token passed to the recovery factory; Kevlar does not forcibly stop either callback when user code
+chooses not to observe that token.
+
+`FallbackOptions<T>` preserves typed outcomes. Plain `Shield` uses `FallbackOptions` and a
+non-generic `FallbackEvent` carrying the exact handled exception. Both option objects are copied
+into the immutable strategy when it is built, so changing the options later has no effect.
+
+Hooks may run concurrently when the same shield executes concurrently, and may re-enter the shield;
+they must therefore be thread-safe and must not depend on strategy locks. `FallbackEvent.Context`
+remains valid until that hook returns or its `ValueTask` completes. Do not retain the pooled context
+or use it from background work after completion.
+
 ## What triggers it
 
 The ambient [handling clause](../handling-failures.md) — exceptions *and* handled results:

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -83,8 +83,8 @@ token passed to the recovery factory; Kevlar does not forcibly stop either callb
 chooses not to observe that token.
 
 `FallbackOptions<T>` preserves typed outcomes. Plain `Shield` uses `FallbackOptions` and a
-non-generic `FallbackEvent` carrying the exact handled exception. Both option objects are copied
-into the immutable strategy when it is built, so changing the options later has no effect.
+non-generic `FallbackEvent` carrying the exact handled exception. Callback properties are
+snapshotted when the shield is built, so replacing them on the options later has no effect.
 
 Hooks may run concurrently when the same shield executes concurrently, and may re-enter the shield;
 they must therefore be thread-safe and must not depend on strategy locks. `FallbackEvent.Context`

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -11,3 +11,28 @@ Kevlar.RetryOptions.DelayGeneratorAsync.get -> System.Func<Kevlar.RetryEvent, Sy
 Kevlar.RetryOptions.DelayGeneratorAsync.set -> void
 Kevlar.RetryOptions<TResult>.DelayGeneratorAsync.get -> System.Func<Kevlar.RetryEvent<TResult>, System.Threading.Tasks.ValueTask<System.TimeSpan?>>?
 Kevlar.RetryOptions<TResult>.DelayGeneratorAsync.set -> void
+Kevlar.FallbackEvent
+Kevlar.FallbackEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.FallbackEvent.Exception.get -> System.Exception!
+Kevlar.FallbackEvent.FallbackEvent() -> void
+Kevlar.FallbackOptions
+Kevlar.FallbackOptions.FallbackOptions() -> void
+Kevlar.FallbackOptions.OnFallback.get -> System.Action<Kevlar.FallbackEvent>?
+Kevlar.FallbackOptions.OnFallback.set -> void
+Kevlar.FallbackOptions.OnFallbackAsync.get -> System.Func<Kevlar.FallbackEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.FallbackOptions.OnFallbackAsync.set -> void
+Kevlar.FallbackOptions<TResult>
+Kevlar.FallbackOptions<TResult>.FallbackOptions() -> void
+Kevlar.FallbackOptions<TResult>.OnFallback.get -> System.Action<Kevlar.FallbackEvent<TResult>>?
+Kevlar.FallbackOptions<TResult>.OnFallback.set -> void
+Kevlar.FallbackOptions<TResult>.OnFallbackAsync.get -> System.Func<Kevlar.FallbackEvent<TResult>, System.Threading.Tasks.ValueTask>?
+Kevlar.FallbackOptions<TResult>.OnFallbackAsync.set -> void
+Kevlar.Shield<TResult>.FallbackWithNotifications(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.FallbackWithNotifications(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.FallbackWithNotifications(TResult fallbackValue, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder.FallbackWithNotifications(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!
+Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(TResult fallbackValue, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
+static Kevlar.ShieldExtensions.FallbackWithNotifications(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.FallbackWithNotifications(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -92,6 +92,14 @@ public sealed class ShieldBuilder
     /// </summary>
     public Shield Fallback(Func<Exception, CancellationToken, ValueTask> fallback) => Seal().Fallback(fallback);
 
+    /// <summary>
+    /// Runs <paramref name="fallback"/> in place of handled failures and uses the configured
+    /// notifications. Applies to void executions only.
+    /// </summary>
+    public Shield FallbackWithNotifications(
+        Func<Exception, CancellationToken, ValueTask> fallback,
+        FallbackOptions options) => Seal().FallbackWithNotifications(fallback, options);
+
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>. The handling clauses remain ambient for later strategies.</summary>
     public Shield Timeout(TimeSpan timeout) => Seal().Timeout(timeout);
 

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -117,11 +117,28 @@ public sealed class ShieldBuilder<TResult>
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
     public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>>? onFallback = null) => Seal().Fallback(fallbackValue, onFallback);
 
+    /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and uses the configured notifications.</summary>
+    public Shield<TResult> FallbackWithNotifications(TResult fallbackValue, FallbackOptions<TResult> options) =>
+        Seal().FallbackWithNotifications(fallbackValue, options);
+
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
     public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null) => Seal().Fallback(fallback, onFallback);
 
+    /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and uses the configured notifications.</summary>
+    public Shield<TResult> FallbackWithNotifications(
+        Func<CancellationToken, ValueTask<TResult>> fallback,
+        FallbackOptions<TResult> options) => Seal().FallbackWithNotifications(fallback, options);
+
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
     public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null) => Seal().Fallback(fallback, onFallback);
+
+    /// <summary>
+    /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives
+    /// the handled outcome, and uses the configured notifications.
+    /// </summary>
+    public Shield<TResult> FallbackWithNotifications(
+        Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
+        FallbackOptions<TResult> options) => Seal().FallbackWithNotifications(fallback, options);
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> Timeout(TimeSpan timeout) => Seal().Timeout(timeout);

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -199,7 +199,26 @@ public static class ShieldExtensions
     {
         Throw.IfNull(shield, nameof(shield));
         Throw.IfNull(fallback, nameof(fallback));
-        return shield.Append(new VoidFallbackStrategy(fallback, shield.JudgeOrDefault));
+        return shield.Append(new VoidFallbackStrategy(fallback, shield.JudgeOrDefault, null, null));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="fallback"/> in place of handled failures and uses the configured
+    /// notifications. Applies to void executions only.
+    /// </summary>
+    public static Shield FallbackWithNotifications(
+        this Shield shield,
+        Func<Exception, CancellationToken, ValueTask> fallback,
+        FallbackOptions options)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfNull(fallback, nameof(fallback));
+        Throw.IfNull(options, nameof(options));
+        return shield.Append(new VoidFallbackStrategy(
+            fallback,
+            shield.JudgeOrDefault,
+            options.OnFallback,
+            options.OnFallbackAsync));
     }
 
     /// <summary>
@@ -211,6 +230,20 @@ public static class ShieldExtensions
     {
         Throw.IfNull(fallback, nameof(fallback));
         return shield.Fallback((_, token) => fallback(token));
+    }
+
+    /// <summary>
+    /// Runs <paramref name="fallback"/> in place of handled failures and uses the configured
+    /// notifications. Applies to void executions only.
+    /// </summary>
+    public static Shield FallbackWithNotifications(
+        this Shield shield,
+        Func<CancellationToken, ValueTask> fallback,
+        FallbackOptions options)
+    {
+        Throw.IfNull(fallback, nameof(fallback));
+        Throw.IfNull(options, nameof(options));
+        return shield.FallbackWithNotifications((_, token) => fallback(token), options);
     }
 
     /// <summary>Returns a copy of this shield with a diagnostic name (surfaced as <see cref="KevlarContext.ShieldName"/>).</summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -171,20 +171,62 @@ public sealed class Shield<TResult>
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
     public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>>? onFallback = null) =>
-        Append(new FallbackStrategy<TResult>((_, _) => new ValueTask<TResult>(fallbackValue), JudgeOrDefault, onFallback));
+        Append(new FallbackStrategy<TResult>((_, _) => new ValueTask<TResult>(fallbackValue), JudgeOrDefault, onFallback, null));
+
+    /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and uses the configured notifications.</summary>
+    public Shield<TResult> FallbackWithNotifications(TResult fallbackValue, FallbackOptions<TResult> options)
+    {
+        Throw.IfNull(options, nameof(options));
+        return Append(new FallbackStrategy<TResult>(
+            (_, _) => new ValueTask<TResult>(fallbackValue),
+            JudgeOrDefault,
+            options.OnFallback,
+            options.OnFallbackAsync));
+    }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
     public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null)
     {
         Throw.IfNull(fallback, nameof(fallback));
-        return Append(new FallbackStrategy<TResult>((_, context) => fallback(context.CancellationToken), JudgeOrDefault, onFallback));
+        return Append(new FallbackStrategy<TResult>((_, context) => fallback(context.CancellationToken), JudgeOrDefault, onFallback, null));
+    }
+
+    /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and uses the configured notifications.</summary>
+    public Shield<TResult> FallbackWithNotifications(
+        Func<CancellationToken, ValueTask<TResult>> fallback,
+        FallbackOptions<TResult> options)
+    {
+        Throw.IfNull(fallback, nameof(fallback));
+        Throw.IfNull(options, nameof(options));
+        return Append(new FallbackStrategy<TResult>(
+            (_, context) => fallback(context.CancellationToken),
+            JudgeOrDefault,
+            options.OnFallback,
+            options.OnFallbackAsync));
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
     public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null)
     {
         Throw.IfNull(fallback, nameof(fallback));
-        return Append(new FallbackStrategy<TResult>((outcome, context) => fallback(outcome, context.CancellationToken), JudgeOrDefault, onFallback));
+        return Append(new FallbackStrategy<TResult>((outcome, context) => fallback(outcome, context.CancellationToken), JudgeOrDefault, onFallback, null));
+    }
+
+    /// <summary>
+    /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives
+    /// the handled outcome, and uses the configured notifications.
+    /// </summary>
+    public Shield<TResult> FallbackWithNotifications(
+        Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
+        FallbackOptions<TResult> options)
+    {
+        Throw.IfNull(fallback, nameof(fallback));
+        Throw.IfNull(options, nameof(options));
+        return Append(new FallbackStrategy<TResult>(
+            (outcome, context) => fallback(outcome, context.CancellationToken),
+            JudgeOrDefault,
+            options.OnFallback,
+            options.OnFallbackAsync));
     }
 
     /// <summary>Appends a custom <see cref="Strategy"/> implementation to the pipeline.</summary>

--- a/src/Kevlar/Strategies/Fallback/FallbackEvent.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackEvent.cs
@@ -1,17 +1,20 @@
 namespace Kevlar;
 
-/// <summary>Describes an outcome being replaced by a fallback.</summary>
-public readonly struct FallbackEvent<TResult>
+/// <summary>Describes an exception being replaced by an untyped fallback.</summary>
+public readonly struct FallbackEvent
 {
-    internal FallbackEvent(Outcome<TResult> outcome, KevlarContext context)
+    internal FallbackEvent(Exception exception, KevlarContext context)
     {
-        Outcome = outcome;
+        Exception = exception;
         Context = context;
     }
 
-    /// <summary>The handled outcome — the exception or result value being replaced.</summary>
-    public Outcome<TResult> Outcome { get; }
+    /// <summary>The handled exception being replaced.</summary>
+    public Exception Exception { get; }
 
-    /// <summary>The ambient execution context.</summary>
+    /// <summary>
+    /// The ambient execution context. It remains valid until the notification callback completes
+    /// and must not be retained afterward.
+    /// </summary>
     public KevlarContext Context { get; }
 }

--- a/src/Kevlar/Strategies/Fallback/FallbackEventOfT.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackEventOfT.cs
@@ -1,0 +1,20 @@
+namespace Kevlar;
+
+/// <summary>Describes an outcome being replaced by a fallback.</summary>
+public readonly struct FallbackEvent<TResult>
+{
+    internal FallbackEvent(Outcome<TResult> outcome, KevlarContext context)
+    {
+        Outcome = outcome;
+        Context = context;
+    }
+
+    /// <summary>The handled outcome — the exception or result value being replaced.</summary>
+    public Outcome<TResult> Outcome { get; }
+
+    /// <summary>
+    /// The ambient execution context. It remains valid until the notification callback completes
+    /// and must not be retained afterward.
+    /// </summary>
+    public KevlarContext Context { get; }
+}

--- a/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
@@ -1,0 +1,16 @@
+namespace Kevlar;
+
+/// <summary>Configures notifications for an untyped fallback strategy.</summary>
+/// <remarks>
+/// After a failure is selected for recovery, Kevlar records the fallback metric, invokes
+/// <see cref="OnFallback"/>, awaits <see cref="OnFallbackAsync"/>, and then runs the recovery
+/// action. A notification failure skips recovery and becomes the execution outcome.
+/// </remarks>
+public sealed class FallbackOptions
+{
+    /// <summary>Invoked synchronously before the recovery action.</summary>
+    public Action<FallbackEvent>? OnFallback { get; set; }
+
+    /// <summary>Invoked and awaited after <see cref="OnFallback"/> and before the recovery action.</summary>
+    public Func<FallbackEvent, ValueTask>? OnFallbackAsync { get; set; }
+}

--- a/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
@@ -1,0 +1,22 @@
+namespace Kevlar;
+
+/// <summary>
+/// Configures result-typed notifications for a fallback strategy on a
+/// <see cref="Shield{TResult}"/>.
+/// </summary>
+/// <remarks>
+/// After an outcome is selected for recovery, Kevlar records the fallback metric, invokes
+/// <see cref="OnFallback"/>, awaits <see cref="OnFallbackAsync"/>, and then runs the recovery
+/// factory. A notification failure skips recovery and becomes the execution outcome.
+/// </remarks>
+public sealed class FallbackOptions<TResult>
+{
+    /// <summary>Invoked synchronously before the recovery factory, with the typed handled outcome.</summary>
+    public Action<FallbackEvent<TResult>>? OnFallback { get; set; }
+
+    /// <summary>
+    /// Invoked and awaited after <see cref="OnFallback"/> and before the recovery factory,
+    /// with the typed handled outcome.
+    /// </summary>
+    public Func<FallbackEvent<TResult>, ValueTask>? OnFallbackAsync { get; set; }
+}

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -8,15 +8,18 @@ internal sealed class FallbackStrategy<TResult> : Strategy
     private readonly Func<Outcome<TResult>, KevlarContext, ValueTask<TResult>> _fallback;
     private readonly OutcomeJudge _judge;
     private readonly Action<FallbackEvent<TResult>>? _onFallback;
+    private readonly Func<FallbackEvent<TResult>, ValueTask>? _onFallbackAsync;
 
     public FallbackStrategy(
         Func<Outcome<TResult>, KevlarContext, ValueTask<TResult>> fallback,
         OutcomeJudge judge,
-        Action<FallbackEvent<TResult>>? onFallback)
+        Action<FallbackEvent<TResult>>? onFallback,
+        Func<FallbackEvent<TResult>, ValueTask>? onFallbackAsync)
     {
         _fallback = fallback;
         _judge = judge;
         _onFallback = onFallback;
+        _onFallbackAsync = onFallbackAsync;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
@@ -50,8 +53,28 @@ internal sealed class FallbackStrategy<TResult> : Strategy
         var typedOutcome = (Outcome<TResult>)(object)outcome;
 
         KevlarMetrics.Fallback(context.ShieldName);
-        _onFallback?.Invoke(new FallbackEvent<TResult>(typedOutcome, context));
+        if (_onFallback is not null || _onFallbackAsync is not null)
+        {
+            var fallbackEvent = new FallbackEvent<TResult>(typedOutcome, context);
+            _onFallback?.Invoke(fallbackEvent);
 
+            if (_onFallbackAsync is not null)
+            {
+                var notification = _onFallbackAsync(fallbackEvent);
+                if (!notification.IsCompletedSuccessfully)
+                {
+                    return AwaitNotificationAsync(notification, outcome, context);
+                }
+
+                notification.GetAwaiter().GetResult();
+            }
+        }
+
+        return InvokeFallback(outcome, context);
+    }
+
+    private ValueTask<Outcome<T>> InvokeFallback<T>(Outcome<T> outcome, KevlarContext context)
+    {
         var fallback = (Func<Outcome<T>, KevlarContext, ValueTask<T>>)(object)_fallback;
 
         try
@@ -65,6 +88,15 @@ internal sealed class FallbackStrategy<TResult> : Strategy
         {
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
         }
+    }
+
+    private async ValueTask<Outcome<T>> AwaitNotificationAsync<T>(
+        ValueTask notification,
+        Outcome<T> outcome,
+        KevlarContext context)
+    {
+        await notification.ConfigureAwait(false);
+        return await InvokeFallback(outcome, context).ConfigureAwait(false);
     }
 
     private static async ValueTask<Outcome<T>> AwaitFallbackAsync<T>(ValueTask<T> execution)
@@ -89,11 +121,19 @@ internal sealed class VoidFallbackStrategy : Strategy
 {
     private readonly Func<Exception, CancellationToken, ValueTask> _fallback;
     private readonly OutcomeJudge _judge;
+    private readonly Action<FallbackEvent>? _onFallback;
+    private readonly Func<FallbackEvent, ValueTask>? _onFallbackAsync;
 
-    public VoidFallbackStrategy(Func<Exception, CancellationToken, ValueTask> fallback, OutcomeJudge judge)
+    public VoidFallbackStrategy(
+        Func<Exception, CancellationToken, ValueTask> fallback,
+        OutcomeJudge judge,
+        Action<FallbackEvent>? onFallback,
+        Func<FallbackEvent, ValueTask>? onFallbackAsync)
     {
         _fallback = fallback;
         _judge = judge;
+        _onFallback = onFallback;
+        _onFallbackAsync = onFallbackAsync;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
@@ -119,6 +159,17 @@ internal sealed class VoidFallbackStrategy : Strategy
                 "Fallback on a non-generic Shield applies only to void executions. " +
                 "For executions that return a value, build a result-aware shield with " +
                 "Shield.For<T>() and use its Fallback overloads."));
+        }
+
+        if (_onFallback is not null || _onFallbackAsync is not null)
+        {
+            var fallbackEvent = new FallbackEvent(exception, context);
+            _onFallback?.Invoke(fallbackEvent);
+
+            if (_onFallbackAsync is not null)
+            {
+                await _onFallbackAsync(fallbackEvent).ConfigureAwait(false);
+            }
         }
 
         try

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -48,6 +48,17 @@ public class AllocationBudgetTests
     private readonly Shield<int> _triggeredFallback = Shield.For<int>()
         .When<InvalidOperationException>()
         .Fallback(7);
+    private readonly Shield<int> _fallbackWithSyncNotification = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .Fallback(7, static _ => { });
+    private readonly Shield<int> _fallbackWithAsyncNotification = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .FallbackWithNotifications(
+            7,
+            new FallbackOptions<int>
+            {
+                OnFallbackAsync = static _ => ValueTask.CompletedTask,
+            });
     private readonly Shield _parallelHedge = Shield.Hedge(2, TimeSpan.Zero);
     private readonly Counter _retryCounter = new();
     private readonly Counter _asyncDelayRetryCounter = new();
@@ -74,6 +85,8 @@ public class AllocationBudgetTests
             test._timeout.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("fallback pass-through", this, static test =>
             test._fallback.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("fallback async notification pass-through", this, static test =>
+            test._fallbackWithAsyncNotification.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("rate limit uncontended", this, static test =>
             test._rateLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("concurrency limit uncontended", this, static test =>
@@ -114,6 +127,10 @@ public class AllocationBudgetTests
             }).GetAwaiter().GetResult());
         AssertBudget("fallback triggered", 512, this, static test =>
             test._triggeredFallback.ExecuteAsync(static _ => throw RecoverableFailure).GetAwaiter().GetResult());
+        AssertBudget("fallback sync notification", 512, this, static test =>
+            test._fallbackWithSyncNotification.ExecuteAsync(static _ => throw RecoverableFailure).GetAwaiter().GetResult());
+        AssertBudget("fallback completed async notification", 512, this, static test =>
+            test._fallbackWithAsyncNotification.ExecuteAsync(static _ => throw RecoverableFailure).GetAwaiter().GetResult());
         AssertBudget("open circuit rejection", 2_048, this, static test =>
         {
             try

--- a/tests/Kevlar.Tests/FallbackAsyncHookTests.cs
+++ b/tests/Kevlar.Tests/FallbackAsyncHookTests.cs
@@ -1,0 +1,294 @@
+namespace Kevlar.Tests;
+
+public class FallbackAsyncHookTests
+{
+    [Test]
+    public async Task Typed_Hooks_Run_In_Order_Before_Recovery_With_The_Exact_Result()
+    {
+        var handled = new object();
+        var recovered = new object();
+        var order = new List<string>();
+        Outcome<object> syncOutcome = default;
+        Outcome<object> asyncOutcome = default;
+        Outcome<object> factoryOutcome = default;
+        var shield = Shield.For<object>()
+            .WhenResult(handled)
+            .FallbackWithNotifications(
+                (outcome, _) =>
+                {
+                    order.Add("factory");
+                    factoryOutcome = outcome;
+                    return new ValueTask<object>(recovered);
+                },
+                new FallbackOptions<object>
+                {
+                    OnFallback = fallback =>
+                    {
+                        order.Add("sync");
+                        syncOutcome = fallback.Outcome;
+                    },
+                    OnFallbackAsync = fallback =>
+                    {
+                        order.Add("async");
+                        asyncOutcome = fallback.Outcome;
+                        return ValueTask.CompletedTask;
+                    },
+                });
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<object>(handled));
+
+        await Assert.That(ReferenceEquals(result, recovered)).IsTrue();
+        await Assert.That(string.Join(",", order)).IsEqualTo("sync,async,factory");
+        await Assert.That(ReferenceEquals(syncOutcome.Result, handled)).IsTrue();
+        await Assert.That(ReferenceEquals(asyncOutcome.Result, handled)).IsTrue();
+        await Assert.That(ReferenceEquals(factoryOutcome.Result, handled)).IsTrue();
+    }
+
+    [Test]
+    public async Task Truly_Asynchronous_Hook_Is_Awaited_Before_Recovery()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var factoryCalls = 0;
+        var shield = Shield.For<int>().FallbackWithNotifications(
+            _ =>
+            {
+                factoryCalls++;
+                return new ValueTask<int>(42);
+            },
+            new FallbackOptions<int>
+            {
+                OnFallbackAsync = async _ =>
+                {
+                    started.SetResult();
+                    await release.Task;
+                },
+            });
+
+        var execution = shield.ExecuteAsync(_ => throw new InvalidOperationException()).AsTask();
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(factoryCalls).IsEqualTo(0);
+
+        release.SetResult();
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(factoryCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Async_Hook_Failure_Surfaces_Exact_Exception_And_Skips_Recovery()
+    {
+        var original = new InvalidOperationException("original");
+        var hookFailure = new ApplicationException("hook failed");
+        Exception? observed = null;
+        var factoryCalls = 0;
+        var shield = Shield.For<int>().FallbackWithNotifications(
+            _ =>
+            {
+                factoryCalls++;
+                return new ValueTask<int>(42);
+            },
+            new FallbackOptions<int>
+            {
+                OnFallbackAsync = fallback =>
+                {
+                    observed = fallback.Outcome.Exception;
+                    return ValueTask.FromException(hookFailure);
+                },
+            });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(_ => throw original);
+
+        await Assert.That(ReferenceEquals(observed, original)).IsTrue();
+        await Assert.That(ReferenceEquals(outcome.Exception, hookFailure)).IsTrue();
+        await Assert.That(factoryCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Async_Hook_Cancellation_Surfaces_Exact_Exception()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var hookCancellation = new OperationCanceledException("hook cancelled", cancellation.Token);
+        var shield = Shield.For<int>().FallbackWithNotifications(
+            42,
+            new FallbackOptions<int>
+            {
+                OnFallbackAsync = _ => ValueTask.FromException(hookCancellation),
+            });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(ReferenceEquals(outcome.Exception, hookCancellation)).IsTrue();
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_Remains_Observable_Without_Forcing_Recovery_To_Stop()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken hookToken = default;
+        CancellationToken factoryToken = default;
+        var shield = Shield.For<int>().FallbackWithNotifications(
+            (_, token) =>
+            {
+                factoryToken = token;
+                return new ValueTask<int>(42);
+            },
+            new FallbackOptions<int>
+            {
+                OnFallbackAsync = async fallback =>
+                {
+                    started.SetResult();
+                    await release.Task;
+                    hookToken = fallback.Context.CancellationToken;
+                },
+            });
+
+        var execution = shield.ExecuteAsync<int>(_ => throw new InvalidOperationException(), cancellation.Token).AsTask();
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        release.SetResult();
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(hookToken).IsEqualTo(cancellation.Token);
+        await Assert.That(hookToken.IsCancellationRequested).IsTrue();
+        await Assert.That(factoryToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task Async_Hooks_Are_Reentrant_And_Concurrent()
+    {
+        var bothStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = 0;
+        var nestedResult = 0;
+        Shield<int>? shield = null;
+        shield = Shield<int>.Empty
+            .WithName("fallback-hook")
+            .FallbackWithNotifications(
+                42,
+                new FallbackOptions<int>
+                {
+                    OnFallbackAsync = async fallback =>
+                    {
+                        await Task.Yield();
+                        nestedResult = await shield!.ExecuteAsync(_ => new ValueTask<int>(7));
+                        await Assert.That(fallback.Context.ShieldName).IsEqualTo("fallback-hook");
+                        if (Interlocked.Increment(ref started) == 2)
+                        {
+                            bothStarted.SetResult();
+                        }
+
+                        await release.Task;
+                    },
+                });
+
+        var first = shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()).AsTask();
+        var second = shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()).AsTask();
+
+        await bothStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        release.SetResult();
+        var results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(results).IsEquivalentTo([42, 42]);
+        await Assert.That(nestedResult).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Untyped_Hooks_Run_In_Order_And_Preserve_Exception_Identity()
+    {
+        var original = new InvalidOperationException("original");
+        var order = new List<string>();
+        Exception? syncException = null;
+        Exception? asyncException = null;
+        var shield = Shield.Empty.FallbackWithNotifications(
+            (exception, _) =>
+            {
+                order.Add("fallback");
+                return ValueTask.CompletedTask;
+            },
+            new FallbackOptions
+            {
+                OnFallback = fallback =>
+                {
+                    order.Add("sync");
+                    syncException = fallback.Exception;
+                },
+                OnFallbackAsync = fallback =>
+                {
+                    order.Add("async");
+                    asyncException = fallback.Exception;
+                    return ValueTask.CompletedTask;
+                },
+            });
+
+        await shield.ExecuteAsync(_ => throw original);
+
+        await Assert.That(string.Join(",", order)).IsEqualTo("sync,async,fallback");
+        await Assert.That(ReferenceEquals(syncException, original)).IsTrue();
+        await Assert.That(ReferenceEquals(asyncException, original)).IsTrue();
+    }
+
+    [Test]
+    public async Task Untyped_Async_Hook_Failure_Is_Preserved_And_Skips_Recovery()
+    {
+        var hookFailure = new ApplicationException("hook failed");
+        var fallbackCalls = 0;
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .FallbackWithNotifications(
+                (_, _) =>
+                {
+                    fallbackCalls++;
+                    return ValueTask.CompletedTask;
+                },
+                new FallbackOptions
+                {
+                    OnFallbackAsync = _ => ValueTask.FromException(hookFailure),
+                });
+
+        Exception? caught = null;
+        try
+        {
+            await shield.ExecuteAsync(_ => throw new InvalidOperationException());
+        }
+        catch (Exception exception)
+        {
+            caught = exception;
+        }
+
+        await Assert.That(ReferenceEquals(caught, hookFailure)).IsTrue();
+        await Assert.That(fallbackCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Notification_Options_Are_Snapshotted_When_The_Shield_Is_Built()
+    {
+        var firstCalls = 0;
+        var secondCalls = 0;
+        var options = new FallbackOptions<int>
+        {
+            OnFallbackAsync = _ =>
+            {
+                firstCalls++;
+                return ValueTask.CompletedTask;
+            },
+        };
+        var shield = Shield.For<int>().FallbackWithNotifications(42, options);
+        options.OnFallbackAsync = _ =>
+        {
+            secondCalls++;
+            return ValueTask.CompletedTask;
+        };
+
+        var result = await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(firstCalls).IsEqualTo(1);
+        await Assert.That(secondCalls).IsEqualTo(0);
+    }
+}

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -331,6 +331,35 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Fallback_Metric_Is_Recorded_Before_Sync_And_Async_Notifications()
+    {
+        using var listener = new KevlarMeterListener();
+        const string name = "metrics-fallback-notifications";
+        var syncObservedMetric = false;
+        var asyncObservedMetric = false;
+        var shield = Shield.For<int>()
+            .When<InvalidOperationException>()
+            .FallbackWithNotifications(
+                42,
+                new FallbackOptions<int>
+                {
+                    OnFallback = _ => syncObservedMetric = listener.Total("kevlar.fallbacks", name) == 1,
+                    OnFallbackAsync = _ =>
+                    {
+                        asyncObservedMetric = listener.Total("kevlar.fallbacks", name) == 1;
+                        return ValueTask.CompletedTask;
+                    },
+                })
+            .WithName(name);
+
+        var result = await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(syncObservedMetric).IsTrue();
+        await Assert.That(asyncObservedMetric).IsTrue();
+    }
+
+    [Test]
     public async Task Concurrent_Execution_Totals_Are_Exact_And_Isolated_By_Name()
     {
         using var listener = new KevlarMeterListener();


### PR DESCRIPTION
Closes #89

## Summary

- add `FallbackOptions` and `FallbackOptions<TResult>` with ordered synchronous and awaited asynchronous notifications
- support typed and untyped `FallbackWithNotifications` APIs without changing existing `Fallback` overloads
- preserve exact outcomes, hook exceptions/cancellation, caller token visibility, reentrancy, concurrency, and pooled-context lifetime
- document behavior and add public API baselines, allocation gates, and BenchmarkDotNet coverage

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (552 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (16 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (19 passed)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (2 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (1 passed)
- `npm ci` and `npm run build` in `docs/`
- package layout/consumer, publish compatibility, and 82 documentation snippet checks

## Benchmarks

ShortRun, triggered fallback: no notification 1.295 us / 200 B; sync 1.291 us / 200 B; completed async 1.302 us / 200 B; yielding async 2.501 us / 846 B.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable synchronous and asynchronous notifications for fallback handling.
  * Added typed and untyped fallback notification options and event details.
  * Notifications are awaited before recovery and support failure and cancellation handling.
  * Added fallback notification support across shields, builders, and extensions.

* **Documentation**
  * Documented notification ordering, execution behavior, concurrency, and context lifetime.

* **Tests**
  * Added coverage for notification behavior, metrics ordering, reentrancy, cancellation, and allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->