### PR TITLE
perf(context): optimize single-property execution

### DIFF
--- a/src/Kevlar/KevlarProperties.cs
+++ b/src/Kevlar/KevlarProperties.cs
@@ -11,6 +11,8 @@ public sealed class KevlarProperties
 {
     private const int RetainedSlotCapacity = 32;
 
+    private PropertyIdentity _firstIdentity;
+    private PropertySlot? _firstItem;
     private Dictionary<PropertyIdentity, PropertySlot>? _items;
 
     internal KevlarProperties()
@@ -28,6 +30,14 @@ public sealed class KevlarProperties
     public bool TryGet<T>(KevlarKey<T> key, out T value)
     {
         var identity = GetIdentity(key);
+        if (_firstItem is not null &&
+            _firstIdentity == identity &&
+            _firstItem is PropertySlot<T> firstSlot &&
+            firstSlot.TryGet(out value))
+        {
+            return true;
+        }
+
         if (_items is not null &&
             _items.TryGetValue(identity, out var stored) &&
             stored is PropertySlot<T> slot &&
@@ -46,46 +56,70 @@ public sealed class KevlarProperties
 
     internal void Clear()
     {
-        if (_items is null)
+        if (_firstItem is null)
         {
             return;
         }
 
-        if (_items.Count > RetainedSlotCapacity)
+        if (_items is { Count: >= RetainedSlotCapacity })
         {
+            _firstIdentity = default;
+            _firstItem = null;
             _items = null;
             return;
         }
 
-        foreach (var slot in _items.Values)
+        _firstItem.Clear();
+        if (_items is not null)
         {
-            slot.Clear();
+            foreach (var slot in _items.Values)
+            {
+                slot.Clear();
+            }
         }
     }
 
     internal void CopyTo(KevlarProperties target)
     {
-        if (_items is null || _items.Count == 0)
+        if (_firstItem is null)
         {
             return;
         }
 
-        foreach (var pair in _items)
+        _firstItem.CopyTo(target, _firstIdentity);
+        if (_items is not null)
         {
-            pair.Value.CopyTo(target, pair.Key);
+            foreach (var pair in _items)
+            {
+                pair.Value.CopyTo(target, pair.Key);
+            }
         }
     }
 
     private void Set<T>(PropertyIdentity identity, T value)
     {
+        if (_firstItem is null)
+        {
+            _firstIdentity = identity;
+            _firstItem = new PropertySlot<T>(value);
+            return;
+        }
+
+        if (_firstIdentity == identity)
+        {
+            ((PropertySlot<T>)_firstItem).Set(value);
+            return;
+        }
+
         var items = _items ??= [];
         if (items.TryGetValue(identity, out var stored))
         {
             ((PropertySlot<T>)stored).Set(value);
-            return;
         }
-
-        items.Add(identity, new PropertySlot<T>(value));
+        else
+        {
+            items.Add(identity, new PropertySlot<T>(value));
+        }
     }
 
     private static PropertyIdentity GetIdentity<T>(KevlarKey<T> key)


### PR DESCRIPTION
## Summary

Add an inline first slot to KevlarProperties and defer dictionary use until a second distinct key is stored.

Single-property context execution is the common path. Name-and-type key identity, pooled clearing, copy behavior, and the 32-slot retention cap remain unchanged. Context pool capacity remains 128.

## Benchmark

BenchmarkDotNet v0.15.8, .NET 10.0.11, Windows 11, Intel i7-12700K, default job.

| Method | Before | After | Change | Allocation |
|---|---:|---:|---:|---:|
| Kevlar_EmptyContextState | 71.167 ns | 59.935 ns | 15.8% faster | 0 B |
| Kevlar_EmptyReferenceState | 3.383 ns | 3.594 ns | control | 0 B |

Command:

`dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*OverheadBenchmarks.Kevlar_EmptyReferenceState" "*OverheadBenchmarks.Kevlar_EmptyContextState"`

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` — 672 passed
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` — 2 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of the first stored property for faster property access and updates.
  * Enhanced clearing and copying behavior while preserving efficient storage.

* **Bug Fixes**
  * Improved consistency when reading, setting, and resetting stored properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->