### PR TITLE
feat(testing): add pipeline descriptors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Analyzer tests
         run: dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename analyzers.trx --results-directory artifacts/test-results/analyzers
 
+      - name: Testing package tests
+        run: dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename testing.trx --results-directory artifacts/test-results/testing
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -160,6 +163,9 @@ jobs:
 
       - name: Collect analyzer coverage
         run: dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/analyzers.cobertura.xml --coverage-output-format cobertura
+
+      - name: Collect testing package coverage
+        run: dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/testing.cobertura.xml --coverage-output-format cobertura
 
       - name: Merge coverage reports
         run: dotnet reportgenerator '-reports:artifacts/coverage/raw/*.cobertura.xml' '-targetdir:artifacts/coverage/report' '-reporttypes:Cobertura;Html'

--- a/Kevlar.slnx
+++ b/Kevlar.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj" />
     <Project Path="src/Kevlar/Kevlar.csproj" />
     <Project Path="src/Kevlar.Analyzers/Kevlar.Analyzers.csproj" />
+    <Project Path="src/Kevlar.Testing/Kevlar.Testing.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj" />
@@ -17,5 +18,6 @@
     <Project Path="tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj" />
     <Project Path="tests/Kevlar.Tests/Kevlar.Tests.csproj" />
     <Project Path="tests/Kevlar.Analyzers.Tests/Kevlar.Analyzers.Tests.csproj" />
+    <Project Path="tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ One clause up top decides what "failure" means for every strategy below it — e
 | `Kevlar.Extensions.DependencyInjection` | Named shields, config-bound shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |
+| `Kevlar.Testing` | Structured pipeline descriptors and framework-independent shape assertions |
 
 ## The five-minute tour
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -4,11 +4,41 @@ sidebar_position: 10
 
 # Testing Your Shields
 
+## Inspecting pipeline shape
+
+Install `Kevlar.Testing` in the test project only:
+
+```shell
+dotnet add package Kevlar.Testing
+```
+
+`GetDescriptor()` returns an immutable snapshot. Strategy kinds, execution order, and the typed configuration properties are stable contracts. `Description` is diagnostic text only; display it in failures, but do not parse it. Descriptors never expose a mutable strategy, callback, monitor, or `TimeProvider` instance.
+
+In a TUnit `[Test]`, use the framework-independent shape assertions alongside TUnit's value assertions:
+
+<!-- doc-test-ignore: The executable documentation harness owns Main; this TUnit example is compiled by Kevlar.Testing.Tests. -->
+```csharp
+var shield = Shield
+    .Timeout(TimeSpan.FromSeconds(2))
+    .Retry(3, Backoff.Constant(TimeSpan.FromMilliseconds(50)))
+    .WithName("catalog");
+
+var descriptor = shield.GetDescriptor()
+    .AssertStrategyCount(2)
+    .AssertStrategyOrder(StrategyKind.Timeout, StrategyKind.Retry);
+
+var retry = descriptor.AssertContainsSingle<RetryStrategyDescriptor>();
+await TUnit.Assertions.Assert.That(retry.MaxRetries).IsEqualTo(3);
+await TUnit.Assertions.Assert.That(descriptor.Name).IsEqualTo("catalog");
+```
+
+`AssertContains<TDescriptor>()` checks presence when repeats are valid. `AssertContainsSingle<TDescriptor>()` also rejects duplicates. All shape failures throw `ShieldAssertionException` with expected and actual pipeline details.
+
 ## Repository quality gates
 
-Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, and analyzer suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
+Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, analyzer, and testing-package suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
 
-The Linux coverage job merges all five suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
+The Linux coverage job merges all six suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
 
 Core strategy mutation testing runs for pull requests that change strategy code or unit tests, every Monday, and on demand. It uses the checked-in Stryker configuration, keeps 74% as the report reference, and treats the aggregate score as informational because timing-sensitive mutants make it nondeterministic. Operational Stryker failures still fail the workflow. Superseded pull-request runs are cancelled, and completed runs publish HTML and JSON reports as the `mutation-report` artifact. The audited initial survivors and threshold policy are recorded in `.github/mutation-baseline.md`. Run the test and mutation checks locally with:
 
@@ -20,12 +50,14 @@ dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout
 dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 $coverageRoot = (New-Item -ItemType Directory -Force artifacts/coverage/raw).FullName
 dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/unit.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/chaos.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/netstandard.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/integration.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/analyzers.cobertura.xml" --coverage-output-format cobertura
+dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/testing.cobertura.xml" --coverage-output-format cobertura
 dotnet reportgenerator '-reports:artifacts/coverage/raw/*.cobertura.xml' '-targetdir:artifacts/coverage/report' '-reporttypes:Cobertura;Html'
 ./.github/scripts/Assert-Coverage.ps1 -Report artifacts/coverage/report/Cobertura.xml -MinimumLinePercent 92 -MinimumBranchPercent 86
 Push-Location src/Kevlar

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -28,6 +28,7 @@ $requiredPackages = @(
     'Kevlar.Chaos'
     'Kevlar.Extensions.DependencyInjection'
     'Kevlar.Extensions.Http'
+    'Kevlar.Testing'
 )
 
 foreach ($packageId in $requiredPackages)
@@ -183,6 +184,7 @@ $builder = [Text.StringBuilder]::new()
 [void]$builder.AppendLine('using Kevlar.Chaos;')
 [void]$builder.AppendLine('using Kevlar.Extensions.DependencyInjection;')
 [void]$builder.AppendLine('using Kevlar.Extensions.Http;')
+[void]$builder.AppendLine('using Kevlar.Testing;')
 [void]$builder.AppendLine('using Microsoft.Extensions.DependencyInjection;')
 [void]$builder.AppendLine('using Microsoft.Extensions.Time.Testing;')
 [void]$builder.AppendLine('using Microsoft.Extensions.Logging;')

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -114,6 +114,10 @@ $expectedDependencies = @{
             'System.Runtime.CompilerServices.Unsafe',
             'System.Threading.Tasks.Extensions')
     }
+    'Kevlar.Testing' = @{
+        'net10.0' = @('Kevlar')
+        '.NETStandard2.0' = @('Kevlar')
+    }
     'Kevlar.Analyzers' = @{
         '.NETStandard2.0' = @()
     }
@@ -262,10 +266,13 @@ using Kevlar;
 using Kevlar.Chaos;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Http;
+using Kevlar.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.Metrics;
 
 var shield = Shield.Empty;
+var descriptor = shield.GetDescriptor();
+descriptor.AssertStrategyCount(0);
 var value = await shield.ExecuteAsync(static cancellationToken =>
     new ValueTask<int>(cancellationToken.CanBeCanceled ? 41 : 42));
 if (value != 42)
@@ -323,6 +330,7 @@ Console.WriteLine("Kevlar package consumer passed.");
     <PackageReference Include="Kevlar.Chaos" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
+    <PackageReference Include="Kevlar.Testing" Version="$Version" />
   </ItemGroup>
 </Project>
 "@

--- a/src/Kevlar.Testing/BackoffDescriptor.cs
+++ b/src/Kevlar.Testing/BackoffDescriptor.cs
@@ -1,0 +1,34 @@
+namespace Kevlar.Testing;
+
+/// <summary>Immutable, callback-free description of retry backoff configuration.</summary>
+public sealed class BackoffDescriptor
+{
+    internal BackoffDescriptor(
+        BackoffKind kind,
+        TimeSpan? baseDelay,
+        double? factor,
+        TimeSpan? maxDelay,
+        bool? jitter)
+    {
+        Kind = kind;
+        BaseDelay = baseDelay;
+        Factor = factor;
+        MaxDelay = maxDelay;
+        Jitter = jitter;
+    }
+
+    /// <summary>The stable backoff category.</summary>
+    public BackoffKind Kind { get; }
+
+    /// <summary>The constant delay, linear step, or exponential initial delay, when applicable.</summary>
+    public TimeSpan? BaseDelay { get; }
+
+    /// <summary>The exponential multiplier, when applicable.</summary>
+    public double? Factor { get; }
+
+    /// <summary>The linear or exponential delay cap, when configured.</summary>
+    public TimeSpan? MaxDelay { get; }
+
+    /// <summary>Whether exponential jitter is enabled, when applicable.</summary>
+    public bool? Jitter { get; }
+}

--- a/src/Kevlar.Testing/BackoffKind.cs
+++ b/src/Kevlar.Testing/BackoffKind.cs
@@ -1,0 +1,20 @@
+namespace Kevlar.Testing;
+
+/// <summary>Stable category for an inert backoff descriptor.</summary>
+public enum BackoffKind
+{
+    /// <summary>No delay between attempts.</summary>
+    None,
+
+    /// <summary>A constant delay.</summary>
+    Constant,
+
+    /// <summary>A linearly increasing delay.</summary>
+    Linear,
+
+    /// <summary>An exponentially increasing delay.</summary>
+    Exponential,
+
+    /// <summary>A caller-defined delay callback whose executable implementation is not exposed.</summary>
+    Custom,
+}

