### PR TITLE
feat(hedging): add per-attempt actions

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/HedgingBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HedgingBenchmarks.cs
@@ -40,7 +40,7 @@ public class HedgingBenchmarks
         options.MaxAttempts = 2;
         options.Delay = TimeSpan.Zero;
         options.ActionGenerator = HedgeActionGenerator.Create<int>(
-            static _ => static _ => new ValueTask<int>(42));
+            static hedge => hedge.OriginalAction);
     });
 
     private static readonly ResiliencePipeline<int> PollyHedge = new ResiliencePipelineBuilder<int>()
@@ -50,27 +50,25 @@ public class HedgingBenchmarks
     private int _attempt;
 
     [BenchmarkCategory("PrimaryWins"), Benchmark(Baseline = true)]
-    public ValueTask<int> Kevlar_PrimaryWins() => KevlarHedge.ExecuteAsync(static _ => new ValueTask<int>(42));
+    public ValueTask<int> KevlarPrimaryWins() => KevlarHedge.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     [BenchmarkCategory("PrimaryWins"), Benchmark]
-    public ValueTask<int> Polly_PrimaryWins() => PollyHedge.ExecuteAsync(static _ => new ValueTask<int>(42));
+    public ValueTask<int> PollyPrimaryWins() => PollyHedge.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     [BenchmarkCategory("HedgeCallbacks"), Benchmark(Baseline = true)]
-    public ValueTask<int> Fixed_Hedge() => ExecuteFailureThenSuccess(FixedLaunch);
+    public ValueTask<int> FixedHedge() => ExecuteFailureThenSuccess(FixedLaunch);
 
     [BenchmarkCategory("HedgeCallbacks"), Benchmark]
-    public ValueTask<int> Sync_Hook() => ExecuteFailureThenSuccess(SyncHookLaunch);
+    public ValueTask<int> SyncHook() => ExecuteFailureThenSuccess(SyncHookLaunch);
 
     [BenchmarkCategory("HedgeCallbacks"), Benchmark]
-    public ValueTask<int> Completed_Async_Hook() => ExecuteFailureThenSuccess(CompletedAsyncHookLaunch);
+    public ValueTask<int> CompletedAsyncHook() => ExecuteFailureThenSuccess(CompletedAsyncHookLaunch);
 
     [BenchmarkCategory("HedgeCallbacks"), Benchmark]
-    public ValueTask<int> Yielding_Async_Hook() => ExecuteFailureThenSuccess(YieldingAsyncHookLaunch);
+    public ValueTask<int> YieldingAsyncHook() => ExecuteFailureThenSuccess(YieldingAsyncHookLaunch);
 
     [BenchmarkCategory("HedgeCallbacks"), Benchmark]
