### PR TITLE
feat(grpc): add streaming client resilience

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/GrpcStreamingBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/GrpcStreamingBenchmarks.cs
@@ -1,0 +1,103 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Kevlar.Extensions.Grpc;
+using System.Runtime.CompilerServices;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>Streaming client happy-path overhead over completed in-memory operations.</summary>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class GrpcStreamingBenchmarks
+{
+    private static readonly BenchmarkRequest Request = new();
+    private static readonly CompletedReader Reader = new();
+    private static readonly CompletedWriter Writer = new();
+    private static readonly ShieldStreamingClientInterceptor Interceptor = new(Shield.Empty);
+    private static readonly Method<BenchmarkRequest, BenchmarkResponse> ServerMethod = new(
+        MethodType.ServerStreaming,
+        "benchmarks.Grpc",
+        "ServerStream",
+        Marshallers.Create(static _ => [], static _ => Request),
+        Marshallers.Create(static _ => [], static _ => new BenchmarkResponse()));
+    private static readonly Method<BenchmarkRequest, BenchmarkResponse> ClientMethod = new(
+        MethodType.ClientStreaming,
+        "benchmarks.Grpc",
+        "ClientStream",
+        Marshallers.Create(static _ => [], static _ => Request),
+        Marshallers.Create(static _ => [], static _ => new BenchmarkResponse()));
+    private static readonly AsyncClientStreamingCall<BenchmarkRequest, BenchmarkResponse> ShieldedClientCall =
+        Interceptor.AsyncClientStreamingCall(
+            new ClientInterceptorContext<BenchmarkRequest, BenchmarkResponse>(
+                ClientMethod,
+                host: null,
+                default),
+            static _ => ClientCall());
+
+    /// <summary>Reads a completed first server-streaming item directly.</summary>
+    [BenchmarkCategory("ServerStreamingFirstMove"), Benchmark(Baseline = true)]
+    public Task<bool> ServerDirect() =>
+        ServerCall().ResponseStream.MoveNext(CancellationToken.None);
+
+    /// <summary>Establishes and reads a completed first item through the streaming interceptor.</summary>
+    [BenchmarkCategory("ServerStreamingFirstMove"), Benchmark]
+    public Task<bool> ServerShielded() => Interceptor.AsyncServerStreamingCall(
+            Request,
+            new ClientInterceptorContext<BenchmarkRequest, BenchmarkResponse>(
+                ServerMethod,
+                host: null,
+                default),
+            static (_, _) => ServerCall())
+        .ResponseStream.MoveNext(CancellationToken.None);
+
+    /// <summary>Writes a completed request-streaming item directly.</summary>
+    [BenchmarkCategory("ClientStreamingWrite"), Benchmark(Baseline = true)]
+    public Task WriteDirect() => Writer.WriteAsync(Request);
+
+    /// <summary>Writes a completed request-streaming item through the streaming interceptor.</summary>
+    [BenchmarkCategory("ClientStreamingWrite"), Benchmark]
+    public Task WriteShielded() => ShieldedClientCall.RequestStream.WriteAsync(Request);
+
+    private static AsyncServerStreamingCall<BenchmarkResponse> ServerCall() => new(
+        Reader,
+        Task.FromResult(new Metadata()),
+        static () => Status.DefaultSuccess,
+        static () => new Metadata(),
+        static () => { });
+
+    private static AsyncClientStreamingCall<BenchmarkRequest, BenchmarkResponse> ClientCall() => new(
+        Writer,
+        Task.FromResult(new BenchmarkResponse()),
+        Task.FromResult(new Metadata()),
+        static () => Status.DefaultSuccess,
+        static () => new Metadata(),
+        static () => { });
+
+    private sealed class CompletedReader : IAsyncStreamReader<BenchmarkResponse>
+    {
+        public BenchmarkResponse Current { get; } = new();
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    private sealed class CompletedWriter : IClientStreamWriter<BenchmarkRequest>
+    {
+        public WriteOptions? WriteOptions { get; set; }
+
+        public Task CompleteAsync() => Task.CompletedTask;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public Task WriteAsync(BenchmarkRequest message) => Task.CompletedTask;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public Task WriteAsync(BenchmarkRequest message, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class BenchmarkRequest;
+
+    private sealed class BenchmarkResponse;
+}

--- a/docs/docs/grpc.md
+++ b/docs/docs/grpc.md
@@ -4,7 +4,7 @@ sidebar_position: 9
 
 # gRPC Integration
 
-`Kevlar.Extensions.Grpc` sends asynchronous unary gRPC client calls through a shared shield. It leaves blocking unary, streaming, and server calls unchanged.
+`Kevlar.Extensions.Grpc` supplies separate interceptors for asynchronous unary and streaming gRPC client calls. Blocking unary and server calls remain unchanged.
 
 ```bash
 dotnet add package Kevlar.Extensions.Grpc
@@ -36,6 +36,46 @@ var client = new Orders.OrdersClient(
 
 The final response or `RpcException` remains the caller's result. Superseded retry calls and losing hedge calls are disposed. Response headers, status, and trailers come from the selected final attempt.
 
+## Streaming calls
+
+Use `ShieldStreamingClientInterceptor` for server-streaming, client-streaming, and duplex calls:
+
+<!-- doc-test-ignore: requires an application-generated gRPC client and channel -->
+```csharp
+var streamingShield = Shield.Timeout(TimeSpan.FromSeconds(5));
+var client = new Orders.OrdersClient(
+    channel.Intercept(new ShieldStreamingClientInterceptor(streamingShield)));
+```
+
+The interceptor uses explicit progress boundaries:
+
+- Server streaming may retry or hedge establishment only until response headers or the first item becomes observable. After that point, it never repeats `MoveNext`, so an item cannot be skipped or duplicated. With an at-most-once shield, each later `MoveNext` remains protected by that shield.
+- Client streaming and duplex never buffer or replay request messages. Their shield must be at-most-once; constructing either call with retry, hedging, or another repeating strategy throws `NotSupportedException` before the RPC starts.
+- Client-streaming response completion, request writes, duplex reads, and duplex writes run through the shield. Disposing the wrapper cancels and disposes the underlying call. Status and trailers remain available after normal completion until disposal.
+
+When server-stream establishment needs retry or hedging and later reads still need a timeout, supply separate shields:
+
+<!-- doc-test-ignore: requires an application-generated gRPC client and channel -->
+```csharp
+var establishment = GrpcShield.WhenTransient().Retry(2, Backoff.None);
+var operations = Shield.Timeout(TimeSpan.FromSeconds(3));
+var interceptor = new ShieldStreamingClientInterceptor(establishment, operations);
+var client = new Orders.OrdersClient(channel.Intercept(interceptor));
+```
+
+The operation shield must be at-most-once. The two-shield constructor rejects retry, hedging, or any custom strategy that may repeat its continuation. With the one-shield constructor, a repeating shield protects only pre-progress server establishment; later reads run directly, and client/duplex calls reject that shield.
+
+| Boundary | Owner |
+|---|---|
+| Server-stream establishment through headers or first item | establishment shield |
+| Individual request writes and post-progress response reads | at-most-once operation shield |
+| Client-streaming response completion | at-most-once operation shield, started when the call is created |
+| Total lifetime, including time when no read/write is active | gRPC deadline, caller cancellation token, or call disposal |
+
+A Kevlar operation timeout is not an idle-stream timer. Use the gRPC deadline when the entire stream needs one absolute budget; its timestamp is preserved across server-establishment attempts.
+
+`WriteAsync(message, cancellationToken)` uses the operation token on modern gRPC APIs. On the `netstandard2.0` compatibility target, where gRPC exposes only `WriteAsync(message)`, cancellation is checked before and after the write and wrapper disposal still cancels the call lifetime. A gRPC deadline remains in the original `CallOptions` for every server-streaming establishment attempt.
+
 ## Dependency injection and named shields
 
 The package integrates with `Grpc.Net.ClientFactory` and the existing Kevlar registry:
@@ -54,10 +94,11 @@ services.AddShield(
 
 services.AddGrpcClient<Orders.OrdersClient>(options =>
         options.Address = new Uri("https://orders.example"))
-    .AddShieldUnaryInterceptor("orders-grpc");
+    .AddShieldUnaryInterceptor("orders-grpc")
+    .AddShieldStreamingInterceptor("orders-grpc");
 ```
 
-`AddShieldUnaryInterceptor` also accepts a `Shield` instance or an `IServiceProvider` factory. Reuse one shield when calls should share circuit-breaker or limiter state.
+Both registration methods accept a `Shield` instance, an `IServiceProvider` factory, or a named shield. Reuse one shield when calls should share circuit-breaker or limiter state. Register both interceptors when a generated client exposes unary and streaming methods; each interceptor handles only its own call shapes.
 
 ## Cancellation, deadlines, and timeouts
 
@@ -78,7 +119,7 @@ Whichever expires first wins. An expired gRPC deadline remains an `RpcException`
 
 Every retry or hedge starts a new RPC with the same request object and call options. Use multiple attempts only for idempotent methods, or when the server provides an idempotency key/deduplication contract. Do not retry or hedge a mutation merely because its transport result is unknown.
 
-The initial package intentionally excludes streaming. Stream lifetime, partial messages, and ownership require a different API and cleanup contract; calls pass through the interceptor unchanged.
+For server streaming, retry and hedge only operations that are safe to repeat before progress. Client and duplex streaming reject repeating strategies because Kevlar deliberately provides no implicit replay buffer. If an application needs replay, implement an explicit bounded message store and a protocol-level idempotency/deduplication contract outside the interceptor.
 
 ## Trimming and NativeAOT
 

--- a/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
+++ b/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Kevlar.Extensions.Grpc</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
-    <Description>Unary gRPC client integration for Kevlar: transient status helpers, cancellation-safe interceptors, and named-shield DI registration.</Description>
+    <Description>gRPC client integration for Kevlar: unary and streaming interceptors, transient status helpers, cancellation safety, and named-shield DI registration.</Description>
     <PackageTags>resilience;grpc;client;interceptor;kevlar</PackageTags>
   </PropertyGroup>
 

--- a/src/Kevlar.Extensions.Grpc/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Grpc/PublicAPI.Unshipped.txt
@@ -1,12 +1,21 @@
 #nullable enable
 Kevlar.Extensions.Grpc.GrpcShield
 Kevlar.Extensions.Grpc.ShieldGrpcClientBuilderExtensions
+Kevlar.Extensions.Grpc.ShieldStreamingClientInterceptor
 Kevlar.Extensions.Grpc.ShieldUnaryClientInterceptor
+Kevlar.Extensions.Grpc.ShieldStreamingClientInterceptor.ShieldStreamingClientInterceptor(Kevlar.Shield! shield) -> void
+Kevlar.Extensions.Grpc.ShieldStreamingClientInterceptor.ShieldStreamingClientInterceptor(Kevlar.Shield! establishmentShield, Kevlar.Shield! operationShield) -> void
 Kevlar.Extensions.Grpc.ShieldUnaryClientInterceptor.ShieldUnaryClientInterceptor(Kevlar.Shield! shield) -> void
 override Kevlar.Extensions.Grpc.ShieldUnaryClientInterceptor.AsyncUnaryCall<TRequest, TResponse>(TRequest! request, Grpc.Core.Interceptors.ClientInterceptorContext<TRequest!, TResponse!> context, Grpc.Core.Interceptors.Interceptor.AsyncUnaryCallContinuation<TRequest!, TResponse!>! continuation) -> Grpc.Core.AsyncUnaryCall<TResponse!>!
+override Kevlar.Extensions.Grpc.ShieldStreamingClientInterceptor.AsyncClientStreamingCall<TRequest, TResponse>(Grpc.Core.Interceptors.ClientInterceptorContext<TRequest!, TResponse!> context, Grpc.Core.Interceptors.Interceptor.AsyncClientStreamingCallContinuation<TRequest!, TResponse!>! continuation) -> Grpc.Core.AsyncClientStreamingCall<TRequest!, TResponse!>!
+override Kevlar.Extensions.Grpc.ShieldStreamingClientInterceptor.AsyncDuplexStreamingCall<TRequest, TResponse>(Grpc.Core.Interceptors.ClientInterceptorContext<TRequest!, TResponse!> context, Grpc.Core.Interceptors.Interceptor.AsyncDuplexStreamingCallContinuation<TRequest!, TResponse!>! continuation) -> Grpc.Core.AsyncDuplexStreamingCall<TRequest!, TResponse!>!
+override Kevlar.Extensions.Grpc.ShieldStreamingClientInterceptor.AsyncServerStreamingCall<TRequest, TResponse>(TRequest! request, Grpc.Core.Interceptors.ClientInterceptorContext<TRequest!, TResponse!> context, Grpc.Core.Interceptors.Interceptor.AsyncServerStreamingCallContinuation<TRequest!, TResponse!>! continuation) -> Grpc.Core.AsyncServerStreamingCall<TResponse!>!
 static Kevlar.Extensions.Grpc.GrpcShield.IsTransient(Grpc.Core.RpcException? exception) -> bool
 static Kevlar.Extensions.Grpc.GrpcShield.IsTransient(Grpc.Core.StatusCode statusCode) -> bool
 static Kevlar.Extensions.Grpc.GrpcShield.WhenTransient() -> Kevlar.ShieldBuilder!
 static Kevlar.Extensions.Grpc.ShieldGrpcClientBuilderExtensions.AddShieldUnaryInterceptor(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Kevlar.Shield! shield) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Grpc.ShieldGrpcClientBuilderExtensions.AddShieldUnaryInterceptor(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, Kevlar.Shield!>! shieldFactory) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Grpc.ShieldGrpcClientBuilderExtensions.AddShieldUnaryInterceptor(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, string! shieldName) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+static Kevlar.Extensions.Grpc.ShieldGrpcClientBuilderExtensions.AddShieldStreamingInterceptor(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Kevlar.Shield! shield) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+static Kevlar.Extensions.Grpc.ShieldGrpcClientBuilderExtensions.AddShieldStreamingInterceptor(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, Kevlar.Shield!>! shieldFactory) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+static Kevlar.Extensions.Grpc.ShieldGrpcClientBuilderExtensions.AddShieldStreamingInterceptor(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, string! shieldName) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Kevlar.Extensions.Grpc/ShieldGrpcClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Grpc/ShieldGrpcClientBuilderExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Kevlar.Extensions.Grpc;
 
-/// <summary>Adds Kevlar unary-call resilience to gRPC clients registered through DI.</summary>
+/// <summary>Adds Kevlar call resilience to gRPC clients registered through DI.</summary>
 public static class ShieldGrpcClientBuilderExtensions
 {
     /// <summary>Sends this client's asynchronous unary calls through the given shield.</summary>
@@ -42,6 +42,45 @@ public static class ShieldGrpcClientBuilderExtensions
 
         return builder.AddInterceptor(services =>
             new ShieldUnaryClientInterceptor(
+                services.GetRequiredService<IKevlarRegistry>().GetShield(shieldName)));
+    }
+
+    /// <summary>Sends this client's asynchronous streaming operations through the given shield.</summary>
+    public static IHttpClientBuilder AddShieldStreamingInterceptor(
+        this IHttpClientBuilder builder,
+        Shield shield)
+    {
+        if (builder is null) { throw new ArgumentNullException(nameof(builder)); }
+        if (shield is null) { throw new ArgumentNullException(nameof(shield)); }
+
+        return builder.AddInterceptor(() => new ShieldStreamingClientInterceptor(shield));
+    }
+
+    /// <summary>Sends this client's asynchronous streaming operations through a shield resolved from DI.</summary>
+    public static IHttpClientBuilder AddShieldStreamingInterceptor(
+        this IHttpClientBuilder builder,
+        Func<IServiceProvider, Shield> shieldFactory)
+    {
+        if (builder is null) { throw new ArgumentNullException(nameof(builder)); }
+        if (shieldFactory is null) { throw new ArgumentNullException(nameof(shieldFactory)); }
+
+        return builder.AddInterceptor(services =>
+            new ShieldStreamingClientInterceptor(shieldFactory(services)));
+    }
+
+    /// <summary>
+    /// Sends this client's asynchronous streaming operations through the named shield registered
+    /// with <see cref="KevlarServiceCollectionExtensions.AddShield(IServiceCollection, string, Shield)"/>.
+    /// </summary>
+    public static IHttpClientBuilder AddShieldStreamingInterceptor(
+        this IHttpClientBuilder builder,
+        string shieldName)
+    {
+        if (builder is null) { throw new ArgumentNullException(nameof(builder)); }
+        if (shieldName is null) { throw new ArgumentNullException(nameof(shieldName)); }
+
+        return builder.AddInterceptor(services =>
+            new ShieldStreamingClientInterceptor(
                 services.GetRequiredService<IKevlarRegistry>().GetShield(shieldName)));
     }
 }

--- a/src/Kevlar.Extensions.Grpc/ShieldStreamingClientInterceptor.cs
+++ b/src/Kevlar.Extensions.Grpc/ShieldStreamingClientInterceptor.cs
@@ -1,0 +1,797 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using System.Runtime.ExceptionServices;
+
+namespace Kevlar.Extensions.Grpc;
+
+/// <summary>Applies explicit, replay-safe resilience boundaries to asynchronous streaming calls.</summary>
+/// <remarks>
+/// Server-streaming calls may retry only until response headers or the first response item become
+/// observable. Client-streaming and duplex calls never replay messages, so their per-operation
+/// shield must invoke its continuation at most once.
+/// </remarks>
+public sealed class ShieldStreamingClientInterceptor : Interceptor
+{
+    private readonly Shield _establishmentShield;
+    private readonly Shield? _operationShield;
+
+    /// <summary>Creates an interceptor that uses the supplied immutable shield at every safe boundary.</summary>
+    public ShieldStreamingClientInterceptor(Shield shield)
+    {
+        _establishmentShield = shield ?? throw new ArgumentNullException(nameof(shield));
+        _operationShield = shield.InvokesContinuationAtMostOnce ? shield : null;
+    }
+
+    /// <summary>
+    /// Creates an interceptor with separate server-stream establishment and per-operation shields.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="establishmentShield"/> may repeat a server-streaming call before progress.
+    /// <paramref name="operationShield"/> protects individual reads, writes, and client-streaming
+    /// response completion, and therefore must invoke each continuation at most once.
+    /// </remarks>
+    public ShieldStreamingClientInterceptor(
+        Shield establishmentShield,
+        Shield operationShield)
+    {
+        _establishmentShield = establishmentShield
+            ?? throw new ArgumentNullException(nameof(establishmentShield));
+        if (operationShield is null) { throw new ArgumentNullException(nameof(operationShield)); }
+        if (!operationShield.InvokesContinuationAtMostOnce)
+        {
+            throw new ArgumentException(
+                "The operation shield cannot use retry, hedging, or another strategy that may " +
+                "invoke an operation more than once.",
+                nameof(operationShield));
+        }
+
+        _operationShield = operationShield;
+    }
+
+    /// <inheritdoc />
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        if (request is null) { throw new ArgumentNullException(nameof(request)); }
+        if (continuation is null) { throw new ArgumentNullException(nameof(continuation)); }
+
+        return new ServerStreamingState<TRequest, TResponse>(
+            _establishmentShield,
+            _operationShield,
+            request,
+            context,
+            continuation).Start();
+    }
+
+    /// <inheritdoc />
+    public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        if (continuation is null) { throw new ArgumentNullException(nameof(continuation)); }
+        EnsureAtMostOnce("client-streaming");
+
+        return new ClientStreamingState<TRequest, TResponse>(
+            _operationShield!,
+            context,
+            continuation).Start();
+    }
+
+    /// <inheritdoc />
+    public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        if (continuation is null) { throw new ArgumentNullException(nameof(continuation)); }
+        EnsureAtMostOnce("duplex-streaming");
+
+        return new DuplexStreamingState<TRequest, TResponse>(
+            _operationShield!,
+            context,
+            continuation).Start();
+    }
+
+    private void EnsureAtMostOnce(string callShape)
+    {
+        if (_operationShield is null)
+        {
+            throw new NotSupportedException(
+                $"The {callShape} interceptor cannot use retry, hedging, or another strategy that " +
+                "may invoke an operation more than once because request messages are never replayed.");
+        }
+    }
+
+    private sealed class ServerStreamingState<TRequest, TResponse> : IAsyncStreamReader<TResponse>
+        where TRequest : class
+        where TResponse : class
+    {
+        private readonly object _gate = new();
+        private readonly SemaphoreSlim _operationGate = new(1, 1);
+        private readonly Shield _establishmentShield;
+        private readonly Shield? _operationShield;
+        private readonly TRequest _request;
+        private readonly ClientInterceptorContext<TRequest, TResponse> _context;
+        private readonly AsyncServerStreamingCallContinuation<TRequest, TResponse> _continuation;
+        private readonly CancellationTokenSource _lifetime;
+        private readonly List<Attempt> _attempts = [];
+
+        private AsyncServerStreamingCall<TResponse>? _terminalCall;
+        private CancellationTokenSource? _terminalCancellation;
+        private bool _selected;
+        private bool _disposed;
+
+        public ServerStreamingState(
+            Shield establishmentShield,
+            Shield? operationShield,
+            TRequest request,
+            ClientInterceptorContext<TRequest, TResponse> context,
+            AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+        {
+            _establishmentShield = establishmentShield;
+            _operationShield = operationShield;
+            _request = request;
+            _context = context;
+            _continuation = continuation;
+            _lifetime = context.Options.CancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(context.Options.CancellationToken)
+                : new CancellationTokenSource();
+        }
+
+        public TResponse Current => TerminalCall().ResponseStream.Current;
+
+        public AsyncServerStreamingCall<TResponse> Start() => new(
+            this,
+            static state => ((ServerStreamingState<TRequest, TResponse>)state).GetResponseHeadersAsync(),
+            static state => ((ServerStreamingState<TRequest, TResponse>)state).TerminalCall().GetStatus(),
+            static state => ((ServerStreamingState<TRequest, TResponse>)state).TerminalCall().GetTrailers(),
+            static state => ((ServerStreamingState<TRequest, TResponse>)state).Dispose(),
+            this);
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            await _operationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (TryGetSelected(out var selected))
+                {
+                    if (_operationShield is null)
+                    {
+                        return await selected.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false);
+                    }
+
+                    return await _operationShield.ExecuteAsync(
+                        selected.ResponseStream,
+                        static (reader, token) => new ValueTask<bool>(reader.MoveNext(token)),
+                        cancellationToken.CanBeCanceled
+                            ? cancellationToken
+                            : _lifetime.Token).ConfigureAwait(false);
+                }
+
+                using var operation = CreateOperationCancellation(cancellationToken);
+                try
+                {
+                    var result = await _establishmentShield.ExecuteAsync(
+                        this,
+                        static (state, token) => state.StartAndReadAsync(token),
+                        operation?.Token ?? _lifetime.Token).ConfigureAwait(false);
+                    Select(result.Call, result.Cancellation);
+                    return result.HasNext;
+                }
+                catch (Exception exception)
+                {
+                    SelectFailure(exception);
+                    RethrowNormalized(exception);
+                    throw;
+                }
+            }
+            finally
+            {
+                _operationGate.Release();
+            }
+        }
+
+        private async Task<Metadata> GetResponseHeadersAsync()
+        {
+            await _operationGate.WaitAsync(_lifetime.Token).ConfigureAwait(false);
+            try
+            {
+                if (TryGetSelected(out var selected))
+                {
+                    return await selected.ResponseHeadersAsync.ConfigureAwait(false);
+                }
+
+                try
+                {
+                    var result = await _establishmentShield.ExecuteAsync(
+                        this,
+                        static (state, token) => state.StartAndReadHeadersAsync(token),
+                        _lifetime.Token).ConfigureAwait(false);
+                    Select(result.Call, result.Cancellation);
+                    return result.Headers;
+                }
+                catch (Exception exception)
+                {
+                    SelectFailure(exception);
+                    RethrowNormalized(exception);
+                    throw;
+                }
+            }
+            finally
+            {
+                _operationGate.Release();
+            }
+        }
+
+        private async ValueTask<ReadResult> StartAndReadAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDeadlineExpired();
+            DisposeSupersededFailures();
+            var attempt = CreateAttempt(cancellationToken);
+            var attemptToken = attempt.Cancellation.Token;
+            try
+            {
+                var hasNext = await attempt.Call.ResponseStream
+                    .MoveNext(attemptToken).ConfigureAwait(false);
+                CompleteAttempt(attempt.Call, exception: null);
+                return new ReadResult(attempt.Call, attempt.Cancellation, hasNext);
+            }
+            catch (Exception exception)
+            {
+                exception = NormalizeAttemptException(exception, cancellationToken);
+                CompleteAttempt(attempt.Call, exception);
+                ExceptionDispatchInfo.Capture(exception).Throw();
+                throw;
+            }
+        }
+
+        private async ValueTask<HeadersResult> StartAndReadHeadersAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDeadlineExpired();
+            DisposeSupersededFailures();
+            var attempt = CreateAttempt(cancellationToken);
+            try
+            {
+                var headers = await attempt.Call.ResponseHeadersAsync.ConfigureAwait(false);
+                CompleteAttempt(attempt.Call, exception: null);
+                return new HeadersResult(attempt.Call, attempt.Cancellation, headers);
+            }
+            catch (Exception exception)
+            {
+                exception = NormalizeAttemptException(exception, cancellationToken);
+                CompleteAttempt(attempt.Call, exception);
+                ExceptionDispatchInfo.Capture(exception).Throw();
+                throw;
+            }
+        }
+
+        private void ThrowIfDeadlineExpired()
+        {
+            if (_context.Options.Deadline is not { } deadline || deadline > DateTime.UtcNow)
+            {
+                return;
+            }
+
+            CancelLifetime(_lifetime);
+            throw new ExpiredDeadlineRpcException(
+                new RpcException(new Status(StatusCode.DeadlineExceeded, "Deadline exceeded.")));
+        }
+
+        private Exception NormalizeAttemptException(
+            Exception exception,
+            CancellationToken cancellationToken)
+        {
+            if (exception is RpcException { StatusCode: StatusCode.Cancelled } rpcCancellation
+                && cancellationToken.IsCancellationRequested)
+            {
+                return new OperationCanceledException(
+                    rpcCancellation.Message,
+                    rpcCancellation,
+                    cancellationToken);
+            }
+
+            if (exception is RpcException { StatusCode: StatusCode.DeadlineExceeded } deadlineException
+                && _context.Options.Deadline is { } deadline
+                && deadline <= DateTime.UtcNow)
+            {
+                CancelLifetime(_lifetime);
+                return new ExpiredDeadlineRpcException(deadlineException);
+            }
+
+            return exception;
+        }
+
+        private void RethrowNormalized(Exception exception)
+        {
+            if (exception is OperationCanceledException cancellation
+                && _context.Options.CancellationToken.IsCancellationRequested
+                && cancellation.CancellationToken != _context.Options.CancellationToken)
+            {
+                throw new OperationCanceledException(
+                    cancellation.Message,
+                    cancellation,
+                    _context.Options.CancellationToken);
+            }
+
+            if (exception is ExpiredDeadlineRpcException deadlineException)
+            {
+                ExceptionDispatchInfo.Capture(deadlineException.Original).Throw();
+            }
+        }
+
+        private Attempt CreateAttempt(CancellationToken cancellationToken)
+        {
+            var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                _lifetime.Token,
+                cancellationToken);
+            AsyncServerStreamingCall<TResponse> call;
+            try
+            {
+                var context = new ClientInterceptorContext<TRequest, TResponse>(
+                    _context.Method,
+                    _context.Host,
+                    _context.Options.WithCancellationToken(cancellation.Token));
+                call = _continuation(_request, context);
+            }
+            catch
+            {
+                cancellation.Dispose();
+                throw;
+            }
+
+            var dispose = false;
+            lock (_gate)
+            {
+                if (_disposed || _selected)
+                {
+                    dispose = true;
+                }
+                else
+                {
+                    _attempts.Add(new Attempt(call, cancellation, Exception: null));
+                }
+            }
+
+            if (dispose)
+            {
+                DisposeAttempt(call, cancellation);
+                throw new ObjectDisposedException(nameof(ShieldStreamingClientInterceptor));
+            }
+
+            return new Attempt(call, cancellation, Exception: null);
+        }
+
+        private void CompleteAttempt(AsyncServerStreamingCall<TResponse> call, Exception? exception)
+        {
+            lock (_gate)
+            {
+                for (var index = _attempts.Count - 1; index >= 0; index--)
+                {
+                    if (ReferenceEquals(_attempts[index].Call, call))
+                    {
+                        _attempts[index] = new Attempt(
+                            call,
+                            _attempts[index].Cancellation,
+                            exception);
+                        return;
+                    }
+                }
+            }
+        }
+
+        private void DisposeSupersededFailures()
+        {
+            List<Attempt>? superseded = null;
+            lock (_gate)
+            {
+                for (var index = _attempts.Count - 1; index >= 0; index--)
+                {
+                    if (_attempts[index].Exception is null)
+                    {
+                        continue;
+                    }
+
+                    (superseded ??= []).Add(_attempts[index]);
+                    _attempts.RemoveAt(index);
+                }
+            }
+
+            DisposeAttempts(superseded);
+        }
+
+        private void SelectFailure(Exception exception)
+        {
+            Attempt? selected = null;
+            lock (_gate)
+            {
+                for (var index = _attempts.Count - 1; index >= 0; index--)
+                {
+                    if (ReferenceEquals(_attempts[index].Exception, exception))
+                    {
+                        selected = _attempts[index];
+                        break;
+                    }
+                }
+
+                if (selected is null)
+                {
+                    for (var index = _attempts.Count - 1; index >= 0; index--)
+                    {
+                        if (_attempts[index].Exception is not null)
+                        {
+                            selected = _attempts[index];
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (selected is { } failure)
+            {
+                Select(failure.Call, failure.Cancellation);
+            }
+        }
+
+        private void Select(
+            AsyncServerStreamingCall<TResponse> call,
+            CancellationTokenSource cancellation)
+        {
+            List<Attempt>? discarded = null;
+            var disposeSelectedLoser = false;
+            lock (_gate)
+            {
+                if (_selected)
+                {
+                    disposeSelectedLoser = !ReferenceEquals(_terminalCall, call);
+                }
+                else
+                {
+                    _selected = true;
+                    _terminalCall = call;
+                    _terminalCancellation = cancellation;
+                    foreach (var attempt in _attempts)
+                    {
+                        if (!ReferenceEquals(attempt.Call, call))
+                        {
+                            (discarded ??= []).Add(attempt);
+                        }
+                    }
+
+                    _attempts.Clear();
+                }
+            }
+
+            if (disposeSelectedLoser)
+            {
+                DisposeAttempt(call, cancellation);
+            }
+            DisposeAttempts(discarded);
+        }
+
+        private bool TryGetSelected(out AsyncServerStreamingCall<TResponse> call)
+        {
+            lock (_gate)
+            {
+                call = _terminalCall!;
+                return _selected && call is not null;
+            }
+        }
+
+        private AsyncServerStreamingCall<TResponse> TerminalCall()
+        {
+            lock (_gate)
+            {
+                return _terminalCall
+                    ?? throw new InvalidOperationException(
+                        "The streaming call has not selected an underlying attempt yet.");
+            }
+        }
+
+        private CancellationTokenSource? CreateOperationCancellation(CancellationToken cancellationToken) =>
+            cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token, cancellationToken)
+                : null;
+
+        private void Dispose()
+        {
+            List<Attempt> attempts;
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                attempts = [.. _attempts];
+                _attempts.Clear();
+                if (_terminalCall is not null && _terminalCancellation is not null)
+                {
+                    attempts.Add(new Attempt(
+                        _terminalCall,
+                        _terminalCancellation,
+                        Exception: null));
+                    _terminalCall = null;
+                    _terminalCancellation = null;
+                }
+            }
+
+            CancelLifetime(_lifetime);
+            DisposeAttempts(attempts);
+            _lifetime.Dispose();
+        }
+
+        private static void DisposeAttempts(List<Attempt>? attempts)
+        {
+            if (attempts is null)
+            {
+                return;
+            }
+
+            foreach (var attempt in attempts)
+            {
+                DisposeAttempt(attempt.Call, attempt.Cancellation);
+            }
+        }
+
+        private static void DisposeAttempt(
+            AsyncServerStreamingCall<TResponse> call,
+            CancellationTokenSource cancellation)
+        {
+            CancelLifetime(cancellation);
+            call.Dispose();
+            cancellation.Dispose();
+        }
+
+        private readonly record struct Attempt(
+            AsyncServerStreamingCall<TResponse> Call,
+            CancellationTokenSource Cancellation,
+            Exception? Exception);
+
+        private readonly record struct ReadResult(
+            AsyncServerStreamingCall<TResponse> Call,
+            CancellationTokenSource Cancellation,
+            bool HasNext);
+
+        private readonly record struct HeadersResult(
+            AsyncServerStreamingCall<TResponse> Call,
+            CancellationTokenSource Cancellation,
+            Metadata Headers);
+
+        private sealed class ExpiredDeadlineRpcException(RpcException original)
+            : Exception(original.Message, original)
+        {
+            public RpcException Original { get; } = original;
+        }
+    }
+
+    private sealed class ClientStreamingState<TRequest, TResponse>
+        where TRequest : class
+        where TResponse : class
+    {
+        private readonly Shield _shield;
+        private readonly CancellationTokenSource _lifetime;
+        private readonly AsyncClientStreamingCall<TRequest, TResponse> _call;
+        private int _disposed;
+
+        public ClientStreamingState(
+            Shield shield,
+            ClientInterceptorContext<TRequest, TResponse> context,
+            AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+        {
+            _shield = shield;
+            _lifetime = CreateLifetime(context.Options.CancellationToken);
+            var attemptContext = new ClientInterceptorContext<TRequest, TResponse>(
+                context.Method,
+                context.Host,
+                context.Options.WithCancellationToken(_lifetime.Token));
+            try
+            {
+                _call = continuation(attemptContext);
+            }
+            catch
+            {
+                _lifetime.Dispose();
+                throw;
+            }
+        }
+
+        public AsyncClientStreamingCall<TRequest, TResponse> Start() => new(
+            new ShieldedClientStreamWriter<TRequest>(_call.RequestStream, _shield, _lifetime),
+            ExecuteResponseAsync(),
+            static state => ((ClientStreamingState<TRequest, TResponse>)state).ExecuteHeadersAsync(),
+            static state => ((ClientStreamingState<TRequest, TResponse>)state)._call.GetStatus(),
+            static state => ((ClientStreamingState<TRequest, TResponse>)state)._call.GetTrailers(),
+            static state => ((ClientStreamingState<TRequest, TResponse>)state).Dispose(),
+            this);
+
+        private Task<TResponse> ExecuteResponseAsync() => _shield.ExecuteAsync(
+            this,
+            static (state, token) => AwaitWithLifetimeAsync(
+                state._call.ResponseAsync,
+                state._lifetime,
+                token),
+            _lifetime.Token).AsTask();
+
+        private Task<Metadata> ExecuteHeadersAsync() => _shield.ExecuteAsync(
+            this,
+            static (state, token) => AwaitWithLifetimeAsync(
+                state._call.ResponseHeadersAsync,
+                state._lifetime,
+                token),
+            _lifetime.Token).AsTask();
+
+        private void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            CancelLifetime(_lifetime);
+            _call.Dispose();
+            _lifetime.Dispose();
+        }
+    }
+
+    private sealed class DuplexStreamingState<TRequest, TResponse>
+        where TRequest : class
+        where TResponse : class
+    {
+        private readonly Shield _shield;
+        private readonly CancellationTokenSource _lifetime;
+        private readonly AsyncDuplexStreamingCall<TRequest, TResponse> _call;
+        private int _disposed;
+
+        public DuplexStreamingState(
+            Shield shield,
+            ClientInterceptorContext<TRequest, TResponse> context,
+            AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+        {
+            _shield = shield;
+            _lifetime = CreateLifetime(context.Options.CancellationToken);
+            var attemptContext = new ClientInterceptorContext<TRequest, TResponse>(
+                context.Method,
+                context.Host,
+                context.Options.WithCancellationToken(_lifetime.Token));
+            try
+            {
+                _call = continuation(attemptContext);
+            }
+            catch
+            {
+                _lifetime.Dispose();
+                throw;
+            }
+        }
+
+        public AsyncDuplexStreamingCall<TRequest, TResponse> Start() => new(
+            new ShieldedClientStreamWriter<TRequest>(_call.RequestStream, _shield, _lifetime),
+            new ShieldedAsyncStreamReader<TResponse>(
+                _call.ResponseStream,
+                _shield,
+                _lifetime.Token),
+            static state => ((DuplexStreamingState<TRequest, TResponse>)state).ExecuteHeadersAsync(),
+            static state => ((DuplexStreamingState<TRequest, TResponse>)state)._call.GetStatus(),
+            static state => ((DuplexStreamingState<TRequest, TResponse>)state)._call.GetTrailers(),
+            static state => ((DuplexStreamingState<TRequest, TResponse>)state).Dispose(),
+            this);
+
+        private Task<Metadata> ExecuteHeadersAsync() => _shield.ExecuteAsync(
+            this,
+            static (state, token) => AwaitWithLifetimeAsync(
+                state._call.ResponseHeadersAsync,
+                state._lifetime,
+                token),
+            _lifetime.Token).AsTask();
+
+        private void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            CancelLifetime(_lifetime);
+            _call.Dispose();
+            _lifetime.Dispose();
+        }
+    }
+
+    private sealed class ShieldedClientStreamWriter<T>(
+        IClientStreamWriter<T> writer,
+        Shield shield,
+        CancellationTokenSource lifetime) : IClientStreamWriter<T>
+    {
+        public WriteOptions? WriteOptions
+        {
+            get => writer.WriteOptions;
+            set => writer.WriteOptions = value;
+        }
+
+        public Task WriteAsync(T message) => WriteAsync(message, lifetime.Token);
+
+        public Task WriteAsync(T message, CancellationToken cancellationToken) => shield.ExecuteAsync(
+            (Writer: writer, Message: message),
+#if NET6_0_OR_GREATER
+            static (state, token) => new ValueTask(state.Writer.WriteAsync(state.Message, token)),
+#else
+            static (state, token) => AwaitWithCancellationAsync(
+                state.Writer.WriteAsync(state.Message),
+                token),
+#endif
+            cancellationToken.CanBeCanceled ? cancellationToken : lifetime.Token).AsTask();
+
+        public Task CompleteAsync() => shield.ExecuteAsync(
+            (Writer: writer, Lifetime: lifetime),
+            static (state, token) => AwaitWithLifetimeAsync(
+                state.Writer.CompleteAsync(),
+                state.Lifetime,
+                token),
+            lifetime.Token).AsTask();
+    }
+
+    private sealed class ShieldedAsyncStreamReader<T>(
+        IAsyncStreamReader<T> reader,
+        Shield shield,
+        CancellationToken lifetimeToken) : IAsyncStreamReader<T>
+    {
+        public T Current => reader.Current;
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken) => shield.ExecuteAsync(
+            reader,
+            static (state, token) => new ValueTask<bool>(state.MoveNext(token)),
+            cancellationToken.CanBeCanceled ? cancellationToken : lifetimeToken).AsTask();
+    }
+
+    private static CancellationTokenSource CreateLifetime(CancellationToken cancellationToken) =>
+        cancellationToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            : new CancellationTokenSource();
+
+    private static async ValueTask<T> AwaitWithLifetimeAsync<T>(
+        Task<T> task,
+        CancellationTokenSource lifetime,
+        CancellationToken cancellationToken)
+    {
+        using var registration = cancellationToken.Register(
+            static state => CancelLifetime((CancellationTokenSource)state!),
+            lifetime);
+        return await task.ConfigureAwait(false);
+    }
+
+    private static async ValueTask AwaitWithLifetimeAsync(
+        Task task,
+        CancellationTokenSource lifetime,
+        CancellationToken cancellationToken)
+    {
+        using var registration = cancellationToken.Register(
+            static state => CancelLifetime((CancellationTokenSource)state!),
+            lifetime);
+        await task.ConfigureAwait(false);
+    }
+
+    private static void CancelLifetime(CancellationTokenSource lifetime)
+    {
+        try
+        {
+            lifetime.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposal may race an in-flight operation's cancellation callback.
+        }
+    }
+
+#if !NET6_0_OR_GREATER
+    private static async ValueTask AwaitWithCancellationAsync(
+        Task task,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await task.ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+#endif
+}