--- a/src/Kevlar.Testing/CircuitBreakerStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/CircuitBreakerStrategyDescriptor.cs
@@ -1,0 +1,46 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only circuit breaker configuration.</summary>
+public sealed class CircuitBreakerStrategyDescriptor : StrategyDescriptor
+{
+    internal CircuitBreakerStrategyDescriptor(
+        string description,
+        int? consecutiveFailures,
+        double? failureRatio,
+        int minimumThroughput,
+        TimeSpan samplingWindow,
+        TimeSpan breakDuration,
+        bool hasMonitor,
+        bool hasNotification)
+        : base(StrategyKind.CircuitBreaker, description)
+    {
+        ConsecutiveFailures = consecutiveFailures;
+        FailureRatio = failureRatio;
+        MinimumThroughput = minimumThroughput;
+        SamplingWindow = samplingWindow;
+        BreakDuration = breakDuration;
+        HasMonitor = hasMonitor;
+        HasNotification = hasNotification;
+    }
+
+    /// <summary>The consecutive-failure threshold in simple mode.</summary>
+    public int? ConsecutiveFailures { get; }
+
+    /// <summary>The failure-ratio threshold in sampling mode.</summary>
+    public double? FailureRatio { get; }
+
+    /// <summary>Minimum sampled executions before ratio mode can trip.</summary>
+    public int MinimumThroughput { get; }
+
+    /// <summary>The rolling sampling window.</summary>
+    public TimeSpan SamplingWindow { get; }
+
+    /// <summary>The fixed open duration.</summary>
+    public TimeSpan BreakDuration { get; }
+
+    /// <summary>Whether a circuit monitor is configured.</summary>
+    public bool HasMonitor { get; }
+
+    /// <summary>Whether a state-change notification is configured.</summary>
+    public bool HasNotification { get; }
+}

--- a/src/Kevlar.Testing/ConcurrencyLimitStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/ConcurrencyLimitStrategyDescriptor.cs
@@ -1,0 +1,18 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only concurrency limiter configuration.</summary>
+public sealed class ConcurrencyLimitStrategyDescriptor : StrategyDescriptor
+{
+    internal ConcurrencyLimitStrategyDescriptor(string description, int maxConcurrency, int maxQueue)
+        : base(StrategyKind.ConcurrencyLimit, description)
+    {
+        MaxConcurrency = maxConcurrency;
+        MaxQueue = maxQueue;
+    }
+
+    /// <summary>The maximum concurrent executions.</summary>
+    public int MaxConcurrency { get; }
+
+    /// <summary>The maximum wait queue size.</summary>
+    public int MaxQueue { get; }
+}

--- a/src/Kevlar.Testing/CustomStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/CustomStrategyDescriptor.cs
@@ -1,0 +1,11 @@
+namespace Kevlar.Testing;
+
+/// <summary>Diagnostic description of a caller-defined strategy.</summary>
+public sealed class CustomStrategyDescriptor : StrategyDescriptor
+{
+    internal CustomStrategyDescriptor(string description, Type strategyType)
+        : base(StrategyKind.Custom, description) => StrategyType = strategyType;
+
+    /// <summary>The caller-defined strategy type.</summary>
+    public Type StrategyType { get; }
+}

--- a/src/Kevlar.Testing/FallbackStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/FallbackStrategyDescriptor.cs
@@ -1,0 +1,24 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only fallback configuration.</summary>
+public sealed class FallbackStrategyDescriptor : StrategyDescriptor
+{
+    internal FallbackStrategyDescriptor(
+        string description,
+        Type? resultType,
+        bool hasNotification)
+        : base(StrategyKind.Fallback, description)
+    {
+        ResultType = resultType;
+        HasNotification = hasNotification;
+    }
+
+    /// <summary>The fallback result type, or <see langword="null"/> for a void fallback.</summary>
+    public Type? ResultType { get; }
+
+    /// <summary>Whether this is a void fallback.</summary>
+    public bool IsVoid => ResultType is null;
+
+    /// <summary>Whether a fallback notification is configured.</summary>
+    public bool HasNotification { get; }
+}

--- a/src/Kevlar.Testing/HedgingStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/HedgingStrategyDescriptor.cs
@@ -1,0 +1,26 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only hedging configuration.</summary>
+public sealed class HedgingStrategyDescriptor : StrategyDescriptor
+{
+    internal HedgingStrategyDescriptor(
+        string description,
+        int maxAttempts,
+        TimeSpan delay,
+        bool hasNotification)
+        : base(StrategyKind.Hedging, description)
+    {
+        MaxAttempts = maxAttempts;
+        Delay = delay;
+        HasNotification = hasNotification;
+    }
+
+    /// <summary>The maximum total attempts, including the primary.</summary>
+    public int MaxAttempts { get; }
+
+    /// <summary>The stagger delay between attempts.</summary>
+    public TimeSpan Delay { get; }
+
+    /// <summary>Whether a hedge notification is configured.</summary>
+    public bool HasNotification { get; }
+}

--- a/src/Kevlar.Testing/Kevlar.Testing.csproj
+++ b/src/Kevlar.Testing/Kevlar.Testing.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <RootNamespace>Kevlar.Testing</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <Description>Structured pipeline inspection and assertion helpers for testing Kevlar shields without parsing display strings.</Description>
+    <PackageTags>resilience;testing;assertions;pipeline-inspection;kevlar</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kevlar.Testing/PublicAPI.Shipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -1,0 +1,63 @@
+Kevlar.Testing.CircuitBreakerStrategyDescriptor
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.BreakDuration.get -> System.TimeSpan
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.ConsecutiveFailures.get -> int?
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.FailureRatio.get -> double?
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.HasMonitor.get -> bool
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.MinimumThroughput.get -> int
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.SamplingWindow.get -> System.TimeSpan
+Kevlar.Testing.ConcurrencyLimitStrategyDescriptor
+Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.MaxConcurrency.get -> int
+Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.MaxQueue.get -> int
+Kevlar.Testing.CustomStrategyDescriptor
+Kevlar.Testing.CustomStrategyDescriptor.StrategyType.get -> System.Type!
+Kevlar.Testing.FallbackStrategyDescriptor
+Kevlar.Testing.FallbackStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.FallbackStrategyDescriptor.IsVoid.get -> bool
+Kevlar.Testing.FallbackStrategyDescriptor.ResultType.get -> System.Type?
+Kevlar.Testing.HedgingStrategyDescriptor
+Kevlar.Testing.HedgingStrategyDescriptor.Delay.get -> System.TimeSpan
+Kevlar.Testing.HedgingStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.HedgingStrategyDescriptor.MaxAttempts.get -> int
+Kevlar.Testing.RateLimitStrategyDescriptor
+Kevlar.Testing.RateLimitStrategyDescriptor.Burst.get -> int
+Kevlar.Testing.RateLimitStrategyDescriptor.Permits.get -> int
+Kevlar.Testing.RateLimitStrategyDescriptor.QueueLimit.get -> int
+Kevlar.Testing.RateLimitStrategyDescriptor.Window.get -> System.TimeSpan
+Kevlar.Testing.RetryStrategyDescriptor
+Kevlar.Testing.RetryStrategyDescriptor.Backoff.get -> Kevlar.Backoff!
+Kevlar.Testing.RetryStrategyDescriptor.HasDelayGenerator.get -> bool
+Kevlar.Testing.RetryStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.RetryStrategyDescriptor.MaxDelay.get -> System.TimeSpan?
+Kevlar.Testing.RetryStrategyDescriptor.MaxRetries.get -> int
+Kevlar.Testing.ShieldAssertionException
+Kevlar.Testing.ShieldAssertionException.ShieldAssertionException(string! message) -> void
+Kevlar.Testing.ShieldDescriptor
+Kevlar.Testing.ShieldDescriptor.Name.get -> string?
+Kevlar.Testing.ShieldDescriptor.ResultType.get -> System.Type?
+Kevlar.Testing.ShieldDescriptor.Strategies.get -> System.Collections.Generic.IReadOnlyList<Kevlar.Testing.StrategyDescriptor!>!
+Kevlar.Testing.ShieldDescriptor.UsesCustomTimeProvider.get -> bool
+Kevlar.Testing.ShieldDescriptorAssertionExtensions
+Kevlar.Testing.ShieldDescriptorExtensions
+Kevlar.Testing.StrategyDescriptor
+Kevlar.Testing.StrategyDescriptor.Description.get -> string!
+Kevlar.Testing.StrategyDescriptor.Kind.get -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.CircuitBreaker = 3 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.ConcurrencyLimit = 5 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.Custom = 0 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.Fallback = 7 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.Hedging = 6 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.RateLimit = 4 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.Retry = 1 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.Timeout = 2 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.TimeoutStrategyDescriptor
+Kevlar.Testing.TimeoutStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.TimeoutStrategyDescriptor.HasTimeoutGenerator.get -> bool
+Kevlar.Testing.TimeoutStrategyDescriptor.Timeout.get -> System.TimeSpan
+static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertContains<TDescriptor>(this Kevlar.Testing.ShieldDescriptor! descriptor) -> TDescriptor!
+static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertContainsSingle<TDescriptor>(this Kevlar.Testing.ShieldDescriptor! descriptor) -> TDescriptor!
+static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyCount(this Kevlar.Testing.ShieldDescriptor! descriptor, int expected) -> Kevlar.Testing.ShieldDescriptor!
+static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyOrder(this Kevlar.Testing.ShieldDescriptor! descriptor, params Kevlar.Testing.StrategyKind[]! expected) -> Kevlar.Testing.ShieldDescriptor!
+static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor(this Kevlar.Shield! shield) -> Kevlar.Testing.ShieldDescriptor!
+static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor<TResult>(this Kevlar.Shield<TResult>! shield) -> Kevlar.Testing.ShieldDescriptor!

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -1,3 +1,15 @@
+Kevlar.Testing.BackoffDescriptor
+Kevlar.Testing.BackoffDescriptor.BaseDelay.get -> System.TimeSpan?
+Kevlar.Testing.BackoffDescriptor.Factor.get -> double?
+Kevlar.Testing.BackoffDescriptor.Jitter.get -> bool?
+Kevlar.Testing.BackoffDescriptor.Kind.get -> Kevlar.Testing.BackoffKind
+Kevlar.Testing.BackoffDescriptor.MaxDelay.get -> System.TimeSpan?
+Kevlar.Testing.BackoffKind
+Kevlar.Testing.BackoffKind.Constant = 1 -> Kevlar.Testing.BackoffKind
+Kevlar.Testing.BackoffKind.Custom = 4 -> Kevlar.Testing.BackoffKind
+Kevlar.Testing.BackoffKind.Exponential = 3 -> Kevlar.Testing.BackoffKind
+Kevlar.Testing.BackoffKind.Linear = 2 -> Kevlar.Testing.BackoffKind
+Kevlar.Testing.BackoffKind.None = 0 -> Kevlar.Testing.BackoffKind
 Kevlar.Testing.CircuitBreakerStrategyDescriptor
 Kevlar.Testing.CircuitBreakerStrategyDescriptor.BreakDuration.get -> System.TimeSpan
 Kevlar.Testing.CircuitBreakerStrategyDescriptor.ConsecutiveFailures.get -> int?
