### PR TITLE
perf(metrics): eliminate state tag allocations

### DIFF
--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -16,6 +16,12 @@ internal static class KevlarMetrics
 {
     public const int MaxTrackedStrategyAliases = 64;
 
+#if NET9_0_OR_GREATER
+    private const int MinimumCachedStrategyIndex = -1;
+    private const int MaximumCachedStrategyIndex = 63;
+    private static readonly object[] BoxedStrategyIndexes = CreateBoxedStrategyIndexes();
+#endif
+
 #if NET8_0_OR_GREATER
     private static readonly Meter Meter = new(KevlarDiagnostics.MeterName, "1.0");
     private static readonly Counter<long> Executions = Meter.CreateCounter<long>(
@@ -272,12 +278,30 @@ internal static class KevlarMetrics
         return tags;
     }
 
+#if NET9_0_OR_GREATER
     private static TagList StateTags(string? shieldName, int strategyIndex)
     {
         var tags = NameTags(shieldName);
-        tags.Add("kevlar.strategy.index", strategyIndex);
+        tags.Add("kevlar.strategy.index", BoxStrategyIndex(strategyIndex));
         return tags;
     }
+
+    private static object BoxStrategyIndex(int strategyIndex) =>
+        strategyIndex is >= MinimumCachedStrategyIndex and <= MaximumCachedStrategyIndex
+            ? BoxedStrategyIndexes[strategyIndex - MinimumCachedStrategyIndex]
+            : strategyIndex;
+
+    private static object[] CreateBoxedStrategyIndexes()
+    {
+        var indexes = new object[MaximumCachedStrategyIndex - MinimumCachedStrategyIndex + 1];
+        for (var index = MinimumCachedStrategyIndex; index <= MaximumCachedStrategyIndex; index++)
+        {
+            indexes[index - MinimumCachedStrategyIndex] = index;
+        }
+
+        return indexes;
+    }
+#endif
 
     private static string StateName(CircuitState state) => state switch
     {

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -17,9 +17,9 @@ internal static class KevlarMetrics
     public const int MaxTrackedStrategyAliases = 64;
 
 #if NET9_0_OR_GREATER
-    private const int MinimumCachedStrategyIndex = -1;
-    private const int MaximumCachedStrategyIndex = 63;
-    private static readonly object[] BoxedStrategyIndexes = CreateBoxedStrategyIndexes();
+    private const int _minimumCachedStrategyIndex = -1;
+    private const int _maximumCachedStrategyIndex = 63;
+    private static readonly object[] _boxedStrategyIndexes = CreateBoxedStrategyIndexes();
 #endif
 
 #if NET8_0_OR_GREATER
@@ -287,16 +287,16 @@ internal static class KevlarMetrics
     }
 
     private static object BoxStrategyIndex(int strategyIndex) =>
-        strategyIndex is >= MinimumCachedStrategyIndex and <= MaximumCachedStrategyIndex
-            ? BoxedStrategyIndexes[strategyIndex - MinimumCachedStrategyIndex]
+        strategyIndex is >= _minimumCachedStrategyIndex and <= _maximumCachedStrategyIndex
+            ? _boxedStrategyIndexes[strategyIndex - _minimumCachedStrategyIndex]
             : strategyIndex;
 
     private static object[] CreateBoxedStrategyIndexes()
     {
-        var indexes = new object[MaximumCachedStrategyIndex - MinimumCachedStrategyIndex + 1];
-        for (var index = MinimumCachedStrategyIndex; index <= MaximumCachedStrategyIndex; index++)
+        var indexes = new object[_maximumCachedStrategyIndex - _minimumCachedStrategyIndex + 1];
+        for (var index = _minimumCachedStrategyIndex; index <= _maximumCachedStrategyIndex; index++)
         {
-            indexes[index - MinimumCachedStrategyIndex] = index;
+            indexes[index - _minimumCachedStrategyIndex] = index;
         }
 
         return indexes;

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using Kevlar.Chaos;
 
 namespace Kevlar.AllocationTests;
@@ -153,6 +154,31 @@ public class AllocationBudgetTests
             test._primaryWinsHedge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("warm partition lookup", this, static test =>
             _ = test._partitioned.GetShield(42));
+    }
+
+    [Test]
+    public void State_Metrics_Allocate_Zero_Bytes_Per_Operation()
+    {
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = static (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == KevlarDiagnostics.MeterName)
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>(static (_, _, _, _) => { });
+        listener.SetMeasurementEventCallback<double>(static (_, _, _, _) => { });
+        listener.Start();
+
+        AssertZero("circuit state metrics", this, static test =>
+            test._breaker.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("rate limit state metrics", this, static test =>
+            test._rateLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("concurrency state metrics", this, static test =>
+            test._concurrencyLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
     }
 
     /// <summary>Verifies bounded allocations for failure and parallel execution paths.</summary>


### PR DESCRIPTION
## Summary

Cache boxed strategy-index tag values used by circuit-breaker, rate-limit, and concurrency-limit state gauges. This preserves every measurement and tag value while removing per-record boxing allocations.

Adds an allocation regression test with an active MeterListener.

## Benchmark

BenchmarkDotNet v0.15.8, .NET 10.0.11, Windows 11, Intel i7-12700K, default job.

| Happy path with listener | Before | After | Allocation |
|---|---:|---:|---:|
| Circuit breaker | 435.11 ns | 434.33 ns | 48 B → 0 B |
| Rate limit | 597.38 ns | 613.66 ns | 30 B → 0 B |
| Concurrency limit | 603.57 ns | 599.46 ns | 48 B → 0 B |

Disabled-listener paths remain allocation-free. Timing is effectively neutral within cross-run variance; improvement is removal of steady-state GC pressure.

Command:

`dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*TelemetryBenchmarks.CircuitBreakerHappyPath*" "*TelemetryBenchmarks.RateLimitHappyPath*" "*TelemetryBenchmarks.ConcurrencyLimitHappyPath*"`

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` — 672 passed
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` — 3 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Preserved zero-allocation behavior for circuit-breaker, rate-limit, and concurrency-limit operations while diagnostics measurements are enabled.
  * No functional behavior changes were introduced.

* **Tests**
  * Added coverage to verify allocation behavior with diagnostics measurement events active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->