-    public ValueTask<int> Generated_Action() =>
-        GeneratedLaunch.ExecuteAsync(static _ =>
-            ValueTask.FromException<int>(new InvalidOperationException()));
+    public ValueTask<int> GeneratedAction() => ExecuteFailureThenSuccess(GeneratedLaunch);
 
     private ValueTask<int> ExecuteFailureThenSuccess(Shield<int> shield)
     {

--- a/benchmarks/Kevlar.Benchmarks/HedgingBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HedgingBenchmarks.cs
@@ -74,9 +74,9 @@ public class HedgingBenchmarks
 
     private ValueTask<int> ExecuteFailureThenSuccess(Shield<int> shield)
     {
-        _attempt = 0;
+        Volatile.Write(ref _attempt, 0);
         return shield.ExecuteAsync(this, static (benchmark, _) =>
-            ++benchmark._attempt == 1
+            Interlocked.Increment(ref benchmark._attempt) == 1
                 ? ValueTask.FromException<int>(new InvalidOperationException())
                 : new ValueTask<int>(42));
     }

--- a/benchmarks/Kevlar.Benchmarks/HedgingBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HedgingBenchmarks.cs
@@ -16,14 +16,68 @@ namespace Kevlar.Benchmarks;
 public class HedgingBenchmarks
 {
     private static readonly Shield<int> KevlarHedge = Shield.For<int>().Hedge(2, TimeSpan.FromSeconds(10));
+    private static readonly Shield<int> FixedLaunch = Shield.For<int>().Hedge(2, TimeSpan.Zero);
+    private static readonly Shield<int> SyncHookLaunch = Shield.For<int>().Hedge(options =>
+    {
+        options.MaxAttempts = 2;
+        options.Delay = TimeSpan.Zero;
+        options.OnHedge = static _ => { };
+    });
+    private static readonly Shield<int> CompletedAsyncHookLaunch = Shield.For<int>().Hedge(options =>
+    {
+        options.MaxAttempts = 2;
+        options.Delay = TimeSpan.Zero;
+        options.OnHedgeAsync = static _ => ValueTask.CompletedTask;
+    });
+    private static readonly Shield<int> YieldingAsyncHookLaunch = Shield.For<int>().Hedge(options =>
+    {
+        options.MaxAttempts = 2;
+        options.Delay = TimeSpan.Zero;
+        options.OnHedgeAsync = static async _ => await Task.Yield();
+    });
+    private static readonly Shield<int> GeneratedLaunch = Shield.For<int>().Hedge(options =>
+    {
+        options.MaxAttempts = 2;
+        options.Delay = TimeSpan.Zero;
+        options.ActionGenerator = HedgeActionGenerator.Create<int>(
+            static _ => static _ => new ValueTask<int>(42));
+    });
 
     private static readonly ResiliencePipeline<int> PollyHedge = new ResiliencePipelineBuilder<int>()
         .AddHedging(new HedgingStrategyOptions<int> { MaxHedgedAttempts = 1, Delay = TimeSpan.FromSeconds(10) })
         .Build();
+
+    private int _attempt;
 
     [BenchmarkCategory("PrimaryWins"), Benchmark(Baseline = true)]
     public ValueTask<int> Kevlar_PrimaryWins() => KevlarHedge.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     [BenchmarkCategory("PrimaryWins"), Benchmark]
     public ValueTask<int> Polly_PrimaryWins() => PollyHedge.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("HedgeCallbacks"), Benchmark(Baseline = true)]
+    public ValueTask<int> Fixed_Hedge() => ExecuteFailureThenSuccess(FixedLaunch);
+
+    [BenchmarkCategory("HedgeCallbacks"), Benchmark]
+    public ValueTask<int> Sync_Hook() => ExecuteFailureThenSuccess(SyncHookLaunch);
+
+    [BenchmarkCategory("HedgeCallbacks"), Benchmark]
+    public ValueTask<int> Completed_Async_Hook() => ExecuteFailureThenSuccess(CompletedAsyncHookLaunch);
+
+    [BenchmarkCategory("HedgeCallbacks"), Benchmark]
+    public ValueTask<int> Yielding_Async_Hook() => ExecuteFailureThenSuccess(YieldingAsyncHookLaunch);
+
+    [BenchmarkCategory("HedgeCallbacks"), Benchmark]
+    public ValueTask<int> Generated_Action() =>
+        GeneratedLaunch.ExecuteAsync(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException()));
+
+    private ValueTask<int> ExecuteFailureThenSuccess(Shield<int> shield)
+    {
+        _attempt = 0;
+        return shield.ExecuteAsync(this, static (benchmark, _) =>
+            ++benchmark._attempt == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException())
+                : new ValueTask<int>(42));
+    }
 }

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -17,6 +17,7 @@ Shield.Hedge(o =>
     o.MaxAttempts = 2;                        // default 2 (total attempts, incl. the first)
     o.Delay = TimeSpan.FromSeconds(1);        // default 1s
     o.OnHedge = e => logger.LogInformation("Hedge attempt {Attempt}", e.Attempt);
+    o.OnHedgeAsync = static _ => ValueTask.CompletedTask;
 });
 ```
 
@@ -27,6 +28,37 @@ Shield.Hedge(o =>
 | `MaxAttempts` | `2` | Total attempts, including the first |
 | `Delay` | `1s` | Wait before launching the next attempt (see special values below) |
 | `OnHedge` | — | Callback when a hedge launches — `e.Attempt` is 1-based, so `2` = first hedge |
+| `OnHedgeAsync` | — | Awaited callback after `OnHedge` and before the attempt starts |
+| `ActionGenerator` | — | Select a different operation for each additional attempt; `null` uses the original |
+
+### Selecting another target
+
+Use `HedgeActionGenerator.Create<TResult>` to send a hedge to a different replica without boxing
+the result. The generator runs after both hedge callbacks and receives the isolated attempt context.
+`OriginalAction` includes strategies nested inside the hedge, so returning it preserves the inner
+pipeline. Returning another operation replaces that inner pipeline for that attempt.
+
+```csharp
+var replicas = new Func<CancellationToken, ValueTask<string>>[]
+{
+    static _ => new ValueTask<string>("primary"),
+    static _ => new ValueTask<string>("secondary"),
+    static _ => new ValueTask<string>("tertiary"),
+};
+var shield = Shield.For<string>().Hedge(o =>
+{
+    o.MaxAttempts = replicas.Length;
+    o.Delay = TimeSpan.FromMilliseconds(100);
+    o.ActionGenerator = HedgeActionGenerator.Create<string>(hedge =>
+        ct => replicas[hedge.Attempt - 1](ct));
+});
+
+// The original callback is attempt 1; generated callbacks are attempts 2 and 3.
+var response = await shield.ExecuteAsync(ct => replicas[0](ct));
+```
+
+For a void execution, use the non-generic `HedgeActionGenerator.Create` overload. A generator must
+match the execution result type; a mismatch fails before the additional operation starts.
 
 ### Special delay values
 
@@ -41,9 +73,12 @@ Multiple invocations of your delegate may be in flight at once — it must be sa
 :::
 
 - Losing attempts are cancelled through their token (use the token you're handed!).
-- Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside `OnHedge`. A cancellation already observable at the launch boundary suppresses `OnHedge` too.
-- The `kevlar.hedges` counter records only attempts that launch after `OnHedge` returns successfully and cancellation is rechecked. Suppressed launches and failing callbacks are not counted.
+- Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside `OnHedge`/`OnHedgeAsync`. A cancellation already observable at the launch boundary suppresses both callbacks.
+- Launch ordering is `OnHedge`, awaited `OnHedgeAsync`, action generation, metrics, then the selected operation. Callback or generator failures preserve their exception identity, cancel in-flight attempts, and are not counted as launched hedges.
 - Each attempt gets a forked context — `Properties` are copied at launch time, so attempts don't see each other's writes.
+- Callback contexts are pooled. Do not retain them after the synchronous callback or returned `ValueTask` completes; a generated action's isolated context remains valid until that attempt completes.
+- Callbacks and generators run without a strategy lock. They may re-enter the same shield, and concurrent shield executions may invoke them concurrently; keep captured state thread-safe.
+- Losing operations are cancelled first, then their isolated contexts are returned to the pool after those operations complete.
 - What counts as a failure is the ambient [handling clause](../handling-failures.md), like every reactive strategy.
 
 ## When to hedge (and when not to)

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -86,3 +86,20 @@ Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(System.Func<System.Threa
 Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(TResult fallbackValue, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
 static Kevlar.ShieldExtensions.FallbackWithNotifications(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.FallbackWithNotifications(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!
+Kevlar.HedgeActionGenerator
+Kevlar.HedgeActionGeneratorEvent
+Kevlar.HedgeActionGeneratorEvent.HedgeActionGeneratorEvent() -> void
+Kevlar.HedgeActionGeneratorEvent.Attempt.get -> int
+Kevlar.HedgeActionGeneratorEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.HedgeActionGeneratorEvent.OriginalAction.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>!
+Kevlar.HedgeActionGeneratorEvent<TResult>
+Kevlar.HedgeActionGeneratorEvent<TResult>.HedgeActionGeneratorEvent() -> void
+Kevlar.HedgeActionGeneratorEvent<TResult>.Attempt.get -> int
+Kevlar.HedgeActionGeneratorEvent<TResult>.Context.get -> Kevlar.KevlarContext!
+Kevlar.HedgeActionGeneratorEvent<TResult>.OriginalAction.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>!
+Kevlar.HedgingOptions.ActionGenerator.get -> Kevlar.HedgeActionGenerator?
+Kevlar.HedgingOptions.ActionGenerator.set -> void
+Kevlar.HedgingOptions.OnHedgeAsync.get -> System.Func<Kevlar.HedgeEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.HedgingOptions.OnHedgeAsync.set -> void
+static Kevlar.HedgeActionGenerator.Create(System.Func<Kevlar.HedgeActionGeneratorEvent, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>?>! generator) -> Kevlar.HedgeActionGenerator!
+static Kevlar.HedgeActionGenerator.Create<TResult>(System.Func<Kevlar.HedgeActionGeneratorEvent<TResult>, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>?>! generator) -> Kevlar.HedgeActionGenerator!

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGenerator.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGenerator.cs
@@ -75,62 +75,20 @@ public sealed class HedgeActionGenerator
 
     private sealed class VoidOriginalActionAdapter(Func<CancellationToken, ValueTask<Nothing>> action)
     {
-        public async ValueTask Invoke(CancellationToken cancellationToken) =>
+        public async ValueTask Invoke(CancellationToken cancellationToken)
+        {
+            // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
             _ = await action(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private sealed class VoidActionAdapter(Func<CancellationToken, ValueTask> action)
     {
         public async ValueTask<Nothing> Invoke(CancellationToken cancellationToken)
         {
+            // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
             await action(cancellationToken).ConfigureAwait(false);
             return Nothing.Value;
         }
     }
-}
-
-/// <summary>Arguments used to select a result-returning operation for a hedged attempt.</summary>
-public readonly struct HedgeActionGeneratorEvent<TResult>
-{
-    internal HedgeActionGeneratorEvent(
-        int attempt,
-        KevlarContext context,
-        Func<CancellationToken, ValueTask<TResult>> originalAction)
-    {
-        Attempt = attempt;
-        Context = context;
-        OriginalAction = originalAction;
-    }
-
-    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
-    public int Attempt { get; }
-
-    /// <summary>The isolated context that belongs to this attempt.</summary>
-    public KevlarContext Context { get; }
-
-    /// <summary>The original operation, including strategies nested inside the hedge.</summary>
-    public Func<CancellationToken, ValueTask<TResult>> OriginalAction { get; }
-}
-
-/// <summary>Arguments used to select a void-returning operation for a hedged attempt.</summary>
-public readonly struct HedgeActionGeneratorEvent
-{
-    internal HedgeActionGeneratorEvent(
-        int attempt,
-        KevlarContext context,
-        Func<CancellationToken, ValueTask> originalAction)
-    {
-        Attempt = attempt;
-        Context = context;
-        OriginalAction = originalAction;
-    }
-
-    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
-    public int Attempt { get; }
-
-    /// <summary>The isolated context that belongs to this attempt.</summary>
-    public KevlarContext Context { get; }
-
-    /// <summary>The original operation, including strategies nested inside the hedge.</summary>
-    public Func<CancellationToken, ValueTask> OriginalAction { get; }
 }

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGenerator.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGenerator.cs
@@ -1,0 +1,136 @@
+using Kevlar.Internal;
+
+namespace Kevlar;
+
+/// <summary>
+/// A result-type-safe factory for selecting a different operation for each hedged attempt.
+/// Create one with <see cref="Create{TResult}"/> or the void <see cref="Create(Func{HedgeActionGeneratorEvent, Func{CancellationToken, ValueTask}})"/> overload.
+/// </summary>
+public sealed class HedgeActionGenerator
+{
+    private readonly Delegate _generator;
+    private readonly Type _resultType;
+
+    private HedgeActionGenerator(Delegate generator, Type resultType)
+    {
+        _generator = generator;
+        _resultType = resultType;
+    }
+
+    /// <summary>Creates a generator for operations returning <typeparamref name="TResult"/>.</summary>
+    /// <remarks>
+    /// Return <see langword="null"/> to run <see cref="HedgeActionGeneratorEvent{TResult}.OriginalAction"/>.
+    /// The returned operation receives the isolated attempt cancellation token.
+    /// </remarks>
+    public static HedgeActionGenerator Create<TResult>(
+        Func<HedgeActionGeneratorEvent<TResult>, Func<CancellationToken, ValueTask<TResult>>?> generator)
+    {
+        Throw.IfNull(generator, nameof(generator));
+        return new HedgeActionGenerator(generator, typeof(TResult));
+    }
+
+    /// <summary>Creates a generator for void-returning operations.</summary>
+    /// <remarks>
+    /// Return <see langword="null"/> to run <see cref="HedgeActionGeneratorEvent.OriginalAction"/>.
+    /// The returned operation receives the isolated attempt cancellation token.
+    /// </remarks>
+    public static HedgeActionGenerator Create(
+        Func<HedgeActionGeneratorEvent, Func<CancellationToken, ValueTask>?> generator)
+    {
+        Throw.IfNull(generator, nameof(generator));
+        var adapter = new VoidGeneratorAdapter(generator);
+        return new HedgeActionGenerator(adapter.Generate, typeof(Nothing));
+    }
+
+    internal Func<CancellationToken, ValueTask<TResult>>? Generate<TResult>(
+        int attempt,
+        KevlarContext context,
+        Func<CancellationToken, ValueTask<TResult>> originalAction)
+    {
+        if (_resultType != typeof(TResult))
+        {
+            throw new InvalidOperationException(
+                $"The hedge action generator was created for '{_resultType}', but this execution returns '{typeof(TResult)}'. " +
+                "Create the generator with the execution's result type.");
+        }
+
+        var generator = (Func<HedgeActionGeneratorEvent<TResult>, Func<CancellationToken, ValueTask<TResult>>?>)_generator;
+        return generator(new HedgeActionGeneratorEvent<TResult>(attempt, context, originalAction));
+    }
+
+    private sealed class VoidGeneratorAdapter(
+        Func<HedgeActionGeneratorEvent, Func<CancellationToken, ValueTask>?> generator)
+    {
+        public Func<CancellationToken, ValueTask<Nothing>>? Generate(
+            HedgeActionGeneratorEvent<Nothing> hedgeEvent)
+        {
+            var original = new VoidOriginalActionAdapter(hedgeEvent.OriginalAction);
+            var action = generator(new HedgeActionGeneratorEvent(
+                hedgeEvent.Attempt,
+                hedgeEvent.Context,
+                original.Invoke));
+            return action is null ? null : new VoidActionAdapter(action).Invoke;
+        }
+    }
+
+    private sealed class VoidOriginalActionAdapter(Func<CancellationToken, ValueTask<Nothing>> action)
+    {
+        public async ValueTask Invoke(CancellationToken cancellationToken) =>
+            _ = await action(cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed class VoidActionAdapter(Func<CancellationToken, ValueTask> action)
+    {
+        public async ValueTask<Nothing> Invoke(CancellationToken cancellationToken)
+        {
+            await action(cancellationToken).ConfigureAwait(false);
+            return Nothing.Value;
+        }
+    }
+}
+
+/// <summary>Arguments used to select a result-returning operation for a hedged attempt.</summary>
+public readonly struct HedgeActionGeneratorEvent<TResult>
+{
+    internal HedgeActionGeneratorEvent(
+        int attempt,
+        KevlarContext context,
+        Func<CancellationToken, ValueTask<TResult>> originalAction)
+    {
+        Attempt = attempt;
+        Context = context;
+        OriginalAction = originalAction;
+    }
+
+    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
+    public int Attempt { get; }
+
+    /// <summary>The isolated context that belongs to this attempt.</summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>The original operation, including strategies nested inside the hedge.</summary>
+    public Func<CancellationToken, ValueTask<TResult>> OriginalAction { get; }
+}
+
+/// <summary>Arguments used to select a void-returning operation for a hedged attempt.</summary>
+public readonly struct HedgeActionGeneratorEvent
+{
+    internal HedgeActionGeneratorEvent(
+        int attempt,
+        KevlarContext context,
+        Func<CancellationToken, ValueTask> originalAction)
+    {
+        Attempt = attempt;
+        Context = context;
+        OriginalAction = originalAction;
+    }
+
+    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
+    public int Attempt { get; }
+
+    /// <summary>The isolated context that belongs to this attempt.</summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>The original operation, including strategies nested inside the hedge.</summary>
+    public Func<CancellationToken, ValueTask> OriginalAction { get; }
+}

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEvent.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEvent.cs
@@ -1,0 +1,27 @@
+namespace Kevlar;
+
+/// <summary>Arguments used to select a void-returning operation for a hedged attempt.</summary>
+public readonly struct HedgeActionGeneratorEvent
+{
+    internal HedgeActionGeneratorEvent(
+        int attempt,
+        KevlarContext context,
+        Func<CancellationToken, ValueTask> originalAction)
+    {
+        Attempt = attempt;
+        Context = context;
+        OriginalAction = originalAction;
+    }
+
+    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
+    public int Attempt { get; }
+
+    /// <summary>The isolated context that belongs to this attempt.</summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>
+    /// The original operation, including strategies nested inside the hedge. The supplied token
+    /// becomes the cancellation token for that nested execution.
+    /// </summary>
+    public Func<CancellationToken, ValueTask> OriginalAction { get; }
+}

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEventOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEventOfT.cs
@@ -1,0 +1,27 @@
+namespace Kevlar;
+
+/// <summary>Arguments used to select a result-returning operation for a hedged attempt.</summary>
+public readonly struct HedgeActionGeneratorEvent<TResult>
+{
+    internal HedgeActionGeneratorEvent(
+        int attempt,
+        KevlarContext context,
+        Func<CancellationToken, ValueTask<TResult>> originalAction)
+    {
+        Attempt = attempt;
+        Context = context;
+        OriginalAction = originalAction;
+    }
+
+    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
+    public int Attempt { get; }
+
+    /// <summary>The isolated context that belongs to this attempt.</summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>
+    /// The original operation, including strategies nested inside the hedge. The supplied token
+    /// becomes the cancellation token for that nested execution.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<TResult>> OriginalAction { get; }
+}

--- a/src/Kevlar/Strategies/Hedging/HedgingOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingOptions.cs
@@ -8,6 +8,9 @@ namespace Kevlar;
 /// <remarks>
 /// The executed delegate may be invoked multiple times concurrently — it must be safe to do so.
 /// Hedging requires asynchronous execution.
+/// Before an additional attempt starts, callbacks run in this order: <see cref="OnHedge"/>,
+/// <see cref="OnHedgeAsync"/>, then <see cref="ActionGenerator"/>. Caller cancellation is checked
+/// before callbacks and again before the generated operation starts.
 /// </remarks>
 public sealed class HedgingOptions
 {
@@ -24,6 +27,16 @@ public sealed class HedgingOptions
 
     /// <summary>Invoked when an additional hedged attempt is launched.</summary>
     public Action<HedgeEvent>? OnHedge { get; set; }
+
+    /// <summary>Invoked and awaited after <see cref="OnHedge"/> and before an additional attempt starts.</summary>
+    public Func<HedgeEvent, ValueTask>? OnHedgeAsync { get; set; }
+
+    /// <summary>
+    /// Selects a replacement operation for each additional attempt. A <see langword="null"/>
+    /// result runs the original operation. Create the generator with the result type used to
+    /// execute the shield; use the void factory for void executions.
+    /// </summary>
+    public HedgeActionGenerator? ActionGenerator { get; set; }
 }
 
 /// <summary>Describes a hedged attempt being launched.</summary>
@@ -38,6 +51,9 @@ public readonly struct HedgeEvent
     /// <summary>The 1-based number of the attempt being launched (2 = first hedge).</summary>
     public int Attempt { get; }
 
-    /// <summary>The ambient execution context.</summary>
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it after synchronous and
+    /// asynchronous hedge callbacks complete.
+    /// </summary>
     public KevlarContext Context { get; }
 }

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -9,6 +9,8 @@ internal sealed class HedgingStrategy : Strategy
     private readonly int _maxAttempts;
     private readonly TimeSpan _delay;
     private readonly Action<HedgeEvent>? _onHedge;
+    private readonly Func<HedgeEvent, ValueTask>? _onHedgeAsync;
+    private readonly HedgeActionGenerator? _actionGenerator;
 
     public HedgingStrategy(HedgingOptions options, OutcomeJudge judge)
     {
@@ -20,6 +22,8 @@ internal sealed class HedgingStrategy : Strategy
         _maxAttempts = options.MaxAttempts;
         _delay = options.Delay;
         _onHedge = options.OnHedge;
+        _onHedgeAsync = options.OnHedgeAsync;
+        _actionGenerator = options.ActionGenerator;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
@@ -44,7 +48,7 @@ internal sealed class HedgingStrategy : Strategy
             throw new NotSupportedException("Hedging requires asynchronous execution. Use ExecuteAsync instead of Execute.");
         }
 
-        var primary = StartAttempt(next, context, attemptNumber: 1);
+        var primary = StartPrimaryAttempt(next, context);
         if (_delay == TimeSpan.Zero || !primary.Execution.IsCompletedSuccessfully)
         {
             return ExecuteCoreAsync(next, context, primary.AsPending(), launched: 1, default);
@@ -85,14 +89,16 @@ internal sealed class HedgingStrategy : Strategy
             }
             else
             {
-                Launch(pending, next, context, ref launched);
+                pending.Add(await StartHedgeAttemptAsync(next, context, launched + 1).ConfigureAwait(false));
+                launched++;
             }
 
             while (true)
             {
                 if (launched < _maxAttempts && _delay == TimeSpan.Zero)
                 {
-                    Launch(pending, next, context, ref launched);
+                    pending.Add(await StartHedgeAttemptAsync(next, context, launched + 1).ConfigureAwait(false));
+                    launched++;
                     continue;
                 }
 
@@ -106,7 +112,8 @@ internal sealed class HedgingStrategy : Strategy
 
                     if (winner == delayTask)
                     {
-                        Launch(pending, next, context, ref launched);
+                        pending.Add(await StartHedgeAttemptAsync(next, context, launched + 1).ConfigureAwait(false));
+                        launched++;
                         continue;
                     }
 
@@ -134,7 +141,8 @@ internal sealed class HedgingStrategy : Strategy
 
                 if (launched < _maxAttempts)
                 {
-                    Launch(pending, next, context, ref launched);
+                    pending.Add(await StartHedgeAttemptAsync(next, context, launched + 1).ConfigureAwait(false));
+                    launched++;
                 }
                 else if (pending.Count == 0)
                 {
@@ -154,25 +162,141 @@ internal sealed class HedgingStrategy : Strategy
         }
     }
 
-    private void Launch<T, TState>(List<HedgeAttempt<T>> pending, Continuation<T, TState> next, KevlarContext context, ref int launched)
+    private ValueTask<HedgeAttempt<T>> StartHedgeAttemptAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        int attemptNumber)
     {
         context.CancellationToken.ThrowIfCancellationRequested();
-        var attemptNumber = ++launched;
-        pending.Add(StartAttempt(next, context, attemptNumber).AsPending());
-    }
+        var hedgeEvent = new HedgeEvent(attemptNumber, context);
+        _onHedge?.Invoke(hedgeEvent);
+        context.CancellationToken.ThrowIfCancellationRequested();
 
-    private StartedAttempt<T> StartAttempt<T, TState>(Continuation<T, TState> next, KevlarContext context, int attemptNumber)
-    {
-        if (attemptNumber > 1)
+        if (_onHedgeAsync is { } onHedgeAsync)
         {
-            _onHedge?.Invoke(new HedgeEvent(attemptNumber, context));
+            var notification = onHedgeAsync(hedgeEvent);
+            if (!notification.IsCompletedSuccessfully)
+            {
+                return AwaitHedgeNotificationAsync(notification, next, context, attemptNumber);
+            }
+
+            notification.GetAwaiter().GetResult();
             context.CancellationToken.ThrowIfCancellationRequested();
-            KevlarMetrics.Hedge(context.ShieldName);
         }
 
+        return new ValueTask<HedgeAttempt<T>>(
+            StartHedgeAttempt(next, context, attemptNumber).AsPending());
+    }
+
+    private async ValueTask<HedgeAttempt<T>> AwaitHedgeNotificationAsync<T, TState>(
+        ValueTask notification,
+        Continuation<T, TState> next,
+        KevlarContext context,
+        int attemptNumber)
+    {
+        await notification.ConfigureAwait(false);
+        context.CancellationToken.ThrowIfCancellationRequested();
+        return StartHedgeAttempt(next, context, attemptNumber).AsPending();
+    }
+
+    private StartedAttempt<T> StartPrimaryAttempt<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
         var cancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);
         var fork = context.Fork(cancellation.Token);
-        return new StartedAttempt<T>(next.InvokeAsync(fork), cancellation, fork);
+        try
+        {
+            return new StartedAttempt<T>(next.InvokeAsync(fork), cancellation, fork);
+        }
+        catch
+        {
+            KevlarContext.Return(fork);
+            cancellation.Dispose();
+            throw;
+        }
+    }
+
+    private StartedAttempt<T> StartHedgeAttempt<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        int attemptNumber)
+    {
+        var cancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);
+        var fork = context.Fork(cancellation.Token);
+        try
+        {
+            Func<CancellationToken, ValueTask<T>>? generatedAction = null;
+            if (_actionGenerator is not null)
+            {
+                Func<CancellationToken, ValueTask<T>> originalAction =
+                    _ => GetOriginalResultAsync(next.InvokeAsync(fork));
+                generatedAction = _actionGenerator.Generate(
+                    attemptNumber,
+                    fork,
+                    originalAction);
+                context.CancellationToken.ThrowIfCancellationRequested();
+            }
+
+            KevlarMetrics.Hedge(context.ShieldName);
+            var execution = generatedAction is null
+                ? next.InvokeAsync(fork)
+                : InvokeGeneratedAction(generatedAction, fork.CancellationToken);
+            return new StartedAttempt<T>(execution, cancellation, fork);
+        }
+        catch
+        {
+            KevlarContext.Return(fork);
+            cancellation.Dispose();
+            throw;
+        }
+    }
+
+    private static ValueTask<T> GetOriginalResultAsync<T>(ValueTask<Outcome<T>> execution)
+    {
+        if (execution.IsCompletedSuccessfully)
+        {
+            return new ValueTask<T>(execution.Result.GetResultOrRethrow());
+        }
+
+        return AwaitOriginalResultAsync(execution);
+    }
+
+    private static async ValueTask<T> AwaitOriginalResultAsync<T>(ValueTask<Outcome<T>> execution) =>
+        (await execution.ConfigureAwait(false)).GetResultOrRethrow();
+
+    private static ValueTask<Outcome<T>> InvokeGeneratedAction<T>(
+        Func<CancellationToken, ValueTask<T>> action,
+        CancellationToken cancellationToken)
+    {
+        ValueTask<T> execution;
+        try
+        {
+            execution = action(cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
+        }
+
+        if (execution.IsCompletedSuccessfully)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromResult(execution.Result));
+        }
+
+        return AwaitGeneratedActionAsync(execution);
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitGeneratedActionAsync<T>(ValueTask<T> execution)
+    {
+        try
+        {
+            return Outcome<T>.FromResult(await execution.ConfigureAwait(false));
+        }
+        catch (Exception exception)
+        {
+            return Outcome<T>.FromException(exception);
+        }
     }
 
     private static Task<Task> WhenAnyAttemptOr<T>(List<HedgeAttempt<T>> pending, Task delayTask)

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -175,6 +175,7 @@ internal sealed class HedgingStrategy : Strategy
         if (_onHedgeAsync is { } onHedgeAsync)
         {
             var notification = onHedgeAsync(hedgeEvent);
+            // Stryker disable once all: Route selection is performance-only; both branches await the hook.
             if (!notification.IsCompletedSuccessfully)
             {
                 return AwaitHedgeNotificationAsync(notification, next, context, attemptNumber);
@@ -194,6 +195,7 @@ internal sealed class HedgingStrategy : Strategy
         KevlarContext context,
         int attemptNumber)
     {
+        // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
         await notification.ConfigureAwait(false);
         context.CancellationToken.ThrowIfCancellationRequested();
         return StartHedgeAttempt(next, context, attemptNumber).AsPending();
@@ -230,7 +232,7 @@ internal sealed class HedgingStrategy : Strategy
             if (_actionGenerator is not null)
             {
                 Func<CancellationToken, ValueTask<T>> originalAction =
-                    _ => GetOriginalResultAsync(next.InvokeAsync(fork));
+                    token => InvokeOriginalAction(next, fork, token);
                 generatedAction = _actionGenerator.Generate(
                     attemptNumber,
                     fork,
@@ -254,6 +256,7 @@ internal sealed class HedgingStrategy : Strategy
 
     private static ValueTask<T> GetOriginalResultAsync<T>(ValueTask<Outcome<T>> execution)
     {
+        // Stryker disable once all: Route selection is performance-only; both branches unwrap the outcome.
         if (execution.IsCompletedSuccessfully)
         {
             return new ValueTask<T>(execution.Result.GetResultOrRethrow());
@@ -262,8 +265,63 @@ internal sealed class HedgingStrategy : Strategy
         return AwaitOriginalResultAsync(execution);
     }
 
-    private static async ValueTask<T> AwaitOriginalResultAsync<T>(ValueTask<Outcome<T>> execution) =>
-        (await execution.ConfigureAwait(false)).GetResultOrRethrow();
+    private static ValueTask<T> InvokeOriginalAction<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext attemptContext,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken == attemptContext.CancellationToken)
+        {
+            return GetOriginalResultAsync(next.InvokeAsync(attemptContext));
+        }
+
+        var invocationContext = attemptContext.Fork(cancellationToken);
+        ValueTask<Outcome<T>> execution;
+        try
+        {
+            execution = next.InvokeAsync(invocationContext);
+        }
+        catch
+        {
+            KevlarContext.Return(invocationContext);
+            throw;
+        }
+
+        if (!execution.IsCompletedSuccessfully)
+        {
+            return AwaitOriginalResultAsync(execution, invocationContext);
+        }
+
+        try
+        {
+            return new ValueTask<T>(execution.Result.GetResultOrRethrow());
+        }
+        finally
+        {
+            KevlarContext.Return(invocationContext);
+        }
+    }
+
+    private static async ValueTask<T> AwaitOriginalResultAsync<T>(ValueTask<Outcome<T>> execution)
+    {
+        // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
+        return (await execution.ConfigureAwait(false)).GetResultOrRethrow();
+    }
+
+    private static async ValueTask<T> AwaitOriginalResultAsync<T>(
+        ValueTask<Outcome<T>> execution,
+        KevlarContext invocationContext)
+    {
+        try
+        {
+            // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
+            return (await execution.ConfigureAwait(false)).GetResultOrRethrow();
+        }
+        finally
+        {
+            KevlarContext.Return(invocationContext);
+        }
+    }
 
     private static ValueTask<Outcome<T>> InvokeGeneratedAction<T>(
         Func<CancellationToken, ValueTask<T>> action,
@@ -279,6 +337,7 @@ internal sealed class HedgingStrategy : Strategy
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
         }
 
+        // Stryker disable once all: Route selection is performance-only; both branches preserve the outcome.
         if (execution.IsCompletedSuccessfully)
         {
             return new ValueTask<Outcome<T>>(Outcome<T>.FromResult(execution.Result));
@@ -291,6 +350,7 @@ internal sealed class HedgingStrategy : Strategy
     {
         try
         {
+            // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
             return Outcome<T>.FromResult(await execution.ConfigureAwait(false));
         }
         catch (Exception exception)

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -270,11 +270,6 @@ internal sealed class HedgingStrategy : Strategy
         KevlarContext attemptContext,
         CancellationToken cancellationToken)
     {
-        if (cancellationToken == attemptContext.CancellationToken)
-        {
-            return GetOriginalResultAsync(next.InvokeAsync(attemptContext));
-        }
-
         var invocationContext = attemptContext.Fork(cancellationToken);
         ValueTask<Outcome<T>> execution;
         try

--- a/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
@@ -226,7 +226,10 @@ public class HedgingActionGeneratorTests
                 ValueTask.FromException<int>(new InvalidOperationException("primary"))))
             .Throws<InvalidOperationException>();
 
-        await Assert.That(exception!.Message).Contains("execution returns 'System.Int32'");
+        await Assert.That(exception!.Message).Contains("created for 'System.String'");
+        await Assert.That(exception.Message).Contains("execution returns 'System.Int32'");
+        await Assert.That(exception.Message)
+            .Contains("Create the generator with the execution's result type.");
     }
 
     [Test]
@@ -357,6 +360,186 @@ public class HedgingActionGeneratorTests
 
         _ = await Assert.That(async () => await execution).Throws<InvalidOperationException>();
         await Assert.That(observed).IsEqualTo("abc-123");
+    }
+
+    [Test]
+    public async Task Generator_Factories_Reject_Null_Delegates()
+    {
+        _ = await Assert.That(() => HedgeActionGenerator.Create<int>(null!))
+            .Throws<ArgumentNullException>();
+        _ = await Assert.That(() => HedgeActionGenerator.Create(null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Void_Null_Generated_Action_Runs_Original_Action()
+    {
+        var attempts = 0;
+        var generatedAttempts = new List<int>();
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create(hedge =>
+            {
+                generatedAttempts.Add(hedge.Attempt);
+                return null;
+            });
+        });
+
+        await shield.ExecuteAsync(_ =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                return ValueTask.FromException(new InvalidOperationException("primary"));
+            }
+
+            return ValueTask.CompletedTask;
+        });
+
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(generatedAttempts).IsEquivalentTo([2]);
+    }
+
+    [Test]
+    public async Task Cancellation_From_Generator_Prevents_Generated_Action_From_Starting()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var actionStarted = false;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(_ =>
+            {
+                cancellation.Cancel();
+                return _ =>
+                {
+                    actionStarted = true;
+                    return new ValueTask<int>(42);
+                };
+            });
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary")), cancellation.Token);
+
+        await Assert.That(actionStarted).IsFalse();
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken)
+            .IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task Synchronous_Generated_Action_Failure_Preserves_Identity()
+    {
+        var expected = new ApplicationException("generated-sync");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(_ =>
+                _ => throw expected);
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary")));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Asynchronous_Generated_Action_Failure_Preserves_Identity()
+    {
+        var expected = new ApplicationException("generated-async");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(_ => async _ =>
+            {
+                await Task.Yield();
+                throw expected;
+            });
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary")));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Generated_Action_Can_Invoke_Synchronously_Completed_Original_Action()
+    {
+        var attempts = 0;
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+                async token => (await hedge.OriginalAction(token)) + 1);
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            var attempt = Interlocked.Increment(ref attempts);
+            return attempt == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException("primary"))
+                : new ValueTask<int>(41);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Generated_Action_Can_Invoke_Asynchronously_Completed_Original_Action()
+    {
+        var attempts = 0;
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+                async token => (await hedge.OriginalAction(token)) + 1);
+        });
+
+        var result = await shield.ExecuteAsync(async _ =>
+        {
+            var attempt = Interlocked.Increment(ref attempts);
+            await Task.Yield();
+            if (attempt == 1)
+            {
+                throw new InvalidOperationException("primary");
+            }
+
+            return 41;
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Void_Generated_Action_Is_Awaited_To_Completion()
+    {
+        var actionCompleted = false;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create(_ => async _ =>
+            {
+                await Task.Yield();
+                actionCompleted = true;
+            });
+        });
+
+        await shield.ExecuteAsync(static _ =>
+            ValueTask.FromException(new InvalidOperationException("primary")));
+
+        await Assert.That(actionCompleted).IsTrue();
     }
 
     private sealed class PropertyObserver(KevlarKey<int> key) : Strategy

--- a/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
@@ -1,0 +1,385 @@
+namespace Kevlar.Tests;
+
+public class HedgingActionGeneratorTests
+{
+    [Test]
+    public async Task Typed_Generator_Selects_A_Distinct_Action()
+    {
+        var primaryCalls = 0;
+        var generatedAttempts = new List<int>();
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+            {
+                generatedAttempts.Add(hedge.Attempt);
+                return _ => new ValueTask<int>(hedge.Attempt * 10);
+            });
+        });
+
+        var result = await shield.ExecuteAsync<int>(_ =>
+        {
+            primaryCalls++;
+            throw new InvalidOperationException("primary");
+        });
+
+        await Assert.That(result).IsEqualTo(20);
+        await Assert.That(primaryCalls).IsEqualTo(1);
+        await Assert.That(generatedAttempts).IsEquivalentTo([2]);
+    }
+
+    [Test]
+    public async Task Null_Generated_Action_Runs_The_Original_Inner_Pipeline()
+    {
+        var key = new KevlarKey<int>("hedge-target");
+        var observer = new PropertyObserver(key);
+        var attempts = 0;
+        var shield = Shield.Hedge(options =>
+            {
+                options.MaxAttempts = 2;
+                options.Delay = Timeout.InfiniteTimeSpan;
+                options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+                {
+                    hedge.Context.Properties.Set(key, hedge.Attempt);
+                    return null;
+                });
+            })
+            .Use(observer);
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            var attempt = Interlocked.Increment(ref attempts);
+            return attempt == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException("primary"))
+                : new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observer.Values).IsEquivalentTo([-1, 2]);
+    }
+
+    [Test]
+    public async Task Untyped_Void_Generator_Selects_A_Distinct_Action()
+    {
+        var originalCalls = 0;
+        var generatedCalls = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create(hedge =>
+            {
+                return _ =>
+                {
+                    generatedCalls += hedge.Attempt;
+                    return ValueTask.CompletedTask;
+                };
+            });
+        });
+
+        await shield.ExecuteAsync(_ =>
+        {
+            originalCalls++;
+            return ValueTask.FromException(new InvalidOperationException("primary"));
+        });
+
+        await Assert.That(originalCalls).IsEqualTo(1);
+        await Assert.That(generatedCalls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Async_Hook_Is_Awaited_Before_Generation_And_Action()
+    {
+        var order = new List<string>();
+        var hookStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.OnHedge = _ => order.Add("sync-hook");
+            options.OnHedgeAsync = async _ =>
+            {
+                order.Add("async-hook-start");
+                hookStarted.TrySetResult();
+                await releaseHook.Task;
+                order.Add("async-hook-end");
+            };
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(_ =>
+            {
+                order.Add("generator");
+                return _ =>
+                {
+                    order.Add("action");
+                    return new ValueTask<int>(42);
+                };
+            });
+        });
+
+        var execution = shield.ExecuteAsync<int>(_ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary"))).AsTask();
+
+        await hookStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(order.SequenceEqual(["sync-hook", "async-hook-start"])).IsTrue();
+        releaseHook.SetResult();
+
+        await Assert.That(await execution).IsEqualTo(42);
+        await Assert.That(order.SequenceEqual(
+            ["sync-hook", "async-hook-start", "async-hook-end", "generator", "action"])).IsTrue();
+    }
+
+    [Test]
+    public async Task Async_Hook_Failure_Preserves_Identity_And_Cancels_Primary()
+    {
+        var expected = new ApplicationException("hook");
+        var primaryCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedgeAsync = async _ =>
+            {
+                await Task.Yield();
+                throw expected;
+            };
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            using var registration = token.Register(() => primaryCancelled.TrySetResult());
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 1;
+        });
+
+        await primaryCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(ReferenceEquals(outcome.Exception, expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_During_Async_Hook_Suppresses_Generation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var generated = false;
+        var attempts = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedgeAsync = _ =>
+            {
+                cancellation.Cancel();
+                return ValueTask.CompletedTask;
+            };
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(_ =>
+            {
+                generated = true;
+                return null;
+            });
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            Interlocked.Increment(ref attempts);
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token);
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken)
+            .IsEqualTo(cancellation.Token);
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(generated).IsFalse();
+    }
+
+    [Test]
+    public async Task Generated_Failures_Are_Judged_Before_A_Later_Action_Wins()
+    {
+        var expected = new InvalidOperationException("generated");
+        var shield = Shield.When<InvalidOperationException>().Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+                hedge.Attempt == 2
+                    ? _ => ValueTask.FromException<int>(expected)
+                    : _ => new ValueTask<int>(42));
+        });
+
+        var result = await shield.ExecuteAsync<int>(_ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary")));
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Generator_Type_Mismatch_Is_Actionable()
+    {
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<string>(_ => null);
+        });
+
+        var exception = await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+                ValueTask.FromException<int>(new InvalidOperationException("primary"))))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).Contains("execution returns 'System.Int32'");
+    }
+
+    [Test]
+    public async Task Generator_Failure_Preserves_Identity_And_Cancels_Primary()
+    {
+        var expected = new ApplicationException("generator");
+        var primaryCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(_ => throw expected);
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(async token =>
+        {
+            using var registration = token.Register(() => primaryCancelled.TrySetResult());
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 1;
+        });
+
+        await primaryCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(ReferenceEquals(outcome.Exception, expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Concurrent_Generated_Attempts_Are_Isolated_And_Losers_Are_Cancelled()
+    {
+        var attemptTwoStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attemptThreeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var primaryCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var loserCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWinner = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var contexts = new Dictionary<int, KevlarContext>();
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.Delay = TimeSpan.Zero;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+            {
+                contexts.Add(hedge.Attempt, hedge.Context);
+                return async token =>
+                {
+                    if (hedge.Attempt == 2)
+                    {
+                        attemptTwoStarted.TrySetResult();
+                        try
+                        {
+                            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                        }
+                        catch (OperationCanceledException) when (token.IsCancellationRequested)
+                        {
+                            loserCancelled.TrySetResult();
+                            throw;
+                        }
+                    }
+
+                    attemptThreeStarted.TrySetResult();
+                    await releaseWinner.Task.WaitAsync(TimeSpan.FromSeconds(5), token);
+                    return 42;
+                };
+            });
+        });
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            using var registration = token.Register(() => primaryCancelled.TrySetResult());
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }).AsTask();
+
+        await Task.WhenAll(attemptTwoStarted.Task, attemptThreeStarted.Task)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(ReferenceEquals(contexts[2], contexts[3])).IsFalse();
+
+        releaseWinner.SetResult();
+        await Assert.That(await execution).IsEqualTo(42);
+        await Task.WhenAll(primaryCancelled.Task, loserCancelled.Task)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Generator_May_Reenter_The_Shield()
+    {
+        Shield<int>? shield = null;
+        var nestedResult = 0;
+        shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(_ =>
+            {
+                nestedResult = shield!.ExecuteAsync(static _ => new ValueTask<int>(7))
+                    .GetAwaiter()
+                    .GetResult();
+                return static _ => new ValueTask<int>(42);
+            });
+        });
+
+        var result = await shield.ExecuteAsync(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary")));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(nestedResult).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task Async_Hook_Context_Remains_Valid_Until_Completion()
+    {
+        var key = new KevlarKey<string>("request-id");
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        string? observed = null;
+        var shield = Shield.Use(new PropertySeedingStrategy(key, "abc-123"))
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 2;
+                options.Delay = Timeout.InfiniteTimeSpan;
+                options.OnHedgeAsync = async hedge =>
+                {
+                    await release.Task;
+                    observed = hedge.Context.Properties.GetOrDefault(key, "missing");
+                };
+            });
+
+        var execution = shield.ExecuteAsync<int>(_ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary"))).AsTask();
+        release.SetResult();
+
+        _ = await Assert.That(async () => await execution).Throws<InvalidOperationException>();
+        await Assert.That(observed).IsEqualTo("abc-123");
+    }
+
+    private sealed class PropertyObserver(KevlarKey<int> key) : Strategy
+    {
+        public List<int> Values { get; } = [];
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            Values.Add(context.Properties.GetOrDefault(key, -1));
+            return await next.InvokeAsync(context);
+        }
+    }
+
+    private sealed class PropertySeedingStrategy(KevlarKey<string> key, string value) : Strategy
+    {
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            context.Properties.Set(key, value);
+            return next.InvokeAsync(context);
+        }
+    }
+}

--- a/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
@@ -359,6 +359,7 @@ public class HedgingActionGeneratorTests
     public async Task Async_Hook_Context_Remains_Valid_Until_Completion()
     {
         var key = new KevlarKey<string>("request-id");
+        var hookStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         string? observed = null;
         var shield = Shield.Use(new PropertySeedingStrategy(key, "abc-123"))
@@ -368,6 +369,7 @@ public class HedgingActionGeneratorTests
                 options.Delay = Timeout.InfiniteTimeSpan;
                 options.OnHedgeAsync = async hedge =>
                 {
+                    hookStarted.TrySetResult();
                     await release.Task;
                     observed = hedge.Context.Properties.GetOrDefault(key, "missing");
                 };
@@ -375,6 +377,7 @@ public class HedgingActionGeneratorTests
 
         var execution = shield.ExecuteAsync<int>(_ =>
             ValueTask.FromException<int>(new InvalidOperationException("primary"))).AsTask();
+        await hookStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         release.SetResult();
 
         _ = await Assert.That(async () => await execution).Throws<InvalidOperationException>();
@@ -600,6 +603,36 @@ public class HedgingActionGeneratorTests
     }
 
     [Test]
+    public async Task Concurrent_Original_Actions_With_The_Same_Token_Use_Distinct_Contexts()
+    {
+        var observer = new ContextIdentityObserver();
+        var attempts = 0;
+        var shield = Shield.For<int>().Hedge(options =>
+            {
+                options.MaxAttempts = 2;
+                options.Delay = Timeout.InfiniteTimeSpan;
+                options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge => async token =>
+                {
+                    var first = hedge.OriginalAction(token).AsTask();
+                    var second = hedge.OriginalAction(token).AsTask();
+                    var results = await Task.WhenAll(first, second);
+                    return results.Sum();
+                });
+            })
+            .Use(observer);
+
+        var result = await shield.ExecuteAsync(_ =>
+            Interlocked.Increment(ref attempts) == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException("primary"))
+                : new ValueTask<int>(21));
+
+        var contexts = observer.Contexts.ToArray();
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(contexts.Length).IsEqualTo(3);
+        await Assert.That(ReferenceEquals(contexts[1], contexts[2])).IsFalse();
+    }
+
+    [Test]
     public async Task Void_Generated_Action_Is_Awaited_To_Completion()
     {
         var actionCompleted = false;
@@ -648,6 +681,34 @@ public class HedgingActionGeneratorTests
             KevlarContext context)
         {
             Values.Add(context.Properties.GetOrDefault(key, -1));
+            return await next.InvokeAsync(context);
+        }
+    }
+
+    private sealed class ContextIdentityObserver : Strategy
+    {
+        private readonly TaskCompletionSource _concurrentInvocations = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _invocations;
+
+        public ConcurrentQueue<KevlarContext> Contexts { get; } = new();
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            Contexts.Enqueue(context);
+            var invocation = Interlocked.Increment(ref _invocations);
+            if (invocation > 1)
+            {
+                if (invocation == 3)
+                {
+                    _concurrentInvocations.TrySetResult();
+                }
+
+                await _concurrentInvocations.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+
             return await next.InvokeAsync(context);
         }
     }

--- a/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace Kevlar.Tests;
 
 public class HedgingActionGeneratorTests
@@ -157,6 +159,23 @@ public class HedgingActionGeneratorTests
     }
 
     [Test]
+    public async Task Synchronously_Faulted_Async_Hook_Preserves_Identity()
+    {
+        var expected = new ApplicationException("hook");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.OnHedgeAsync = _ => ValueTask.FromException(expected);
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary")));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, expected)).IsTrue();
+    }
+
+    [Test]
     public async Task Caller_Cancellation_During_Async_Hook_Suppresses_Generation()
     {
         using var cancellation = new CancellationTokenSource();
@@ -263,14 +282,14 @@ public class HedgingActionGeneratorTests
         var primaryCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var loserCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseWinner = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var contexts = new Dictionary<int, KevlarContext>();
+        var contexts = new ConcurrentDictionary<int, KevlarContext>();
         var shield = Shield.For<int>().Hedge(options =>
         {
             options.MaxAttempts = 3;
             options.Delay = TimeSpan.Zero;
             options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
             {
-                contexts.Add(hedge.Attempt, hedge.Context);
+                contexts[hedge.Attempt] = hedge.Context;
                 return async token =>
                 {
                     if (hedge.Attempt == 2)
@@ -522,6 +541,65 @@ public class HedgingActionGeneratorTests
     }
 
     [Test]
+    public async Task Original_Action_Uses_The_Supplied_Cancellation_Token()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        var observedToken = default(CancellationToken);
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+                _ => hedge.OriginalAction(cancellation.Token));
+        });
+
+        var result = await shield.ExecuteAsync(token =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                return ValueTask.FromException<int>(new InvalidOperationException("primary"));
+            }
+
+            observedToken = token;
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observedToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task Async_Original_Action_Uses_The_Supplied_Cancellation_Token()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        var observedToken = default(CancellationToken);
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
+                _ => hedge.OriginalAction(cancellation.Token));
+        });
+
+        var result = await shield.ExecuteAsync(async token =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                throw new InvalidOperationException("primary");
+            }
+
+            await Task.Yield();
+            observedToken = token;
+            return 42;
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observedToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
     public async Task Void_Generated_Action_Is_Awaited_To_Completion()
     {
         var actionCompleted = false;
@@ -540,6 +618,25 @@ public class HedgingActionGeneratorTests
             ValueTask.FromException(new InvalidOperationException("primary")));
 
         await Assert.That(actionCompleted).IsTrue();
+    }
+
+    [Test]
+    public async Task Void_Generated_Action_Can_Invoke_Original_Action()
+    {
+        var attempts = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = HedgeActionGenerator.Create(hedge =>
+                token => hedge.OriginalAction(token));
+        });
+
+        await shield.ExecuteAsync(_ => Interlocked.Increment(ref attempts) == 1
+            ? ValueTask.FromException(new InvalidOperationException("primary"))
+            : ValueTask.CompletedTask);
+
+        await Assert.That(attempts).IsEqualTo(2);
     }
 
     private sealed class PropertyObserver(KevlarKey<int> key) : Strategy


### PR DESCRIPTION
## Summary
- add typed and void per-attempt hedge action generators
- add awaited asynchronous hedge notifications with defined cancellation, ordering, context, cleanup, concurrency, and reentrancy semantics
- add behavioral tests, docs, public API baselines, and allocation/performance benchmarks

Closes #88

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (614 passed)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (2 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m`
- `pwsh scripts/Verify-Packages.ps1 ...`
- `pwsh scripts/Verify-DocSnippets.ps1 ...` (85 compiled)
- `npm run build` in `docs/`
- BenchmarkDotNet ShortRun: fixed 2.261 us / 1136 B; sync hook 2.257 us / 1136 B; completed async hook 2.487 us / 1136 B; yielding async hook 4.807 us / 2126 B; generated action 2.823 us / 1200 B; primary win 128.1 ns / 0 B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous notifications before additional hedge attempts.
  * Added per-attempt action generation for customized hedged operations.
  * Added support for result-returning and void operations, with fallback to the original action.
  * Added cancellation handling and isolated execution contexts for generated attempts.

* **Documentation**
  * Expanded hedging guidance with callback ordering, cancellation, context lifetime, reentrancy, and usage examples.

* **Tests**
  * Added comprehensive coverage for generated actions, callbacks, failures, cancellation, concurrency, and completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->