### PR TITLE
perf(concurrency): fast-path uncontended permits

### DIFF
--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -199,15 +199,13 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     private void ReleasePermit()
     {
-        // A waiter registers before retrying the atomic pool, so a concurrent release either
-        // replenishes that pool for the retry or signals the semaphore after the retry fails.
-        if (Volatile.Read(ref _waiters) > 0)
+        // Publish first. A waiter that registers concurrently either claims this permit on its
+        // atomic retry, or leaves it here for this release to transfer to the semaphore.
+        Interlocked.Increment(ref _available);
+        if (Volatile.Read(ref _waiters) > 0 && TryAcquirePermit())
         {
             _semaphore.Release();
-            return;
         }
-
-        Interlocked.Increment(ref _available);
     }
 
     private void UpdateMetricsState(int inflightDelta, int queuedDelta)

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -7,10 +7,13 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 {
     private readonly Lock _metricsPublicationGate = new();
     private readonly HashSet<StrategyMetricAlias> _metricsAliases = [];
+    // Atomic permits serve the uncontended path; the semaphore carries permits only to registered waiters.
     private readonly SemaphoreSlim _semaphore;
     private readonly int _maxConcurrency;
     private readonly int _maxQueue;
     private readonly long _capacity;
+    private int _available;
+    private int _waiters;
     private StrategyMetricAlias[] _metricsAliasSnapshot = [];
     private long _pending;
     private long _metricsState;
@@ -21,10 +24,11 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     {
         Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");
         Throw.IfOutOfRange(options.MaxQueue < 0, nameof(options), "MaxQueue must not be negative.");
-        _semaphore = new SemaphoreSlim(options.MaxConcurrency, options.MaxConcurrency);
+        _semaphore = new SemaphoreSlim(0, options.MaxConcurrency);
         _maxConcurrency = options.MaxConcurrency;
         _maxQueue = options.MaxQueue;
         _capacity = options.MaxConcurrency + (long)options.MaxQueue;
+        _available = options.MaxConcurrency;
     }
 
     public override string Describe() =>
@@ -44,47 +48,54 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         var queued = false;
         try
         {
-            if (context.IsSynchronous)
+            context.CancellationToken.ThrowIfCancellationRequested();
+            if (!TryAcquirePermit())
             {
-                if (!_semaphore.Wait(0, context.CancellationToken))
+                queued = true;
+                UpdateMetricsState(inflightDelta: 0, queuedDelta: 1);
+                Interlocked.Increment(ref _waiters);
+                try
                 {
-                    queued = true;
-                    UpdateMetricsState(inflightDelta: 0, queuedDelta: 1);
-                    RecordState(alias);
-                    _semaphore.Wait(context.CancellationToken);
-                }
-            }
-            else
-            {
-                if (!_semaphore.Wait(0, context.CancellationToken))
-                {
-                    using var waitCancellation = context.CancellationToken.CanBeCanceled
-                        ? CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken)
-                        : new CancellationTokenSource();
-                    var wait = _semaphore.WaitAsync(waitCancellation.Token);
-                    queued = true;
-                    UpdateMetricsState(inflightDelta: 0, queuedDelta: 1);
-                    try
+                    if (!TryAcquirePermit())
                     {
-                        RecordState(alias);
-                    }
-                    catch (Exception publicationFailure)
-                    {
-                        waitCancellation.Cancel();
-                        try
+                        if (context.IsSynchronous)
                         {
+                            RecordState(alias);
+                            _semaphore.Wait(context.CancellationToken);
+                        }
+                        else
+                        {
+                            using var waitCancellation = context.CancellationToken.CanBeCanceled
+                                ? CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken)
+                                : new CancellationTokenSource();
+                            var wait = _semaphore.WaitAsync(waitCancellation.Token);
+                            try
+                            {
+                                RecordState(alias);
+                            }
+                            catch (Exception publicationFailure)
+                            {
+                                waitCancellation.Cancel();
+                                try
+                                {
+                                    await wait.ConfigureAwait(false);
+                                    ReleasePermit();
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    // Cancellation withdrew the wait before it took a permit.
+                                }
+
+                                ExceptionDispatchInfo.Capture(publicationFailure).Throw();
+                            }
+
                             await wait.ConfigureAwait(false);
-                            _semaphore.Release();
                         }
-                        catch (OperationCanceledException)
-                        {
-                            // Cancellation withdrew the wait before it took a permit.
-                        }
-
-                        ExceptionDispatchInfo.Capture(publicationFailure).Throw();
                     }
-
-                    await wait.ConfigureAwait(false);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _waiters);
                 }
             }
         }
