### PR TITLE
feat(chaos): add controlled fault injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Unit tests
         run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename unit.trx --results-directory artifacts/test-results/unit
 
+      - name: Chaos tests
+        run: dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename chaos.trx --results-directory artifacts/test-results/chaos
+
       - name: netstandard2.0 asset tests
         run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename netstandard.trx --results-directory artifacts/test-results/netstandard
 
@@ -145,6 +148,9 @@ jobs:
 
       - name: Collect unit coverage
         run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/unit.cobertura.xml --coverage-output-format cobertura
+
+      - name: Collect chaos coverage
+        run: dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/chaos.cobertura.xml --coverage-output-format cobertura
 
       - name: Collect netstandard2.0 asset coverage
         run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/netstandard.cobertura.xml --coverage-output-format cobertura

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
   <ItemGroup>
     <!-- Core (netstandard2.0 only) -->
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
     <PackageVersion Include="Reservoir" Version="1.4.0" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />

--- a/Kevlar.slnx
+++ b/Kevlar.slnx
@@ -4,12 +4,14 @@
     <Project Path="benchmarks/Kevlar.StressTests/Kevlar.StressTests.csproj" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/Kevlar.Chaos/Kevlar.Chaos.csproj" />
     <Project Path="src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj" />
     <Project Path="src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj" />
     <Project Path="src/Kevlar/Kevlar.csproj" />
     <Project Path="src/Kevlar.Analyzers/Kevlar.Analyzers.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj" />
     <Project Path="tests/Kevlar.AllocationTests/Kevlar.AllocationTests.csproj" />
     <Project Path="tests/Kevlar.IntegrationTests/Kevlar.IntegrationTests.csproj" />
     <Project Path="tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ One clause up top decides what "failure" means for every strategy below it — e
 | Package | Purpose |
 |---|---|
 | `Kevlar` | The core: all strategies |
+| `Kevlar.Chaos` | Opt-in latency, fault, typed outcome and custom behavior injection |
 | `Kevlar.Extensions.DependencyInjection` | Named shields, config-bound shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |

--- a/benchmarks/Kevlar.Benchmarks/ChaosBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/ChaosBenchmarks.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Kevlar.Chaos;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>Measures disabled, excluded, and injected chaos paths against an empty shield.</summary>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class ChaosBenchmarks
+{
+    private static readonly Shield Empty = Shield.Empty;
+    private static readonly Shield Disabled = ChaosShield.Fault(static _ => { });
+    private static readonly Shield Excluded = ChaosShield.Fault(static options =>
+    {
+        options.Enabled = true;
+        options.InjectionRate = 0;
+    });
+    private static readonly Shield Latency = ChaosShield.Latency(static options => options.Enabled = true);
+    private static readonly Shield<int> Outcome = ChaosShield.Outcome<int>(static options =>
+    {
+        options.Enabled = true;
+        options.Result = 42;
+    });
+    private static readonly Shield Behavior = ChaosShield.Behavior(static options =>
+    {
+        options.Enabled = true;
+        options.Behavior = static _ => ValueTask.CompletedTask;
+    });
+
+    /// <summary>Executes an empty shield baseline.</summary>
+    [BenchmarkCategory("PassThrough"), Benchmark(Baseline = true)]
+    public ValueTask<int> Empty_Shield() => Empty.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    /// <summary>Executes a default-disabled chaos strategy.</summary>
+    [BenchmarkCategory("PassThrough"), Benchmark]
+    public ValueTask<int> Disabled_Chaos() => Disabled.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    /// <summary>Executes enabled chaos excluded by a zero injection rate.</summary>
+    [BenchmarkCategory("PassThrough"), Benchmark]
+    public ValueTask<int> Excluded_Chaos() => Excluded.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    /// <summary>Injects zero-duration latency.</summary>
+    [BenchmarkCategory("Injected"), Benchmark(Baseline = true)]
+    public ValueTask<int> Zero_Latency() => Latency.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    /// <summary>Injects a typed result.</summary>
+    [BenchmarkCategory("Injected"), Benchmark]
+    public ValueTask<int> Typed_Outcome() => Outcome.ExecuteAsync(static _ => new ValueTask<int>(0));
+
+    /// <summary>Injects synchronously completing custom behavior.</summary>
+    [BenchmarkCategory("Injected"), Benchmark]
+    public ValueTask<int> Completed_Behavior() => Behavior.ExecuteAsync(static _ => new ValueTask<int>(42));
+}

