### PR TITLE
feat(testing): add telemetry recording helpers

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -34,6 +34,47 @@ await TUnit.Assertions.Assert.That(descriptor.Name).IsEqualTo("catalog");
 
 `AssertContains<TDescriptor>()` checks presence when repeats are valid. `AssertContainsSingle<TDescriptor>()` also rejects duplicates. All shape failures throw `ShieldAssertionException` with expected and actual pipeline details.
 
+## Recording telemetry and callbacks
+
+`TelemetryRecorder` is an opt-in test listener. It captures immutable snapshots of Kevlar meter
+measurements and exposes `Record` overloads that can be assigned directly to strategy callbacks.
+The recorder copies metric tags and callback values immediately; it never retains a pooled
+`KevlarContext`.
+
+<!-- doc-test-ignore: The executable documentation harness owns Main; this TUnit example is compiled by Kevlar.Testing.Tests. -->
+```csharp
+using var telemetry = new TelemetryRecorder();
+var shield = Shield.Retry(options =>
+{
+    options.MaxRetries = 1;
+    options.Backoff = Backoff.None;
+    options.OnRetry = telemetry.Record;
+}).WithName("catalog");
+
+await shield.ExecuteOutcomeAsync<int>(static _ =>
+    ValueTask.FromException<int>(new InvalidOperationException("offline")));
+await telemetry.WaitForCallbackCountAsync(1);
+
+var retry = telemetry.Callbacks.Single();
+await TUnit.Assertions.Assert.That(retry.Kind).IsEqualTo(CallbackKind.Retry);
+await TUnit.Assertions.Assert.That(retry.Attempt).IsEqualTo(1);
+await TUnit.Assertions.Assert.That(retry.ShieldName).IsEqualTo("catalog");
+
+var execution = telemetry.Metrics.Single(record =>
+    record.InstrumentName == "kevlar.executions");
+await TUnit.Assertions.Assert.That(
+    execution.Tags["kevlar.execution.outcome"]).IsEqualTo("failure");
+```
+
+The callback overloads cover typed and untyped retries and fallbacks, plus timeout, hedge, and
+circuit-transition notifications. `WaitForMetricCountAsync` and `WaitForCallbackCountAsync` are
+cancellation-aware, so tests can await concurrent pipelines without polling. Metric records retain
+the documented low-cardinality tags; unnamed shields simply omit `kevlar.shield.name`.
+
+Dispose the recorder at the end of each test to detach its `MeterListener`. Metric capture is
+available on .NET 8 and later, matching core telemetry; callback recording remains available on
+`netstandard2.0`. Construct with `captureMetrics: false` when a test needs callbacks only.
+
 ## Repository quality gates
 
 Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, analyzer, and testing-package suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.

--- a/src/Kevlar.Testing/CallbackKind.cs
+++ b/src/Kevlar.Testing/CallbackKind.cs
@@ -1,0 +1,20 @@
+namespace Kevlar.Testing;
+
+/// <summary>Identifies a Kevlar strategy callback captured by <see cref="TelemetryRecorder"/>.</summary>
+public enum CallbackKind
+{
+    /// <summary>A retry callback.</summary>
+    Retry,
+
+    /// <summary>A timeout callback.</summary>
+    Timeout,
+
+    /// <summary>A hedge callback.</summary>
+    Hedge,
+
+    /// <summary>A fallback callback.</summary>
+    Fallback,
+
+    /// <summary>A circuit-breaker transition callback.</summary>
+    CircuitTransition,
+}