@@ -139,7 +150,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         catch (Exception publicationFailure)
         {
             UpdateMetricsState(inflightDelta: -1, queuedDelta: 0);
-            _semaphore.Release();
+            ReleasePermit();
             Interlocked.Decrement(ref _pending);
             try
             {
@@ -163,10 +174,40 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         finally
         {
             UpdateMetricsState(inflightDelta: -1, queuedDelta: 0);
-            _semaphore.Release();
+            ReleasePermit();
             Interlocked.Decrement(ref _pending);
             RecordState(alias);
         }
+    }
+
+    private bool TryAcquirePermit()
+    {
+        while (true)
+        {
+            var available = Volatile.Read(ref _available);
+            if (available == 0)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _available, available - 1, available) == available)
+            {
+                return true;
+            }
+        }
+    }
+
+    private void ReleasePermit()
+    {
+        // A waiter registers before retrying the atomic pool, so a concurrent release either
+        // replenishes that pool for the retry or signals the semaphore after the retry fails.
+        if (Volatile.Read(ref _waiters) > 0)
+        {
+            _semaphore.Release();
+            return;
+        }
+
+        Interlocked.Increment(ref _available);
     }
 
     private void UpdateMetricsState(int inflightDelta, int queuedDelta)

--- a/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
@@ -3,6 +3,23 @@ namespace Kevlar.Tests;
 public class BulkheadTests
 {
     [Test]
+    public async Task Uncontended_Async_Execution_Completes_Synchronously()
+    {
+        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1);
+
+        var first = shield.ExecuteAsync(
+            static _ => new ValueTask<int>(42));
+
+        await Assert.That(first.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(await first).IsEqualTo(42);
+
+        var afterRelease = shield.ExecuteAsync(
+            static _ => new ValueTask<int>(43));
+        await Assert.That(afterRelease.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(await afterRelease).IsEqualTo(43);
+    }
+
+    [Test]
     public async Task Rejects_When_Concurrency_And_Queue_Are_Full()
     {
         var shield = Shield.ConcurrencyLimit(maxConcurrency: 1);


### PR DESCRIPTION
## Summary

- use atomic permit acquisition for the uncontended concurrency-limit path
- retain `SemaphoreSlim` only as the handoff queue for registered waiters
- preserve capacity, cancellation, metrics, and publication-failure accounting

## Profiling finding

An EventPipe CPU sample of the five-strategy chain attributed roughly one-third of sampled workload time to `Monitor.Enter_Slowpath` under `SemaphoreSlim.WaitCore` and `SemaphoreSlim.Release`. Even when a permit was immediately available, each execution entered the semaphore's monitor-backed path.

## Benchmark

BenchmarkDotNet 0.15.8, default job, .NET 10.0.11, Windows 11, Intel Core Ultra 9 185H. Both runs used the same checkout base and machine.

| Benchmark | Before | After | Change | Allocated |
|---|---:|---:|---:|---:|
| `Kevlar_Uncontended` | 312.3 ns | 218.3 ns | **30.1% faster (1.43x)** | 0 B -> 0 B |

Command:

```powershell
dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*ConcurrencyLimitBenchmarks.Kevlar_Uncontended"
```

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (612 passed, including concurrency race/edge cases)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (2 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved concurrency-limit handling for uncontended operations, reducing unnecessary waiting overhead.
  * Uncontended asynchronous executions can now complete immediately while returning the expected results.

* **Reliability**
  * Improved coordination between synchronous and asynchronous waits.
  * Enhanced permit availability and handoff when concurrent operations complete.
  * Improved cancellation, permit release, and cleanup when operations fail to start.
  * Ensured permits remain immediately available for subsequent operations after release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->