--- a/benchmarks/Kevlar.Benchmarks/ChaosBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/ChaosBenchmarks.cs
@@ -10,20 +10,20 @@ namespace Kevlar.Benchmarks;
 [CategoriesColumn]
 public class ChaosBenchmarks
 {
-    private static readonly Shield Empty = Shield.Empty;
-    private static readonly Shield Disabled = ChaosShield.Fault(static _ => { });
-    private static readonly Shield Excluded = ChaosShield.Fault(static options =>
+    private static readonly Shield _empty = Shield.Empty;
+    private static readonly Shield _disabled = ChaosShield.Fault(static _ => { });
+    private static readonly Shield _excluded = ChaosShield.Fault(static options =>
     {
         options.Enabled = true;
         options.InjectionRate = 0;
     });
-    private static readonly Shield Latency = ChaosShield.Latency(static options => options.Enabled = true);
-    private static readonly Shield<int> Outcome = ChaosShield.Outcome<int>(static options =>
+    private static readonly Shield _latency = ChaosShield.Latency(static options => options.Enabled = true);
+    private static readonly Shield<int> _outcome = ChaosShield.Outcome<int>(static options =>
     {
         options.Enabled = true;
         options.Result = 42;
     });
-    private static readonly Shield Behavior = ChaosShield.Behavior(static options =>
+    private static readonly Shield _behavior = ChaosShield.Behavior(static options =>
     {
         options.Enabled = true;
         options.Behavior = static _ => ValueTask.CompletedTask;
@@ -31,25 +31,25 @@ public class ChaosBenchmarks
 
     /// <summary>Executes an empty shield baseline.</summary>
     [BenchmarkCategory("PassThrough"), Benchmark(Baseline = true)]
-    public ValueTask<int> Empty_Shield() => Empty.ExecuteAsync(static _ => new ValueTask<int>(42));
+    public ValueTask<int> Empty_Shield() => _empty.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     /// <summary>Executes a default-disabled chaos strategy.</summary>
     [BenchmarkCategory("PassThrough"), Benchmark]
-    public ValueTask<int> Disabled_Chaos() => Disabled.ExecuteAsync(static _ => new ValueTask<int>(42));
+    public ValueTask<int> Disabled_Chaos() => _disabled.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     /// <summary>Executes enabled chaos excluded by a zero injection rate.</summary>
     [BenchmarkCategory("PassThrough"), Benchmark]
-    public ValueTask<int> Excluded_Chaos() => Excluded.ExecuteAsync(static _ => new ValueTask<int>(42));
+    public ValueTask<int> Excluded_Chaos() => _excluded.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     /// <summary>Injects zero-duration latency.</summary>
     [BenchmarkCategory("Injected"), Benchmark(Baseline = true)]
-    public ValueTask<int> Zero_Latency() => Latency.ExecuteAsync(static _ => new ValueTask<int>(42));
+    public ValueTask<int> Zero_Latency() => _latency.ExecuteAsync(static _ => new ValueTask<int>(42));
 
     /// <summary>Injects a typed result.</summary>
     [BenchmarkCategory("Injected"), Benchmark]
-    public ValueTask<int> Typed_Outcome() => Outcome.ExecuteAsync(static _ => new ValueTask<int>(0));
+    public ValueTask<int> Typed_Outcome() => _outcome.ExecuteAsync(static _ => new ValueTask<int>(0));
 
     /// <summary>Injects synchronously completing custom behavior.</summary>
     [BenchmarkCategory("Injected"), Benchmark]
-    public ValueTask<int> Completed_Behavior() => Behavior.ExecuteAsync(static _ => new ValueTask<int>(42));
+    public ValueTask<int> Completed_Behavior() => _behavior.ExecuteAsync(static _ => new ValueTask<int>(42));
 }

--- a/benchmarks/Kevlar.Benchmarks/Kevlar.Benchmarks.csproj
+++ b/benchmarks/Kevlar.Benchmarks/Kevlar.Benchmarks.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Kevlar.Chaos\Kevlar.Chaos.csproj" />
     <ProjectReference Include="..\..\src\Kevlar\Kevlar.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.DependencyInjection\Kevlar.Extensions.DependencyInjection.csproj" />
   </ItemGroup>

--- a/docs/docs/chaos.md
+++ b/docs/docs/chaos.md
@@ -1,0 +1,125 @@
+---
+sidebar_position: 11
+---
+
+# Chaos engineering
+
+`Kevlar.Chaos` is an optional package for deliberately injecting latency, exceptions, typed
+results, and caller-defined behavior through ordinary shields.
+
+```bash
+dotnet add package Kevlar.Chaos
+```
+
+Every chaos strategy is disabled by default. Enabling one should be an explicit, reviewable
+decision. Bound its blast radius with a low rate plus an operation, environment, predicate, or
+dynamic kill switch. Do not broadly enable chaos in production; start in tests or staging, keep
+an immediate disable path, monitor injection metrics, and expand gradually.
+
+## Inject latency and faults
+
+```csharp
+var latency = ChaosShield.Latency(options =>
+{
+    options.Enabled = true;
+    options.Delay = TimeSpan.FromMilliseconds(250);
+    options.InjectionRate = 0.02;
+    options.Environment = "staging";
+});
+
+var faults = ChaosShield.Fault(options =>
+{
+    options.Enabled = true;
+    options.ExceptionGenerator = context =>
+        new IOException($"Injected fault in {context.ShieldName}");
+    options.Operation = "checkout";
+    options.InjectionRate = 0.01;
+});
+
+using (ChaosScope.Begin(operation: "checkout", environment: "staging"))
+{
+    var result = await Shield.Compose(latency, faults)
+        .WithName("payments")
+        .ExecuteAsync(token => LoadUserAsync(id, token), cancellationToken);
+}
+```
+
+Latency honors the shield's `TimeProvider` and caller cancellation token. Fault injection
+short-circuits the pipeline with the exact configured exception. If no exception is configured,
+`ChaosInjectedException` is used.
+
+## Inject typed outcomes
+
+Typed outcome injection is useful for failures represented as values, such as HTTP responses or
+sentinels. It returns a `Shield<TResult>`, so normal typed handling and composition remain available:
+
+```csharp
+var unavailable = ChaosShield.Outcome<int>(options =>
+{
+    options.Enabled = true;
+    options.Result = -1;
+    options.InjectionRate = 0.05;
+});
+
+var shield = Shield.For<int>()
+    .WhenResult(-1)
+    .Fallback(0)
+    .Wrap(unavailable);
+
+var value = await shield.ExecuteAsync(static _ => new ValueTask<int>(42));
+```
+
+## Dynamic control and deterministic runs
+
+`Enabled` is the primary safety gate. `EnabledGenerator` can add a live kill switch;
+`InjectionRateGenerator` and `Predicate` receive the current `KevlarContext`. Fixed configuration
+is copied when the shield is built, while generators are evaluated on every execution.
+
+```csharp
+var chaosEnabled = true;
+var deterministic = ChaosShield.Fault(options =>
+{
+    options.Enabled = true;
+    options.EnabledGenerator = _ => chaosEnabled;
+    options.Predicate = context => !context.IsSynchronous;
+    options.InjectionRateGenerator = context =>
+        context.ShieldName == "test-run" ? 0.25 : 0;
+    options.Seed = 42;
+}).WithName("test-run");
+```
+
+A seed makes the random sample sequence reproducible. One shield instance is thread-safe and can
+be shared, but concurrent callers can consume that deterministic sequence in different orders;
+use separate seeded shields when each scenario needs its own exact sequence.
+
+## Custom behavior
+
+`ChaosShield.Behavior` awaits caller-supplied behavior before continuing. It can model effects
+that are not just a delay or result, and any exception it throws is preserved as the execution
+failure.
+
+```csharp
+var behavior = ChaosShield.Behavior(options =>
+{
+    options.Enabled = true;
+    options.Behavior = context =>
+    {
+        Console.WriteLine($"Injecting custom behavior into {context.ShieldName}");
+        return ValueTask.CompletedTask;
+    };
+});
+```
+
+## Observe injections
+
+`OnInjected` receives a `ChaosEvent` immediately before an injection. It identifies the injection
+kind, effective rate and sample, operation, environment, and `KevlarContext`. The context is pooled:
+copy values inside the callback rather than retaining the context or event.
+
+On .NET 8+, the `Kevlar.Chaos` meter publishes the `kevlar.chaos.injections` counter. Its tags are
+`kevlar.chaos.kind` plus the available `kevlar.shield.name`, `kevlar.chaos.operation`, and
+`kevlar.chaos.environment` values. Subscribe with OpenTelemetry using
+`AddMeter(ChaosDiagnostics.MeterName)`.
+
+For latency tests, attach a `FakeTimeProvider` with `WithTimeProvider` and advance virtual time;
+no real waiting is required.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -13,6 +13,7 @@ dotnet add package Kevlar
 Optional satellites:
 
 ```bash
+dotnet add package Kevlar.Chaos                          # controlled fault injection
 dotnet add package Kevlar.Extensions.DependencyInjection   # named shields + IKevlarRegistry
 dotnet add package Kevlar.Extensions.Http                  # HttpClientFactory integration
 ```

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -35,6 +35,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 | Package | Purpose |
 |---|---|
 | `Kevlar` | The core: all strategies |
+| `Kevlar.Chaos` | Opt-in latency, fault, typed outcome and custom behavior injection |
 | `Kevlar.Extensions.DependencyInjection` | Named shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -6,9 +6,9 @@ sidebar_position: 10
 
 ## Repository quality gates
 
-Pull requests build on Windows and Linux, then run the unit, netstandard2.0 asset, integration, and analyzer suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
+Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, and analyzer suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
 
-The Linux coverage job merges all four suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
+The Linux coverage job merges all five suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
 
 Core strategy mutation testing runs for pull requests that change strategy code or unit tests, every Monday, and on demand. It uses the checked-in Stryker configuration, keeps 74% as the report reference, and treats the aggregate score as informational because timing-sensitive mutants make it nondeterministic. Operational Stryker failures still fail the workflow. Superseded pull-request runs are cancelled, and completed runs publish HTML and JSON reports as the `mutation-report` artifact. The audited initial survivors and threshold policy are recorded in `.github/mutation-baseline.md`. Run the test and mutation checks locally with:
 
@@ -16,11 +16,13 @@ Core strategy mutation testing runs for pull requests that change strategy code 
 dotnet tool restore
 dotnet build Kevlar.slnx -c Release
 dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 $coverageRoot = (New-Item -ItemType Directory -Force artifacts/coverage/raw).FullName
 dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/unit.cobertura.xml" --coverage-output-format cobertura
+dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/chaos.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/netstandard.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/integration.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/analyzers.cobertura.xml" --coverage-output-format cobertura

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
     'executing',
     'dependency-injection',
     'http',
+    'chaos',
     'custom-strategies',
     'library-authors',
     'analyzers',

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -25,6 +25,7 @@ $documentPaths = @(
 $requiredPackages = @(
     'Kevlar'
     'Kevlar.Analyzers'
+    'Kevlar.Chaos'
     'Kevlar.Extensions.DependencyInjection'
     'Kevlar.Extensions.Http'
 )
@@ -179,6 +180,7 @@ $builder = [Text.StringBuilder]::new()
 [void]$builder.AppendLine('#pragma warning disable CS0162 // Harness appends a fallback return after documentation control flow.')
 [void]$builder.AppendLine('using System.Net;')
 [void]$builder.AppendLine('using Kevlar;')
+[void]$builder.AppendLine('using Kevlar.Chaos;')
 [void]$builder.AppendLine('using Kevlar.Extensions.DependencyInjection;')
 [void]$builder.AppendLine('using Kevlar.Extensions.Http;')
 [void]$builder.AppendLine('using Microsoft.Extensions.DependencyInjection;')

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -107,6 +107,7 @@ $expectedDependencies = @{
     }
     'Kevlar.Chaos' = @{
         'net10.0' = @('Kevlar')
+        'net8.0' = @('Kevlar')
         '.NETStandard2.0' = @('Kevlar', 'Microsoft.Bcl.TimeProvider', 'System.Threading.Tasks.Extensions')
     }
     'Kevlar.Analyzers' = @{
@@ -202,6 +203,13 @@ foreach ($packageId in $expectedDependencies.Keys)
                 "lib/netstandard2.0/$packageId.dll",
                 "lib/netstandard2.0/$packageId.xml"
             )
+            if ($packageId -eq 'Kevlar.Chaos')
+            {
+                $expectedAssets += @(
+                    "lib/net8.0/$packageId.dll",
+                    "lib/net8.0/$packageId.xml"
+                )
+            }
             Assert-Set "$packageId library assets" ($entries | Where-Object { $_ -like 'lib/*' }) $expectedAssets
             if ($entries | Where-Object { $_ -match '^(analyzers|build|buildTransitive|tools)/' })
             {
@@ -251,6 +259,7 @@ using Kevlar.Chaos;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Http;
 using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics.Metrics;
 
 var shield = Shield.Empty;
 var value = await shield.ExecuteAsync(static cancellationToken =>
@@ -260,6 +269,19 @@ if (value != 42)
     throw new InvalidOperationException("Core package execution failed.");
 }
 
+var injections = 0;
+using var listener = new MeterListener();
+listener.InstrumentPublished = (instrument, activeListener) =>
+{
+    if (instrument.Meter.Name == ChaosDiagnostics.MeterName
+        && instrument.Name == "kevlar.chaos.injections")
+    {
+        activeListener.EnableMeasurementEvents(instrument);
+    }
+};
+listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => injections += (int)measurement);
+listener.Start();
+
 var chaos = ChaosShield.Outcome<int>(options =>
 {
     options.Enabled = true;
@@ -268,6 +290,10 @@ var chaos = ChaosShield.Outcome<int>(options =>
 if (await chaos.ExecuteAsync(static _ => new ValueTask<int>(0)) != 42)
 {
     throw new InvalidOperationException("Chaos package execution failed.");
+}
+if (injections != 1)
+{
+    throw new InvalidOperationException($"Chaos package metrics failed: expected 1 injection, actual {injections}.");
 }
 
 IServiceCollection services = new ServiceCollection();

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -108,7 +108,11 @@ $expectedDependencies = @{
     'Kevlar.Chaos' = @{
         'net10.0' = @('Kevlar')
         'net8.0' = @('Kevlar')
-        '.NETStandard2.0' = @('Kevlar', 'Microsoft.Bcl.TimeProvider', 'System.Threading.Tasks.Extensions')
+        '.NETStandard2.0' = @(
+            'Kevlar',
+            'Microsoft.Bcl.TimeProvider',
+            'System.Runtime.CompilerServices.Unsafe',
+            'System.Threading.Tasks.Extensions')
     }
     'Kevlar.Analyzers' = @{
         '.NETStandard2.0' = @()

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -105,6 +105,10 @@ $expectedDependencies = @{
         'net10.0' = @('Kevlar', 'Microsoft.Extensions.Http')
         '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Http')
     }
+    'Kevlar.Chaos' = @{
+        'net10.0' = @('Kevlar')
+        '.NETStandard2.0' = @('Kevlar', 'Microsoft.Bcl.TimeProvider', 'System.Threading.Tasks.Extensions')
+    }
     'Kevlar.Analyzers' = @{
         '.NETStandard2.0' = @()
     }
@@ -243,6 +247,7 @@ try
 
     $runtimeProgram = @'
 using Kevlar;
+using Kevlar.Chaos;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -253,6 +258,16 @@ var value = await shield.ExecuteAsync(static cancellationToken =>
 if (value != 42)
 {
     throw new InvalidOperationException("Core package execution failed.");
+}
+
+var chaos = ChaosShield.Outcome<int>(options =>
+{
+    options.Enabled = true;
+    options.Result = 42;
+});
+if (await chaos.ExecuteAsync(static _ => new ValueTask<int>(0)) != 42)
+{
+    throw new InvalidOperationException("Chaos package execution failed.");
 }
 
 IServiceCollection services = new ServiceCollection();
@@ -275,6 +290,7 @@ Console.WriteLine("Kevlar package consumer passed.");
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Kevlar" Version="$Version" />
+    <PackageReference Include="Kevlar.Chaos" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
   </ItemGroup>

--- a/scripts/Verify-PublishCompatibility.ps1
+++ b/scripts/Verify-PublishCompatibility.ps1
@@ -109,6 +109,7 @@ try
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Kevlar" Version="$Version" />
+    <PackageReference Include="Kevlar.Chaos" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$ConfigurationVersion" />
@@ -120,6 +121,7 @@ try
     Write-TextFile (Join-Path $consumerDirectory 'Program.cs') @'
 using System.Net;
 using Kevlar;
+using Kevlar.Chaos;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Http;
 using Microsoft.Extensions.Configuration;
@@ -138,6 +140,16 @@ if (typed.Execute(static _ => 42) != 42
     || await typed.ExecuteAsync(static _ => new ValueTask<int>(42)) != 42)
 {
     throw new InvalidOperationException("Typed execution failed.");
+}
+
+var chaos = ChaosShield.Outcome<int>(options =>
+{
+    options.Enabled = true;
+    options.Result = 42;
+});
+if (await chaos.ExecuteAsync(static _ => new ValueTask<int>(0)) != 42)
+{
+    throw new InvalidOperationException("Chaos package execution failed.");
 }
 
 var retryAttempts = 0;

--- a/src/Kevlar.Chaos/ChaosBehaviorOptions.cs
+++ b/src/Kevlar.Chaos/ChaosBehaviorOptions.cs
@@ -1,0 +1,10 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Configures caller-supplied behavior injection.</summary>
+public sealed class ChaosBehaviorOptions : ChaosOptions
+{
+    /// <summary>
+    /// Gets or sets asynchronous behavior invoked before the shield continues. The default does nothing.
+    /// </summary>
+    public Func<KevlarContext, ValueTask>? Behavior { get; set; }
+}

--- a/src/Kevlar.Chaos/ChaosDiagnostics.cs
+++ b/src/Kevlar.Chaos/ChaosDiagnostics.cs
@@ -1,0 +1,13 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Names for Kevlar.Chaos telemetry.</summary>
+/// <remarks>
+/// On .NET 8+ the <c>kevlar.chaos.injections</c> counter is published by a meter named
+/// <see cref="MeterName"/>. Its attributes identify injection kind, shield name, operation,
+/// and environment. On <c>netstandard2.0</c> the instrument is inert.
+/// </remarks>
+public static class ChaosDiagnostics
+{
+    /// <summary>Gets the name of the Kevlar.Chaos meter.</summary>
+    public const string MeterName = "Kevlar.Chaos";
+}

--- a/src/Kevlar.Chaos/ChaosEvent.cs
+++ b/src/Kevlar.Chaos/ChaosEvent.cs
@@ -1,0 +1,43 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Describes one chaos injection.</summary>
+/// <remarks>
+/// <see cref="Context"/> is pooled and valid only for the duration of the callback. Copy any
+/// values that must be retained.
+/// </remarks>
+public readonly struct ChaosEvent
+{
+    internal ChaosEvent(
+        ChaosInjectionKind kind,
+        KevlarContext context,
+        string? operation,
+        string? environment,
+        double injectionRate,
+        double sample)
+    {
+        Kind = kind;
+        Context = context;
+        Operation = operation;
+        Environment = environment;
+        InjectionRate = injectionRate;
+        Sample = sample;
+    }
+
+    /// <summary>Gets the injected behavior kind.</summary>
+    public ChaosInjectionKind Kind { get; }
+
+    /// <summary>Gets the current Kevlar execution context.</summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>Gets the operation from the active <see cref="ChaosScope"/>, if any.</summary>
+    public string? Operation { get; }
+
+    /// <summary>Gets the environment from the active <see cref="ChaosScope"/>, if any.</summary>
+    public string? Environment { get; }
+
+    /// <summary>Gets the effective injection rate used for this decision.</summary>
+    public double InjectionRate { get; }
+
+    /// <summary>Gets the random sample used for this decision.</summary>
+    public double Sample { get; }
+}

--- a/src/Kevlar.Chaos/ChaosFaultOptions.cs
+++ b/src/Kevlar.Chaos/ChaosFaultOptions.cs
@@ -1,0 +1,12 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Configures exception injection.</summary>
+public sealed class ChaosFaultOptions : ChaosOptions
+{
+    /// <summary>Gets or sets the exception instance to inject.</summary>
+    /// <remarks>A <see cref="ChaosInjectedException"/> is used when this value is null.</remarks>
+    public Exception? Exception { get; set; }
+
+    /// <summary>Gets or sets a callback that creates the exception for each injected execution.</summary>
+    public Func<KevlarContext, Exception>? ExceptionGenerator { get; set; }
+}

--- a/src/Kevlar.Chaos/ChaosInjectedException.cs
+++ b/src/Kevlar.Chaos/ChaosInjectedException.cs
@@ -1,0 +1,26 @@
+namespace Kevlar.Chaos;
+
+/// <summary>The default exception produced by fault injection.</summary>
+public sealed class ChaosInjectedException : Exception
+{
+    /// <summary>Initializes a new chaos-injected exception.</summary>
+    public ChaosInjectedException()
+        : base("A fault was injected by Kevlar.Chaos.")
+    {
+    }
+
+    /// <summary>Initializes a new chaos-injected exception with a custom message.</summary>
+    /// <param name="message">The exception message.</param>
+    public ChaosInjectedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a new chaos-injected exception with a custom message and inner exception.</summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The exception that caused this exception.</param>
+    public ChaosInjectedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Kevlar.Chaos/ChaosInjectionKind.cs
+++ b/src/Kevlar.Chaos/ChaosInjectionKind.cs
@@ -1,0 +1,17 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Identifies the kind of chaos injected into an execution.</summary>
+public enum ChaosInjectionKind
+{
+    /// <summary>An artificial delay.</summary>
+    Latency,
+
+    /// <summary>An exception outcome.</summary>
+    Fault,
+
+    /// <summary>A caller-supplied result outcome.</summary>
+    Outcome,
+
+    /// <summary>Caller-supplied asynchronous behavior.</summary>
+    Behavior,
+}

--- a/src/Kevlar.Chaos/ChaosLatencyOptions.cs
+++ b/src/Kevlar.Chaos/ChaosLatencyOptions.cs
@@ -1,0 +1,11 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Configures artificial latency injection.</summary>
+public sealed class ChaosLatencyOptions : ChaosOptions
+{
+    /// <summary>Gets or sets the artificial delay. The default is zero.</summary>
+    public TimeSpan Delay { get; set; }
+
+    /// <summary>Gets or sets a callback that computes the delay for each injected execution.</summary>
+    public Func<KevlarContext, TimeSpan>? DelayGenerator { get; set; }
+}

--- a/src/Kevlar.Chaos/ChaosOptions.cs
+++ b/src/Kevlar.Chaos/ChaosOptions.cs
@@ -1,0 +1,35 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Common controls for explicitly enabling and bounding chaos injection.</summary>
+public abstract class ChaosOptions
+{
+    /// <summary>
+    /// Gets or sets whether injection is permitted. The default is <see langword="false"/>.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Gets or sets the probability of injection, from zero through one. The default is one.</summary>
+    public double InjectionRate { get; set; } = 1;
+
+    /// <summary>Gets or sets a callback that computes the injection rate for each execution.</summary>
+    /// <remarks>When set, this callback takes precedence over <see cref="InjectionRate"/>.</remarks>
+    public Func<KevlarContext, double>? InjectionRateGenerator { get; set; }
+
+    /// <summary>Gets or sets a dynamic kill switch evaluated after <see cref="Enabled"/>.</summary>
+    public Func<KevlarContext, bool>? EnabledGenerator { get; set; }
+
+    /// <summary>Gets or sets an additional execution predicate that bounds the blast radius.</summary>
+    public Func<KevlarContext, bool>? Predicate { get; set; }
+
+    /// <summary>Gets or sets the required <see cref="ChaosScope.Operation"/> value.</summary>
+    public string? Operation { get; set; }
+
+    /// <summary>Gets or sets the required <see cref="ChaosScope.Environment"/> value.</summary>
+    public string? Environment { get; set; }
+
+    /// <summary>Gets or sets an optional deterministic random seed.</summary>
+    public int? Seed { get; set; }
+
+    /// <summary>Gets or sets a synchronous callback invoked immediately before injection.</summary>
+    public Action<ChaosEvent>? OnInjected { get; set; }
+}

--- a/src/Kevlar.Chaos/ChaosOutcomeOptions.cs
+++ b/src/Kevlar.Chaos/ChaosOutcomeOptions.cs
@@ -1,0 +1,12 @@
+namespace Kevlar.Chaos;
+
+/// <summary>Configures typed result injection.</summary>
+/// <typeparam name="TResult">The result type.</typeparam>
+public sealed class ChaosOutcomeOptions<TResult> : ChaosOptions
+{
+    /// <summary>Gets or sets the result to inject.</summary>
+    public TResult? Result { get; set; }
+
+    /// <summary>Gets or sets a callback that creates the result for each injected execution.</summary>
+    public Func<KevlarContext, TResult>? ResultGenerator { get; set; }
+}

--- a/src/Kevlar.Chaos/ChaosScope.cs
+++ b/src/Kevlar.Chaos/ChaosScope.cs
@@ -1,0 +1,70 @@
+using System.Threading;
+
+namespace Kevlar.Chaos;
+
+/// <summary>
+/// Carries optional operation and environment labels used to bound chaos injection.
+/// </summary>
+public static class ChaosScope
+{
+    private static readonly AsyncLocal<State?> Current = new();
+
+    /// <summary>Gets the current operation label, if any.</summary>
+    public static string? Operation => Current.Value?.Operation;
+
+    /// <summary>Gets the current environment label, if any.</summary>
+    public static string? Environment => Current.Value?.Environment;
+
+    /// <summary>
+    /// Begins an asynchronous-flow scope. Omitted values inherit from the enclosing scope.
+    /// </summary>
+    /// <param name="operation">The operation label.</param>
+    /// <param name="environment">The environment label.</param>
+    /// <returns>A handle that restores the enclosing scope when disposed.</returns>
+    public static IDisposable Begin(string? operation = null, string? environment = null)
+    {
+        var prior = Current.Value;
+        Current.Value = new State(operation ?? prior?.Operation, environment ?? prior?.Environment);
+        return new ScopeHandle(prior);
+    }
+
+    internal static void Capture(out string? operation, out string? environment)
+    {
+        var current = Current.Value;
+        operation = current?.Operation;
+        environment = current?.Environment;
+    }
+
+    private sealed class State
+    {
+        public State(string? operation, string? environment)
+        {
+            Operation = operation;
+            Environment = environment;
+        }
+
+        public string? Operation { get; }
+
+        public string? Environment { get; }
+    }
+
+    private sealed class ScopeHandle : IDisposable
+    {
+        private State? _prior;
+        private bool _disposed;
+
+        public ScopeHandle(State? prior) => _prior = prior;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            Current.Value = _prior;
+            _prior = null;
+            _disposed = true;
+        }
+    }
+}

--- a/src/Kevlar.Chaos/ChaosScope.cs
+++ b/src/Kevlar.Chaos/ChaosScope.cs
@@ -7,13 +7,13 @@ namespace Kevlar.Chaos;
 /// </summary>
 public static class ChaosScope
 {
-    private static readonly AsyncLocal<State?> Current = new();
+    private static readonly AsyncLocal<State?> _current = new();
 
     /// <summary>Gets the current operation label, if any.</summary>
-    public static string? Operation => Current.Value?.Operation;
+    public static string? Operation => _current.Value?.Operation;
 
     /// <summary>Gets the current environment label, if any.</summary>
-    public static string? Environment => Current.Value?.Environment;
+    public static string? Environment => _current.Value?.Environment;
 
     /// <summary>
     /// Begins an asynchronous-flow scope. Omitted values inherit from the enclosing scope.
@@ -23,14 +23,14 @@ public static class ChaosScope
     /// <returns>A handle that restores the enclosing scope when disposed.</returns>
     public static IDisposable Begin(string? operation = null, string? environment = null)
     {
-        var prior = Current.Value;
-        Current.Value = new State(operation ?? prior?.Operation, environment ?? prior?.Environment);
+        var prior = _current.Value;
+        _current.Value = new State(operation ?? prior?.Operation, environment ?? prior?.Environment);
         return new ScopeHandle(prior);
     }
 
     internal static void Capture(out string? operation, out string? environment)
     {
-        var current = Current.Value;
+        var current = _current.Value;
         operation = current?.Operation;
         environment = current?.Environment;
     }
@@ -62,7 +62,7 @@ public static class ChaosScope
                 return;
             }
 
-            Current.Value = _prior;
+            _current.Value = _prior;
             _prior = null;
             _disposed = true;
         }

--- a/src/Kevlar.Chaos/ChaosShield.cs
+++ b/src/Kevlar.Chaos/ChaosShield.cs
@@ -1,0 +1,60 @@
+using Kevlar.Chaos.Internal;
+
+namespace Kevlar.Chaos;
+
+/// <summary>Creates opt-in shields that inject controlled chaos.</summary>
+public static class ChaosShield
+{
+    /// <summary>Creates a shield that injects artificial latency.</summary>
+    /// <param name="configure">Configures explicit enablement, blast radius, and delay.</param>
+    public static Shield Latency(Action<ChaosLatencyOptions> configure)
+    {
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+        var options = new ChaosLatencyOptions();
+        configure(options);
+        return Shield.Use(new LatencyChaosStrategy(options));
+    }
+
+    /// <summary>Creates a shield that short-circuits executions with an exception.</summary>
+    /// <param name="configure">Configures explicit enablement, blast radius, and exception.</param>
+    public static Shield Fault(Action<ChaosFaultOptions> configure)
+    {
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+        var options = new ChaosFaultOptions();
+        configure(options);
+        return Shield.Use(new FaultChaosStrategy(options));
+    }
+
+    /// <summary>Creates a typed shield that short-circuits executions with a result.</summary>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="configure">Configures explicit enablement, blast radius, and result.</param>
+    public static Shield<TResult> Outcome<TResult>(Action<ChaosOutcomeOptions<TResult>> configure)
+    {
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+        var options = new ChaosOutcomeOptions<TResult>();
+        configure(options);
+        return Shield<TResult>.Empty.Use(new OutcomeChaosStrategy<TResult>(options));
+    }
+
+    /// <summary>Creates a shield that runs caller-supplied behavior before continuing.</summary>
+    /// <param name="configure">Configures explicit enablement, blast radius, and behavior.</param>
+    public static Shield Behavior(Action<ChaosBehaviorOptions> configure)
+    {
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+        var options = new ChaosBehaviorOptions();
+        configure(options);
+        return Shield.Use(new BehaviorChaosStrategy(options));
+    }
+}

--- a/src/Kevlar.Chaos/Internal/BehaviorChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/BehaviorChaosStrategy.cs
@@ -21,12 +21,12 @@ internal sealed class BehaviorChaosStrategy : ChaosStrategy
             return next.InvokeAsync(context);
         }
 
-        Notify(ChaosInjectionKind.Behavior, context, decision);
         if (_behavior is null)
         {
             return next.InvokeAsync(context);
         }
 
+        Notify(ChaosInjectionKind.Behavior, context, decision);
         var behavior = _behavior(context);
         if (behavior.IsCompletedSuccessfully)
         {

--- a/src/Kevlar.Chaos/Internal/BehaviorChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/BehaviorChaosStrategy.cs
@@ -16,12 +16,12 @@ internal sealed class BehaviorChaosStrategy : ChaosStrategy
         Continuation<T, TState> next,
         KevlarContext context)
     {
-        if (!TryDecide(context, out var decision))
+        if (_behavior is null)
         {
             return next.InvokeAsync(context);
         }
 
-        if (_behavior is null)
+        if (!TryDecide(context, out var decision))
         {
             return next.InvokeAsync(context);
         }

--- a/src/Kevlar.Chaos/Internal/BehaviorChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/BehaviorChaosStrategy.cs
@@ -1,0 +1,48 @@
+namespace Kevlar.Chaos.Internal;
+
+internal sealed class BehaviorChaosStrategy : ChaosStrategy
+{
+    private readonly Func<KevlarContext, ValueTask>? _behavior;
+
+    public BehaviorChaosStrategy(ChaosBehaviorOptions options)
+        : base(options)
+    {
+        _behavior = options.Behavior;
+    }
+
+    public override string Describe() => "ChaosBehavior";
+
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        if (!TryDecide(context, out var decision))
+        {
+            return next.InvokeAsync(context);
+        }
+
+        Notify(ChaosInjectionKind.Behavior, context, decision);
+        if (_behavior is null)
+        {
+            return next.InvokeAsync(context);
+        }
+
+        var behavior = _behavior(context);
+        if (behavior.IsCompletedSuccessfully)
+        {
+            behavior.GetAwaiter().GetResult();
+            return next.InvokeAsync(context);
+        }
+
+        return AwaitBehaviorAsync(behavior, next, context);
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitBehaviorAsync<T, TState>(
+        ValueTask behavior,
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        await behavior.ConfigureAwait(false);
+        return await next.InvokeAsync(context).ConfigureAwait(false);
+    }
+}

--- a/src/Kevlar.Chaos/Internal/ChaosDecision.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosDecision.cs
@@ -1,0 +1,20 @@
+namespace Kevlar.Chaos.Internal;
+
+internal readonly struct ChaosDecision
+{
+    public ChaosDecision(string? operation, string? environment, double rate, double sample)
+    {
+        Operation = operation;
+        Environment = environment;
+        Rate = rate;
+        Sample = sample;
+    }
+
+    public string? Operation { get; }
+
+    public string? Environment { get; }
+
+    public double Rate { get; }
+
+    public double Sample { get; }
+}

--- a/src/Kevlar.Chaos/Internal/ChaosDelay.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosDelay.cs
@@ -21,7 +21,7 @@ internal static class ChaosDelay
         TimeSpan delay,
         CancellationToken cancellationToken)
     {
-#if NET
+#if NET8_0_OR_GREATER
         return Task.Delay(delay, timeProvider, cancellationToken);
 #else
         return timeProvider.Delay(delay, cancellationToken);

--- a/src/Kevlar.Chaos/Internal/ChaosDelay.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosDelay.cs
@@ -1,0 +1,30 @@
+namespace Kevlar.Chaos.Internal;
+
+internal static class ChaosDelay
+{
+    public static readonly TimeSpan Maximum = TimeSpan.FromMilliseconds(uint.MaxValue - 1d);
+
+    public static ValueTask DelayAsync(KevlarContext context, TimeSpan delay)
+    {
+        var task = CreateTask(context.TimeProvider, delay, context.CancellationToken);
+        if (context.IsSynchronous)
+        {
+            task.GetAwaiter().GetResult();
+            return default;
+        }
+
+        return new ValueTask(task);
+    }
+
+    private static Task CreateTask(
+        TimeProvider timeProvider,
+        TimeSpan delay,
+        CancellationToken cancellationToken)
+    {
+#if NET
+        return Task.Delay(delay, timeProvider, cancellationToken);
+#else
+        return timeProvider.Delay(delay, cancellationToken);
+#endif
+    }
+}

--- a/src/Kevlar.Chaos/Internal/ChaosMetrics.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosMetrics.cs
@@ -1,0 +1,70 @@
+#if NET8_0_OR_GREATER
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+#endif
+
+namespace Kevlar.Chaos.Internal;
+
+internal static class ChaosMetrics
+{
+#if NET8_0_OR_GREATER
+    private static readonly Meter Meter = new(ChaosDiagnostics.MeterName, "1.0");
+    private static readonly Counter<long> Injections = Meter.CreateCounter<long>(
+        "kevlar.chaos.injections",
+        "{injection}",
+        "Chaos injections applied to shield executions.");
+#endif
+
+#if NET8_0_OR_GREATER
+    public static bool Enabled => Injections.Enabled;
+#else
+    public static bool Enabled => false;
+#endif
+
+    public static void Injection(
+        ChaosInjectionKind kind,
+        string? shieldName,
+        string? operation,
+        string? environment)
+    {
+#if NET8_0_OR_GREATER
+        if (!Enabled)
+        {
+            return;
+        }
+
+        var tags = new TagList
+        {
+            { "kevlar.chaos.kind", KindName(kind) },
+        };
+
+        if (shieldName is not null)
+        {
+            tags.Add("kevlar.shield.name", shieldName);
+        }
+
+        if (operation is not null)
+        {
+            tags.Add("kevlar.chaos.operation", operation);
+        }
+
+        if (environment is not null)
+        {
+            tags.Add("kevlar.chaos.environment", environment);
+        }
+
+        Injections.Add(1, tags);
+#endif
+    }
+
+#if NET8_0_OR_GREATER
+    private static string KindName(ChaosInjectionKind kind) => kind switch
+    {
+        ChaosInjectionKind.Latency => "latency",
+        ChaosInjectionKind.Fault => "fault",
+        ChaosInjectionKind.Outcome => "outcome",
+        ChaosInjectionKind.Behavior => "behavior",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+    };
+#endif
+}

--- a/src/Kevlar.Chaos/Internal/ChaosMetrics.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosMetrics.cs
@@ -8,15 +8,15 @@ namespace Kevlar.Chaos.Internal;
 internal static class ChaosMetrics
 {
 #if NET8_0_OR_GREATER
-    private static readonly Meter Meter = new(ChaosDiagnostics.MeterName, "1.0");
-    private static readonly Counter<long> Injections = Meter.CreateCounter<long>(
+    private static readonly Meter _meter = new(ChaosDiagnostics.MeterName, "1.0");
+    private static readonly Counter<long> _injections = _meter.CreateCounter<long>(
         "kevlar.chaos.injections",
         "{injection}",
         "Chaos injections applied to shield executions.");
 #endif
 
 #if NET8_0_OR_GREATER
-    public static bool Enabled => Injections.Enabled;
+    public static bool Enabled => _injections.Enabled;
 #else
     public static bool Enabled => false;
 #endif
@@ -53,7 +53,7 @@ internal static class ChaosMetrics
             tags.Add("kevlar.chaos.environment", environment);
         }
 
-        Injections.Add(1, tags);
+        _injections.Add(1, tags);
 #endif
     }
 

--- a/src/Kevlar.Chaos/Internal/ChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosStrategy.cs
@@ -1,0 +1,124 @@
+using System.Threading;
+
+namespace Kevlar.Chaos.Internal;
+
+internal abstract class ChaosStrategy : Strategy
+{
+    private const long GoldenRatio = unchecked((long)0x9E3779B97F4A7C15UL);
+    private static long _nextUnseeded = DateTime.UtcNow.Ticks;
+
+    private readonly bool _enabled;
+    private readonly double _injectionRate;
+    private readonly Func<KevlarContext, double>? _injectionRateGenerator;
+    private readonly Func<KevlarContext, bool>? _enabledGenerator;
+    private readonly Func<KevlarContext, bool>? _predicate;
+    private readonly string? _requiredOperation;
+    private readonly string? _requiredEnvironment;
+    private readonly Action<ChaosEvent>? _onInjected;
+    private long _randomState;
+
+    protected ChaosStrategy(ChaosOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+        ValidateRate(options.InjectionRate, nameof(options.InjectionRate));
+
+        _enabled = options.Enabled;
+        _injectionRate = options.InjectionRate;
+        _injectionRateGenerator = options.InjectionRateGenerator;
+        _enabledGenerator = options.EnabledGenerator;
+        _predicate = options.Predicate;
+        _requiredOperation = options.Operation;
+        _requiredEnvironment = options.Environment;
+        _onInjected = options.OnInjected;
+        _randomState = options.Seed is { } seed
+            ? seed
+            : Interlocked.Add(ref _nextUnseeded, GoldenRatio);
+    }
+
+    protected bool TryDecide(KevlarContext context, out ChaosDecision decision)
+    {
+        decision = default;
+        if (!_enabled)
+        {
+            return false;
+        }
+
+        if (_enabledGenerator is not null && !_enabledGenerator(context))
+        {
+            return false;
+        }
+
+        if (_predicate is not null && !_predicate(context))
+        {
+            return false;
+        }
+
+        string? operation = null;
+        string? environment = null;
+        if (_requiredOperation is not null
+            || _requiredEnvironment is not null
+            || _onInjected is not null
+            || ChaosMetrics.Enabled)
+        {
+            ChaosScope.Capture(out operation, out environment);
+        }
+
+        if (_requiredOperation is not null && !string.Equals(_requiredOperation, operation, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (_requiredEnvironment is not null && !string.Equals(_requiredEnvironment, environment, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var rate = _injectionRateGenerator?.Invoke(context) ?? _injectionRate;
+        ValidateRate(rate, "generated injection rate");
+        if (rate <= 0)
+        {
+            return false;
+        }
+
+        var sample = rate >= 1 ? 0 : NextSample();
+        if (sample >= rate)
+        {
+            return false;
+        }
+
+        decision = new ChaosDecision(operation, environment, rate, sample);
+        return true;
+    }
+
+    protected void Notify(ChaosInjectionKind kind, KevlarContext context, ChaosDecision decision)
+    {
+        ChaosMetrics.Injection(kind, context.ShieldName, decision.Operation, decision.Environment);
+        _onInjected?.Invoke(new ChaosEvent(
+            kind,
+            context,
+            decision.Operation,
+            decision.Environment,
+            decision.Rate,
+            decision.Sample));
+    }
+
+    private double NextSample()
+    {
+        var value = unchecked((ulong)Interlocked.Add(ref _randomState, GoldenRatio));
+        value = (value ^ (value >> 30)) * 0xBF58476D1CE4E5B9UL;
+        value = (value ^ (value >> 27)) * 0x94D049BB133111EBUL;
+        value ^= value >> 31;
+        return (value >> 11) * (1.0 / (1UL << 53));
+    }
+
+    private static void ValidateRate(double rate, string parameterName)
+    {
+        if (double.IsNaN(rate) || rate < 0 || rate > 1)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, rate, "Injection rate must be between zero and one.");
+        }
+    }
+}

--- a/src/Kevlar.Chaos/Internal/ChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosStrategy.cs
@@ -95,7 +95,6 @@ internal abstract class ChaosStrategy : Strategy
 
     protected void Notify(ChaosInjectionKind kind, KevlarContext context, ChaosDecision decision)
     {
-        ChaosMetrics.Injection(kind, context.ShieldName, decision.Operation, decision.Environment);
         _onInjected?.Invoke(new ChaosEvent(
             kind,
             context,
@@ -103,6 +102,7 @@ internal abstract class ChaosStrategy : Strategy
             decision.Environment,
             decision.Rate,
             decision.Sample));
+        ChaosMetrics.Injection(kind, context.ShieldName, decision.Operation, decision.Environment);
     }
 
     private double NextSample()

--- a/src/Kevlar.Chaos/Internal/FaultChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/FaultChaosStrategy.cs
@@ -1,0 +1,37 @@
+namespace Kevlar.Chaos.Internal;
+
+internal sealed class FaultChaosStrategy : ChaosStrategy
+{
+    private readonly Exception _exception;
+    private readonly Func<KevlarContext, Exception>? _exceptionGenerator;
+
+    public FaultChaosStrategy(ChaosFaultOptions options)
+        : base(options)
+    {
+        _exception = options.Exception ?? new ChaosInjectedException();
+        _exceptionGenerator = options.ExceptionGenerator;
+    }
+
+    public override string Describe() => _exceptionGenerator is null
+        ? $"ChaosFault({_exception.GetType().Name})"
+        : "ChaosFault(dynamic)";
+
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        if (!TryDecide(context, out var decision))
+        {
+            return next.InvokeAsync(context);
+        }
+
+        var exception = _exceptionGenerator is null ? _exception : _exceptionGenerator(context);
+        if (exception is null)
+        {
+            throw new InvalidOperationException("The chaos exception generator returned null.");
+        }
+
+        Notify(ChaosInjectionKind.Fault, context, decision);
+        return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
+    }
+}

--- a/src/Kevlar.Chaos/Internal/LatencyChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/LatencyChaosStrategy.cs
@@ -1,0 +1,62 @@
+namespace Kevlar.Chaos.Internal;
+
+internal sealed class LatencyChaosStrategy : ChaosStrategy
+{
+    private readonly TimeSpan _delay;
+    private readonly Func<KevlarContext, TimeSpan>? _delayGenerator;
+
+    public LatencyChaosStrategy(ChaosLatencyOptions options)
+        : base(options)
+    {
+        ValidateDelay(options.Delay, nameof(options.Delay));
+        _delay = options.Delay;
+        _delayGenerator = options.DelayGenerator;
+    }
+
+    public override string Describe() => _delayGenerator is null
+        ? $"ChaosLatency({_delay.TotalMilliseconds:0.###}ms)"
+        : "ChaosLatency(dynamic)";
+
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        if (!TryDecide(context, out var decision))
+        {
+            return next.InvokeAsync(context);
+        }
+
+        var delay = _delayGenerator?.Invoke(context) ?? _delay;
+        ValidateDelay(delay, "generated delay");
+        Notify(ChaosInjectionKind.Latency, context, decision);
+
+        var wait = ChaosDelay.DelayAsync(context, delay);
+        if (wait.IsCompletedSuccessfully)
+        {
+            wait.GetAwaiter().GetResult();
+            return next.InvokeAsync(context);
+        }
+
+        return AwaitDelayAsync(wait, next, context);
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitDelayAsync<T, TState>(
+        ValueTask wait,
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        await wait.ConfigureAwait(false);
+        return await next.InvokeAsync(context).ConfigureAwait(false);
+    }
+
+    private static void ValidateDelay(TimeSpan delay, string parameterName)
+    {
+        if (delay < TimeSpan.Zero || delay > ChaosDelay.Maximum)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                delay,
+                "Chaos latency must be non-negative and within the runtime timer limit.");
+        }
+    }
+}

--- a/src/Kevlar.Chaos/Internal/OutcomeChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/OutcomeChaosStrategy.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+
+namespace Kevlar.Chaos.Internal;
+
+internal sealed class OutcomeChaosStrategy<TResult> : ChaosStrategy
+{
+    private readonly TResult? _result;
+    private readonly Func<KevlarContext, TResult>? _resultGenerator;
+
+    public OutcomeChaosStrategy(ChaosOutcomeOptions<TResult> options)
+        : base(options)
+    {
+        _result = options.Result;
+        _resultGenerator = options.ResultGenerator;
+    }
+
+    public override string Describe() => _resultGenerator is null
+        ? "ChaosOutcome"
+        : "ChaosOutcome(dynamic)";
+
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        if (!TryDecide(context, out var decision))
+        {
+            return next.InvokeAsync(context);
+        }
+
+        Debug.Assert(typeof(T) == typeof(TResult), "Outcome chaos only executes inside a matching Shield<TResult>.");
+        var typedResult = _resultGenerator is null ? _result : _resultGenerator(context);
+        var result = (T)(object?)typedResult!;
+
+        Notify(ChaosInjectionKind.Outcome, context, decision);
+        return new ValueTask<Outcome<T>>(Outcome<T>.FromResult(result));
+    }
+}

--- a/src/Kevlar.Chaos/Internal/OutcomeChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/OutcomeChaosStrategy.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Kevlar.Chaos.Internal;
 
@@ -29,7 +30,7 @@ internal sealed class OutcomeChaosStrategy<TResult> : ChaosStrategy
 
         Debug.Assert(typeof(T) == typeof(TResult), "Outcome chaos only executes inside a matching Shield<TResult>.");
         var typedResult = _resultGenerator is null ? _result : _resultGenerator(context);
-        var result = (T)(object?)typedResult!;
+        var result = Unsafe.As<TResult?, T>(ref typedResult);
 
         Notify(ChaosInjectionKind.Outcome, context, decision);
         return new ValueTask<Outcome<T>>(Outcome<T>.FromResult(result));

--- a/src/Kevlar.Chaos/Kevlar.Chaos.csproj
+++ b/src/Kevlar.Chaos/Kevlar.Chaos.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <RootNamespace>Kevlar.Chaos</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <Description>Opt-in chaos engineering strategies for Kevlar: deterministic latency, fault, outcome and custom behavior injection with explicit blast-radius controls.</Description>
+    <PackageTags>resilience;chaos-engineering;fault-injection;testing;kevlar</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kevlar.Chaos/Kevlar.Chaos.csproj
+++ b/src/Kevlar.Chaos/Kevlar.Chaos.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kevlar.Chaos</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>

--- a/src/Kevlar.Chaos/Kevlar.Chaos.csproj
+++ b/src/Kevlar.Chaos/Kevlar.Chaos.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
   </ItemGroup>
 

--- a/src/Kevlar.Chaos/PublicAPI.Shipped.txt
+++ b/src/Kevlar.Chaos/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Kevlar.Chaos/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Chaos/PublicAPI.Unshipped.txt
@@ -1,0 +1,71 @@
+#nullable enable
+const Kevlar.Chaos.ChaosDiagnostics.MeterName = "Kevlar.Chaos" -> string!
+Kevlar.Chaos.ChaosBehaviorOptions
+Kevlar.Chaos.ChaosBehaviorOptions.Behavior.get -> System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.ValueTask>?
+Kevlar.Chaos.ChaosBehaviorOptions.Behavior.set -> void
+Kevlar.Chaos.ChaosBehaviorOptions.ChaosBehaviorOptions() -> void
+Kevlar.Chaos.ChaosDiagnostics
+Kevlar.Chaos.ChaosEvent
+Kevlar.Chaos.ChaosEvent.ChaosEvent() -> void
+Kevlar.Chaos.ChaosEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.Chaos.ChaosEvent.Environment.get -> string?
+Kevlar.Chaos.ChaosEvent.InjectionRate.get -> double
+Kevlar.Chaos.ChaosEvent.Kind.get -> Kevlar.Chaos.ChaosInjectionKind
+Kevlar.Chaos.ChaosEvent.Operation.get -> string?
+Kevlar.Chaos.ChaosEvent.Sample.get -> double
+Kevlar.Chaos.ChaosFaultOptions
+Kevlar.Chaos.ChaosFaultOptions.ChaosFaultOptions() -> void
+Kevlar.Chaos.ChaosFaultOptions.Exception.get -> System.Exception?
+Kevlar.Chaos.ChaosFaultOptions.Exception.set -> void
+Kevlar.Chaos.ChaosFaultOptions.ExceptionGenerator.get -> System.Func<Kevlar.KevlarContext!, System.Exception!>?
+Kevlar.Chaos.ChaosFaultOptions.ExceptionGenerator.set -> void
+Kevlar.Chaos.ChaosInjectedException
+Kevlar.Chaos.ChaosInjectedException.ChaosInjectedException() -> void
+Kevlar.Chaos.ChaosInjectedException.ChaosInjectedException(string! message) -> void
+Kevlar.Chaos.ChaosInjectedException.ChaosInjectedException(string! message, System.Exception! innerException) -> void
+Kevlar.Chaos.ChaosInjectionKind
+Kevlar.Chaos.ChaosInjectionKind.Behavior = 3 -> Kevlar.Chaos.ChaosInjectionKind
+Kevlar.Chaos.ChaosInjectionKind.Fault = 1 -> Kevlar.Chaos.ChaosInjectionKind
+Kevlar.Chaos.ChaosInjectionKind.Latency = 0 -> Kevlar.Chaos.ChaosInjectionKind
+Kevlar.Chaos.ChaosInjectionKind.Outcome = 2 -> Kevlar.Chaos.ChaosInjectionKind
+Kevlar.Chaos.ChaosLatencyOptions
+Kevlar.Chaos.ChaosLatencyOptions.ChaosLatencyOptions() -> void
+Kevlar.Chaos.ChaosLatencyOptions.Delay.get -> System.TimeSpan
+Kevlar.Chaos.ChaosLatencyOptions.Delay.set -> void
+Kevlar.Chaos.ChaosLatencyOptions.DelayGenerator.get -> System.Func<Kevlar.KevlarContext!, System.TimeSpan>?
+Kevlar.Chaos.ChaosLatencyOptions.DelayGenerator.set -> void
+Kevlar.Chaos.ChaosOptions
+Kevlar.Chaos.ChaosOptions.ChaosOptions() -> void
+Kevlar.Chaos.ChaosOptions.Enabled.get -> bool
+Kevlar.Chaos.ChaosOptions.Enabled.set -> void
+Kevlar.Chaos.ChaosOptions.EnabledGenerator.get -> System.Func<Kevlar.KevlarContext!, bool>?
+Kevlar.Chaos.ChaosOptions.EnabledGenerator.set -> void
+Kevlar.Chaos.ChaosOptions.Environment.get -> string?
+Kevlar.Chaos.ChaosOptions.Environment.set -> void
+Kevlar.Chaos.ChaosOptions.InjectionRate.get -> double
+Kevlar.Chaos.ChaosOptions.InjectionRate.set -> void
+Kevlar.Chaos.ChaosOptions.InjectionRateGenerator.get -> System.Func<Kevlar.KevlarContext!, double>?
+Kevlar.Chaos.ChaosOptions.InjectionRateGenerator.set -> void
+Kevlar.Chaos.ChaosOptions.OnInjected.get -> System.Action<Kevlar.Chaos.ChaosEvent>?
+Kevlar.Chaos.ChaosOptions.OnInjected.set -> void
+Kevlar.Chaos.ChaosOptions.Operation.get -> string?
+Kevlar.Chaos.ChaosOptions.Operation.set -> void
+Kevlar.Chaos.ChaosOptions.Predicate.get -> System.Func<Kevlar.KevlarContext!, bool>?
+Kevlar.Chaos.ChaosOptions.Predicate.set -> void
+Kevlar.Chaos.ChaosOptions.Seed.get -> int?
+Kevlar.Chaos.ChaosOptions.Seed.set -> void
+Kevlar.Chaos.ChaosOutcomeOptions<TResult>
+Kevlar.Chaos.ChaosOutcomeOptions<TResult>.ChaosOutcomeOptions() -> void
+Kevlar.Chaos.ChaosOutcomeOptions<TResult>.Result.get -> TResult?
+Kevlar.Chaos.ChaosOutcomeOptions<TResult>.Result.set -> void
+Kevlar.Chaos.ChaosOutcomeOptions<TResult>.ResultGenerator.get -> System.Func<Kevlar.KevlarContext!, TResult>?
+Kevlar.Chaos.ChaosOutcomeOptions<TResult>.ResultGenerator.set -> void
+Kevlar.Chaos.ChaosScope
+Kevlar.Chaos.ChaosShield
+static Kevlar.Chaos.ChaosScope.Begin(string? operation = null, string? environment = null) -> System.IDisposable!
+static Kevlar.Chaos.ChaosScope.Environment.get -> string?
+static Kevlar.Chaos.ChaosScope.Operation.get -> string?
+static Kevlar.Chaos.ChaosShield.Behavior(System.Action<Kevlar.Chaos.ChaosBehaviorOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.Chaos.ChaosShield.Fault(System.Action<Kevlar.Chaos.ChaosFaultOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.Chaos.ChaosShield.Latency(System.Action<Kevlar.Chaos.ChaosLatencyOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.Chaos.ChaosShield.Outcome<TResult>(System.Action<Kevlar.Chaos.ChaosOutcomeOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -1,3 +1,5 @@
+using Kevlar.Chaos;
+
 namespace Kevlar.AllocationTests;
 
 /// <summary>Guards documented allocation budgets for representative shield execution paths.</summary>
@@ -22,6 +24,12 @@ public class AllocationBudgetTests
     });
     private readonly Shield _breaker = Shield.CircuitBreaker(5, TimeSpan.FromMinutes(1));
     private readonly Shield _timeout = Shield.Timeout(TimeSpan.FromMinutes(1));
+    private readonly Shield _disabledChaos = ChaosShield.Fault(static _ => { });
+    private readonly Shield _excludedChaos = ChaosShield.Fault(static options =>
+    {
+        options.Enabled = true;
+        options.InjectionRate = 0;
+    });
     private readonly Shield<int> _fallback = Shield.For<int>()
         .When<InvalidOperationException>()
         .Fallback(7);
@@ -104,6 +112,10 @@ public class AllocationBudgetTests
             test._breaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("timeout happy path", this, static test =>
             test._timeout.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("chaos disabled", this, static test =>
+            test._disabledChaos.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("chaos excluded by rate", this, static test =>
+            test._excludedChaos.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("fallback pass-through", this, static test =>
             test._fallback.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("fallback async notification pass-through", this, static test =>

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -30,6 +30,11 @@ public class AllocationBudgetTests
         options.Enabled = true;
         options.InjectionRate = 0;
     });
+    private readonly Shield<int> _enabledOutcomeChaos = ChaosShield.Outcome<int>(static options =>
+    {
+        options.Enabled = true;
+        options.Result = 42;
+    });
     private readonly Shield<int> _fallback = Shield.For<int>()
         .When<InvalidOperationException>()
         .Fallback(7);
@@ -116,6 +121,8 @@ public class AllocationBudgetTests
             test._disabledChaos.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("chaos excluded by rate", this, static test =>
             test._excludedChaos.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("chaos outcome injected", this, static test =>
+            test._enabledOutcomeChaos.ExecuteAsync(static _ => new ValueTask<int>(0)).GetAwaiter().GetResult());
         AssertZero("fallback pass-through", this, static test =>
             test._fallback.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("fallback async notification pass-through", this, static test =>

--- a/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
@@ -554,18 +554,35 @@ public class ChaosStrategyTests
     }
 
     [Test]
-    public async Task Missing_Behavior_Does_Not_Report_An_Injection()
+    public async Task Missing_Behavior_Skips_Decision_And_Injection_Callbacks()
     {
+        var decisionCallbacks = 0;
         var injections = 0;
         var shield = ChaosShield.Behavior(options =>
         {
             options.Enabled = true;
+            options.EnabledGenerator = _ =>
+            {
+                decisionCallbacks++;
+                return true;
+            };
+            options.Predicate = _ =>
+            {
+                decisionCallbacks++;
+                return true;
+            };
+            options.InjectionRateGenerator = _ =>
+            {
+                decisionCallbacks++;
+                return 1;
+            };
             options.OnInjected = _ => injections++;
         });
 
         var result = await shield.ExecuteAsync(static _ => new ValueTask<int>(42));
 
         await Assert.That(result).IsEqualTo(42);
+        await Assert.That(decisionCallbacks).IsEqualTo(0);
         await Assert.That(injections).IsEqualTo(0);
     }
 

--- a/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
@@ -1,0 +1,582 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Chaos.Tests;
+
+public class ChaosStrategyTests
+{
+    [Test]
+    public async Task Chaos_Is_Disabled_By_Default_For_Every_Injection_Type()
+    {
+        var behaviorCalls = 0;
+        var actionCalls = 0;
+        var fault = ChaosShield.Fault(_ => { });
+        var latency = ChaosShield.Latency(options => options.Delay = TimeSpan.FromDays(1));
+        var outcome = ChaosShield.Outcome<int>(options => options.Result = -1);
+        var behavior = ChaosShield.Behavior(options => options.Behavior = _ =>
+        {
+            behaviorCalls++;
+            return ValueTask.CompletedTask;
+        });
+
+        var faultResult = await fault.ExecuteAsync(_ => new ValueTask<int>(1));
+        var latencyResult = await latency.ExecuteAsync(_ => new ValueTask<int>(2));
+        var outcomeResult = await outcome.ExecuteAsync(_ => new ValueTask<int>(3));
+        var behaviorResult = await behavior.ExecuteAsync(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<int>(4);
+        });
+
+        await Assert.That(faultResult).IsEqualTo(1);
+        await Assert.That(latencyResult).IsEqualTo(2);
+        await Assert.That(outcomeResult).IsEqualTo(3);
+        await Assert.That(behaviorResult).IsEqualTo(4);
+        await Assert.That(behaviorCalls).IsEqualTo(0);
+        await Assert.That(actionCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Latency_Uses_TimeProvider_And_Waits_Before_The_Action()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var actionCalls = 0;
+        var shield = ChaosShield.Latency(options =>
+        {
+            options.Enabled = true;
+            options.Delay = TimeSpan.FromSeconds(2);
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<int>(42);
+        }).AsTask();
+
+        await Assert.That(execution.IsCompleted).IsFalse();
+        await Assert.That(actionCalls).IsEqualTo(0);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(actionCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Latency_Cancellation_Preserves_The_Caller_Token_And_Skips_The_Action()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var actionCalls = 0;
+        var shield = ChaosShield.Latency(options =>
+        {
+            options.Enabled = true;
+            options.Delay = TimeSpan.FromDays(1);
+        });
+
+        var execution = shield.ExecuteAsync(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<int>(42);
+        }, cancellation.Token).AsTask();
+        cancellation.Cancel();
+
+        OperationCanceledException? caught = null;
+        try
+        {
+            await execution.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (OperationCanceledException exception)
+        {
+            caught = exception;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.CancellationToken).IsEqualTo(cancellation.Token);
+        await Assert.That(actionCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Fault_Short_Circuits_With_Exact_Exception_For_Result_And_Void_Execution()
+    {
+        var injected = new TestException("injected");
+        var actionCalls = 0;
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.Exception = injected;
+        });
+
+        var typed = await shield.ExecuteOutcomeAsync<int>(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<int>(42);
+        });
+        Exception? untyped = null;
+        try
+        {
+            await shield.ExecuteAsync(_ =>
+            {
+                actionCalls++;
+                return ValueTask.CompletedTask;
+            });
+        }
+        catch (Exception exception)
+        {
+            untyped = exception;
+        }
+
+        await Assert.That(ReferenceEquals(typed.Exception, injected)).IsTrue();
+        await Assert.That(ReferenceEquals(untyped, injected)).IsTrue();
+        await Assert.That(actionCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Typed_Outcome_Preserves_Result_Identity_And_Composes_With_Fallback()
+    {
+        var injected = new Payload("injected");
+        var recovered = new Payload("recovered");
+        var chaos = ChaosShield.Outcome<Payload>(options =>
+        {
+            options.Enabled = true;
+            options.Result = injected;
+        });
+        var shield = Shield.For<Payload>()
+            .WhenResult(value => ReferenceEquals(value, injected))
+            .Fallback(recovered)
+            .Wrap(chaos);
+
+        var chaosOutcome = await chaos.ExecuteOutcomeAsync(_ => new ValueTask<Payload>(new Payload("real")));
+        var result = await shield.ExecuteAsync(_ => new ValueTask<Payload>(new Payload("real")));
+
+        await Assert.That(ReferenceEquals(chaosOutcome.Result, injected)).IsTrue();
+        await Assert.That(ReferenceEquals(result, recovered)).IsTrue();
+    }
+
+    [Test]
+    public async Task Behavior_Is_Awaited_Before_Continuing_And_Can_Inject_An_Exact_Failure()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var order = new List<string>();
+        var shield = ChaosShield.Behavior(options =>
+        {
+            options.Enabled = true;
+            options.Behavior = async _ =>
+            {
+                order.Add("behavior-start");
+                started.SetResult();
+                await release.Task;
+                order.Add("behavior-end");
+            };
+        });
+
+        var execution = shield.ExecuteAsync(_ =>
+        {
+            order.Add("action");
+            return new ValueTask<int>(42);
+        }).AsTask();
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(order).IsEquivalentTo(["behavior-start"]);
+        release.SetResult();
+
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(string.Join(",", order)).IsEqualTo("behavior-start,behavior-end,action");
+
+        var injected = new TestException("behavior");
+        var failing = ChaosShield.Behavior(options =>
+        {
+            options.Enabled = true;
+            options.Behavior = _ => ValueTask.FromException(injected);
+        });
+        var failed = await failing.ExecuteOutcomeAsync<int>(_ => new ValueTask<int>(1));
+
+        await Assert.That(ReferenceEquals(failed.Exception, injected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Seeded_Rate_Is_Deterministic_And_The_Generator_Receives_Context()
+    {
+        var first = CreateSeededFault(seed: 42);
+        var second = CreateSeededFault(seed: 42);
+        var firstSequence = await ExecuteSequence(first, 32);
+        var secondSequence = await ExecuteSequence(second, 32);
+
+        await Assert.That(firstSequence.SequenceEqual(secondSequence)).IsTrue();
+        await Assert.That(firstSequence.Distinct().Count()).IsEqualTo(2);
+
+        var generated = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.InjectionRate = 0;
+            options.InjectionRateGenerator = context => context.ShieldName == "inject" ? 1 : 0;
+        }).WithName("inject");
+        var outcome = await generated.ExecuteOutcomeAsync<int>(_ => new ValueTask<int>(42));
+
+        await Assert.That(outcome.Exception).IsTypeOf<ChaosInjectedException>();
+    }
+
+    [Test]
+    public async Task Scope_Bounds_Operation_And_Environment_And_Flows_Across_Awaits()
+    {
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.Operation = "checkout";
+            options.Environment = "staging";
+        });
+
+        var outside = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+        Outcome<int> wrong;
+        using (ChaosScope.Begin(operation: "search", environment: "staging"))
+        {
+            wrong = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(2));
+        }
+
+        Outcome<int> matched;
+        using (ChaosScope.Begin(operation: "checkout", environment: "staging"))
+        {
+            await Task.Yield();
+            matched = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(3));
+        }
+
+        await Assert.That(outside.Result).IsEqualTo(1);
+        await Assert.That(wrong.Result).IsEqualTo(2);
+        await Assert.That(matched.Exception).IsTypeOf<ChaosInjectedException>();
+        await Assert.That(ChaosScope.Operation).IsNull();
+        await Assert.That(ChaosScope.Environment).IsNull();
+    }
+
+    [Test]
+    public async Task Predicate_And_Dynamic_Enablement_Bound_The_Blast_Radius()
+    {
+        var killSwitch = true;
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.EnabledGenerator = _ => killSwitch;
+            options.Predicate = context => !context.IsSynchronous;
+        });
+
+        var injected = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+        var synchronous = shield.Execute(_ => 2);
+        killSwitch = false;
+        var disabled = await shield.ExecuteAsync(_ => new ValueTask<int>(3));
+
+        await Assert.That(injected.Exception).IsTypeOf<ChaosInjectedException>();
+        await Assert.That(synchronous).IsEqualTo(2);
+        await Assert.That(disabled).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Injection_Event_Identifies_Type_Scope_Rate_And_Context()
+    {
+        ChaosEvent observed = default;
+        string? observedShieldName = null;
+        var shield = ChaosShield.Outcome<int>(options =>
+        {
+            options.Enabled = true;
+            options.Result = 42;
+            options.OnInjected = injection =>
+            {
+                observed = injection;
+                observedShieldName = injection.Context.ShieldName;
+            };
+        }).WithName("chaos-event");
+
+        using (ChaosScope.Begin("checkout", "test"))
+        {
+            _ = await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        }
+
+        await Assert.That(observed.Kind).IsEqualTo(ChaosInjectionKind.Outcome);
+        await Assert.That(observedShieldName).IsEqualTo("chaos-event");
+        await Assert.That(observed.Operation).IsEqualTo("checkout");
+        await Assert.That(observed.Environment).IsEqualTo("test");
+        await Assert.That(observed.InjectionRate).IsEqualTo(1);
+        await Assert.That(observed.Sample).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Configuration_Is_Snapshotted_When_The_Shield_Is_Built()
+    {
+        ChaosFaultOptions? captured = null;
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = false;
+            captured = options;
+        });
+
+        captured!.Enabled = true;
+        captured.InjectionRate = 1;
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Sync_Execution_Supports_Every_Semantically_Valid_Injection()
+    {
+        var latency = ChaosShield.Latency(options => options.Enabled = true);
+        var outcome = ChaosShield.Outcome<int>(options =>
+        {
+            options.Enabled = true;
+            options.Result = 7;
+        });
+        var behaviorCalls = 0;
+        var behavior = ChaosShield.Behavior(options =>
+        {
+            options.Enabled = true;
+            options.Behavior = _ =>
+            {
+                behaviorCalls++;
+                return ValueTask.CompletedTask;
+            };
+        });
+
+        await Assert.That(latency.Execute(_ => 1)).IsEqualTo(1);
+        await Assert.That(outcome.Execute(_ => 2)).IsEqualTo(7);
+        await Assert.That(behavior.Execute(_ => 3)).IsEqualTo(3);
+        await Assert.That(behaviorCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dynamic_Generator_Failures_Are_Preserved_As_Outcomes()
+    {
+        var generatedFailure = new TestException("generator");
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.InjectionRateGenerator = _ => throw generatedFailure;
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, generatedFailure)).IsTrue();
+    }
+
+    [Test]
+    public async Task Invalid_Fixed_And_Generated_Values_Are_Rejected()
+    {
+        await Assert.That(() => ChaosShield.Fault(options => options.InjectionRate = 1.1))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => ChaosShield.Latency(options => options.Delay = TimeSpan.FromMilliseconds(-1)))
+            .Throws<ArgumentOutOfRangeException>();
+
+        var generated = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.InjectionRateGenerator = _ => double.NaN;
+        });
+        var outcome = await generated.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(outcome.Exception).IsTypeOf<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Concurrent_Executions_Safely_Share_Seeded_Random_State()
+    {
+        var shield = CreateSeededFault(42);
+
+        var outcomes = await Task.WhenAll(Enumerable.Range(0, 2_000).Select(async _ =>
+            await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(1))));
+
+        var injected = outcomes.Count(static outcome => outcome.Exception is ChaosInjectedException);
+        await Assert.That(injected).IsGreaterThan(0);
+        await Assert.That(injected).IsLessThan(outcomes.Length);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Metrics_Distinguish_Every_Injection_Kind()
+    {
+        var prefix = $"chaos-metrics-{Guid.NewGuid():N}";
+        var observed = new ConcurrentDictionary<string, string>();
+        string? observedOperation = null;
+        string? observedEnvironment = null;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, activeListener) =>
+        {
+            if (instrument.Meter.Name == ChaosDiagnostics.MeterName
+                && instrument.Name == "kevlar.chaos.injections")
+            {
+                activeListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            string? shieldName = null;
+            string? kind = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "kevlar.shield.name")
+                {
+                    shieldName = tag.Value?.ToString();
+                }
+                else if (tag.Key == "kevlar.chaos.kind")
+                {
+                    kind = tag.Value?.ToString();
+                }
+                else if (tag.Key == "kevlar.chaos.operation")
+                {
+                    observedOperation = tag.Value?.ToString();
+                }
+                else if (tag.Key == "kevlar.chaos.environment")
+                {
+                    observedEnvironment = tag.Value?.ToString();
+                }
+            }
+
+            if (shieldName is not null && kind is not null && shieldName.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                observed[shieldName] = kind;
+            }
+        });
+        listener.Start();
+
+        var latency = ChaosShield.Latency(static options => options.Enabled = true)
+            .WithName($"{prefix}-latency");
+        var fault = ChaosShield.Fault(static options => options.Enabled = true)
+            .WithName($"{prefix}-fault");
+        var outcome = ChaosShield.Outcome<int>(static options => options.Enabled = true)
+            .WithName($"{prefix}-outcome");
+        var behavior = ChaosShield.Behavior(static options => options.Enabled = true)
+            .WithName($"{prefix}-behavior");
+
+        using (ChaosScope.Begin("metrics-operation", "metrics-environment"))
+        {
+            _ = await latency.ExecuteAsync(static _ => new ValueTask<int>(1));
+            _ = await fault.ExecuteOutcomeAsync(static _ => new ValueTask<int>(1));
+            _ = await outcome.ExecuteAsync(static _ => new ValueTask<int>(1));
+            _ = await behavior.ExecuteAsync(static _ => new ValueTask<int>(1));
+        }
+
+        await Assert.That(observed[$"{prefix}-latency"]).IsEqualTo("latency");
+        await Assert.That(observed[$"{prefix}-fault"]).IsEqualTo("fault");
+        await Assert.That(observed[$"{prefix}-outcome"]).IsEqualTo("outcome");
+        await Assert.That(observed[$"{prefix}-behavior"]).IsEqualTo("behavior");
+        await Assert.That(observedOperation).IsEqualTo("metrics-operation");
+        await Assert.That(observedEnvironment).IsEqualTo("metrics-environment");
+    }
+
+    [Test]
+    public async Task Dynamic_Payload_Generators_Receive_Context()
+    {
+        var resultShield = ChaosShield.Outcome<string>(options =>
+        {
+            options.Enabled = true;
+            options.ResultGenerator = context => context.ShieldName!;
+        }).WithName("generated-result");
+        var faultShield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.ExceptionGenerator = context => new TestException(context.ShieldName!);
+        }).WithName("generated-fault");
+
+        var result = await resultShield.ExecuteAsync(static _ => new ValueTask<string>("real"));
+        var fault = await faultShield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(1));
+
+        await Assert.That(result).IsEqualTo("generated-result");
+        await Assert.That(fault.Exception!.Message).IsEqualTo("generated-fault");
+        await Assert.That(resultShield.ToString()).Contains("ChaosOutcome(dynamic)");
+        await Assert.That(faultShield.ToString()).Contains("ChaosFault(dynamic)");
+    }
+
+    [Test]
+    public async Task Nested_Scopes_Inherit_And_Restore_Labels()
+    {
+        using (ChaosScope.Begin(operation: "outer-operation", environment: "outer-environment"))
+        {
+            var inner = ChaosScope.Begin(operation: "inner-operation");
+            await Assert.That(ChaosScope.Operation).IsEqualTo("inner-operation");
+            await Assert.That(ChaosScope.Environment).IsEqualTo("outer-environment");
+            inner.Dispose();
+            inner.Dispose();
+
+            await Assert.That(ChaosScope.Operation).IsEqualTo("outer-operation");
+            await Assert.That(ChaosScope.Environment).IsEqualTo("outer-environment");
+        }
+
+        await Assert.That(ChaosScope.Operation).IsNull();
+        await Assert.That(ChaosScope.Environment).IsNull();
+    }
+
+    [Test]
+    public async Task Injection_Callback_Failure_Is_Preserved()
+    {
+        var injected = new TestException("callback");
+        var shield = ChaosShield.Latency(options =>
+        {
+            options.Enabled = true;
+            options.OnInjected = _ => throw injected;
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(1));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, injected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Factories_Reject_Null_Configuration_Callbacks()
+    {
+        await Assert.That(() => ChaosShield.Latency(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => ChaosShield.Fault(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => ChaosShield.Outcome<int>(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => ChaosShield.Behavior(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Dynamic_Latency_Uses_Generated_Delay_And_Describes_Itself()
+    {
+        var shield = ChaosShield.Latency(options =>
+        {
+            options.Enabled = true;
+            options.DelayGenerator = static _ => TimeSpan.Zero;
+        });
+
+        var result = await shield.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(shield.ToString()).Contains("ChaosLatency(dynamic)");
+    }
+
+    [Test]
+    public async Task Null_Generated_Exception_Is_Reported_As_A_Configuration_Failure()
+    {
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.ExceptionGenerator = static _ => null!;
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(outcome.Exception).IsTypeOf<InvalidOperationException>();
+    }
+
+    private static Shield CreateSeededFault(int seed) => ChaosShield.Fault(options =>
+    {
+        options.Enabled = true;
+        options.InjectionRate = 0.5;
+        options.Seed = seed;
+    });
+
+    private static async Task<bool[]> ExecuteSequence(Shield shield, int count)
+    {
+        var sequence = new bool[count];
+        for (var index = 0; index < count; index++)
+        {
+            var outcome = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+            sequence[index] = outcome.Exception is ChaosInjectedException;
+        }
+
+        return sequence;
+    }
+
+    private sealed record Payload(string Value);
+
+    private sealed class TestException(string message) : Exception(message);
+}

--- a/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
@@ -410,6 +410,8 @@ public class ChaosStrategyTests
         {
             string? shieldName = null;
             string? kind = null;
+            string? operation = null;
+            string? environment = null;
             foreach (var tag in tags)
             {
                 if (tag.Key == "kevlar.shield.name")
@@ -422,17 +424,19 @@ public class ChaosStrategyTests
                 }
                 else if (tag.Key == "kevlar.chaos.operation")
                 {
-                    observedOperation = tag.Value?.ToString();
+                    operation = tag.Value?.ToString();
                 }
                 else if (tag.Key == "kevlar.chaos.environment")
                 {
-                    observedEnvironment = tag.Value?.ToString();
+                    environment = tag.Value?.ToString();
                 }
             }
 
             if (shieldName is not null && kind is not null && shieldName.StartsWith(prefix, StringComparison.Ordinal))
             {
                 observed[shieldName] = kind;
+                observedOperation = operation;
+                observedEnvironment = environment;
             }
         });
         listener.Start();
@@ -443,7 +447,11 @@ public class ChaosStrategyTests
             .WithName($"{prefix}-fault");
         var outcome = ChaosShield.Outcome<int>(static options => options.Enabled = true)
             .WithName($"{prefix}-outcome");
-        var behavior = ChaosShield.Behavior(static options => options.Enabled = true)
+        var behavior = ChaosShield.Behavior(static options =>
+        {
+            options.Enabled = true;
+            options.Behavior = static _ => ValueTask.CompletedTask;
+        })
             .WithName($"{prefix}-behavior");
 
         using (ChaosScope.Begin("metrics-operation", "metrics-environment"))
@@ -543,6 +551,22 @@ public class ChaosStrategyTests
 
         await Assert.That(ReferenceEquals(outcome.Exception, injected)).IsTrue();
         await Assert.That(measurements).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Missing_Behavior_Does_Not_Report_An_Injection()
+    {
+        var injections = 0;
+        var shield = ChaosShield.Behavior(options =>
+        {
+            options.Enabled = true;
+            options.OnInjected = _ => injections++;
+        });
+
+        var result = await shield.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(injections).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
@@ -505,18 +505,44 @@ public class ChaosStrategyTests
     }
 
     [Test]
+    [NotInParallel]
     public async Task Injection_Callback_Failure_Is_Preserved()
     {
         var injected = new TestException("callback");
+        var shieldName = $"callback-failure-{Guid.NewGuid():N}";
+        var measurements = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, activeListener) =>
+        {
+            if (instrument.Meter.Name == ChaosDiagnostics.MeterName
+                && instrument.Name == "kevlar.chaos.injections")
+            {
+                activeListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "kevlar.shield.name"
+                    && string.Equals(tag.Value?.ToString(), shieldName, StringComparison.Ordinal))
+                {
+                    measurements++;
+                }
+            }
+        });
+        listener.Start();
+
         var shield = ChaosShield.Latency(options =>
         {
             options.Enabled = true;
             options.OnInjected = _ => throw injected;
-        });
+        }).WithName(shieldName);
 
         var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(1));
 
         await Assert.That(ReferenceEquals(outcome.Exception, injected)).IsTrue();
+        await Assert.That(measurements).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
+++ b/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
@@ -4,16 +4,15 @@
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Kevlar.Chaos\Kevlar.Chaos.csproj" />
-    <ProjectReference Include="..\..\src\Kevlar\Kevlar.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Kevlar" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Analyzers" VersionOverride="$(KevlarPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="Kevlar.Chaos" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.Http" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />


### PR DESCRIPTION
## Summary

- add the optional Kevlar.Chaos package with latency, fault, typed outcome, and custom behavior strategies
- keep injection disabled by default; add operation/environment scopes, predicates, dynamic kill switches, rates, deterministic seeds, and TimeProvider support
- publish injection callbacks and metrics; add safety docs, CI/package consumers, allocation gates, and benchmarks

Closes #78

## Validation

- dotnet build Kevlar.slnx -c Release
- all 662 functional tests and 2 allocation gates
- merged coverage: 95.02% lines, 91.62% branches
- package layout plus net8/net10 trimmed and single-file consumers
- 88 compiled documentation snippets and Docusaurus production build
- BenchmarkDotNet ShortRun: disabled 58.94 ns, rate-excluded 58.99 ns, typed outcome 40.98 ns, zero latency 73.10 ns, completed behavior 69.09 ns; all 0 B/op

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the optional Kevlar.Chaos package for controlled latency, faults, typed outcomes, and custom behaviors.
  * Added configurable injection rates, filters, deterministic sampling, scopes, callbacks, and telemetry.
* **Documentation**
  * Added installation guidance, safety information, usage examples, and troubleshooting details.
* **Testing**
  * Added comprehensive chaos, allocation, compatibility, coverage, and performance validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->