### PR TITLE
feat(testing): add deterministic time helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ One clause up top decides what "failure" means for every strategy below it — e
 | `Kevlar.Extensions.DependencyInjection` | Named shields, config-bound shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |
-| `Kevlar.Testing` | Structured pipeline descriptors and framework-independent shape assertions |
+| `Kevlar.Testing` | Pipeline descriptors, shape assertions, and deterministic fake-time helpers |
 
 ## The five-minute tour
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -151,6 +151,48 @@ Copies still share stateful strategies. Circuit breakers and rate limiters norma
 Start the execution first (note the `.AsTask()` without `await`), *then* advance time. If you advance before the shield has scheduled its delay, there's nothing to advance past and the pending task will hang waiting for a tick that already happened.
 :::
 
+### Bounded deterministic helpers
+
+On .NET 8 and later, `Kevlar.Testing` references `Microsoft.Extensions.TimeProvider.Testing` and adds bounded helpers for pending executions and fake-time advancement. Conditions read only state owned by your test; the helpers never expose or retain a pooled `KevlarContext` or mutable strategy object.
+
+<!-- doc-test-ignore: TUnit owns test discovery; this complete example is covered by Kevlar.Testing.Tests. -->
+```csharp
+using Kevlar.Testing;
+using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions;
+using TUnit.Core;
+
+[Test]
+public async Task Retries_Without_Sleeps()
+{
+    var time = new FakeTimeProvider();
+    var attempts = 0;
+    var shield = Shield
+        .Retry(2, Backoff.Constant(TimeSpan.FromSeconds(10)))
+        .WithTimeProvider(time);
+    var execution = shield.ExecuteAsync<int>(_ =>
+    {
+        var attempt = Interlocked.Increment(ref attempts);
+        return attempt < 3
+            ? ValueTask.FromException<int>(new InvalidOperationException())
+            : new ValueTask<int>(42);
+    }).AsTask();
+
+    await execution.WaitForPendingAsync(
+        () => Volatile.Read(ref attempts) == 1,
+        "the first retry delay");
+    await time.AdvanceUntilAsync(
+        TimeSpan.FromSeconds(10),
+        () => Volatile.Read(ref attempts) == 3,
+        "all retry attempts",
+        maxAdvances: 2);
+
+    await Assert.That(await execution).IsEqualTo(42);
+}
+```
+
+Both helpers use finite scheduler/advance counts and throw `ShieldAssertionException` with the condition, execution status, fake UTC time, and configured bounds when progress is not observed. Use a caller-owned counter, gate, callback flag, or fake-clock deadline as the condition; then await the execution normally to inspect its result or exception.
+
 ## Testing circuit breakers
 
 Drive the breaker through its state machine without real clocks:

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -191,7 +191,7 @@ public async Task Retries_Without_Sleeps()
 }
 ```
 
-Both helpers use finite scheduler/advance counts and throw `ShieldAssertionException` with the condition, execution status, fake UTC time, and configured bounds when progress is not observed. Use a caller-owned counter, gate, callback flag, or fake-clock deadline as the condition; then await the execution normally to inspect its result or exception.
+Both helpers use finite scheduler/advance counts. `WaitForPendingAsync` reports the condition, execution status, and scheduler-yield bound when progress is not observed. `AdvanceUntilAsync` reports the condition, fake UTC time, and advance bound. Use a caller-owned counter, gate, callback flag, or fake-clock deadline as the condition; then await the execution normally to inspect its result or exception.
 
 ## Testing circuit breakers
 

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -115,7 +115,8 @@ $expectedDependencies = @{
             'System.Threading.Tasks.Extensions')
     }
     'Kevlar.Testing' = @{
-        'net10.0' = @('Kevlar')
+        'net10.0' = @('Kevlar', 'Microsoft.Extensions.TimeProvider.Testing')
+        'net8.0' = @('Kevlar', 'Microsoft.Extensions.TimeProvider.Testing')
         '.NETStandard2.0' = @('Kevlar')
     }
     'Kevlar.Analyzers' = @{
@@ -211,7 +212,7 @@ foreach ($packageId in $expectedDependencies.Keys)
                 "lib/netstandard2.0/$packageId.dll",
                 "lib/netstandard2.0/$packageId.xml"
             )
-            if ($packageId -eq 'Kevlar.Chaos')
+            if ($packageId -in @('Kevlar.Chaos', 'Kevlar.Testing'))
             {
                 $expectedAssets += @(
                     "lib/net8.0/$packageId.dll",

--- a/src/Kevlar.Testing/FakeTimeProviderExtensions.cs
+++ b/src/Kevlar.Testing/FakeTimeProviderExtensions.cs
@@ -1,0 +1,79 @@
+#if NET8_0_OR_GREATER
+using System.Globalization;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Testing;
+
+/// <summary>Provides bounded deterministic advancement for <see cref="FakeTimeProvider"/>.</summary>
+public static class FakeTimeProviderExtensions
+{
+    /// <summary>Advances fake time in fixed steps until a caller-observable condition is satisfied.</summary>
+    /// <param name="timeProvider">The fake clock used by the shield.</param>
+    /// <param name="step">The positive amount advanced in each step.</param>
+    /// <param name="condition">A predicate over caller-owned test state.</param>
+    /// <param name="conditionDescription">A description included in bounded-failure diagnostics.</param>
+    /// <param name="maxAdvances">The maximum number of time advances.</param>
+    /// <param name="maxYieldsPerAdvance">
+    /// The maximum scheduler yields allowed for continuations after each advance.
+    /// </param>
+    /// <param name="cancellationToken">Cancels the bounded advancement.</param>
+    /// <exception cref="ShieldAssertionException">The condition is not met within the configured bounds.</exception>
+    public static async ValueTask AdvanceUntilAsync(
+        this FakeTimeProvider timeProvider,
+        TimeSpan step,
+        Func<bool> condition,
+        string conditionDescription,
+        int maxAdvances = 100,
+        int maxYieldsPerAdvance = 100,
+        CancellationToken cancellationToken = default)
+    {
+        Validate(timeProvider, step, condition, conditionDescription, maxAdvances, maxYieldsPerAdvance);
+        if (condition())
+        {
+            return;
+        }
+
+        for (var advance = 0; advance < maxAdvances; advance++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            timeProvider.Advance(step);
+            if (await SchedulerDrain.ObserveAsync(
+                condition,
+                maxYieldsPerAdvance,
+                cancellationToken).ConfigureAwait(false))
+            {
+                return;
+            }
+        }
+
+        if (condition())
+        {
+            return;
+        }
+
+        throw new ShieldAssertionException(
+            $"Expected {conditionDescription} after {DescribeAdvances(maxAdvances)} of " +
+            $"{step.ToString("c", CultureInfo.InvariantCulture)}. Current UTC time: " +
+            $"{timeProvider.GetUtcNow():O}.");
+    }
+
+    private static void Validate(
+        FakeTimeProvider timeProvider,
+        TimeSpan step,
+        Func<bool> condition,
+        string conditionDescription,
+        int maxAdvances,
+        int maxYieldsPerAdvance)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(condition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(conditionDescription);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(step, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxAdvances);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxYieldsPerAdvance);
+    }
+
+    private static string DescribeAdvances(int count) =>
+        count == 1 ? "1 advance" : $"{count} advances";
+}
+#endif

--- a/src/Kevlar.Testing/Kevlar.Testing.csproj
+++ b/src/Kevlar.Testing/Kevlar.Testing.csproj
@@ -1,16 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kevlar.Testing</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
-    <Description>Structured pipeline inspection and assertion helpers for testing Kevlar shields without parsing display strings.</Description>
-    <PackageTags>resilience;testing;assertions;pipeline-inspection;kevlar</PackageTags>
+    <Description>Pipeline inspection, assertions, and deterministic time helpers for testing Kevlar shields.</Description>
+    <PackageTags>resilience;testing;assertions;pipeline-inspection;fake-time;kevlar</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.$(TargetFramework).txt" />
   </ItemGroup>
 
 </Project>

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.net10.0.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.net10.0.txt
@@ -1,0 +1,2 @@
+Kevlar.Testing.FakeTimeProviderExtensions
+static Kevlar.Testing.FakeTimeProviderExtensions.AdvanceUntilAsync(this Microsoft.Extensions.Time.Testing.FakeTimeProvider! timeProvider, System.TimeSpan step, System.Func<bool>! condition, string! conditionDescription, int maxAdvances = 100, int maxYieldsPerAdvance = 100, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.net8.0.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.net8.0.txt
@@ -1,0 +1,2 @@
+Kevlar.Testing.FakeTimeProviderExtensions
+static Kevlar.Testing.FakeTimeProviderExtensions.AdvanceUntilAsync(this Microsoft.Extensions.Time.Testing.FakeTimeProvider! timeProvider, System.TimeSpan step, System.Func<bool>! condition, string! conditionDescription, int maxAdvances = 100, int maxYieldsPerAdvance = 100, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -45,6 +45,7 @@ Kevlar.Testing.RetryStrategyDescriptor.MaxRetries.get -> int
 Kevlar.Testing.ShieldAssertionException
 Kevlar.Testing.ShieldAssertionException.ShieldAssertionException(string! message) -> void
 Kevlar.Testing.ShieldDescriptor
+Kevlar.Testing.ShieldExecutionExtensions
 Kevlar.Testing.ShieldDescriptor.Name.get -> string?
 Kevlar.Testing.ShieldDescriptor.ResultType.get -> System.Type?
 Kevlar.Testing.ShieldDescriptor.Strategies.get -> System.Collections.Generic.IReadOnlyList<Kevlar.Testing.StrategyDescriptor!>!
@@ -109,3 +110,4 @@ Kevlar.Testing.TelemetryRecorder.Record<TResult>(Kevlar.RetryEvent<TResult> item
 Kevlar.Testing.TelemetryRecorder.TelemetryRecorder(bool captureMetrics = true) -> void
 Kevlar.Testing.TelemetryRecorder.WaitForCallbackCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Kevlar.Testing.TelemetryRecorder.WaitForMetricCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Kevlar.Testing.ShieldExecutionExtensions.WaitForPendingAsync(this System.Threading.Tasks.Task! execution, System.Func<bool>! workStarted, string! workDescription, int maxYields = 100, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask

--- a/src/Kevlar.Testing/SchedulerDrain.cs
+++ b/src/Kevlar.Testing/SchedulerDrain.cs
@@ -18,6 +18,7 @@ internal static class SchedulerDrain
             await Task.Yield();
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         return condition();
     }
 }

--- a/src/Kevlar.Testing/SchedulerDrain.cs
+++ b/src/Kevlar.Testing/SchedulerDrain.cs
@@ -2,26 +2,22 @@ namespace Kevlar.Testing;
 
 internal static class SchedulerDrain
 {
-    public static Task<bool> ObserveAsync(
+    public static async Task<bool> ObserveAsync(
         Func<bool> condition,
         int maxYields,
-        CancellationToken cancellationToken) => Task.Factory.StartNew(
-            () =>
+        CancellationToken cancellationToken)
+    {
+        for (var yield = 0; yield < maxYields; yield++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (condition())
             {
-                for (var yield = 0; yield < maxYields; yield++)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    if (condition())
-                    {
-                        return true;
-                    }
+                return true;
+            }
 
-                    Thread.Yield();
-                }
+            await Task.Yield();
+        }
 
-                return condition();
-            },
-            cancellationToken,
-            TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning,
-            TaskScheduler.Default);
+        return condition();
+    }
 }

--- a/src/Kevlar.Testing/SchedulerDrain.cs
+++ b/src/Kevlar.Testing/SchedulerDrain.cs
@@ -1,0 +1,27 @@
+namespace Kevlar.Testing;
+
+internal static class SchedulerDrain
+{
+    public static Task<bool> ObserveAsync(
+        Func<bool> condition,
+        int maxYields,
+        CancellationToken cancellationToken) => Task.Factory.StartNew(
+            () =>
+            {
+                for (var yield = 0; yield < maxYields; yield++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (condition())
+                    {
+                        return true;
+                    }
+
+                    Thread.Yield();
+                }
+
+                return condition();
+            },
+            cancellationToken,
+            TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+}

--- a/src/Kevlar.Testing/ShieldExecutionExtensions.cs
+++ b/src/Kevlar.Testing/ShieldExecutionExtensions.cs
@@ -1,0 +1,70 @@
+namespace Kevlar.Testing;
+
+/// <summary>Provides bounded, scheduler-driven waits for shield executions under test.</summary>
+public static class ShieldExecutionExtensions
+{
+    /// <summary>
+    /// Waits until caller-observable work has started while verifying that the execution remains pending.
+    /// </summary>
+    /// <param name="execution">The shield execution expected to remain incomplete.</param>
+    /// <param name="workStarted">
+    /// A predicate over caller-owned test state that becomes <see langword="true"/> when the expected
+    /// work has started.
+    /// </param>
+    /// <param name="workDescription">A description included in bounded-failure diagnostics.</param>
+    /// <param name="maxYields">The maximum number of scheduler yields used to observe the work.</param>
+    /// <param name="cancellationToken">Cancels the bounded wait.</param>
+    /// <exception cref="ShieldAssertionException">
+    /// The execution completes before the work is observed, or the work is not observed within the bound.
+    /// </exception>
+    public static async ValueTask WaitForPendingAsync(
+        this Task execution,
+        Func<bool> workStarted,
+        string workDescription,
+        int maxYields = 100,
+        CancellationToken cancellationToken = default)
+    {
+        if (execution is null)
+        {
+            throw new ArgumentNullException(nameof(execution));
+        }
+
+        if (workStarted is null)
+        {
+            throw new ArgumentNullException(nameof(workStarted));
+        }
+
+        if (string.IsNullOrWhiteSpace(workDescription))
+        {
+            throw new ArgumentException("A work description is required.", nameof(workDescription));
+        }
+
+        if (maxYields <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxYields), "MaxYields must be positive.");
+        }
+
+        var observed = await SchedulerDrain.ObserveAsync(
+            () => execution.IsCompleted || workStarted(),
+            maxYields,
+            cancellationToken).ConfigureAwait(false);
+        if (execution.IsCompleted)
+        {
+            throw new ShieldAssertionException(
+                $"Expected {workDescription} to become pending, but the execution completed " +
+                $"with status {execution.Status}.");
+        }
+
+        if (observed)
+        {
+            return;
+        }
+
+        throw new ShieldAssertionException(
+            $"Expected {workDescription} to become pending within {DescribeYields(maxYields)}, " +
+            $"but it was not observed. Execution status: {execution.Status}.");
+    }
+
+    private static string DescribeYields(int count) =>
+        count == 1 ? "1 scheduler yield" : $"{count} scheduler yields";
+}

--- a/tests/Kevlar.Testing.Tests/TimeControlTests.cs
+++ b/tests/Kevlar.Testing.Tests/TimeControlTests.cs
@@ -204,6 +204,27 @@ public class TimeControlTests
     }
 
     [Test]
+    public async Task Pending_Wait_Preserves_Cancellation_After_Final_Yield()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var wait = pending.Task.WaitForPendingAsync(
+            () =>
+            {
+                cancellation.Cancel();
+                return false;
+            },
+            "cancelled work",
+            maxYields: 1,
+            cancellationToken: cancellation.Token);
+        var exception = await Assert.That(async () => await wait)
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
     public async Task Bounds_Report_Execution_And_Condition_Details()
     {
         var completed = Task.CompletedTask;

--- a/tests/Kevlar.Testing.Tests/TimeControlTests.cs
+++ b/tests/Kevlar.Testing.Tests/TimeControlTests.cs
@@ -1,0 +1,265 @@
+using Kevlar.Testing;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Testing.Tests;
+
+public class TimeControlTests
+{
+    [Test]
+    public async Task Retry_Advances_Until_All_Delays_Complete()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var attempts = 0;
+        var shield = Shield
+            .Retry(2, Backoff.Constant(TimeSpan.FromSeconds(1)))
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync<int>(_ =>
+        {
+            var attempt = Interlocked.Increment(ref attempts);
+            return attempt < 3
+                ? ValueTask.FromException<int>(new InvalidOperationException($"attempt {attempt}"))
+                : new ValueTask<int>(42);
+        }).AsTask();
+
+        await execution.WaitForPendingAsync(
+            () => Volatile.Read(ref attempts) == 1,
+            "the first retry delay");
+        await timeProvider.AdvanceUntilAsync(
+            TimeSpan.FromSeconds(1),
+            () => Volatile.Read(ref attempts) == 3,
+            "all retry attempts",
+            maxAdvances: 2);
+
+        await Assert.That(await execution).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Timeout_Advances_To_The_Deadline()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deadline = timeProvider.GetUtcNow() + TimeSpan.FromSeconds(5);
+        var shield = Shield.Timeout(TimeSpan.FromSeconds(5)).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync<int>(async token =>
+        {
+            started.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token).ConfigureAwait(false);
+            return 0;
+        }).AsTask();
+
+        await execution.WaitForPendingAsync(
+            () => started.Task.IsCompleted,
+            "the timed execution");
+        await timeProvider.AdvanceUntilAsync(
+            TimeSpan.FromSeconds(5),
+            () => timeProvider.GetUtcNow() >= deadline,
+            "the timeout deadline",
+            maxAdvances: 1);
+
+        _ = await Assert.That(async () => await execution).Throws<TimeoutExceededException>();
+    }
+
+    [Test]
+    public async Task Circuit_Breaker_Window_Advances_Without_Real_Time()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var shield = Shield
+            .CircuitBreaker(1, TimeSpan.FromSeconds(10))
+            .WithTimeProvider(timeProvider);
+
+        _ = await Assert.That(() => shield.Execute<int>(
+                static _ => throw new InvalidOperationException("open")))
+            .Throws<InvalidOperationException>();
+        _ = await Assert.That(() => shield.Execute(static _ => 1))
+            .Throws<CircuitOpenException>();
+
+        var closesAt = timeProvider.GetUtcNow() + TimeSpan.FromSeconds(10);
+        await timeProvider.AdvanceUntilAsync(
+            TimeSpan.FromSeconds(2),
+            () => timeProvider.GetUtcNow() >= closesAt,
+            "the circuit-breaker window",
+            maxAdvances: 5);
+
+        await Assert.That(shield.Execute(static _ => 42)).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Rate_Limit_Replenishment_Completes_Queued_Execution()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var executions = 0;
+        var shield = Shield
+            .RateLimit(options =>
+            {
+                options.Permits = 1;
+                options.Window = TimeSpan.FromSeconds(1);
+                options.QueueLimit = 1;
+            })
+            .WithTimeProvider(timeProvider);
+
+        await Assert.That(await shield.ExecuteAsync(_ =>
+        {
+            Interlocked.Increment(ref executions);
+            return new ValueTask<int>(1);
+        })).IsEqualTo(1);
+        var queued = shield.ExecuteAsync(_ =>
+        {
+            Interlocked.Increment(ref executions);
+            return new ValueTask<int>(2);
+        }).AsTask();
+
+        await queued.WaitForPendingAsync(
+            () => !queued.IsCompleted,
+            "the rate-limit queue");
+        await timeProvider.AdvanceUntilAsync(
+            TimeSpan.FromSeconds(1),
+            () => Volatile.Read(ref executions) == 2,
+            "the queued rate-limit execution",
+            maxAdvances: 1);
+
+        await Assert.That(await queued).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Concurrency_Queue_Completes_After_Permit_Release()
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.ConcurrencyLimit(1, maxQueue: 1);
+        var first = shield.ExecuteAsync<int>(async _ =>
+        {
+            started.TrySetResult();
+            await release.Task.ConfigureAwait(false);
+            return 1;
+        }).AsTask();
+        var queued = shield.ExecuteAsync(static _ => new ValueTask<int>(2)).AsTask();
+
+        await queued.WaitForPendingAsync(
+            () => started.Task.IsCompleted,
+            "the concurrency-limit queue");
+        release.TrySetResult();
+        await Assert.That(await first).IsEqualTo(1);
+
+        await Assert.That(await queued).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Hedging_Stagger_Advances_To_The_Next_Attempt()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var attempts = 0;
+        var shield = Shield
+            .Hedge(2, TimeSpan.FromSeconds(1))
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync<int>(async token =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+
+            return 42;
+        }).AsTask();
+
+        await execution.WaitForPendingAsync(
+            () => Volatile.Read(ref attempts) == 1,
+            "the primary hedge attempt");
+        await timeProvider.AdvanceUntilAsync(
+            TimeSpan.FromSeconds(1),
+            () => Volatile.Read(ref attempts) == 2,
+            "the hedged attempt",
+            maxAdvances: 1);
+
+        await Assert.That(await execution).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Cancellation_Completes_A_Pending_Execution()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var execution = Shield.Empty.ExecuteAsync<int>(async token =>
+        {
+            started.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 0;
+        }, cancellation.Token).AsTask();
+
+        await execution.WaitForPendingAsync(
+            () => started.Task.IsCompleted,
+            "the cancellable execution");
+        cancellation.Cancel();
+
+        _ = await Assert.That(async () => await execution).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task Bounds_Report_Execution_And_Condition_Details()
+    {
+        var completed = Task.CompletedTask;
+        var pendingFailure = await Assert.That(async () => await completed.WaitForPendingAsync(
+                static () => false,
+                "a retry delay",
+                maxYields: 1))
+            .Throws<ShieldAssertionException>();
+        await Assert.That(pendingFailure!.Message).Contains("a retry delay");
+        await Assert.That(pendingFailure.Message).Contains("RanToCompletion");
+
+        var neverStarts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var missingWork = await Assert.That(async () => await neverStarts.Task.WaitForPendingAsync(
+                static () => false,
+                "a missing attempt",
+                maxYields: 1))
+            .Throws<ShieldAssertionException>();
+        await Assert.That(missingWork!.Message).Contains("1 scheduler yield");
+        await Assert.That(missingWork.Message).Contains("WaitingForActivation");
+
+        var timeProvider = new FakeTimeProvider();
+        var advanceFailure = await Assert.That(async () => await timeProvider.AdvanceUntilAsync(
+                TimeSpan.FromSeconds(1),
+                static () => false,
+                "an unreachable state",
+                maxAdvances: 2,
+                maxYieldsPerAdvance: 1))
+            .Throws<ShieldAssertionException>();
+        await Assert.That(advanceFailure!.Message).Contains("an unreachable state");
+        await Assert.That(advanceFailure.Message).Contains("2 advances");
+        await Assert.That(advanceFailure.Message).Contains("00:00:01");
+    }
+
+    [Test]
+    public async Task Invalid_Bounds_Are_Rejected()
+    {
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _ = await Assert.That(
+                async () => await pending.Task.WaitForPendingAsync(
+                    static () => false,
+                    "pending work",
+                    maxYields: 0))
+            .Throws<ArgumentOutOfRangeException>();
+
+        var timeProvider = new FakeTimeProvider();
+        _ = await Assert.That(async () => await timeProvider.AdvanceUntilAsync(
+                TimeSpan.Zero,
+                static () => false,
+                "work",
+                maxAdvances: 1))
+            .Throws<ArgumentOutOfRangeException>();
+        _ = await Assert.That(async () => await timeProvider.AdvanceUntilAsync(
+                TimeSpan.FromSeconds(1),
+                static () => false,
+                "work",
+                maxAdvances: 0))
+            .Throws<ArgumentOutOfRangeException>();
+        _ = await Assert.That(async () => await timeProvider.AdvanceUntilAsync(
+                TimeSpan.FromSeconds(1),
+                static () => false,
+                "work",
+                maxYieldsPerAdvance: 0))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/Kevlar.Testing.Tests/TimeControlTests.cs
+++ b/tests/Kevlar.Testing.Tests/TimeControlTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using Kevlar.Testing;
 using Microsoft.Extensions.Time.Testing;
 
@@ -89,6 +90,8 @@ public class TimeControlTests
     [Test]
     public async Task Rate_Limit_Replenishment_Completes_Queued_Execution()
     {
+        const string ShieldName = "testing-rate-queue";
+        using var admission = new QueueAdmissionSignal("kevlar.rate_limit.queued", ShieldName);
         var timeProvider = new FakeTimeProvider();
         var executions = 0;
         var shield = Shield
@@ -98,7 +101,8 @@ public class TimeControlTests
                 options.Window = TimeSpan.FromSeconds(1);
                 options.QueueLimit = 1;
             })
-            .WithTimeProvider(timeProvider);
+            .WithTimeProvider(timeProvider)
+            .WithName(ShieldName);
 
         await Assert.That(await shield.ExecuteAsync(_ =>
         {
@@ -112,7 +116,7 @@ public class TimeControlTests
         }).AsTask();
 
         await queued.WaitForPendingAsync(
-            () => !queued.IsCompleted,
+            () => admission.WasObserved,
             "the rate-limit queue");
         await timeProvider.AdvanceUntilAsync(
             TimeSpan.FromSeconds(1),
@@ -126,9 +130,11 @@ public class TimeControlTests
     [Test]
     public async Task Concurrency_Queue_Completes_After_Permit_Release()
     {
+        const string ShieldName = "testing-concurrency-queue";
+        using var admission = new QueueAdmissionSignal("kevlar.concurrency_limit.queued", ShieldName);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var shield = Shield.ConcurrencyLimit(1, maxQueue: 1);
+        var shield = Shield.ConcurrencyLimit(1, maxQueue: 1).WithName(ShieldName);
         var first = shield.ExecuteAsync<int>(async _ =>
         {
             started.TrySetResult();
@@ -138,7 +144,7 @@ public class TimeControlTests
         var queued = shield.ExecuteAsync(static _ => new ValueTask<int>(2)).AsTask();
 
         await queued.WaitForPendingAsync(
-            () => started.Task.IsCompleted,
+            () => admission.WasObserved,
             "the concurrency-limit queue");
         release.TrySetResult();
         await Assert.That(await first).IsEqualTo(1);
@@ -261,5 +267,53 @@ public class TimeControlTests
                 "work",
                 maxYieldsPerAdvance: 0))
             .Throws<ArgumentOutOfRangeException>();
+    }
+
+    private sealed class QueueAdmissionSignal : IDisposable
+    {
+        private readonly string _instrumentName;
+        private readonly MeterListener _listener = new();
+        private readonly string _shieldName;
+        private int _wasObserved;
+
+        public QueueAdmissionSignal(string instrumentName, string shieldName)
+        {
+            _instrumentName = instrumentName;
+            _shieldName = shieldName;
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Kevlar" && instrument.Name == _instrumentName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>(ObserveMeasurement);
+            _listener.Start();
+        }
+
+        public bool WasObserved => Volatile.Read(ref _wasObserved) != 0;
+
+        public void Dispose() => _listener.Dispose();
+
+        private void ObserveMeasurement(
+            Instrument instrument,
+            long value,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags,
+            object? state)
+        {
+            if (value != 1)
+            {
+                return;
+            }
+
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "kevlar.shield.name" && Equals(tag.Value, _shieldName))
+                {
+                    Volatile.Write(ref _wasObserved, 1);
+                    return;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add bounded pending-execution observation and predicate-driven FakeTimeProvider advancement helpers
- keep the testing-only time-provider dependency inside Kevlar.Testing while retaining netstandard2.0 descriptor assets
- cover retry, timeout, circuit breaker, rate limit, concurrency limit, hedging, cancellation, diagnostics, and invalid bounds
- document TUnit usage and validate net8.0/net10.0 package assets

Closes #99

## Validation

- dotnet build Kevlar.slnx -c Release
- all six test projects: 791 tests passed
- dotnet pack Kevlar.slnx -c Release --no-build -p:Version=0.0.0-issue99.2
- pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/issue99-2 -Version 0.0.0-issue99.2
- pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/issue99-2 -Version 0.0.0-issue99.2
- npm run build (docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bounded helpers for waiting on pending executions and advancing fake time until conditions are met.
  - Added cancellation support, configurable limits, and detailed diagnostics for failed waits or time advances.
  - Added .NET 8 support for the testing package.

- **Documentation**
  - Documented deterministic fake-time helpers, retry examples, supported conditions, bounds, and failure diagnostics.
  - Updated package descriptions to highlight deterministic testing utilities.

- **Tests**
  - Added coverage for retries, timeouts, circuit breakers, rate limits, concurrency, hedging, cancellation, validation, and diagnostic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->