--- a/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
@@ -549,6 +549,164 @@ public class GrpcResilienceTests
         await Assert.That(response.Attempt).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task Named_DI_Shield_Configures_Streaming_Operations()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        var services = new ServiceCollection();
+        services.AddShield("grpc-stream", Shield.Timeout(TimeSpan.FromSeconds(5)));
+        services.AddGrpcClient<Resilience.ResilienceClient>(options =>
+            options.Address = new Uri("http://localhost"))
+            .ConfigurePrimaryHttpMessageHandler(server.CreateHandler)
+            .AddShieldStreamingInterceptor("grpc-stream");
+        await using var provider = services.BuildServiceProvider();
+        using var call = provider.GetRequiredService<Resilience.ResilienceClient>().ClientStream();
+
+        await call.RequestStream.WriteAsync(new TestRequest());
+        await call.RequestStream.CompleteAsync();
+        var response = await call.ResponseAsync;
+
+        await Assert.That(response.Attempt).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Server_Streaming_Retries_The_Loopback_Call_Before_Progress()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        using var call = server.StreamingClient(
+                GrpcShield.WhenTransient().Retry(1, Backoff.None))
+            .ServerStream(new TestRequest { Scenario = "stream-transient" });
+
+        var hasNext = await call.ResponseStream.MoveNext(CancellationToken.None);
+
+        await Assert.That(hasNext).IsTrue();
+        await Assert.That(call.ResponseStream.Current.Attempt).IsEqualTo(2);
+        await Assert.That((await call.ResponseHeadersAsync).GetValue("attempt")).IsEqualTo("2");
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsFalse();
+        await Assert.That(call.GetStatus().StatusCode).IsEqualTo(StatusCode.OK);
+        await Assert.That(call.GetTrailers().GetValue("completed")).IsEqualTo("true");
+        await Assert.That(server.State.Attempts("stream-transient")).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Client_Streaming_Loopback_Writes_Each_Message_Once()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        using var call = server.StreamingClient(Shield.Empty).ClientStream();
+
+        await call.RequestStream.WriteAsync(new TestRequest { Scenario = "first" });
+        await call.RequestStream.WriteAsync(new TestRequest { Scenario = "second" });
+        await call.RequestStream.CompleteAsync();
+        var response = await call.ResponseAsync;
+
+        await Assert.That(response.Attempt).IsEqualTo(2);
+        await Assert.That((await call.ResponseHeadersAsync).GetValue("shape")).IsEqualTo("client");
+        await Assert.That(call.GetTrailers().GetValue("completed")).IsEqualTo("true");
+    }
+
+    [Test]
+    public async Task Duplex_Streaming_Loopback_Does_Not_Buffer_Or_Duplicate_Messages()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        using var call = server.StreamingClient(Shield.Empty).DuplexStream();
+
+        await call.RequestStream.WriteAsync(new TestRequest { Scenario = "first" });
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+        await Assert.That(call.ResponseStream.Current.Attempt).IsEqualTo(1);
+        await call.RequestStream.WriteAsync(new TestRequest { Scenario = "second" });
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+        await Assert.That(call.ResponseStream.Current.Attempt).IsEqualTo(2);
+        await call.RequestStream.CompleteAsync();
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsFalse();
+    }
+
+    [Test]
+    public async Task Server_Streaming_Loopback_Does_Not_Retry_After_Partial_Progress()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        using var call = server.StreamingClient(
+                GrpcShield.WhenTransient().Retry(2, Backoff.None))
+            .ServerStream(new TestRequest { Scenario = "stream-mid-failure" });
+
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+        var exception = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None))
+            .Throws<RpcException>();
+
+        await Assert.That(exception!.StatusCode).IsEqualTo(StatusCode.Unavailable);
+        await Assert.That(server.State.Attempts("stream-mid-failure")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Server_Streaming_Loopback_Caller_Cancellation_Preserves_The_Token()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        using var cancellation = new CancellationTokenSource();
+        using var call = server.StreamingClient(Shield.Empty).ServerStream(
+            new TestRequest { Scenario = "stream-wait" },
+            cancellationToken: cancellation.Token);
+        var move = call.ResponseStream.MoveNext(CancellationToken.None);
+        await server.State.WaitForEntryAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        cancellation.Cancel();
+        var exception = await Assert.That(async () => await move)
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+        await server.State.WaitForCancellationAsync().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Server_Streaming_Loopback_Deadline_Owns_The_Total_Lifetime()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        using var call = server.StreamingClient(
+                GrpcShield.WhenTransient().RetryForever(Backoff.None))
+            .ServerStream(
+                new TestRequest { Scenario = "stream-wait" },
+                deadline: DateTime.UtcNow.AddMilliseconds(250));
+
+        var exception = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None)
+                    .WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<RpcException>();
+
+        await Assert.That(exception!.StatusCode).IsEqualTo(StatusCode.DeadlineExceeded);
+        await Assert.That(server.State.Attempts("stream-wait")).IsEqualTo(1);
+        await server.State.WaitForCancellationAsync().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Server_Streaming_Loopback_Timeout_Cancels_The_Active_Read()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        using var call = server.StreamingClient(
+                Shield.Timeout(TimeSpan.FromMilliseconds(100)))
+            .ServerStream(new TestRequest { Scenario = "stream-wait" });
+
+        _ = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None))
+            .Throws<TimeoutExceededException>();
+
+        await server.State.WaitForCancellationAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(server.State.Attempts("stream-wait")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Disposing_Partially_Consumed_Loopback_Stream_Cancels_The_Server()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        var call = server.StreamingClient(Shield.Empty)
+            .ServerStream(new TestRequest { Scenario = "stream-partial" });
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+        await server.State.WaitForEntryAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        call.Dispose();
+
+        await server.State.WaitForCancellationAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(server.State.Attempts("stream-partial")).IsEqualTo(1);
+    }
+
     private static AsyncUnaryCall<TestReply> Call(
         Task<TestReply> response,
         Action? dispose = null,
@@ -670,6 +828,9 @@ public class GrpcResilienceTests
         public Resilience.ResilienceClient Client(Shield shield) =>
             new(Channel.Intercept(new ShieldUnaryClientInterceptor(shield)));
 
+        public Resilience.ResilienceClient StreamingClient(Shield shield) =>
+            new(Channel.Intercept(new ShieldStreamingClientInterceptor(shield)));
+
         public HttpMessageHandler CreateHandler() => _application.GetTestServer().CreateHandler();
 
         public async ValueTask DisposeAsync()
@@ -752,6 +913,81 @@ public class GrpcResilienceTests
             }
 
             return new TestReply { Attempt = attempt };