@@ -25,7 +37,7 @@ Kevlar.Testing.RateLimitStrategyDescriptor.Permits.get -> int
 Kevlar.Testing.RateLimitStrategyDescriptor.QueueLimit.get -> int
 Kevlar.Testing.RateLimitStrategyDescriptor.Window.get -> System.TimeSpan
 Kevlar.Testing.RetryStrategyDescriptor
-Kevlar.Testing.RetryStrategyDescriptor.Backoff.get -> Kevlar.Backoff!
+Kevlar.Testing.RetryStrategyDescriptor.Backoff.get -> Kevlar.Testing.BackoffDescriptor!
 Kevlar.Testing.RetryStrategyDescriptor.HasDelayGenerator.get -> bool
 Kevlar.Testing.RetryStrategyDescriptor.HasNotification.get -> bool
 Kevlar.Testing.RetryStrategyDescriptor.MaxDelay.get -> System.TimeSpan?

--- a/src/Kevlar.Testing/RateLimitStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/RateLimitStrategyDescriptor.cs
@@ -1,0 +1,31 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only rate limiter configuration.</summary>
+public sealed class RateLimitStrategyDescriptor : StrategyDescriptor
+{
+    internal RateLimitStrategyDescriptor(
+        string description,
+        int permits,
+        TimeSpan window,
+        int burst,
+        int queueLimit)
+        : base(StrategyKind.RateLimit, description)
+    {
+        Permits = permits;
+        Window = window;
+        Burst = burst;
+        QueueLimit = queueLimit;
+    }
+
+    /// <summary>Permits replenished per window.</summary>
+    public int Permits { get; }
+
+    /// <summary>The replenishment window.</summary>
+    public TimeSpan Window { get; }
+
+    /// <summary>The maximum burst capacity.</summary>
+    public int Burst { get; }
+
+    /// <summary>The maximum wait queue size.</summary>
+    public int QueueLimit { get; }
+}

--- a/src/Kevlar.Testing/RetryStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/RetryStrategyDescriptor.cs
@@ -1,0 +1,36 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only retry configuration.</summary>
+public sealed class RetryStrategyDescriptor : StrategyDescriptor
+{
+    internal RetryStrategyDescriptor(
+        string description,
+        int maxRetries,
+        Backoff backoff,
+        TimeSpan? maxDelay,
+        bool hasDelayGenerator,
+        bool hasNotification)
+        : base(StrategyKind.Retry, description)
+    {
+        MaxRetries = maxRetries;
+        Backoff = backoff;
+        MaxDelay = maxDelay;
+        HasDelayGenerator = hasDelayGenerator;
+        HasNotification = hasNotification;
+    }
+
+    /// <summary>Maximum retries after the initial attempt.</summary>
+    public int MaxRetries { get; }
+
+    /// <summary>The immutable backoff configuration.</summary>
+    public Backoff Backoff { get; }
+
+    /// <summary>The absolute delay cap, when configured.</summary>
+    public TimeSpan? MaxDelay { get; }
+
+    /// <summary>Whether a synchronous or asynchronous delay generator is configured.</summary>
+    public bool HasDelayGenerator { get; }
+
+    /// <summary>Whether a synchronous or asynchronous retry notification is configured.</summary>
+    public bool HasNotification { get; }
+}

--- a/src/Kevlar.Testing/RetryStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/RetryStrategyDescriptor.cs
@@ -6,7 +6,7 @@ public sealed class RetryStrategyDescriptor : StrategyDescriptor
     internal RetryStrategyDescriptor(
         string description,
         int maxRetries,
-        Backoff backoff,
+        BackoffDescriptor backoff,
         TimeSpan? maxDelay,
         bool hasDelayGenerator,
         bool hasNotification)
@@ -22,8 +22,8 @@ public sealed class RetryStrategyDescriptor : StrategyDescriptor
     /// <summary>Maximum retries after the initial attempt.</summary>
     public int MaxRetries { get; }
 
-    /// <summary>The immutable backoff configuration.</summary>
-    public Backoff Backoff { get; }
+    /// <summary>An inert snapshot of the backoff configuration.</summary>
+    public BackoffDescriptor Backoff { get; }
 
     /// <summary>The absolute delay cap, when configured.</summary>
     public TimeSpan? MaxDelay { get; }

--- a/src/Kevlar.Testing/ShieldAssertionException.cs
+++ b/src/Kevlar.Testing/ShieldAssertionException.cs
@@ -1,0 +1,11 @@
+namespace Kevlar.Testing;
+
+/// <summary>Thrown when a structured shield assertion fails.</summary>
+public sealed class ShieldAssertionException : Exception
+{
+    /// <summary>Creates an assertion failure with an actionable message.</summary>
+    public ShieldAssertionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Kevlar.Testing/ShieldDescriptor.cs
+++ b/src/Kevlar.Testing/ShieldDescriptor.cs
@@ -1,0 +1,29 @@
+namespace Kevlar.Testing;
+
+/// <summary>Immutable, read-only description of a shield pipeline.</summary>
+public sealed class ShieldDescriptor
+{
+    internal ShieldDescriptor(
+        string? name,
+        Type? resultType,
+        bool usesCustomTimeProvider,
+        IReadOnlyList<StrategyDescriptor> strategies)
+    {
+        Name = name;
+        ResultType = resultType;
+        UsesCustomTimeProvider = usesCustomTimeProvider;
+        Strategies = strategies;
+    }
+
+    /// <summary>The shield name, or <see langword="null"/> for an unnamed shield.</summary>
+    public string? Name { get; }
+
+    /// <summary>The result type for a typed shield, or <see langword="null"/> for an untyped shield.</summary>
+    public Type? ResultType { get; }
+
+    /// <summary>Whether the shield has an explicitly configured <see cref="TimeProvider"/>.</summary>
+    public bool UsesCustomTimeProvider { get; }
+
+    /// <summary>Strategies in execution order, outermost first.</summary>
+    public IReadOnlyList<StrategyDescriptor> Strategies { get; }
+}

--- a/src/Kevlar.Testing/ShieldDescriptorAssertionExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorAssertionExtensions.cs
@@ -1,0 +1,116 @@
+namespace Kevlar.Testing;
+
+/// <summary>Framework-independent assertions for structured shield descriptors.</summary>
+public static class ShieldDescriptorAssertionExtensions
+{
+    /// <summary>Asserts at least one descriptor of <typeparamref name="TDescriptor"/> and returns the first.</summary>
+    public static TDescriptor AssertContains<TDescriptor>(this ShieldDescriptor descriptor)
+        where TDescriptor : StrategyDescriptor
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        foreach (var strategy in descriptor.Strategies)
+        {
+            if (strategy is TDescriptor typed)
+            {
+                return typed;
+            }
+        }
+
+        throw new ShieldAssertionException(
+            $"Expected at least one {typeof(TDescriptor).Name}, actual 0. " +
+            $"Pipeline: [{Format(descriptor.Strategies.Select(static item => item.Kind))}].");
+    }
+
+    /// <summary>Asserts the exact strategy order and returns the descriptor for chaining.</summary>
+    public static ShieldDescriptor AssertStrategyOrder(
+        this ShieldDescriptor descriptor,
+        params StrategyKind[] expected)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (expected is null)
+        {
+            throw new ArgumentNullException(nameof(expected));
+        }
+
+        if (descriptor.Strategies.Count == expected.Length)
+        {
+            var matches = true;
+            for (var index = 0; index < expected.Length; index++)
+            {
+                matches &= descriptor.Strategies[index].Kind == expected[index];
+            }
+
+            if (matches)
+            {
+                return descriptor;
+            }
+        }
+
+        throw new ShieldAssertionException(
+            $"Shield strategy order mismatch: expected [{Format(expected)}], " +
+            $"actual [{Format(descriptor.Strategies.Select(static item => item.Kind))}].");
+    }
+
+    /// <summary>Asserts the exact number of strategies and returns the descriptor for chaining.</summary>
+    public static ShieldDescriptor AssertStrategyCount(this ShieldDescriptor descriptor, int expected)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (expected < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expected), "Expected count must not be negative.");
+        }
+
+        if (descriptor.Strategies.Count != expected)
+        {
+            throw new ShieldAssertionException(
+                $"Shield strategy count mismatch: expected {expected} strategies, " +
+                $"actual {descriptor.Strategies.Count}.");
+        }
+
+        return descriptor;
+    }
+
+    /// <summary>Asserts exactly one descriptor of <typeparamref name="TDescriptor"/> and returns it.</summary>
+    public static TDescriptor AssertContainsSingle<TDescriptor>(this ShieldDescriptor descriptor)
+        where TDescriptor : StrategyDescriptor
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        TDescriptor? match = null;
+        var count = 0;
+        foreach (var strategy in descriptor.Strategies)
+        {
+            if (strategy is TDescriptor typed)
+            {
+                match = typed;
+                count++;
+            }
+        }
+
+        if (count != 1)
+        {
+            throw new ShieldAssertionException(
+                $"Expected exactly one {typeof(TDescriptor).Name}, actual {count}. " +
+                $"Pipeline: [{Format(descriptor.Strategies.Select(static item => item.Kind))}].");
+        }
+
+        return match!;
+    }
+
+    private static string Format(IEnumerable<StrategyKind> kinds) => string.Join(", ", kinds);
+}

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -54,7 +54,7 @@ public static class ShieldDescriptorExtensions
             RetryStrategy retry => new RetryStrategyDescriptor(
                 description,
                 retry.MaxRetries,
-                retry.Backoff,
+                DescribeBackoff(retry.Backoff),
                 retry.MaxDelay,
                 retry.HasDelayGenerator,
                 retry.HasNotification),