--- a/src/Kevlar.Testing/CallbackRecord.cs
+++ b/src/Kevlar.Testing/CallbackRecord.cs
@@ -1,0 +1,62 @@
+namespace Kevlar.Testing;
+
+/// <summary>An immutable snapshot of a strategy callback.</summary>
+public sealed class CallbackRecord
+{
+    internal CallbackRecord(
+        long sequence,
+        CallbackKind kind,
+        string? shieldName = null,
+        int? attempt = null,
+        TimeSpan? delay = null,
+        TimeSpan? timeout = null,
+        Exception? exception = null,
+        object? result = null,
+        CircuitState? from = null,
+        CircuitState? to = null)
+    {
+        Sequence = sequence;
+        Kind = kind;
+        ShieldName = shieldName;
+        Attempt = attempt;
+        Delay = delay;
+        Timeout = timeout;
+        Exception = exception;
+        Result = result;
+        From = from;
+        To = to;
+    }
+
+    /// <summary>The recorder-wide sequence number.</summary>
+    public long Sequence { get; }
+
+    /// <summary>The callback family.</summary>
+    public CallbackKind Kind { get; }
+
+    /// <summary>The shield name copied from the callback context, when available.</summary>
+    public string? ShieldName { get; }
+
+    /// <summary>The retry or hedge attempt number, when applicable.</summary>
+    public int? Attempt { get; }
+
+    /// <summary>The retry delay, when applicable.</summary>
+    public TimeSpan? Delay { get; }
+
+    /// <summary>The exceeded timeout, when applicable.</summary>
+    public TimeSpan? Timeout { get; }
+
+    /// <summary>The captured exception, when applicable.</summary>
+    public Exception? Exception { get; }
+
+    /// <summary>The captured result, when applicable.</summary>
+    public object? Result { get; }
+
+    /// <summary>The circuit state left, when applicable.</summary>
+    public CircuitState? From { get; }
+
+    /// <summary>The circuit state entered, when applicable.</summary>
+    public CircuitState? To { get; }
+
+    internal CallbackRecord WithSequence(long sequence) => new(
+        sequence, Kind, ShieldName, Attempt, Delay, Timeout, Exception, Result, From, To);
+}