+        }
+
+        public override async Task ServerStream(
+            TestRequest request,
+            IServerStreamWriter<TestReply> responseStream,
+            ServerCallContext context)
+        {
+            var attempt = state.Record(request.Scenario);
+            if (request.Scenario == "stream-transient" && attempt == 1)
+            {
+                throw new RpcException(new Status(StatusCode.Unavailable, "transient"));
+            }
+
+            await context.WriteResponseHeadersAsync(
+                new Metadata { { "attempt", attempt.ToString() } });
+            context.ResponseTrailers.Add("completed", "true");
+            if (request.Scenario is "stream-mid-failure" or "stream-partial")
+            {
+                await responseStream.WriteAsync(
+                    new TestReply { Attempt = attempt },
+                    context.CancellationToken);
+                if (request.Scenario == "stream-mid-failure")
+                {
+                    throw new RpcException(new Status(StatusCode.Unavailable, "mid-stream"));
+                }
+            }
+
+            if (request.Scenario is "stream-wait" or "stream-partial")
+            {
+                state.Entered();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, context.CancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    state.Cancelled();
+                    throw;
+                }
+
+                return;
+            }
+
+            await responseStream.WriteAsync(
+                new TestReply { Attempt = attempt },
+                context.CancellationToken);
+        }
+
+        public override async Task<TestReply> ClientStream(
+            IAsyncStreamReader<TestRequest> requestStream,
+            ServerCallContext context)
+        {
+            await context.WriteResponseHeadersAsync(new Metadata { { "shape", "client" } });
+            context.ResponseTrailers.Add("completed", "true");
+            var count = 0;
+            while (await requestStream.MoveNext(context.CancellationToken))
+            {
+                count++;
+            }
+
+            return new TestReply { Attempt = count };
+        }
+
+        public override async Task DuplexStream(
+            IAsyncStreamReader<TestRequest> requestStream,
+            IServerStreamWriter<TestReply> responseStream,
+            ServerCallContext context)
+        {
+            var count = 0;
+            while (await requestStream.MoveNext(context.CancellationToken))
+            {
+                await responseStream.WriteAsync(
+                    new TestReply { Attempt = ++count },
+                    context.CancellationToken);
+            }
         }
     }
 }