@@ -98,4 +98,18 @@ public static class ShieldDescriptorExtensions
             core.BreakDuration,
             core.HasMonitor,
             core.HasNotification);
+
+    private static BackoffDescriptor DescribeBackoff(Backoff backoff) => new(
+        backoff.ConfigurationKind switch
+        {
+            BackoffConfigurationKind.None => BackoffKind.None,
+            BackoffConfigurationKind.Constant => BackoffKind.Constant,
+            BackoffConfigurationKind.Linear => BackoffKind.Linear,
+            BackoffConfigurationKind.Exponential => BackoffKind.Exponential,
+            _ => BackoffKind.Custom,
+        },
+        backoff.BaseDelay,
+        backoff.Factor,
+        backoff.MaxDelay,
+        backoff.Jitter);
 }

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -1,0 +1,101 @@
+using Kevlar.Strategies;
+
+namespace Kevlar.Testing;
+
+/// <summary>Creates structured, read-only descriptors for shields.</summary>
+public static class ShieldDescriptorExtensions
+{
+    /// <summary>Describes an untyped shield without executing it.</summary>
+    public static ShieldDescriptor GetDescriptor(this Shield shield)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return Create(shield.Name, resultType: null, shield.Time is not null, shield.Strategies);
+    }
+
+    /// <summary>Describes a typed shield without executing it.</summary>
+    public static ShieldDescriptor GetDescriptor<TResult>(this Shield<TResult> shield)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return Create(shield.Name, typeof(TResult), shield.Time is not null, shield.Strategies);
+    }
+
+    private static ShieldDescriptor Create(
+        string? name,
+        Type? resultType,
+        bool usesCustomTimeProvider,
+        Strategy[] strategies)
+    {
+        var descriptors = new StrategyDescriptor[strategies.Length];
+        for (var index = 0; index < strategies.Length; index++)
+        {
+            descriptors[index] = Describe(strategies[index]);
+        }
+
+        return new ShieldDescriptor(
+            name,
+            resultType,
+            usesCustomTimeProvider,
+            Array.AsReadOnly(descriptors));
+    }
+
+    private static StrategyDescriptor Describe(Strategy strategy)
+    {
+        var description = strategy.Describe();
+        return strategy switch
+        {
+            RetryStrategy retry => new RetryStrategyDescriptor(
+                description,
+                retry.MaxRetries,
+                retry.Backoff,
+                retry.MaxDelay,
+                retry.HasDelayGenerator,
+                retry.HasNotification),
+            TimeoutStrategy timeout => new TimeoutStrategyDescriptor(
+                description,
+                timeout.Timeout,
+                timeout.HasTimeoutGenerator,
+                timeout.HasNotification),
+            CircuitBreakerStrategy circuit => DescribeCircuitBreaker(description, circuit.Core),
+            RateLimitStrategy rateLimit => new RateLimitStrategyDescriptor(
+                description,
+                rateLimit.Permits,
+                rateLimit.Window,
+                rateLimit.Burst,
+                rateLimit.QueueLimit),
+            ConcurrencyLimitStrategy concurrency => new ConcurrencyLimitStrategyDescriptor(
+                description,
+                concurrency.MaxConcurrency,
+                concurrency.MaxQueue),
+            HedgingStrategy hedging => new HedgingStrategyDescriptor(
+                description,
+                hedging.MaxAttempts,
+                hedging.Delay,
+                hedging.HasNotification),
+            IFallbackStrategyInspection fallback => new FallbackStrategyDescriptor(
+                description,
+                fallback.ResultType,
+                fallback.HasNotification),
+            _ => new CustomStrategyDescriptor(description, strategy.GetType()),
+        };
+    }
+
+    private static CircuitBreakerStrategyDescriptor DescribeCircuitBreaker(
+        string description,
+        CircuitBreakerCore core) => new(
+            description,
+            core.ConsecutiveFailures,
+            core.FailureRatio,
+            core.MinimumThroughput,
+            core.SamplingWindow,
+            core.BreakDuration,
+            core.HasMonitor,
+            core.HasNotification);
+}

--- a/src/Kevlar.Testing/StrategyDescriptor.cs
+++ b/src/Kevlar.Testing/StrategyDescriptor.cs
@@ -1,0 +1,17 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only description of one strategy in a shield pipeline.</summary>
+public abstract class StrategyDescriptor
+{
+    internal StrategyDescriptor(StrategyKind kind, string description)
+    {
+        Kind = kind;
+        Description = description;
+    }
+
+    /// <summary>The stable strategy category.</summary>
+    public StrategyKind Kind { get; }
+
+    /// <summary>A human-readable diagnostic description. Do not parse this value as a contract.</summary>
+    public string Description { get; }
+}

--- a/src/Kevlar.Testing/StrategyKind.cs
+++ b/src/Kevlar.Testing/StrategyKind.cs
@@ -1,0 +1,29 @@
+namespace Kevlar.Testing;
+
+/// <summary>Stable category for a strategy in a shield descriptor.</summary>
+public enum StrategyKind
+{
+    /// <summary>A caller-defined strategy.</summary>
+    Custom,
+
+    /// <summary>A retry strategy.</summary>
+    Retry,
+
+    /// <summary>A timeout strategy.</summary>
+    Timeout,
+
+    /// <summary>A circuit breaker strategy.</summary>
+    CircuitBreaker,
+
+    /// <summary>A rate limiter strategy.</summary>
+    RateLimit,
+
+    /// <summary>A concurrency limiter strategy.</summary>
+    ConcurrencyLimit,
+
+    /// <summary>A hedging strategy.</summary>
+    Hedging,
+
+    /// <summary>A fallback strategy.</summary>
+    Fallback,
+}

--- a/src/Kevlar.Testing/TimeoutStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/TimeoutStrategyDescriptor.cs
@@ -1,0 +1,26 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only timeout configuration.</summary>
+public sealed class TimeoutStrategyDescriptor : StrategyDescriptor
+{
+    internal TimeoutStrategyDescriptor(
+        string description,
+        TimeSpan timeout,
+        bool hasTimeoutGenerator,
+        bool hasNotification)
+        : base(StrategyKind.Timeout, description)
+    {
+        Timeout = timeout;
+        HasTimeoutGenerator = hasTimeoutGenerator;
+        HasNotification = hasNotification;
+    }
+
+    /// <summary>The fixed timeout value, used when no generator is configured.</summary>
+    public TimeSpan Timeout { get; }
+
+    /// <summary>Whether a dynamic timeout generator is configured.</summary>
+    public bool HasTimeoutGenerator { get; }
+
+    /// <summary>Whether a synchronous or asynchronous timeout notification is configured.</summary>
+    public bool HasNotification { get; }
+}

