### PR TITLE
perf(execution): fast-path empty outcome calls

### DIFF
--- a/src/Kevlar/Internal/ShieldEngine.cs
+++ b/src/Kevlar/Internal/ShieldEngine.cs
@@ -72,6 +72,28 @@ internal static class ShieldEngine
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(new OperationCanceledException(cancellationToken)));
         }
 
+        if (head is null)
+        {
+            ValueTask<T> execution;
+            try
+            {
+                execution = action(state, cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                RecordExecution(startedAt, shieldName, success: false);
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
+            }
+
+            if (execution.IsCompletedSuccessfully)
+            {
+                RecordExecution(startedAt, shieldName, success: true);
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromResult(execution.Result));
+            }
+
+            return AwaitDirectOutcomeAsync(execution, shieldName, startedAt);
+        }
+
         var context = KevlarContext.Rent(cancellationToken, isSynchronous: false, timeProvider, shieldName);
         var pipeline = RunAsync(head, state, action, context);
 
@@ -211,6 +233,25 @@ internal static class ShieldEngine
             RecordExecution(startedAt, shieldName, success: false);
             throw;
         }
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitDirectOutcomeAsync<T>(
+        ValueTask<T> execution,
+        string? shieldName,
+        long startedAt)
+    {
+        Outcome<T> outcome;
+        try
+        {
+            outcome = Outcome<T>.FromResult(await execution.ConfigureAwait(false));
+        }
+        catch (Exception exception)
+        {
+            outcome = Outcome<T>.FromException(exception);
+        }
+
+        RecordExecution(startedAt, shieldName, outcome.IsSuccess);
+        return outcome;
     }
 
     private static async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(


### PR DESCRIPTION
## Summary

- bypass context rental and pipeline construction for `ExecuteOutcomeAsync` when the shield has no strategies
- preserve synchronous and asynchronous exception capture as `Outcome<T>`
- preserve cancellation and execution-metrics behavior

## Profiling finding

`ExecuteOutcomeAsync` did not share the existing empty-pipeline fast path used by `ExecuteAsync`. A no-strategy outcome call therefore paid for `KevlarContext.Rent`, continuation construction, and context return on every execution.

## Benchmark

BenchmarkDotNet 0.15.8, default job, .NET 10.0.11, Windows 11, Intel Core Ultra 9 185H. Both runs used the same checkout base and machine.

| Benchmark | Before | After | Change | Allocated |
|---|---:|---:|---:|---:|
| `Kevlar_EmptyOutcomeState` | 110.5 ns | 21.28 ns | **80.7% faster (5.2x)** | 0 B -> 0 B |

Commands:

```powershell
dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*EmptyOutcomeState*"
```

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (612 passed)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (2 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of errors during direct actions so failures are returned consistently instead of causing unexpected interruptions.
  * Preserved successful results for both immediate and asynchronous actions.
  * Execution metrics are now recorded consistently for asynchronous processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->