--- a/tests/Kevlar.IntegrationTests/GrpcStreamingResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/GrpcStreamingResilienceTests.cs
@@ -1,0 +1,585 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Kevlar.Extensions.Grpc;
+
+namespace Kevlar.IntegrationTests;
+
+[NotInParallel]
+public class GrpcStreamingResilienceTests
+{
+    private static readonly Method<StreamRequest, StreamReply> ServerStreamingMethod =
+        CreateMethod(MethodType.ServerStreaming);
+    private static readonly Method<StreamRequest, StreamReply> ClientStreamingMethod =
+        CreateMethod(MethodType.ClientStreaming);
+    private static readonly Method<StreamRequest, StreamReply> DuplexStreamingMethod =
+        CreateMethod(MethodType.DuplexStreaming);
+
+    [Test]
+    public async Task Server_Stream_Retries_Before_First_Item_And_Selects_Final_Metadata()
+    {
+        var attempts = 0;
+        var disposed = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(
+            GrpcShield.WhenTransient().Retry(1, Backoff.None));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) =>
+            {
+                var attempt = Interlocked.Increment(ref attempts);
+                var reader = attempt == 1
+                    ? Reader((_, _) => Task.FromException<(bool, StreamReply?)>(Transient()))
+                    : Reader((_, _) => Task.FromResult<(bool, StreamReply?)>(
+                        (true, new StreamReply { Attempt = attempt })));
+                return ServerCall(
+                    reader,
+                    () => Interlocked.Increment(ref disposed),
+                    headers: new Metadata { { "attempt", attempt.ToString() } },
+                    trailers: new Metadata { { "selected", attempt.ToString() } });
+            });
+
+        var hasNext = await call.ResponseStream.MoveNext(CancellationToken.None);
+
+        await Assert.That(hasNext).IsTrue();
+        await Assert.That(call.ResponseStream.Current.Attempt).IsEqualTo(2);
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(disposed).IsEqualTo(1);
+        await Assert.That((await call.ResponseHeadersAsync).GetValue("attempt")).IsEqualTo("2");
+        await Assert.That(call.GetTrailers().GetValue("selected")).IsEqualTo("2");
+    }
+
+    [Test]
+    public async Task Server_Stream_Does_Not_Retry_After_First_Item()
+    {
+        var attempts = 0;
+        var moves = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(
+            GrpcShield.WhenTransient().Retry(3, Backoff.None));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) =>
+            {
+                Interlocked.Increment(ref attempts);
+                return ServerCall(Reader((_, _) =>
+                {
+                    if (Interlocked.Increment(ref moves) == 1)
+                    {
+                        return Task.FromResult<(bool, StreamReply?)>(
+                            (true, new StreamReply { Attempt = 1 }));
+                    }
+
+                    return Task.FromException<(bool, StreamReply?)>(Transient());
+                }));
+            });
+
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+        _ = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None))
+            .Throws<RpcException>();
+
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(moves).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Server_Headers_Commit_The_Stream_Before_Any_Item()
+    {
+        var attempts = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(
+            GrpcShield.WhenTransient().Retry(2, Backoff.None));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) =>
+            {
+                var attempt = Interlocked.Increment(ref attempts);
+                return ServerCall(
+                    Reader((_, _) => Task.FromException<(bool, StreamReply?)>(Transient())),
+                    headers: new Metadata { { "attempt", attempt.ToString() } });
+            });
+
+        await Assert.That((await call.ResponseHeadersAsync).GetValue("attempt")).IsEqualTo("1");
+        _ = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None))
+            .Throws<RpcException>();
+
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Server_Stream_Retries_Header_Failure_Before_Commit()
+    {
+        var attempts = 0;
+        var disposed = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(
+            GrpcShield.WhenTransient().Retry(1, Backoff.None));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) =>
+            {
+                var attempt = Interlocked.Increment(ref attempts);
+                return ServerCall(
+                    Reader((_, _) => Task.FromResult<(bool, StreamReply?)>((false, null))),
+                    () => Interlocked.Increment(ref disposed),
+                    responseHeaders: attempt == 1
+                        ? Task.FromException<Metadata>(Transient())
+                        : Task.FromResult(new Metadata { { "attempt", "2" } }));
+            });
+
+        var headers = await call.ResponseHeadersAsync;
+
+        await Assert.That(headers.GetValue("attempt")).IsEqualTo("2");
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(disposed).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Server_Stream_Hedge_Cancels_And_Disposes_The_Loser()
+    {
+        var attempts = 0;
+        var disposed = 0;
+        var loserCancelled = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new ShieldStreamingClientInterceptor(
+            Shield.Hedge(2, TimeSpan.Zero));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) =>
+            {
+                var attempt = Interlocked.Increment(ref attempts);
+                if (attempt == 1)
+                {
+                    return ServerCall(
+                        Reader(async (_, token) =>
+                        {
+                            try
+                            {
+                                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                                return (false, null);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                loserCancelled.TrySetResult();
+                                throw;
+                            }
+                        }),
+                        () => Interlocked.Increment(ref disposed));
+                }
+
+                return ServerCall(Reader((_, _) =>
+                    Task.FromResult<(bool, StreamReply?)>(
+                        (true, new StreamReply { Attempt = attempt }))));
+            });
+
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+
+        await loserCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(call.ResponseStream.Current.Attempt).IsEqualTo(2);
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(disposed).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Server_Stream_AtMostOnce_Shield_Applies_To_Each_MoveNext()
+    {
+        var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new ShieldStreamingClientInterceptor(
+            Shield.Timeout(TimeSpan.FromMilliseconds(50)));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) => ServerCall(Reader((move, token) =>
+            {
+                if (move == 1)
+                {
+                    return Task.FromResult<(bool, StreamReply?)>(
+                        (true, new StreamReply { Attempt = 1 }));
+                }
+
+                var completion = new TaskCompletionSource<(bool, StreamReply?)>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                token.Register(() =>
+                {
+                    cancelled.TrySetResult();
+                    completion.TrySetCanceled(token);
+                });
+                return completion.Task;
+            })));
+
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+        _ = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None))
+            .Throws<TimeoutExceededException>();
+        await cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Separate_Shields_Retry_Establishment_And_Timeout_Later_Reads()
+    {
+        var attempts = 0;
+        var cancelled = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new ShieldStreamingClientInterceptor(
+            GrpcShield.WhenTransient().Retry(1, Backoff.None),
+            Shield.Timeout(TimeSpan.FromMilliseconds(50)));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    return ServerCall(Reader((_, _) =>
+                        Task.FromException<(bool, StreamReply?)>(Transient())));
+                }
+
+                return ServerCall(Reader((move, token) =>
+                {
+                    if (move == 1)
+                    {
+                        return Task.FromResult<(bool, StreamReply?)>(
+                            (true, new StreamReply { Attempt = 2 }));
+                    }
+
+                    var completion = new TaskCompletionSource<(bool, StreamReply?)>(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                    token.Register(() =>
+                    {
+                        cancelled.TrySetResult();
+                        completion.TrySetCanceled(token);
+                    });
+                    return completion.Task;
+                }));
+            });
+
+        await Assert.That(await call.ResponseStream.MoveNext(CancellationToken.None)).IsTrue();
+        _ = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None))
+            .Throws<TimeoutExceededException>();
+
+        await cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Client_Stream_Response_Leaves_Metadata_Available_Until_Disposed()
+    {
+        var disposed = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(Shield.Empty);
+        var call = interceptor.AsyncClientStreamingCall(
+            Context(ClientStreamingMethod),
+            _ => ClientCall(
+                new DelegateWriter(),
+                Task.FromResult(new StreamReply { Attempt = 1 }),
+                () => Interlocked.Increment(ref disposed),
+                new Metadata { { "terminal", "true" } }));
+
+        var response = await call.ResponseAsync;
+
+        await Assert.That(response.Attempt).IsEqualTo(1);
+        await Assert.That(disposed).IsEqualTo(0);
+        await Assert.That(call.GetStatus()).IsEqualTo(Status.DefaultSuccess);
+        await Assert.That(call.GetTrailers().GetValue("terminal")).IsEqualTo("true");
+        call.Dispose();
+        call.Dispose();
+        await Assert.That(disposed).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Client_Stream_Write_Timeout_Cancels_Underlying_Call_Without_Replay()
+    {
+        var writes = 0;
+        var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var writer = new DelegateWriter((_, token) =>
+        {
+            Interlocked.Increment(ref writes);
+            var completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            token.Register(() =>
+            {
+                cancelled.TrySetResult();
+                completion.TrySetCanceled(token);
+            });
+            return completion.Task;
+        });
+        var interceptor = new ShieldStreamingClientInterceptor(
+            Shield.Timeout(TimeSpan.FromMilliseconds(50)));
+        using var call = interceptor.AsyncClientStreamingCall(
+            Context(ClientStreamingMethod),
+            _ => ClientCall(writer, Task.FromResult(new StreamReply())));
+
+        _ = await Assert.That(async () =>
+                await call.RequestStream.WriteAsync(new StreamRequest()))
+            .Throws<TimeoutExceededException>();
+
+        await cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(writes).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Duplex_Stream_Shields_Reads_And_Writes_Without_Replay()
+    {
+        var writes = 0;
+        var moves = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(Shield.Empty);
+        using var call = interceptor.AsyncDuplexStreamingCall(
+            Context(DuplexStreamingMethod),
+            _ => DuplexCall(
+                new DelegateWriter((_, _) =>
+                {
+                    Interlocked.Increment(ref writes);
+                    return Task.CompletedTask;
+                }),
+                Reader((_, _) =>
+                {
+                    Interlocked.Increment(ref moves);
+                    return Task.FromResult<(bool, StreamReply?)>(
+                        (true, new StreamReply { Attempt = 7 }));
+                })));
+
+        await call.RequestStream.WriteAsync(new StreamRequest());
+        var hasNext = await call.ResponseStream.MoveNext(CancellationToken.None);
+
+        await Assert.That(hasNext).IsTrue();
+        await Assert.That(call.ResponseStream.Current.Attempt).IsEqualTo(7);
+        await Assert.That(writes).IsEqualTo(1);
+        await Assert.That(moves).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Request_Streaming_Rejects_Strategies_That_Can_Replay_Operations()
+    {
+        var interceptor = new ShieldStreamingClientInterceptor(
+            Shield.When(static _ => true).Retry(1, Backoff.None));
+
+        _ = await Assert.That(() => interceptor.AsyncClientStreamingCall(
+                Context(ClientStreamingMethod),
+                _ => ClientCall(new DelegateWriter(), Task.FromResult(new StreamReply()))))
+            .Throws<NotSupportedException>();
+        _ = await Assert.That(() => interceptor.AsyncDuplexStreamingCall(
+                Context(DuplexStreamingMethod),
+                _ => DuplexCall(new DelegateWriter(), Reader((_, _) =>
+                    Task.FromResult<(bool, StreamReply?)>((false, null))))))
+            .Throws<NotSupportedException>();
+    }
+
+    [Test]
+    public async Task Disposing_Server_Stream_Cancels_And_Disposes_Active_Attempt()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var disposed = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(Shield.Empty);
+        var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(ServerStreamingMethod),
+            (_, _) => ServerCall(
+                Reader((_, token) =>
+                {
+                    started.TrySetResult();
+                    var completion = new TaskCompletionSource<(bool, StreamReply?)>(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                    token.Register(() =>
+                    {
+                        cancelled.TrySetResult();
+                        completion.TrySetCanceled(token);
+                    });
+                    return completion.Task;
+                }),
+                () => Interlocked.Increment(ref disposed)));
+        var move = call.ResponseStream.MoveNext(CancellationToken.None);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        call.Dispose();
+        call.Dispose();
+
+        _ = await Assert.That(async () => await move).Throws<OperationCanceledException>();
+        await cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(disposed).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Expired_Deadline_Stops_Unconditional_Server_Stream_Retry()
+    {
+        var expected = new RpcException(
+            new Status(StatusCode.DeadlineExceeded, "deadline"));
+        var attempts = 0;
+        var interceptor = new ShieldStreamingClientInterceptor(
+            Shield.When(static _ => true).RetryForever(Backoff.None));
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(
+                ServerStreamingMethod,
+                new CallOptions(deadline: DateTime.UtcNow.AddMilliseconds(50))),
+            (_, _) =>
+            {
+                Interlocked.Increment(ref attempts);
+                return ServerCall(Reader(async (_, _) =>
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+                    throw expected;
+                }));
+            });
+
+        var actual = await Assert.That(async () =>
+                await call.ResponseStream.MoveNext(CancellationToken.None)
+                    .WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<RpcException>();
+
+        await Assert.That(ReferenceEquals(actual, expected)).IsTrue();
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Caller_Cancellation_On_Server_Stream_Preserves_Caller_Token()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new ShieldStreamingClientInterceptor(Shield.Empty);
+        using var call = interceptor.AsyncServerStreamingCall(
+            new StreamRequest(),
+            Context(
+                ServerStreamingMethod,
+                new CallOptions(cancellationToken: cancellation.Token)),
+            (_, _) => ServerCall(Reader(async (_, token) =>
+            {
+                started.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    return (false, null);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new RpcException(new Status(StatusCode.Cancelled, "cancelled"));
+                }
+            })));
+        var move = call.ResponseStream.MoveNext(CancellationToken.None);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cancellation.Cancel();
+        var exception = await Assert.That(async () => await move)
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task Streaming_Interceptor_Rejects_Null_Shield()
+    {
+        _ = await Assert.That(() => new ShieldStreamingClientInterceptor(null!))
+            .Throws<ArgumentNullException>();
+        _ = await Assert.That(() => new ShieldStreamingClientInterceptor(null!, Shield.Empty))
+            .Throws<ArgumentNullException>();
+        _ = await Assert.That(() => new ShieldStreamingClientInterceptor(Shield.Empty, null!))
+            .Throws<ArgumentNullException>();
+        _ = await Assert.That(() => new ShieldStreamingClientInterceptor(
+                Shield.Empty,
+                Shield.Retry(1, Backoff.None)))
+            .Throws<ArgumentException>();
+    }
+
+    private static ClientInterceptorContext<StreamRequest, StreamReply> Context(
+        Method<StreamRequest, StreamReply> method,
+        CallOptions options = default) => new(method, host: null, options);
+
+    private static Method<StreamRequest, StreamReply> CreateMethod(MethodType type) => new(
+        type,
+        "kevlar.tests.Streaming",
+        type.ToString(),
+        Marshallers.Create(static _ => [], static _ => new StreamRequest()),
+        Marshallers.Create(static _ => [], static _ => new StreamReply()));
+
+    private static RpcException Transient() =>
+        new(new Status(StatusCode.Unavailable, "transient"));
+
+    private static DelegateReader Reader(
+        Func<int, CancellationToken, Task<(bool HasNext, StreamReply? Current)>> move) => new(move);
+
+    private static AsyncServerStreamingCall<StreamReply> ServerCall(
+        IAsyncStreamReader<StreamReply> reader,
+        Action? dispose = null,
+        Metadata? headers = null,
+        Metadata? trailers = null,
+        Task<Metadata>? responseHeaders = null) => new(
+        reader,
+        responseHeaders ?? Task.FromResult(headers ?? new Metadata()),
+        static () => Status.DefaultSuccess,
+        () => trailers ?? new Metadata(),
+        dispose ?? NoOp);
+
+    private static AsyncClientStreamingCall<StreamRequest, StreamReply> ClientCall(
+        IClientStreamWriter<StreamRequest> writer,
+        Task<StreamReply> response,
+        Action? dispose = null,
+        Metadata? trailers = null) => new(
+        writer,
+        response,
+        Task.FromResult(new Metadata()),
+        static () => Status.DefaultSuccess,
+        () => trailers ?? new Metadata(),
+        dispose ?? NoOp);
+
+    private static AsyncDuplexStreamingCall<StreamRequest, StreamReply> DuplexCall(
+        IClientStreamWriter<StreamRequest> writer,
+        IAsyncStreamReader<StreamReply> reader) => new(
+        writer,
+        reader,
+        Task.FromResult(new Metadata()),
+        static () => Status.DefaultSuccess,
+        static () => new Metadata(),
+        NoOp);
+
+    private static void NoOp()
+    {
+    }
+
+    private sealed class DelegateReader(
+        Func<int, CancellationToken, Task<(bool HasNext, StreamReply? Current)>> move) :
+        IAsyncStreamReader<StreamReply>
+    {
+        private int _moves;
+
+        public StreamReply Current { get; private set; } = null!;
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            var result = await move(Interlocked.Increment(ref _moves), cancellationToken)
+                .ConfigureAwait(false);
+            if (result.HasNext)
+            {
+                Current = result.Current!;
+            }
+
+            return result.HasNext;
+        }
+    }
+
+    private sealed class DelegateWriter(
+        Func<StreamRequest, CancellationToken, Task>? write = null) :
+        IClientStreamWriter<StreamRequest>
+    {
+        public WriteOptions? WriteOptions { get; set; }
+
+        public Task CompleteAsync() => Task.CompletedTask;
+
+        public Task WriteAsync(StreamRequest message) =>
+            (write ?? CompletedWrite)(message, CancellationToken.None);
+
+        public Task WriteAsync(StreamRequest message, CancellationToken cancellationToken) =>
+            (write ?? CompletedWrite)(message, cancellationToken);
+
+        private static Task CompletedWrite(StreamRequest _, CancellationToken __) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class StreamRequest;
+
+    private sealed class StreamReply
+    {
+        public int Attempt { get; init; }
+    }
+}

--- a/tests/Kevlar.IntegrationTests/Protos/resilience.proto
+++ b/tests/Kevlar.IntegrationTests/Protos/resilience.proto
@@ -6,6 +6,9 @@ package kevlar.tests;
 
 service Resilience {
   rpc Unary (TestRequest) returns (TestReply);
+  rpc ServerStream (TestRequest) returns (stream TestReply);
+  rpc ClientStream (stream TestRequest) returns (TestReply);
+  rpc DuplexStream (stream TestRequest) returns (stream TestReply);
 }
 
 message TestRequest {


### PR DESCRIPTION
## Summary

- add replay-safe server-, client-, and duplex-streaming interceptors with explicit establishment and operation shields
- preserve cancellation, deadline, metadata, disposal, and post-progress semantics across streaming call shapes
- add DI registration, loopback/regression coverage, documentation, and direct-versus-shielded benchmarks

Closes #79

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (614 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (66 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (27 passed)
- `./scripts/Verify-DocSnippets.ps1` (90 snippets)
- `npm run build`
- package layout, trimming, and single-file compatibility checks
- BenchmarkDotNet ShortRun: write direct 1.143 ns / shielded 20.595 ns, server first move direct 18.628 ns / shielded 344.483 ns