--- a/src/Kevlar/Backoff.cs
+++ b/src/Kevlar/Backoff.cs
@@ -63,6 +63,16 @@ public abstract class Backoff
     /// <summary>Returns the delay before the given 1-based retry attempt.</summary>
     public abstract TimeSpan GetDelay(int attempt);
 
+    internal abstract BackoffConfigurationKind ConfigurationKind { get; }
+
+    internal virtual TimeSpan? BaseDelay => null;
+
+    internal virtual double? Factor => null;
+
+    internal virtual TimeSpan? MaxDelay => null;
+
+    internal virtual bool? Jitter => null;
+
     private protected static void ValidateAttempt(int attempt) =>
         Throw.IfOutOfRange(attempt < 1, nameof(attempt), "Attempt must be at least 1.");
 
@@ -100,6 +110,11 @@ public abstract class Backoff
             return _delay;
         }
 
+        internal override BackoffConfigurationKind ConfigurationKind =>
+            _delay == TimeSpan.Zero ? BackoffConfigurationKind.None : BackoffConfigurationKind.Constant;
+
+        internal override TimeSpan? BaseDelay => _delay;
+
         public override string ToString() =>
             _delay == TimeSpan.Zero ? "no delay" : $"constant {DescribeHelper.Time(_delay)}";
     }
@@ -120,6 +135,12 @@ public abstract class Backoff
             ValidateAttempt(attempt);
             return FromTicksClamped((double)_step.Ticks * attempt, _maxDelay);
         }
+
+        internal override BackoffConfigurationKind ConfigurationKind => BackoffConfigurationKind.Linear;
+
+        internal override TimeSpan? BaseDelay => _step;
+
+        internal override TimeSpan? MaxDelay => _maxDelay;
 
         public override string ToString()
         {
@@ -156,6 +177,16 @@ public abstract class Backoff
             return FromTicksClamped(ticks, _maxDelay);
         }
 
+        internal override BackoffConfigurationKind ConfigurationKind => BackoffConfigurationKind.Exponential;
+
+        internal override TimeSpan? BaseDelay => _initialDelay;
+
+        internal override double? Factor => _factor;
+
+        internal override TimeSpan? MaxDelay => _maxDelay;
+
+        internal override bool? Jitter => _jitter;
+
         public override string ToString()
         {
             var jitter = _jitter ? " +jitter" : string.Empty;
@@ -177,6 +208,17 @@ public abstract class Backoff
             return delay < TimeSpan.Zero ? TimeSpan.Zero : DelayHelper.Clamp(delay);
         }
 
+        internal override BackoffConfigurationKind ConfigurationKind => BackoffConfigurationKind.Custom;
+
         public override string ToString() => "custom backoff";
     }
+}
+
+internal enum BackoffConfigurationKind
+{
+    None,
+    Constant,
+    Linear,
+    Exponential,
+    Custom,
 }

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />
+    <InternalsVisibleTo Include="Kevlar.Testing" />
   </ItemGroup>
 
 </Project>

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -92,6 +92,20 @@ internal sealed class CircuitBreakerCore
         ? DescribeHelper.Time(_breakDuration)
         : "dynamic";
 
