### PR TITLE
feat(testing): add resilience state probes

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -75,6 +75,37 @@ Dispose the recorder at the end of each test to detach its `MeterListener`. Metr
 available on .NET 8 and later, matching core telemetry; callback recording remains available on
 `netstandard2.0`. Construct with `captureMetrics: false` when a test needs callbacks only.
 
+## Probing live resilience state
+
+`GetStateSnapshot()` returns an immutable snapshot of circuit-breaker, rate-limiter, and
+concurrency-limiter state. The snapshot contract is explicitly versioned; `ContractVersion == 1`
+contains only stable state values and the original strategy index, never mutable strategy objects.
+Stateless strategies are omitted.
+
+<!-- doc-test-ignore: The executable documentation harness owns Main; this TUnit example is compiled by Kevlar.Testing.Tests. -->
+```csharp
+var shield = Shield.ConcurrencyLimit(1, maxQueue: 1);
+var probe = new ExecutionProbe();
+
+await shield.ExecuteAsync(probe.Wrap(static _ => ValueTask.CompletedTask));
+
+var state = shield.GetStateSnapshot();
+var limiter = state.Strategies.OfType<ConcurrencyLimitStateSnapshot>().Single();
+await TUnit.Assertions.Assert.That(state.ContractVersion).IsEqualTo(1);
+await TUnit.Assertions.Assert.That(limiter.AvailablePermits).IsEqualTo(1);
+await TUnit.Assertions.Assert.That(probe.AttemptCount).IsEqualTo(1);
+```
+
+`ExecutionProbe.Wrap` supports typed and untyped asynchronous delegates. It counts each delegate
+invocation as an attempt and records cancellation only while that attempt is active.
+`WaitForAttemptCountAsync` and `WaitForCancellationCountAsync` let concurrent tests synchronize
+without parsing diagnostics or adding hooks to production pipelines.
+
+Snapshots are observations, not reservations: another execution may change state immediately after
+capture. Composed shields that share a stateful strategy report that same underlying state. Rate
+limits use the shield's configured `TimeProvider`, so tests can advance `FakeTimeProvider` before
+capturing replenished availability.
+
 ## Repository quality gates
 
 Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, analyzer, and testing-package suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.

--- a/src/Kevlar.Testing/CircuitBreakerStateSnapshot.cs
+++ b/src/Kevlar.Testing/CircuitBreakerStateSnapshot.cs
@@ -1,0 +1,14 @@
+namespace Kevlar.Testing;
+
+/// <summary>An immutable circuit-breaker state snapshot.</summary>
+public sealed class CircuitBreakerStateSnapshot : StrategyStateSnapshot
+{
+    internal CircuitBreakerStateSnapshot(int strategyIndex, CircuitState state)
+        : base(StrategyKind.CircuitBreaker, strategyIndex)
+    {
+        State = state;
+    }
+
+    /// <summary>Gets the circuit state.</summary>
+    public CircuitState State { get; }
+}

--- a/src/Kevlar.Testing/ConcurrencyLimitStateSnapshot.cs
+++ b/src/Kevlar.Testing/ConcurrencyLimitStateSnapshot.cs
@@ -1,0 +1,27 @@
+namespace Kevlar.Testing;
+
+/// <summary>An immutable concurrency-limiter state snapshot.</summary>
+public sealed class ConcurrencyLimitStateSnapshot : StrategyStateSnapshot
+{
+    internal ConcurrencyLimitStateSnapshot(
+        int strategyIndex,
+        int availablePermits,
+        int runningExecutions,
+        int queuedExecutions)
+        : base(StrategyKind.ConcurrencyLimit, strategyIndex)
+    {
+        AvailablePermits = availablePermits;
+        RunningExecutions = runningExecutions;
+        QueuedExecutions = queuedExecutions;
+    }
+
+    /// <summary>Gets the number of permits currently available.</summary>
+    public int AvailablePermits { get; }
+
+    /// <summary>Gets the number of admitted executions currently running.</summary>
+    public int RunningExecutions { get; }
+
+    /// <summary>Gets the number of executions currently waiting for a permit.</summary>
+    public int QueuedExecutions { get; }
+
+}

