### PR TITLE
perf(partitioning): optimize warm cache locking

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/PartitioningBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/PartitioningBenchmarks.cs
@@ -9,6 +9,11 @@ namespace Kevlar.Benchmarks;
 [CategoriesColumn]
 public class PartitioningBenchmarks
 {
+    private const int ConcurrentLookupsPerInvoke = 1_024;
+
+    private static readonly PartitionedShield<int> ConcurrentWarm = new(
+        static _ => Shield.Retry(0, Backoff.None));
+
     private readonly PartitionedShield<int> _warm = new(
         static _ => Shield.Retry(0, Backoff.None));
     private readonly PartitionedShield<int> _evicting = new(
@@ -19,12 +24,23 @@ public class PartitioningBenchmarks
 
     public PartitioningBenchmarks()
     {
+        _ = ConcurrentWarm.GetShield(42);
         _ = _warm.GetShield(42);
         _ = _evicting.GetShield(0);
     }
 
     [BenchmarkCategory("WarmLookup"), Benchmark]
     public Shield Warm_Lookup() => _warm.GetShield(42);
+
+    [BenchmarkCategory("WarmLookupContended"), Benchmark(OperationsPerInvoke = ConcurrentLookupsPerInvoke)]
+    public int Warm_Concurrent_Lookups()
+    {
+        Parallel.For(
+            fromInclusive: 0,
+            toExclusive: ConcurrentLookupsPerInvoke,
+            static _ => ConcurrentWarm.GetShield(42));
+        return ConcurrentWarm.Count;
+    }
 
     [BenchmarkCategory("FirstCreation"), Benchmark]
     public Shield Cold_FirstCreation()

--- a/src/Kevlar/Internal/PartitionCache.cs
+++ b/src/Kevlar/Internal/PartitionCache.cs
@@ -6,7 +6,7 @@ internal sealed class PartitionCache<TKey, TShield>
     where TKey : notnull
     where TShield : class
 {
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private readonly Dictionary<TKey, Entry> _entries;
     private readonly Dictionary<TKey, Creation> _creations;
     private readonly Func<TKey, TShield> _factory;


### PR DESCRIPTION
## Summary

- replace the partition cache's generic monitor object with the dedicated `Lock` primitive already used elsewhere in Kevlar
- add a permanent steady-state contention benchmark covering 1,024 concurrent warm lookups per invocation
- keep the bounded LRU and single-creation semantics unchanged

## Profiling finding

Warm partition lookup is allocation-free but every hit enters the cache's global lock to maintain LRU order. The existing `High_Key_Concurrency` benchmark creates cold distinct keys, so it did not measure steady-state contention on retained entries.

This PR improves the lock primitive and adds the missing workload. It does not claim to remove the global-lock scalability ceiling; the contended result remains within measurement noise and now gives future structural changes a regression target.

## Benchmark

BenchmarkDotNet 0.15.8, default job, .NET 10.0.11, Windows 11, Intel Core Ultra 9 185H. Both runs used the same checkout base and machine. `Warm_Concurrent_Lookups` declares `OperationsPerInvoke = 1024`, so time and allocation are reported per lookup.

| Benchmark | Before | After | Change | Allocated |
|---|---:|---:|---:|---:|
| `Warm_Lookup` | 33.89 ns | 30.00 ns | **11.5% faster (1.13x)** | 0 B -> 0 B |
| `Warm_Concurrent_Lookups` | 538.38 ns | 523.70 ns | 2.7% faster; error ranges overlap | 5 B -> 6 B |

The small allocation in the concurrent case is `Parallel.For` harness overhead amortized across 1,024 operations; the ordinary warm lookup remains allocation-free.

Command:

```powershell
dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*PartitioningBenchmarks.Warm_Lookup" "*PartitioningBenchmarks.Warm_Concurrent_Lookups"
```

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (612 passed)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (2 passed)