+    internal int? ConsecutiveFailures => _consecutiveFailureLimit;
+
+    internal double? FailureRatio => _failureRatio;
+
+    internal int MinimumThroughput => _minimumThroughput;
+
+    internal TimeSpan SamplingWindow => _samplingWindow;
+
+    internal TimeSpan BreakDuration => _breakDuration;
+
+    internal bool HasMonitor => _monitor is not null;
+
+    internal bool HasNotification => _onStateChanged is not null;
+
     public CircuitState State
     {
         get

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -31,7 +31,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
         var recordState = RegisterMetricsAlias(alias);
         if (_core.RequiresAsyncExecution)
         {
-            return await ExecuteConfiguredAsync(next, context, alias, recordState).ConfigureAwait(false);
+            return ExecuteConfiguredAsync(next, context, alias, recordState);
         }
 
         if (!_core.TryEnter(context.TimeProvider, out var rejection, out var admittedProbeGeneration))

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -20,6 +20,8 @@ internal sealed class CircuitBreakerStrategy : Strategy
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 
+    internal CircuitBreakerCore Core => _core;
+
     public override string Describe() => _core.Describe();
 
     /// <inheritdoc />

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -20,6 +20,10 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 
+    internal int MaxConcurrency => _maxConcurrency;
+
+    internal int MaxQueue => _maxQueue;
+
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
     {
         Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -28,7 +28,8 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
 
     Type? IFallbackStrategyInspection.ResultType => typeof(TResult);
 
-    bool IFallbackStrategyInspection.HasNotification => _onFallback is not null;
+    bool IFallbackStrategyInspection.HasNotification =>
+        _onFallback is not null || _onFallbackAsync is not null;
 
     public override string Describe() => "Fallback";
 
@@ -146,7 +147,8 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
 
     Type? IFallbackStrategyInspection.ResultType => null;
 
-    bool IFallbackStrategyInspection.HasNotification => false;
+    bool IFallbackStrategyInspection.HasNotification =>
+        _onFallback is not null || _onFallbackAsync is not null;
 
     public override string Describe() => "Fallback";
 

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -3,7 +3,7 @@ using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
 
-internal sealed class FallbackStrategy<TResult> : Strategy
+internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyInspection
 {
     private readonly Func<Outcome<TResult>, KevlarContext, ValueTask<TResult>> _fallback;
     private readonly OutcomeJudge _judge;
@@ -25,6 +25,10 @@ internal sealed class FallbackStrategy<TResult> : Strategy
     internal override OutcomeJudge? ReactiveJudge => _judge;
 
     internal override bool IsFallback => true;
+
+    Type? IFallbackStrategyInspection.ResultType => typeof(TResult);
+
+    bool IFallbackStrategyInspection.HasNotification => _onFallback is not null;
 
     public override string Describe() => "Fallback";
 
@@ -117,7 +121,7 @@ internal sealed class FallbackStrategy<TResult> : Strategy
 /// in place of a handled failure. Result-returning executions are rejected with a descriptive
 /// error, because a void fallback cannot produce a result value.
 /// </summary>
-internal sealed class VoidFallbackStrategy : Strategy
+internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspection
 {
     private readonly Func<Exception, CancellationToken, ValueTask> _fallback;
     private readonly OutcomeJudge _judge;
@@ -139,6 +143,10 @@ internal sealed class VoidFallbackStrategy : Strategy
     internal override OutcomeJudge? ReactiveJudge => _judge;
 
     internal override bool IsFallback => true;
+
+    Type? IFallbackStrategyInspection.ResultType => null;
+
+    bool IFallbackStrategyInspection.HasNotification => false;
 
     public override string Describe() => "Fallback";
 

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -24,6 +24,12 @@ internal sealed class HedgingStrategy : Strategy
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 
+    internal int MaxAttempts => _maxAttempts;
+
+    internal TimeSpan Delay => _delay;
+
+    internal bool HasNotification => _onHedge is not null;
+
     public override string Describe() => $"Hedge({_maxAttempts} attempts, delay {DescribeHelper.Time(_delay)})";
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -38,6 +38,14 @@ internal sealed class RateLimitStrategy : Strategy
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 
+    internal int Permits => _permits;
+
+    internal TimeSpan Window => _window;
+
+    internal int Burst => _burst;
+
+    internal int QueueLimit => _queueLimit;
+
     public RateLimitStrategy(RateLimitOptions options)
     {
         Throw.IfOutOfRange(options.Permits <= 0, nameof(options), "Permits must be positive.");

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -32,6 +32,16 @@ internal sealed class RetryStrategy : Strategy
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 
+    internal int MaxRetries => _maxRetries;
+
+    internal Backoff Backoff => _backoff;
+
+    internal TimeSpan? MaxDelay => _maxDelay;
+
+    internal bool HasDelayGenerator => _delayGenerator is not null || _delayGeneratorAsync is not null;
+
+    internal bool HasNotification => _onRetry is not null || _onRetryAsync is not null;
+
     public override string Describe()
     {
         var cap = _maxDelay is { } max ? $", ≤{DescribeHelper.Time(max)}" : string.Empty;

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -29,6 +29,12 @@ internal sealed class TimeoutStrategy : Strategy
         ? $"Timeout({DescribeHelper.Time(_timeout)})"
         : "Timeout(dynamic)";
 
+    internal TimeSpan Timeout => _timeout;
+
+    internal bool HasTimeoutGenerator => _timeoutGenerator is not null;
+
+    internal bool HasNotification => _onTimeout is not null || _onTimeoutAsync is not null;
+
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         if (_timeoutGenerator is null)

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -50,6 +50,13 @@ public abstract class Strategy
     protected internal virtual bool IsDuplicateReferenceUnsafe => false;
 }
 
+internal interface IFallbackStrategyInspection
+{
+    Type? ResultType { get; }
+
+    bool HasNotification { get; }
+}
+
 /// <summary>
 /// The rest of a shield pipeline, from a strategy's point of view. Invoking it runs every
 /// remaining strategy and finally the user's delegate. It may be invoked multiple times

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Kevlar.Chaos" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.Http" VersionOverride="$(KevlarPackageVersion)" />
+    <PackageReference Include="Kevlar.Testing" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
+++ b/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\..\src\Kevlar.Testing\Kevlar.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -70,6 +70,8 @@ public class PipelineDescriptorTests
         await Assert.That(retry.MaxRetries).IsEqualTo(4);
         await Assert.That(retry.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(1));
         await Assert.That(retry.HasNotification).IsTrue();
+        await Assert.That(retry.Backoff.Kind).IsEqualTo(BackoffKind.Constant);
+        await Assert.That(retry.Backoff.BaseDelay).IsEqualTo(TimeSpan.FromMilliseconds(50));
 
         var breaker = descriptor.AssertContainsSingle<CircuitBreakerStrategyDescriptor>();
         await Assert.That(breaker.FailureRatio).IsEqualTo(0.25);
@@ -149,6 +151,53 @@ public class PipelineDescriptorTests
     }
 
     [Test]
+    public async Task Custom_Backoff_Is_Described_Without_Executing_Or_Exposing_Callback()
+    {
+        var callbackCalls = 0;
+        var shield = Shield.Retry(1, Backoff.Custom(_ =>
+        {
+            callbackCalls++;
+            return TimeSpan.FromSeconds(callbackCalls);
+        }));
+
+        var backoff = shield.GetDescriptor()
+            .AssertContainsSingle<RetryStrategyDescriptor>()
+            .Backoff;
+
+        await Assert.That(backoff.Kind).IsEqualTo(BackoffKind.Custom);
+        await Assert.That(backoff.BaseDelay).IsNull();
+        await Assert.That(backoff.Factor).IsNull();
+        await Assert.That(backoff.MaxDelay).IsNull();
+        await Assert.That(backoff.Jitter).IsNull();
+        await Assert.That(callbackCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Built_In_Backoff_Options_Are_Captured_As_Inert_Values()
+    {
+        var none = DescribeBackoff(Backoff.None);
+        var linear = DescribeBackoff(Backoff.Linear(
+            TimeSpan.FromMilliseconds(20),
+            TimeSpan.FromSeconds(2)));
+        var exponential = DescribeBackoff(Backoff.Exponential(
+            TimeSpan.FromMilliseconds(30),
+            factor: 3,
+            maxDelay: TimeSpan.FromSeconds(4),
+            jitter: false));
+
+        await Assert.That(none.Kind).IsEqualTo(BackoffKind.None);
+        await Assert.That(none.BaseDelay).IsEqualTo(TimeSpan.Zero);
+        await Assert.That(linear.Kind).IsEqualTo(BackoffKind.Linear);
+        await Assert.That(linear.BaseDelay).IsEqualTo(TimeSpan.FromMilliseconds(20));
+        await Assert.That(linear.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(exponential.Kind).IsEqualTo(BackoffKind.Exponential);
+        await Assert.That(exponential.BaseDelay).IsEqualTo(TimeSpan.FromMilliseconds(30));
+        await Assert.That(exponential.Factor).IsEqualTo(3);
+        await Assert.That(exponential.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(4));
+        await Assert.That(exponential.Jitter).IsFalse();
+    }
+
+    [Test]
     public async Task Assertion_Failures_Explain_Expected_And_Actual_Shape()
     {
         var descriptor = Shield.Timeout(TimeSpan.FromSeconds(1)).GetDescriptor();
@@ -176,4 +225,10 @@ public class PipelineDescriptorTests
             Continuation<T, TState> next,
             KevlarContext context) => next.InvokeAsync(context);
     }
+
+    private static BackoffDescriptor DescribeBackoff(Backoff backoff) =>
+        Shield.Retry(1, backoff)
+            .GetDescriptor()
+            .AssertContainsSingle<RetryStrategyDescriptor>()
+            .Backoff;
 }

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -69,6 +69,7 @@ public class PipelineDescriptorTests
         var retry = descriptor.AssertContainsSingle<RetryStrategyDescriptor>();
         await Assert.That(retry.MaxRetries).IsEqualTo(4);
         await Assert.That(retry.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(1));
+        await Assert.That(retry.HasDelayGenerator).IsFalse();
         await Assert.That(retry.HasNotification).IsTrue();
         await Assert.That(retry.Backoff.Kind).IsEqualTo(BackoffKind.Constant);
         await Assert.That(retry.Backoff.BaseDelay).IsEqualTo(TimeSpan.FromMilliseconds(50));
@@ -78,9 +79,12 @@ public class PipelineDescriptorTests
         await Assert.That(breaker.MinimumThroughput).IsEqualTo(8);
         await Assert.That(breaker.SamplingWindow).IsEqualTo(TimeSpan.FromSeconds(20));
         await Assert.That(breaker.BreakDuration).IsEqualTo(TimeSpan.FromSeconds(7));
+        await Assert.That(breaker.HasMonitor).IsFalse();
+        await Assert.That(breaker.HasNotification).IsTrue();
 
         var rateLimit = descriptor.AssertContainsSingle<RateLimitStrategyDescriptor>();
         await Assert.That(rateLimit.Permits).IsEqualTo(10);
+        await Assert.That(rateLimit.Window).IsEqualTo(TimeSpan.FromSeconds(5));
         await Assert.That(rateLimit.Burst).IsEqualTo(12);
         await Assert.That(rateLimit.QueueLimit).IsEqualTo(3);
 
@@ -90,6 +94,7 @@ public class PipelineDescriptorTests
 
         var hedge = descriptor.AssertContainsSingle<HedgingStrategyDescriptor>();
         await Assert.That(hedge.MaxAttempts).IsEqualTo(3);
+        await Assert.That(hedge.Delay).IsEqualTo(TimeSpan.FromMilliseconds(25));
         await Assert.That(hedge.HasNotification).IsTrue();
     }
 
@@ -114,6 +119,16 @@ public class PipelineDescriptorTests
         var fallback = descriptor.AssertContainsSingle<FallbackStrategyDescriptor>();
         await Assert.That(fallback.ResultType).IsEqualTo(typeof(int));
         await Assert.That(fallback.IsVoid).IsFalse();
+        await Assert.That(fallback.HasNotification).IsFalse();
+
+        var voidFallback = Shield
+            .When<InvalidOperationException>()
+            .Fallback(static (_, _) => default)
+            .GetDescriptor()
+            .AssertContainsSingle<FallbackStrategyDescriptor>();
+        await Assert.That(voidFallback.ResultType).IsNull();
+        await Assert.That(voidFallback.IsVoid).IsTrue();
+        await Assert.That(voidFallback.HasNotification).IsFalse();
     }
 
     [Test]

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -1,0 +1,179 @@
+using Kevlar.Testing;
+using Microsoft.Extensions.Time.Testing;
+using System.Collections.ObjectModel;
+
+namespace Kevlar.Testing.Tests;
+
+public class PipelineDescriptorTests
+{
+    [Test]
+    public async Task Descriptor_Preserves_Order_Metadata_And_Safe_Configuration()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var shield = Shield
+            .Timeout(options =>
+            {
+                options.Timeout = TimeSpan.FromSeconds(2);
+                options.OnTimeout = _ => { };
+            })
+            .Retry(options =>
+            {
+                options.MaxRetries = 4;
+                options.Backoff = Backoff.Constant(TimeSpan.FromMilliseconds(50));
+                options.MaxDelay = TimeSpan.FromSeconds(1);
+                options.OnRetryAsync = _ => default;
+            })
+            .CircuitBreaker(options =>
+            {
+                options.FailureRatio = 0.25;
+                options.MinimumThroughput = 8;
+                options.SamplingWindow = TimeSpan.FromSeconds(20);
+                options.BreakDuration = TimeSpan.FromSeconds(7);
+                options.OnStateChanged = _ => { };
+            })
+            .RateLimit(options =>
+            {
+                options.Permits = 10;
+                options.Window = TimeSpan.FromSeconds(5);
+                options.Burst = 12;
+                options.QueueLimit = 3;
+            })
+            .ConcurrencyLimit(6, maxQueue: 2)
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 3;
+                options.Delay = TimeSpan.FromMilliseconds(25);
+                options.OnHedge = _ => { };
+            })
+            .WithName("orders")
+            .WithTimeProvider(timeProvider);
+
+        var descriptor = shield.GetDescriptor();
+
+        await Assert.That(descriptor.Name).IsEqualTo("orders");
+        await Assert.That(descriptor.ResultType).IsNull();
+        await Assert.That(descriptor.UsesCustomTimeProvider).IsTrue();
+        descriptor.AssertStrategyOrder(
+            StrategyKind.Timeout,
+            StrategyKind.Retry,
+            StrategyKind.CircuitBreaker,
+            StrategyKind.RateLimit,
+            StrategyKind.ConcurrencyLimit,
+            StrategyKind.Hedging);
+
+        var timeout = descriptor.AssertContainsSingle<TimeoutStrategyDescriptor>();
+        await Assert.That(timeout.Timeout).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(timeout.HasTimeoutGenerator).IsFalse();
+        await Assert.That(timeout.HasNotification).IsTrue();
+
+        var retry = descriptor.AssertContainsSingle<RetryStrategyDescriptor>();
+        await Assert.That(retry.MaxRetries).IsEqualTo(4);
+        await Assert.That(retry.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(1));
+        await Assert.That(retry.HasNotification).IsTrue();
+
+        var breaker = descriptor.AssertContainsSingle<CircuitBreakerStrategyDescriptor>();
+        await Assert.That(breaker.FailureRatio).IsEqualTo(0.25);
+        await Assert.That(breaker.MinimumThroughput).IsEqualTo(8);
+        await Assert.That(breaker.SamplingWindow).IsEqualTo(TimeSpan.FromSeconds(20));
+        await Assert.That(breaker.BreakDuration).IsEqualTo(TimeSpan.FromSeconds(7));
+
+        var rateLimit = descriptor.AssertContainsSingle<RateLimitStrategyDescriptor>();
+        await Assert.That(rateLimit.Permits).IsEqualTo(10);
+        await Assert.That(rateLimit.Burst).IsEqualTo(12);
+        await Assert.That(rateLimit.QueueLimit).IsEqualTo(3);
+
+        var concurrency = descriptor.AssertContainsSingle<ConcurrencyLimitStrategyDescriptor>();
+        await Assert.That(concurrency.MaxConcurrency).IsEqualTo(6);
+        await Assert.That(concurrency.MaxQueue).IsEqualTo(2);
+
+        var hedge = descriptor.AssertContainsSingle<HedgingStrategyDescriptor>();
+        await Assert.That(hedge.MaxAttempts).IsEqualTo(3);
+        await Assert.That(hedge.HasNotification).IsTrue();
+    }
+
+    [Test]
+    public async Task Typed_Fallback_And_Composition_Are_Described_Without_State_Exposure()
+    {
+        var outer = Shield.For<int>()
+            .WhenResult(-1)
+            .Fallback(42)
+            .Retry(2, Backoff.None)
+            .WithName("typed");
+        var composed = outer.Wrap(Shield.Timeout(TimeSpan.FromSeconds(3)));
+
+        var descriptor = composed.GetDescriptor();
+
+        await Assert.That(descriptor.Name).IsEqualTo("typed");
+        await Assert.That(descriptor.ResultType).IsEqualTo(typeof(int));
+        descriptor.AssertStrategyOrder(
+            StrategyKind.Fallback,
+            StrategyKind.Retry,
+            StrategyKind.Timeout);
+        var fallback = descriptor.AssertContainsSingle<FallbackStrategyDescriptor>();
+        await Assert.That(fallback.ResultType).IsEqualTo(typeof(int));
+        await Assert.That(fallback.IsVoid).IsFalse();
+    }
+
+    [Test]
+    public async Task Custom_Strategy_Uses_A_Diagnostic_Descriptor()
+    {
+        var shield = Shield.Empty.Use(new PassThroughStrategy());
+
+        var custom = shield.GetDescriptor().AssertContainsSingle<CustomStrategyDescriptor>();
+
+        await Assert.That(custom.StrategyType).IsEqualTo(typeof(PassThroughStrategy));
+        await Assert.That(custom.Description).IsEqualTo("pass-through");
+    }
+
+    [Test]
+    public async Task Descriptor_Is_An_Immutable_Snapshot_For_Unnamed_Untyped_Shields()
+    {
+        var shield = Shield.Empty
+            .Retry(1, Backoff.None)
+            .Retry(2, Backoff.None);
+
+        var descriptor = shield.GetDescriptor();
+        var strategies = (IList<StrategyDescriptor>)descriptor.Strategies;
+
+        await Assert.That(descriptor.Name).IsNull();
+        await Assert.That(descriptor.ResultType).IsNull();
+        await Assert.That(descriptor.UsesCustomTimeProvider).IsFalse();
+        await Assert.That(descriptor.Strategies).IsTypeOf<ReadOnlyCollection<StrategyDescriptor>>();
+        await Assert.That(strategies.IsReadOnly).IsTrue();
+        descriptor.AssertStrategyCount(2);
+        await Assert.That(descriptor.AssertContains<RetryStrategyDescriptor>().MaxRetries).IsEqualTo(1);
+
+        var mutation = await Assert.That(() => strategies[0] = strategies[1])
+            .Throws<NotSupportedException>();
+        await Assert.That(mutation).IsNotNull();
+    }
+
+    [Test]
+    public async Task Assertion_Failures_Explain_Expected_And_Actual_Shape()
+    {
+        var descriptor = Shield.Timeout(TimeSpan.FromSeconds(1)).GetDescriptor();
+
+        var orderFailure = await Assert.That(() => descriptor.AssertStrategyOrder(StrategyKind.Retry))
+            .Throws<ShieldAssertionException>();
+        await Assert.That(orderFailure!.Message).Contains("expected [Retry]");
+        await Assert.That(orderFailure.Message).Contains("actual [Timeout]");
+
+        var countFailure = await Assert.That(() => descriptor.AssertStrategyCount(2))
+            .Throws<ShieldAssertionException>();
+        await Assert.That(countFailure!.Message).Contains("expected 2 strategies, actual 1");
+
+        var presenceFailure = await Assert.That(
+                () => descriptor.AssertContains<RetryStrategyDescriptor>())
+            .Throws<ShieldAssertionException>();
+        await Assert.That(presenceFailure!.Message).Contains("Expected at least one RetryStrategyDescriptor");
+    }
+
+    private sealed class PassThroughStrategy : Strategy
+    {
+        public override string Describe() => "pass-through";
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
+    }
+}