--- a/src/Kevlar.Testing/ExecutionProbe.cs
+++ b/src/Kevlar.Testing/ExecutionProbe.cs
@@ -1,0 +1,154 @@
+namespace Kevlar.Testing;
+
+/// <summary>Counts delegate attempts and cancellation requests without changing shield behavior.</summary>
+public sealed class ExecutionProbe
+{
+    private readonly object _gate = new();
+    private TaskCompletionSource<bool> _changed = CreateSignal();
+    private long _state;
+
+    /// <summary>Gets the number of delegate invocations observed so far.</summary>
+    public int AttemptCount => CaptureCounts().Attempts;
+
+    /// <summary>Gets the number of active attempt tokens that requested cancellation.</summary>
+    public int CancellationCount => CaptureCounts().Cancellations;
+
+    /// <summary>Wraps an untyped asynchronous execution delegate.</summary>
+    public Func<CancellationToken, ValueTask> Wrap(Func<CancellationToken, ValueTask> action)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return token => InvokeAsync(action, token);
+    }
+
+    /// <summary>Wraps a typed asynchronous execution delegate.</summary>
+    public Func<CancellationToken, ValueTask<TResult>> Wrap<TResult>(
+        Func<CancellationToken, ValueTask<TResult>> action)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return token => InvokeAsync(action, token);
+    }
+
+    /// <summary>Gets an immutable snapshot of current counts.</summary>
+    public ExecutionProbeSnapshot GetSnapshot()
+    {
+        var counts = CaptureCounts();
+        return new ExecutionProbeSnapshot(counts.Attempts, counts.Cancellations);
+    }
+
+    /// <summary>Waits until at least <paramref name="count"/> attempts have started.</summary>
+    public Task WaitForAttemptCountAsync(int count, CancellationToken cancellationToken = default) =>
+        WaitForCountAsync(static probe => probe.AttemptCount, count, cancellationToken);
+
+    /// <summary>Waits until at least <paramref name="count"/> active attempts observed cancellation.</summary>
+    public Task WaitForCancellationCountAsync(int count, CancellationToken cancellationToken = default) =>
+        WaitForCountAsync(static probe => probe.CancellationCount, count, cancellationToken);
+
+    private async ValueTask InvokeAsync(
+        Func<CancellationToken, ValueTask> action,
+        CancellationToken cancellationToken)
+    {
+        RecordAttempt();
+        using var registration = cancellationToken.Register(
+            static state => ((ExecutionProbe)state!).RecordCancellation(), this);
+        await action(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<TResult> InvokeAsync<TResult>(
+        Func<CancellationToken, ValueTask<TResult>> action,
+        CancellationToken cancellationToken)
+    {
+        RecordAttempt();
+        using var registration = cancellationToken.Register(
+            static state => ((ExecutionProbe)state!).RecordCancellation(), this);
+        return await action(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void RecordAttempt()
+    {
+        Interlocked.Add(ref _state, 1L << 32);
+        SignalChanged();
+    }
+
+    private void RecordCancellation()
+    {
+        Interlocked.Increment(ref _state);
+        SignalChanged();
+    }
+
+    private void SignalChanged()
+    {
+        TaskCompletionSource<bool> signal;
+        lock (_gate)
+        {
+            signal = _changed;
+            _changed = CreateSignal();
+        }
+
+        signal.TrySetResult(true);
+    }
+
+    private async Task WaitForCountAsync(
+        Func<ExecutionProbe, int> getCount,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        if (count < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        while (getCount(this) < count)
+        {
+            Task signal;
+            lock (_gate)
+            {
+                if (getCount(this) >= count)
+                {
+                    return;
+                }
+
+                signal = _changed.Task;
+            }
+
+            await WaitWithCancellationAsync(signal, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WaitWithCancellationAsync(Task task, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            await task.ConfigureAwait(false);
+            return;
+        }
+
+        var cancellation = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(
+            static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true), cancellation);
+        if (ReferenceEquals(
+            await Task.WhenAny(task, cancellation.Task).ConfigureAwait(false),
+            cancellation.Task))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        await task.ConfigureAwait(false);
+    }
+
+    private static TaskCompletionSource<bool> CreateSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private (int Attempts, int Cancellations) CaptureCounts()
+    {
+        var state = Volatile.Read(ref _state);
+        return ((int)(state >> 32), (int)(state & uint.MaxValue));
+    }
+}

--- a/src/Kevlar.Testing/ExecutionProbeSnapshot.cs
+++ b/src/Kevlar.Testing/ExecutionProbeSnapshot.cs
@@ -1,0 +1,20 @@
+namespace Kevlar.Testing;
+
+/// <summary>An immutable, versioned snapshot of execution-probe observations.</summary>
+public sealed class ExecutionProbeSnapshot
+{
+    internal ExecutionProbeSnapshot(int attemptCount, int cancellationCount)
+    {
+        AttemptCount = attemptCount;
+        CancellationCount = cancellationCount;
+    }
+
+    /// <summary>Gets the snapshot contract version.</summary>
+    public int ContractVersion => 1;
+
+    /// <summary>Gets the number of delegate invocations.</summary>
+    public int AttemptCount { get; }
+
+    /// <summary>Gets the number of active attempt tokens that requested cancellation.</summary>
+    public int CancellationCount { get; }
+}

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -73,6 +73,37 @@ static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyCount(th
 static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyOrder(this Kevlar.Testing.ShieldDescriptor! descriptor, params Kevlar.Testing.StrategyKind[]! expected) -> Kevlar.Testing.ShieldDescriptor!
 static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor(this Kevlar.Shield! shield) -> Kevlar.Testing.ShieldDescriptor!
 static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor<TResult>(this Kevlar.Shield<TResult>! shield) -> Kevlar.Testing.ShieldDescriptor!
+Kevlar.Testing.CircuitBreakerStateSnapshot
+Kevlar.Testing.CircuitBreakerStateSnapshot.State.get -> Kevlar.CircuitState
+Kevlar.Testing.ConcurrencyLimitStateSnapshot
+Kevlar.Testing.ConcurrencyLimitStateSnapshot.AvailablePermits.get -> int
+Kevlar.Testing.ConcurrencyLimitStateSnapshot.QueuedExecutions.get -> int
+Kevlar.Testing.ConcurrencyLimitStateSnapshot.RunningExecutions.get -> int
+Kevlar.Testing.ExecutionProbe
+Kevlar.Testing.ExecutionProbe.AttemptCount.get -> int
+Kevlar.Testing.ExecutionProbe.CancellationCount.get -> int
+Kevlar.Testing.ExecutionProbe.ExecutionProbe() -> void
+Kevlar.Testing.ExecutionProbe.GetSnapshot() -> Kevlar.Testing.ExecutionProbeSnapshot!
+Kevlar.Testing.ExecutionProbe.WaitForAttemptCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Kevlar.Testing.ExecutionProbe.WaitForCancellationCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Kevlar.Testing.ExecutionProbe.Wrap(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! action) -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>!
+Kevlar.Testing.ExecutionProbe.Wrap<TResult>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! action) -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>!
+Kevlar.Testing.ExecutionProbeSnapshot
+Kevlar.Testing.ExecutionProbeSnapshot.AttemptCount.get -> int
+Kevlar.Testing.ExecutionProbeSnapshot.CancellationCount.get -> int
+Kevlar.Testing.ExecutionProbeSnapshot.ContractVersion.get -> int
+Kevlar.Testing.RateLimitStateSnapshot
+Kevlar.Testing.RateLimitStateSnapshot.AvailablePermits.get -> long
+Kevlar.Testing.RateLimitStateSnapshot.QueuedExecutions.get -> int
+Kevlar.Testing.ShieldStateSnapshot
+Kevlar.Testing.ShieldStateSnapshot.ContractVersion.get -> int
+Kevlar.Testing.ShieldStateSnapshot.Strategies.get -> System.Collections.Generic.IReadOnlyList<Kevlar.Testing.StrategyStateSnapshot!>!
+Kevlar.Testing.ShieldStateSnapshotExtensions
+Kevlar.Testing.StrategyStateSnapshot
+Kevlar.Testing.StrategyStateSnapshot.Kind.get -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyStateSnapshot.StrategyIndex.get -> int
+static Kevlar.Testing.ShieldStateSnapshotExtensions.GetStateSnapshot(this Kevlar.Shield! shield) -> Kevlar.Testing.ShieldStateSnapshot!
+static Kevlar.Testing.ShieldStateSnapshotExtensions.GetStateSnapshot<TResult>(this Kevlar.Shield<TResult>! shield) -> Kevlar.Testing.ShieldStateSnapshot!
 Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.CircuitTransition = 4 -> Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.Fallback = 3 -> Kevlar.Testing.CallbackKind

--- a/src/Kevlar.Testing/RateLimitStateSnapshot.cs
+++ b/src/Kevlar.Testing/RateLimitStateSnapshot.cs
@@ -1,0 +1,18 @@
+namespace Kevlar.Testing;
+
+/// <summary>An immutable rate-limiter state snapshot.</summary>
+public sealed class RateLimitStateSnapshot : StrategyStateSnapshot
+{
+    internal RateLimitStateSnapshot(int strategyIndex, long availablePermits, int queuedExecutions)
+        : base(StrategyKind.RateLimit, strategyIndex)
+    {
+        AvailablePermits = availablePermits;
+        QueuedExecutions = queuedExecutions;
+    }
+
+    /// <summary>Gets the estimated number of immediately available permits.</summary>
+    public long AvailablePermits { get; }
+
+    /// <summary>Gets the number of executions currently waiting for a permit.</summary>
+    public int QueuedExecutions { get; }
+}

--- a/src/Kevlar.Testing/ShieldStateSnapshot.cs
+++ b/src/Kevlar.Testing/ShieldStateSnapshot.cs
@@ -1,0 +1,16 @@
+namespace Kevlar.Testing;
+
+/// <summary>An immutable, versioned snapshot of a shield's observable strategy state.</summary>
+public sealed class ShieldStateSnapshot
+{
+    internal ShieldStateSnapshot(IReadOnlyList<StrategyStateSnapshot> strategies)
+    {
+        Strategies = strategies;
+    }
+
+    /// <summary>Gets the snapshot contract version.</summary>
+    public int ContractVersion => 1;
+
+    /// <summary>Gets state snapshots in pipeline order. Stateless strategies are omitted.</summary>
+    public IReadOnlyList<StrategyStateSnapshot> Strategies { get; }
+}

--- a/src/Kevlar.Testing/ShieldStateSnapshotExtensions.cs
+++ b/src/Kevlar.Testing/ShieldStateSnapshotExtensions.cs
@@ -1,0 +1,68 @@
+using Kevlar.Strategies;
+
+namespace Kevlar.Testing;
+
+/// <summary>Captures read-only state snapshots from shields.</summary>
+public static class ShieldStateSnapshotExtensions
+{
+    /// <summary>Captures the current state of an untyped shield's stateful strategies.</summary>
+    public static ShieldStateSnapshot GetStateSnapshot(this Shield shield)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return Capture(shield.Strategies, shield.TimeOrSystem);
+    }
+
+    /// <summary>Captures the current state of a typed shield's stateful strategies.</summary>
+    public static ShieldStateSnapshot GetStateSnapshot<TResult>(this Shield<TResult> shield)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return Capture(shield.Strategies, shield.TimeOrSystem);
+    }
+
+    private static ShieldStateSnapshot Capture(Strategy[] strategies, TimeProvider timeProvider)
+    {
+        var snapshots = new List<StrategyStateSnapshot>();
+        for (var index = 0; index < strategies.Length; index++)
+        {
+            var snapshot = Capture(strategies[index], index, timeProvider);
+            if (snapshot is not null)
+            {
+                snapshots.Add(snapshot);
+            }
+        }
+
+        return new ShieldStateSnapshot(Array.AsReadOnly(snapshots.ToArray()));
+    }
+
+    private static StrategyStateSnapshot? Capture(
+        Strategy strategy,
+        int strategyIndex,
+        TimeProvider timeProvider)
+    {
+        switch (strategy)
+        {
+            case CircuitBreakerStrategy circuit:
+                return new CircuitBreakerStateSnapshot(strategyIndex, circuit.Core.State);
+            case RateLimitStrategy rateLimit:
+                var rate = rateLimit.CaptureState(timeProvider);
+                return new RateLimitStateSnapshot(strategyIndex, rate.Available, rate.Queued);
+            case ConcurrencyLimitStrategy concurrency:
+                var current = concurrency.CaptureState();
+                return new ConcurrencyLimitStateSnapshot(
+                    strategyIndex,
+                    current.Available,
+                    current.Running,
+                    current.Queued);
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Kevlar.Testing/StrategyStateSnapshot.cs
+++ b/src/Kevlar.Testing/StrategyStateSnapshot.cs
@@ -1,0 +1,17 @@
+namespace Kevlar.Testing;
+
+/// <summary>Base type for an immutable snapshot of one stateful strategy.</summary>
+public abstract class StrategyStateSnapshot
+{
+    private protected StrategyStateSnapshot(StrategyKind kind, int strategyIndex)
+    {
+        Kind = kind;
+        StrategyIndex = strategyIndex;
+    }
+
+    /// <summary>Gets the strategy kind.</summary>
+    public StrategyKind Kind { get; }
+
+    /// <summary>Gets the zero-based position of the strategy in the shield.</summary>
+    public int StrategyIndex { get; }
+}

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -24,6 +24,14 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     internal int MaxQueue => _maxQueue;
 
+    internal (int Available, int Running, int Queued) CaptureState()
+    {
+        var state = Volatile.Read(ref _metricsState);
+        var running = (int)(state >> 32);
+        var queued = (int)(state & uint.MaxValue);
+        return (_maxConcurrency - running, running, queued);
+    }
+
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
     {
         Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -591,7 +591,7 @@ internal sealed class RateLimitStrategy : Strategy
         }
     }
 
-    private (long Available, int Queued) CaptureState(TimeProvider timeProvider)
+    internal (long Available, int Queued) CaptureState(TimeProvider timeProvider)
     {
         double theoreticalArrival;
         int queued;

--- a/tests/Kevlar.Testing.Tests/StateProbeTests.cs
+++ b/tests/Kevlar.Testing.Tests/StateProbeTests.cs
@@ -1,0 +1,199 @@
+using Kevlar.Testing;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Testing.Tests;
+
+public class StateProbeTests
+{
+    [Test]
+    public async Task StateSnapshot_Reports_Circuit_And_Limiter_State()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.Monitor = monitor;
+            })
+            .RateLimit(options =>
+            {
+                options.Permits = 2;
+                options.Burst = 2;
+                options.Window = TimeSpan.FromSeconds(1);
+                options.QueueLimit = 1;
+            })
+            .ConcurrencyLimit(2, maxQueue: 1)
+            .WithTimeProvider(timeProvider);
+
+        monitor.Isolate();
+        var snapshot = shield.GetStateSnapshot();
+
+        await Assert.That(snapshot.ContractVersion).IsEqualTo(1);
+        await Assert.That(snapshot.Strategies).Count().IsEqualTo(3);
+
+        var circuit = snapshot.Strategies.OfType<CircuitBreakerStateSnapshot>().Single();
+        await Assert.That(circuit.StrategyIndex).IsEqualTo(0);
+        await Assert.That(circuit.State).IsEqualTo(CircuitState.Isolated);
+
+        var rate = snapshot.Strategies.OfType<RateLimitStateSnapshot>().Single();
+        await Assert.That(rate.StrategyIndex).IsEqualTo(1);
+        await Assert.That(rate.AvailablePermits).IsEqualTo(2L);
+        await Assert.That(rate.QueuedExecutions).IsEqualTo(0);
+
+        var concurrency = snapshot.Strategies.OfType<ConcurrencyLimitStateSnapshot>().Single();
+        await Assert.That(concurrency.StrategyIndex).IsEqualTo(2);
+        await Assert.That(concurrency.AvailablePermits).IsEqualTo(2);
+        await Assert.That(concurrency.RunningExecutions).IsEqualTo(0);
+        await Assert.That(concurrency.QueuedExecutions).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task StateSnapshot_Tracks_Rate_Queue_With_Fake_Time()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var shield = Shield
+            .RateLimit(options =>
+            {
+                options.Permits = 1;
+                options.Burst = 1;
+                options.Window = TimeSpan.FromSeconds(1);
+                options.QueueLimit = 1;
+            })
+            .WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(static _ => ValueTask.CompletedTask);
+        var queuedExecution = shield.ExecuteAsync(static _ => ValueTask.CompletedTask).AsTask();
+
+        var queued = shield.GetStateSnapshot().Strategies.OfType<RateLimitStateSnapshot>().Single();
+        await Assert.That(queued.AvailablePermits).IsEqualTo(0L);
+        await Assert.That(queued.QueuedExecutions).IsEqualTo(1);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await queuedExecution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var completed = shield.GetStateSnapshot().Strategies.OfType<RateLimitStateSnapshot>().Single();
+        await Assert.That(completed.QueuedExecutions).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task StateSnapshot_Remains_Coherent_For_Shared_Composed_State()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shared = Shield.ConcurrencyLimit(1, maxQueue: 1);
+        var firstAlias = Shield.Compose(shared).WithName("first");
+        var secondAlias = Shield.Compose(shared).WithName("second");
+
+        var running = firstAlias.ExecuteAsync(async _ =>
+        {
+            entered.TrySetResult();
+            await release.Task.ConfigureAwait(false);
+        }).AsTask();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var queued = secondAlias.ExecuteAsync(static _ => ValueTask.CompletedTask).AsTask();
+        var firstSnapshot = firstAlias.GetStateSnapshot().Strategies
+            .OfType<ConcurrencyLimitStateSnapshot>().Single();
+        var secondSnapshot = secondAlias.GetStateSnapshot().Strategies
+            .OfType<ConcurrencyLimitStateSnapshot>().Single();
+
+        await Assert.That(firstSnapshot.RunningExecutions).IsEqualTo(1);
+        await Assert.That(firstSnapshot.QueuedExecutions).IsEqualTo(1);
+        await Assert.That(secondSnapshot.AvailablePermits).IsEqualTo(firstSnapshot.AvailablePermits);
+        await Assert.That(secondSnapshot.RunningExecutions).IsEqualTo(firstSnapshot.RunningExecutions);
+        await Assert.That(secondSnapshot.QueuedExecutions).IsEqualTo(firstSnapshot.QueuedExecutions);
+
+        release.TrySetResult();
+        await Task.WhenAll(running, queued).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ExecutionProbe_Counts_Typed_And_Untyped_Attempts()
+    {
+        var untypedProbe = new ExecutionProbe();
+        var untypedInvocations = 0;
+        var untypedShield = Shield.When<InvalidOperationException>().Retry(2, Backoff.None);
+
+        await untypedShield.ExecuteAsync(untypedProbe.Wrap(_ =>
+        {
+            if (Interlocked.Increment(ref untypedInvocations) < 3)
+            {
+                throw new InvalidOperationException("retry");
+            }
+
+            return ValueTask.CompletedTask;
+        }));
+
+        var typedProbe = new ExecutionProbe();
+        var typedInvocations = 0;
+        var typedShield = Shield.For<int>().WhenResult(static result => result == 0).Retry(1, Backoff.None);
+        var result = await typedShield.ExecuteAsync(typedProbe.Wrap<int>(_ =>
+            new ValueTask<int>(Interlocked.Increment(ref typedInvocations) - 1)));
+
+        await Assert.That(untypedProbe.AttemptCount).IsEqualTo(3);
+        await Assert.That(typedProbe.AttemptCount).IsEqualTo(2);
+        await Assert.That(result).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecutionProbe_Observes_Active_Attempt_Cancellation()
+    {
+        var probe = new ExecutionProbe();
+        using var cancellation = new CancellationTokenSource();
+        var execution = Shield.Empty.ExecuteAsync(probe.Wrap(async token =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, token).ConfigureAwait(false);
+        }), cancellation.Token).AsTask();
+
+        await probe.WaitForAttemptCountAsync(1).WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await execution);
+        await probe.WaitForCancellationCountAsync(1).WaitAsync(TimeSpan.FromSeconds(5));
+
+        var snapshot = probe.GetSnapshot();
+        await Assert.That(snapshot.ContractVersion).IsEqualTo(1);
+        await Assert.That(snapshot.AttemptCount).IsEqualTo(1);
+        await Assert.That(snapshot.CancellationCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StateSnapshot_Supports_Typed_Shields_And_Immutable_Collections()
+    {
+        var shield = Shield.For<int>().ConcurrencyLimit(3, maxQueue: 2);
+
+        var snapshot = shield.GetStateSnapshot();
+        var concurrency = snapshot.Strategies.OfType<ConcurrencyLimitStateSnapshot>().Single();
+
+        await Assert.That(concurrency.AvailablePermits).IsEqualTo(3);
+        await Assert.That(snapshot.Strategies).IsAssignableTo<IList<StrategyStateSnapshot>>();
+        var list = (IList<StrategyStateSnapshot>)snapshot.Strategies;
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            Task.Run(() => list.Add(concurrency)));
+    }
+
+    [Test]
+    public async Task ExecutionProbe_Wait_Preserves_Cancellation_Token()
+    {
+        var probe = new ExecutionProbe();
+        using var cancellation = new CancellationTokenSource();
+
+        var wait = probe.WaitForAttemptCountAsync(1, cancellation.Token);
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () => await wait);
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task StateSnapshot_Rejects_Null_Typed_And_Untyped_Shields()
+    {
+        Shield? untyped = null;
+        Shield<int>? typed = null;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            Task.Run(() => untyped!.GetStateSnapshot()));
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            Task.Run(() => typed!.GetStateSnapshot()));
+    }
+}

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -1,5 +1,6 @@
 namespace Kevlar.Testing.Tests;
 
+[NotInParallel]
 public class TelemetryRecorderTests
 {
     [Test]


### PR DESCRIPTION
Closes #100

Adds immutable v1 state snapshots for circuit breakers, rate limiters, and concurrency limiters, plus typed/untyped ExecutionProbe wrappers for deterministic attempt and cancellation assertions. Snapshot reads reuse existing state atomics and locks; production execution paths gain no probe hooks or extra work.

Validation:
- dotnet build Kevlar.slnx -c Release
- Kevlar.Tests: 670 passed
- Kevlar.Testing.Tests: 21 passed
- Kevlar.IntegrationTests: 34 passed
- Kevlar.Analyzers.Tests: 38 passed
- Kevlar.Chaos.Tests: 23 passed
- Kevlar.AllocationTests: 2 passed
- dotnet pack + Verify-Packages.ps1 passed
- Verify-DocSnippets.ps1: 97 snippets passed
- docs npm run build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added immutable state snapshots for shields, circuit breakers, rate limits, and concurrency limits.
  * Added execution probes to track attempts and cancellation requests, with asynchronous wait support.
  * Added snapshot support for typed and untyped shields, including strategy ordering and contract versions.

* **Documentation**
  * Added guidance and examples for inspecting resilience state during live testing.

* **Tests**
  * Added coverage for limiter queues, circuit states, retries, cancellations, shared state, and fake-time behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->