--- a/src/Kevlar.Testing/MetricRecord.cs
+++ b/src/Kevlar.Testing/MetricRecord.cs
@@ -1,0 +1,32 @@
+namespace Kevlar.Testing;
+
+/// <summary>An immutable snapshot of one Kevlar metric measurement.</summary>
+public sealed class MetricRecord
+{
+    internal MetricRecord(
+        long sequence,
+        string instrumentName,
+        double value,
+        IReadOnlyDictionary<string, object?> tags)
+    {
+        Sequence = sequence;
+        InstrumentName = instrumentName;
+        Value = value;
+        Tags = tags;
+    }
+
+    /// <summary>The recorder-wide sequence number.</summary>
+    public long Sequence { get; }
+
+    /// <summary>The documented Kevlar instrument name.</summary>
+    public string InstrumentName { get; }
+
+    /// <summary>The numeric measurement converted to <see cref="double"/>.</summary>
+    public double Value { get; }
+
+    /// <summary>A copied snapshot of the measurement's low-cardinality tags.</summary>
+    public IReadOnlyDictionary<string, object?> Tags { get; }
+
+    internal MetricRecord WithSequence(long sequence) =>
+        new(sequence, InstrumentName, Value, Tags);
+}

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -73,3 +73,39 @@ static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyCount(th
 static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyOrder(this Kevlar.Testing.ShieldDescriptor! descriptor, params Kevlar.Testing.StrategyKind[]! expected) -> Kevlar.Testing.ShieldDescriptor!
 static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor(this Kevlar.Shield! shield) -> Kevlar.Testing.ShieldDescriptor!
 static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor<TResult>(this Kevlar.Shield<TResult>! shield) -> Kevlar.Testing.ShieldDescriptor!
+Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackKind.CircuitTransition = 4 -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackKind.Fallback = 3 -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackKind.Hedge = 2 -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackKind.Retry = 0 -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackKind.Timeout = 1 -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackRecord
+Kevlar.Testing.CallbackRecord.Attempt.get -> int?
+Kevlar.Testing.CallbackRecord.Delay.get -> System.TimeSpan?
+Kevlar.Testing.CallbackRecord.Exception.get -> System.Exception?
+Kevlar.Testing.CallbackRecord.From.get -> Kevlar.CircuitState?
+Kevlar.Testing.CallbackRecord.Kind.get -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackRecord.Result.get -> object?
+Kevlar.Testing.CallbackRecord.Sequence.get -> long
+Kevlar.Testing.CallbackRecord.ShieldName.get -> string?
+Kevlar.Testing.CallbackRecord.Timeout.get -> System.TimeSpan?
+Kevlar.Testing.CallbackRecord.To.get -> Kevlar.CircuitState?
+Kevlar.Testing.MetricRecord
+Kevlar.Testing.MetricRecord.InstrumentName.get -> string!
+Kevlar.Testing.MetricRecord.Sequence.get -> long
+Kevlar.Testing.MetricRecord.Tags.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!
+Kevlar.Testing.MetricRecord.Value.get -> double
+Kevlar.Testing.TelemetryRecorder
+Kevlar.Testing.TelemetryRecorder.Callbacks.get -> System.Collections.Generic.IReadOnlyList<Kevlar.Testing.CallbackRecord!>!
+Kevlar.Testing.TelemetryRecorder.Dispose() -> void
+Kevlar.Testing.TelemetryRecorder.Metrics.get -> System.Collections.Generic.IReadOnlyList<Kevlar.Testing.MetricRecord!>!
+Kevlar.Testing.TelemetryRecorder.Record(Kevlar.CircuitStateChangedEvent item) -> void
+Kevlar.Testing.TelemetryRecorder.Record(Kevlar.FallbackEvent item) -> void
+Kevlar.Testing.TelemetryRecorder.Record(Kevlar.HedgeEvent item) -> void
+Kevlar.Testing.TelemetryRecorder.Record(Kevlar.RetryEvent item) -> void
+Kevlar.Testing.TelemetryRecorder.Record(Kevlar.TimeoutEvent item) -> void
+Kevlar.Testing.TelemetryRecorder.Record<TResult>(Kevlar.FallbackEvent<TResult> item) -> void
+Kevlar.Testing.TelemetryRecorder.Record<TResult>(Kevlar.RetryEvent<TResult> item) -> void
+Kevlar.Testing.TelemetryRecorder.TelemetryRecorder(bool captureMetrics = true) -> void
+Kevlar.Testing.TelemetryRecorder.WaitForCallbackCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Kevlar.Testing.TelemetryRecorder.WaitForMetricCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Kevlar.Testing/TelemetryRecorder.cs
+++ b/src/Kevlar.Testing/TelemetryRecorder.cs
@@ -1,0 +1,244 @@
+#if NET8_0_OR_GREATER
+using System.Collections.ObjectModel;
+using System.Diagnostics.Metrics;
+#endif
+
+namespace Kevlar.Testing;
+
+/// <summary>
+/// Records Kevlar metrics and strategy callbacks for deterministic tests. Assign the
+/// <see cref="Record(RetryEvent)"/> overloads directly to strategy notification options.
+/// </summary>
+public sealed class TelemetryRecorder : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly List<MetricRecord> _metrics = [];
+    private readonly List<CallbackRecord> _callbacks = [];
+    private TaskCompletionSource<bool> _changed = CreateSignal();
+#if NET8_0_OR_GREATER
+    private readonly MeterListener? _listener;
+#endif
+    private long _sequence;
+    private bool _disposed;
+
+    /// <summary>Creates a recorder, optionally subscribing to Kevlar metrics.</summary>
+    public TelemetryRecorder(bool captureMetrics = true)
+    {
+#if NET8_0_OR_GREATER
+        if (captureMetrics)
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = static (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == KevlarDiagnostics.MeterName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            _listener.SetMeasurementEventCallback<long>(
+                (instrument, value, tags, _) => AddMetric(instrument.Name, value, tags));
+            _listener.SetMeasurementEventCallback<double>(
+                (instrument, value, tags, _) => AddMetric(instrument.Name, value, tags));
+            _listener.Start();
+        }
+#else
+        _ = captureMetrics;
+#endif
+    }
+
+    /// <summary>Gets a stable snapshot of captured metric measurements.</summary>
+    public IReadOnlyList<MetricRecord> Metrics
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _metrics.ToArray();
+            }
+        }
+    }
+
+    /// <summary>Gets a stable snapshot of captured callback events.</summary>
+    public IReadOnlyList<CallbackRecord> Callbacks
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _callbacks.ToArray();
+            }
+        }
+    }
+
+    /// <summary>Records an untyped retry callback.</summary>
+    public void Record(RetryEvent item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.Retry, item.Context.ShieldName, item.Attempt,
+        item.Delay, exception: item.Exception, result: item.Result));
+
+    /// <summary>Records a typed retry callback.</summary>
+    public void Record<TResult>(RetryEvent<TResult> item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.Retry, item.Context.ShieldName, item.Attempt,
+        item.Delay, exception: item.Outcome.Exception, result: item.Outcome.Result));
+
+    /// <summary>Records a timeout callback.</summary>
+    public void Record(TimeoutEvent item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.Timeout, item.Context.ShieldName, timeout: item.Timeout));
+
+    /// <summary>Records a hedge callback.</summary>
+    public void Record(HedgeEvent item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.Hedge, item.Context.ShieldName, item.Attempt));
+
+    /// <summary>Records an untyped fallback callback.</summary>
+    public void Record(FallbackEvent item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.Fallback, item.Context.ShieldName, exception: item.Exception));
+
+    /// <summary>Records a typed fallback callback.</summary>
+    public void Record<TResult>(FallbackEvent<TResult> item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.Fallback, item.Context.ShieldName,
+        exception: item.Outcome.Exception, result: item.Outcome.Result));
+
+    /// <summary>Records a circuit-breaker transition callback.</summary>
+    public void Record(CircuitStateChangedEvent item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.CircuitTransition, exception: item.LastException,
+        from: item.From, to: item.To));
+
+    /// <summary>Waits until at least <paramref name="count"/> metrics have been captured.</summary>
+    public Task WaitForMetricCountAsync(int count, CancellationToken cancellationToken = default) =>
+        WaitForCountAsync(static recorder => recorder._metrics.Count, count, cancellationToken);
+
+    /// <summary>Waits until at least <paramref name="count"/> callbacks have been captured.</summary>
+    public Task WaitForCallbackCountAsync(int count, CancellationToken cancellationToken = default) =>
+        WaitForCountAsync(static recorder => recorder._callbacks.Count, count, cancellationToken);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        TaskCompletionSource<bool> signal;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            signal = _changed;
+        }
+
+#if NET8_0_OR_GREATER
+        _listener?.Dispose();
+#endif
+        signal.TrySetResult(true);
+    }
+
+#if NET8_0_OR_GREATER
+    private void AddMetric<T>(string instrumentName, T value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        where T : struct, IConvertible
+    {
+        var copiedTags = new Dictionary<string, object?>(tags.Length, StringComparer.Ordinal);
+        foreach (var tag in tags)
+        {
+            copiedTags[tag.Key] = tag.Value;
+        }
+
+        AddMetric(new MetricRecord(
+            0,
+            instrumentName,
+            Convert.ToDouble(value),
+            new ReadOnlyDictionary<string, object?>(copiedTags)));
+    }
+#endif
+
+    private void AddMetric(MetricRecord record)
+    {
+        TaskCompletionSource<bool> signal;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _metrics.Add(record.WithSequence(++_sequence));
+            signal = _changed;
+            _changed = CreateSignal();
+        }
+
+        signal.TrySetResult(true);
+    }
+
+    private void AddCallback(CallbackRecord record)
+    {
+        TaskCompletionSource<bool> signal;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(TelemetryRecorder));
+            }
+
+            _callbacks.Add(record.WithSequence(++_sequence));
+            signal = _changed;
+            _changed = CreateSignal();
+        }
+
+        signal.TrySetResult(true);
+    }
+
+    private async Task WaitForCountAsync(
+        Func<TelemetryRecorder, int> getCount,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        while (true)
+        {
+            Task signal;
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(TelemetryRecorder));
+                }
+
+                if (getCount(this) >= count)
+                {
+                    return;
+                }
+
+                signal = _changed.Task;
+            }
+
+            await WaitWithCancellationAsync(signal, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WaitWithCancellationAsync(Task task, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            await task.ConfigureAwait(false);
+            return;
+        }
+
+        var cancellation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(
+            static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(), cancellation);
+        var completed = await Task.WhenAny(task, cancellation.Task).ConfigureAwait(false);
+        if (ReferenceEquals(completed, cancellation.Task))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        await task.ConfigureAwait(false);
+    }
+
+    private static TaskCompletionSource<bool> CreateSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -1,0 +1,212 @@
+namespace Kevlar.Testing.Tests;
+
+public class TelemetryRecorderTests
+{
+    [Test]
+    public async Task Records_Metrics_With_Documented_Attributes()
+    {
+        using var recorder = new TelemetryRecorder();
+        var named = Shield.Empty.WithName("orders");
+
+        await named.ExecuteAsync(static _ => ValueTask.CompletedTask);
+        await Shield.Empty.ExecuteOutcomeAsync<int>(
+            static _ => ValueTask.FromException<int>(new InvalidOperationException()));
+        await recorder.WaitForMetricCountAsync(4).WaitAsync(TimeSpan.FromSeconds(5));
+
+        var executions = recorder.Metrics
+            .Where(record => record.InstrumentName == "kevlar.executions")
+            .ToArray();
+        await Assert.That(executions.Length).IsEqualTo(2);
+        await Assert.That(executions[0].Tags["kevlar.shield.name"]).IsEqualTo("orders");
+        await Assert.That(executions[0].Tags["kevlar.execution.outcome"]).IsEqualTo("success");
+        await Assert.That(executions[1].Tags.ContainsKey("kevlar.shield.name")).IsFalse();
+        await Assert.That(executions[1].Tags["kevlar.execution.outcome"]).IsEqualTo("failure");
+    }
+
+    [Test]
+    public async Task Records_Typed_And_Untyped_Callbacks_In_Order()
+    {
+        using var recorder = new TelemetryRecorder(captureMetrics: false);
+        var typed = Shield.For<int>()
+            .WhenResult(static result => result < 0)
+            .Fallback(42, recorder.Record)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = recorder.Record;
+            })
+            .WithName("typed");
+        var attempts = 0;
+
+        var result = await typed.ExecuteAsync(_ => new ValueTask<int>(
+            Interlocked.Increment(ref attempts) == 1 ? -1 : -2));
+
+        await Assert.That(result).IsEqualTo(42);
+        var records = recorder.Callbacks;
+        await Assert.That(records.Select(record => record.Kind)
+            .SequenceEqual([CallbackKind.Retry, CallbackKind.Fallback])).IsTrue();
+        await Assert.That(records[0].Attempt).IsEqualTo(1);
+        await Assert.That(records[0].Result).IsEqualTo(-1);
+        await Assert.That(records[0].ShieldName).IsEqualTo("typed");
+        await Assert.That(records[1].Result).IsEqualTo(-2);
+
+        var untyped = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.OnRetry = recorder.Record;
+        });
+        await untyped.ExecuteOutcomeAsync<int>(static _ => throw new ApplicationException("failure"));
+
+        await Assert.That(recorder.Callbacks[2].Exception).IsTypeOf<ApplicationException>();
+        await Assert.That(recorder.Callbacks[2].ShieldName).IsNull();
+    }
+
+    [Test]
+    public async Task Waiters_Observe_Concurrent_Records_And_Disposal_Stops_Metrics()
+    {
+        using var recorder = new TelemetryRecorder();
+        var shields = Enumerable.Range(0, 8)
+            .Select(index => Shield.Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = recorder.Record;
+            }).WithName($"shield-{index}"))
+            .ToArray();
+
+        var wait = recorder.WaitForCallbackCountAsync(shields.Length);
+        await Task.WhenAll(shields.Select(shield => shield.ExecuteOutcomeAsync<int>(
+            static _ => throw new InvalidOperationException()).AsTask()));
+        await wait.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(recorder.Callbacks.Count).IsEqualTo(shields.Length);
+        await Assert.That(recorder.Callbacks.Select(record => record.ShieldName).Distinct().Count())
+            .IsEqualTo(shields.Length);
+
+        var metricCount = recorder.Metrics.Count;
+        recorder.Dispose();
+        await Shield.Empty.ExecuteAsync(static _ => ValueTask.CompletedTask);
+        await Assert.That(recorder.Metrics.Count).IsEqualTo(metricCount);
+    }
+
+    [Test]
+    public async Task Records_Timeout_Hedge_And_Circuit_Callbacks()
+    {
+        using var recorder = new TelemetryRecorder(captureMetrics: false);
+        var timeout = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromMilliseconds(1);
+            options.OnTimeout = recorder.Record;
+        }).WithName("timeout");
+        await timeout.ExecuteOutcomeAsync<int>(static async token =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 0;
+        });
+
+        var hedge = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedge = recorder.Record;
+        }).WithName("hedge");
+        await hedge.ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException()));
+
+        var breaker = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.OnStateChanged = recorder.Record;
+        });
+        await breaker.ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new ApplicationException("break")));
+
+        var records = recorder.Callbacks;
+        await Assert.That(records.Select(record => record.Kind).SequenceEqual(
+            [CallbackKind.Timeout, CallbackKind.Hedge, CallbackKind.CircuitTransition])).IsTrue();
+        await Assert.That(records[0].ShieldName).IsEqualTo("timeout");
+        await Assert.That(records[0].Timeout).IsEqualTo(TimeSpan.FromMilliseconds(1));
+        await Assert.That(records[1].ShieldName).IsEqualTo("hedge");
+        await Assert.That(records[1].Attempt).IsEqualTo(2);
+        await Assert.That(records[2].From).IsEqualTo(CircuitState.Closed);
+        await Assert.That(records[2].To).IsEqualTo(CircuitState.Open);
+        await Assert.That(records[2].Exception).IsTypeOf<ApplicationException>();
+    }
+
+    [Test]
+    public async Task Waiters_Honor_Cancellation()
+    {
+        using var recorder = new TelemetryRecorder(captureMetrics: false);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var exception = await Assert.That(async () =>
+                await recorder.WaitForCallbackCountAsync(1, cancellation.Token))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task Records_Every_Documented_Metric_Family()
+    {
+        using var recorder = new TelemetryRecorder();
+        var name = $"metric-families-{Guid.NewGuid():N}";
+
+        var retryAttempts = 0;
+        await Shield.Retry(1, Backoff.None).WithName(name).ExecuteAsync(_ =>
+            Interlocked.Increment(ref retryAttempts) == 1
+                ? ValueTask.FromException(new InvalidOperationException())
+                : ValueTask.CompletedTask);
+
+        await Shield.Timeout(TimeSpan.FromMilliseconds(1)).WithName(name)
+            .ExecuteOutcomeAsync<int>(static async token =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return 0;
+            });
+
+        await Shield.Hedge(2, TimeSpan.Zero).WithName(name).ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException()));
+        await Shield.For<int>().When<InvalidOperationException>().Fallback(42).WithName(name)
+            .ExecuteAsync<int>(static _ => throw new InvalidOperationException());
+
+        var breaker = Shield.CircuitBreaker(1, TimeSpan.FromMinutes(1)).WithName(name);
+        await breaker.ExecuteOutcomeAsync<int>(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException()));
+        await breaker.ExecuteOutcomeAsync<int>(static _ => new ValueTask<int>(42));
+
+        await Shield.ConcurrencyLimit(1).WithName(name)
+            .ExecuteAsync(static _ => ValueTask.CompletedTask);
+        await Shield.RateLimit(1, TimeSpan.FromMinutes(1)).WithName(name)
+            .ExecuteAsync(static _ => ValueTask.CompletedTask);
+
+        var namedInstruments = recorder.Metrics
+            .Where(record => record.Tags.TryGetValue("kevlar.shield.name", out var value)
+                && Equals(value, name))
+            .Select(record => record.InstrumentName)
+            .ToHashSet(StringComparer.Ordinal);
+        var expectedNamed = new[]
+        {
+            "kevlar.executions",
+            "kevlar.execution.duration",
+            "kevlar.retries",
+            "kevlar.timeouts",
+            "kevlar.hedges",
+            "kevlar.fallbacks",
+            "kevlar.rejections",
+            "kevlar.circuit_breaker.state",
+            "kevlar.concurrency_limit.inflight",
+            "kevlar.concurrency_limit.queued",
+            "kevlar.concurrency_limit.capacity",
+            "kevlar.rate_limit.available",
+            "kevlar.rate_limit.queued",
+        };
+
+        await Assert.That(expectedNamed.All(namedInstruments.Contains)).IsTrue();
+        await Assert.That(recorder.Metrics.Any(record =>
+            record.InstrumentName == "kevlar.circuit_breaker.transitions")).IsTrue();
+    }
+}


### PR DESCRIPTION
Closes #98

Adds an opt-in TelemetryRecorder to Kevlar.Testing for deterministic, concurrency-safe metric and callback capture. Records use immutable snapshots, copy tags immediately, preserve callback outcomes, and never retain pooled KevlarContext instances.

Validation:
- dotnet build Kevlar.slnx -c Release
- Kevlar.Tests: 644 passed
- Kevlar.Testing.Tests: 13 passed
- Kevlar.IntegrationTests: 16 passed
- Kevlar.Analyzers.Tests: 38 passed
- Kevlar.Chaos.Tests: 23 passed
- Kevlar.AllocationTests: 2 passed
- dotnet pack + Verify-Packages.ps1 passed
- Verify-DocSnippets.ps1 reaches the new excluded TUnit snippet; current main fails unrelated pre-existing snippets for APIs not yet present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a telemetry recorder for capturing retry, timeout, hedge, fallback, and circuit-state events.
  * Added metric snapshots with instrument names, values, tags, and ordering information.
  * Added asynchronous helpers for waiting on callback or metric counts, including cancellation support.
  * Added callback categories and detailed event records for test assertions.

* **Documentation**
  * Added usage guidance and an executable example for telemetry recording in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->