--- a/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
@@ -20,6 +20,18 @@ public class BulkheadTests
     }
 
     [Test]
+    public async Task Rejects_Invalid_Limits_With_Descriptive_Errors()
+    {
+        await Assert.That(() => Shield.ConcurrencyLimit(maxConcurrency: 0))
+            .Throws<ArgumentOutOfRangeException>()
+            .WithMessage("MaxConcurrency must be positive. (Parameter 'options')");
+
+        await Assert.That(() => Shield.ConcurrencyLimit(maxConcurrency: 1, maxQueue: -1))
+            .Throws<ArgumentOutOfRangeException>()
+            .WithMessage("MaxQueue must not be negative. (Parameter 'options')");
+    }
+
+    [Test]
     public async Task Rejects_When_Concurrency_And_Queue_Are_Full()
     {
         var shield = Shield.ConcurrencyLimit(maxConcurrency: 1);

--- a/tests/Kevlar.Tests/StrategyInspectionTests.cs
+++ b/tests/Kevlar.Tests/StrategyInspectionTests.cs
@@ -1,0 +1,71 @@
+using Kevlar.Strategies;
+
+namespace Kevlar.Tests;
+
+public class StrategyInspectionTests
+{
+    [Test]
+    public async Task Inspection_Metadata_Reflects_Configured_Callbacks()
+    {
+        var retry = GetStrategy<RetryStrategy>(Shield.Retry(options =>
+        {
+            options.DelayGeneratorAsync = static _ => default;
+            options.OnRetryAsync = static _ => default;
+        }));
+        var fixedRetry = GetStrategy<RetryStrategy>(Shield.Retry(2, Backoff.None));
+        await Assert.That(retry.HasDelayGenerator).IsTrue();
+        await Assert.That(retry.HasNotification).IsTrue();
+        await Assert.That(fixedRetry.HasDelayGenerator).IsFalse();
+        await Assert.That(fixedRetry.HasNotification).IsFalse();
+
+        var timeout = GetStrategy<TimeoutStrategy>(Shield.Timeout(options =>
+        {
+            options.TimeoutGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
+            options.OnTimeoutAsync = static _ => default;
+        }));
+        var fixedTimeout = GetStrategy<TimeoutStrategy>(Shield.Timeout(TimeSpan.FromSeconds(1)));
+        await Assert.That(timeout.HasTimeoutGenerator).IsTrue();
+        await Assert.That(timeout.HasNotification).IsTrue();
+        await Assert.That(fixedTimeout.HasTimeoutGenerator).IsFalse();
+        await Assert.That(fixedTimeout.HasNotification).IsFalse();
+
+        var notifiedHedge = GetStrategy<HedgingStrategy>(Shield.Hedge(options =>
+        {
+            options.OnHedge = static _ => { };
+        }));
+        var fixedHedge = GetStrategy<HedgingStrategy>(Shield.Hedge(2, TimeSpan.Zero));
+        await Assert.That(notifiedHedge.HasNotification).IsTrue();
+        await Assert.That(fixedHedge.HasNotification).IsFalse();
+
+        var monitoredCircuit = GetStrategy<CircuitBreakerStrategy>(Shield.CircuitBreaker(options =>
+        {
+            options.Monitor = new CircuitBreakerMonitor();
+            options.OnStateChanged = static _ => { };
+        }));
+        var fixedCircuit = GetStrategy<CircuitBreakerStrategy>(
+            Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)));
+        await Assert.That(monitoredCircuit.Core.HasMonitor).IsTrue();
+        await Assert.That(monitoredCircuit.Core.HasNotification).IsTrue();
+        await Assert.That(fixedCircuit.Core.HasMonitor).IsFalse();
+        await Assert.That(fixedCircuit.Core.HasNotification).IsFalse();
+
+        var notifiedFallback = GetInspection(Shield.For<int>().Fallback(42, static _ => { }));
+        var fixedFallback = GetInspection(Shield.For<int>().Fallback(42));
+        var voidFallback = GetInspection(
+            Shield.When<InvalidOperationException>().Fallback(static (_, _) => default));
+        await Assert.That(notifiedFallback.HasNotification).IsTrue();
+        await Assert.That(fixedFallback.HasNotification).IsFalse();
+        await Assert.That(voidFallback.HasNotification).IsFalse();
+        await Assert.That(notifiedFallback.ResultType).IsEqualTo(typeof(int));
+        await Assert.That(voidFallback.ResultType).IsNull();
+    }
+
+    private static TStrategy GetStrategy<TStrategy>(Shield shield)
+        where TStrategy : Strategy => (TStrategy)shield.Strategies.Single();
+
+    private static IFallbackStrategyInspection GetInspection<TResult>(Shield<TResult> shield) =>
+        (IFallbackStrategyInspection)shield.Strategies.Single();
+
+    private static IFallbackStrategyInspection GetInspection(Shield shield) =>
+        (IFallbackStrategyInspection)shield.Strategies.Single();
+}

--- a/tests/Kevlar.Tests/StrategyInspectionTests.cs
+++ b/tests/Kevlar.Tests/StrategyInspectionTests.cs
@@ -7,55 +7,102 @@ public class StrategyInspectionTests
     [Test]
     public async Task Inspection_Metadata_Reflects_Configured_Callbacks()
     {
+        var retryBackoff = Backoff.Linear(TimeSpan.FromMilliseconds(125));
+        var retryMaxDelay = TimeSpan.FromSeconds(9);
         var retry = GetStrategy<RetryStrategy>(Shield.Retry(options =>
         {
+            options.MaxRetries = 7;
+            options.Backoff = retryBackoff;
+            options.MaxDelay = retryMaxDelay;
             options.DelayGeneratorAsync = static _ => default;
             options.OnRetryAsync = static _ => default;
         }));
         var fixedRetry = GetStrategy<RetryStrategy>(Shield.Retry(2, Backoff.None));
+        await Assert.That(retry.MaxRetries).IsEqualTo(7);
+        await Assert.That(retry.Backoff).IsSameReferenceAs(retryBackoff);
+        await Assert.That(retry.MaxDelay).IsEqualTo(retryMaxDelay);
         await Assert.That(retry.HasDelayGenerator).IsTrue();
         await Assert.That(retry.HasNotification).IsTrue();
+        await Assert.That(fixedRetry.MaxRetries).IsEqualTo(2);
+        await Assert.That(fixedRetry.Backoff).IsSameReferenceAs(Backoff.None);
+        await Assert.That(fixedRetry.MaxDelay).IsNull();
         await Assert.That(fixedRetry.HasDelayGenerator).IsFalse();
         await Assert.That(fixedRetry.HasNotification).IsFalse();
 
+        var timeoutDuration = TimeSpan.FromSeconds(7);
         var timeout = GetStrategy<TimeoutStrategy>(Shield.Timeout(options =>
         {
+            options.Timeout = timeoutDuration;
             options.TimeoutGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
             options.OnTimeoutAsync = static _ => default;
         }));
         var fixedTimeout = GetStrategy<TimeoutStrategy>(Shield.Timeout(TimeSpan.FromSeconds(1)));
+        await Assert.That(timeout.Timeout).IsEqualTo(timeoutDuration);
         await Assert.That(timeout.HasTimeoutGenerator).IsTrue();
         await Assert.That(timeout.HasNotification).IsTrue();
+        await Assert.That(fixedTimeout.Timeout).IsEqualTo(TimeSpan.FromSeconds(1));
         await Assert.That(fixedTimeout.HasTimeoutGenerator).IsFalse();
         await Assert.That(fixedTimeout.HasNotification).IsFalse();
 
         var notifiedHedge = GetStrategy<HedgingStrategy>(Shield.Hedge(options =>
         {
+            options.MaxAttempts = 4;
+            options.Delay = TimeSpan.FromMilliseconds(17);
             options.OnHedge = static _ => { };
         }));
         var fixedHedge = GetStrategy<HedgingStrategy>(Shield.Hedge(2, TimeSpan.Zero));
+        await Assert.That(notifiedHedge.MaxAttempts).IsEqualTo(4);
+        await Assert.That(notifiedHedge.Delay).IsEqualTo(TimeSpan.FromMilliseconds(17));
         await Assert.That(notifiedHedge.HasNotification).IsTrue();
+        await Assert.That(fixedHedge.MaxAttempts).IsEqualTo(2);
+        await Assert.That(fixedHedge.Delay).IsEqualTo(TimeSpan.Zero);
         await Assert.That(fixedHedge.HasNotification).IsFalse();
 
         var monitoredCircuit = GetStrategy<CircuitBreakerStrategy>(Shield.CircuitBreaker(options =>
         {
+            options.FailureRatio = 0.25;
+            options.MinimumThroughput = 7;
+            options.SamplingWindow = TimeSpan.FromSeconds(13);
+            options.BreakDuration = TimeSpan.FromSeconds(19);
             options.Monitor = new CircuitBreakerMonitor();
             options.OnStateChanged = static _ => { };
         }));
         var fixedCircuit = GetStrategy<CircuitBreakerStrategy>(
             Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)));
+        await Assert.That(monitoredCircuit.Core.ConsecutiveFailures).IsNull();
+        await Assert.That(monitoredCircuit.Core.FailureRatio).IsEqualTo(0.25);
+        await Assert.That(monitoredCircuit.Core.MinimumThroughput).IsEqualTo(7);
+        await Assert.That(monitoredCircuit.Core.SamplingWindow).IsEqualTo(TimeSpan.FromSeconds(13));
+        await Assert.That(monitoredCircuit.Core.BreakDuration).IsEqualTo(TimeSpan.FromSeconds(19));
         await Assert.That(monitoredCircuit.Core.HasMonitor).IsTrue();
         await Assert.That(monitoredCircuit.Core.HasNotification).IsTrue();
+        await Assert.That(fixedCircuit.Core.ConsecutiveFailures).IsEqualTo(2);
+        await Assert.That(fixedCircuit.Core.FailureRatio).IsNull();
+        await Assert.That(fixedCircuit.Core.BreakDuration).IsEqualTo(TimeSpan.FromSeconds(1));
         await Assert.That(fixedCircuit.Core.HasMonitor).IsFalse();
         await Assert.That(fixedCircuit.Core.HasNotification).IsFalse();
 
         var notifiedFallback = GetInspection(Shield.For<int>().Fallback(42, static _ => { }));
+        var asyncNotifiedFallback = GetInspection(Shield.For<int>().FallbackWithNotifications(
+            42,
+            new FallbackOptions<int> { OnFallbackAsync = static _ => default }));
         var fixedFallback = GetInspection(Shield.For<int>().Fallback(42));
         var voidFallback = GetInspection(
             Shield.When<InvalidOperationException>().Fallback(static (_, _) => default));
+        var notifiedVoidFallback = GetInspection(
+            Shield.When<InvalidOperationException>().FallbackWithNotifications(
+                static (_, _) => default,
+                new FallbackOptions { OnFallback = static _ => { } }));
+        var asyncNotifiedVoidFallback = GetInspection(
+            Shield.When<InvalidOperationException>().FallbackWithNotifications(
+                static (_, _) => default,
+                new FallbackOptions { OnFallbackAsync = static _ => default }));
         await Assert.That(notifiedFallback.HasNotification).IsTrue();
+        await Assert.That(asyncNotifiedFallback.HasNotification).IsTrue();
         await Assert.That(fixedFallback.HasNotification).IsFalse();
         await Assert.That(voidFallback.HasNotification).IsFalse();
+        await Assert.That(notifiedVoidFallback.HasNotification).IsTrue();
+        await Assert.That(asyncNotifiedVoidFallback.HasNotification).IsTrue();
         await Assert.That(notifiedFallback.ResultType).IsEqualTo(typeof(int));
         await Assert.That(voidFallback.ResultType).IsNull();
     }


### PR DESCRIPTION
Adds the isolated Kevlar.Testing package with immutable typed pipeline descriptors and framework-independent shape assertions. Integrates public API, package consumer, documentation, and CI checks; production execution paths gain no hooks or allocations. Validation: Release build; 563 unit, 1 netstandard, 16 integration, 19 analyzer, 5 testing, and 2 allocation tests; package verification; 83 documentation snippets; Docusaurus build. Closes #97.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `Kevlar.Testing` package for inspecting shield pipelines without executing them.
  * Added descriptors for pipeline metadata, strategy order, configuration, callbacks, and backoff settings.
  * Added framework-independent assertions for strategy counts, ordering, and descriptor types.
* **Documentation**
  * Documented pipeline inspection, assertions, package usage, and coverage commands.
* **Tests**
  * Added comprehensive coverage for descriptors, strategy metadata, assertions, and immutable snapshots.
  * Integrated the testing suite into automated builds and coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->