### PR TITLE
perf(circuit): fast-path configured execution

### DIFF
--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -196,9 +196,19 @@ internal sealed class CircuitBreakerStrategy : Strategy
         bool recordState)
     {
         var entry = _core.TryEnterAsync(context.TimeProvider);
-        return entry.IsCompletedSuccessfully
-            ? ExecuteConfiguredEntry(entry.Result, next, context, alias, recordState)
-            : AwaitConfiguredEntryAsync(entry, next, context, alias, recordState);
+        if (!entry.IsCompletedSuccessfully)
+        {
+            return AwaitConfiguredEntryAsync(entry, next, context, alias, recordState);
+        }
+
+        try
+        {
+            return ExecuteConfiguredEntry(entry.Result, next, context, alias, recordState);
+        }
+        catch (Exception exception)
+        {
+            return new ValueTask<Outcome<T>>(Task.FromException<Outcome<T>>(exception));
+        }
     }
 
     private async ValueTask<Outcome<T>> AwaitConfiguredEntryAsync<T, TState>(

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -189,13 +189,36 @@ internal sealed class CircuitBreakerStrategy : Strategy
         }
     }
 
-    private async ValueTask<Outcome<T>> ExecuteConfiguredAsync<T, TState>(
+    private ValueTask<Outcome<T>> ExecuteConfiguredAsync<T, TState>(
         Continuation<T, TState> next,
         KevlarContext context,
         StrategyMetricAlias alias,
         bool recordState)
     {
-        var entry = await _core.TryEnterAsync(context.TimeProvider).ConfigureAwait(false);
+        var entry = _core.TryEnterAsync(context.TimeProvider);
+        return entry.IsCompletedSuccessfully
+            ? ExecuteConfiguredEntry(entry.Result, next, context, alias, recordState)
+            : AwaitConfiguredEntryAsync(entry, next, context, alias, recordState);
+    }
+
+    private async ValueTask<Outcome<T>> AwaitConfiguredEntryAsync<T, TState>(
+        ValueTask<CircuitBreakerCore.EntryResult> entry,
+        Continuation<T, TState> next,
+        KevlarContext context,
+        StrategyMetricAlias alias,
+        bool recordState)
+    {
+        var result = await entry.ConfigureAwait(false);
+        return await ExecuteConfiguredEntry(result, next, context, alias, recordState).ConfigureAwait(false);
+    }
+
+    private ValueTask<Outcome<T>> ExecuteConfiguredEntry<T, TState>(
+        CircuitBreakerCore.EntryResult entry,
+        Continuation<T, TState> next,
+        KevlarContext context,
+        StrategyMetricAlias alias,
+        bool recordState)
+    {
         if (!entry.Allowed)
         {
             if (recordState)
@@ -204,7 +227,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
             }
 
             KevlarMetrics.Rejection(context.ShieldName, "circuit_open");
-            return Outcome<T>.FromException(entry.Rejection!);
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(entry.Rejection!));
         }
 
         if (recordState)
@@ -220,21 +243,76 @@ internal sealed class CircuitBreakerStrategy : Strategy
             }
         }
 
-        var outcome = await next.InvokeAsync(context).ConfigureAwait(false);
+        var execution = next.InvokeAsync(context);
+        return execution.IsCompletedSuccessfully
+            ? CompleteConfigured(execution.Result, context, entry.AdmittedProbeGeneration, alias, recordState)
+            : AwaitConfiguredOutcomeAsync(
+                execution,
+                context,
+                entry.AdmittedProbeGeneration,
+                alias,
+                recordState);
+    }
 
+    private async ValueTask<Outcome<T>> AwaitConfiguredOutcomeAsync<T>(
+        ValueTask<Outcome<T>> execution,
+        KevlarContext context,
+        long admittedProbeGeneration,
+        StrategyMetricAlias alias,
+        bool recordState)
+    {
+        var outcome = await execution.ConfigureAwait(false);
+        return await CompleteConfigured(
+            outcome,
+            context,
+            admittedProbeGeneration,
+            alias,
+            recordState).ConfigureAwait(false);
+    }
+
+    private ValueTask<Outcome<T>> CompleteConfigured<T>(
+        Outcome<T> outcome,
+        KevlarContext context,
+        long admittedProbeGeneration,
+        StrategyMetricAlias alias,
+        bool recordState)
+    {
+        ValueTask recording;
         if (_judge.ShouldHandle(in outcome))
         {
-            await _core.RecordFailureAsync(context.TimeProvider, in outcome, context).ConfigureAwait(false);
+            recording = _core.RecordFailureAsync(context.TimeProvider, in outcome, context);
         }
         else if (outcome.Exception is OperationCanceledException && context.CancellationToken.IsCancellationRequested)
         {
-            _core.AbandonProbe(entry.AdmittedProbeGeneration);
+            _core.AbandonProbe(admittedProbeGeneration);
+            recording = default;
         }
         else
         {
-            await _core.RecordSuccessAsync(context.TimeProvider).ConfigureAwait(false);
+            recording = _core.RecordSuccessAsync(context.TimeProvider);
         }
 
+        if (!recording.IsCompletedSuccessfully)
+        {
+            return AwaitConfiguredRecordingAsync(recording, outcome, alias, recordState);
+        }
+
+        recording.GetAwaiter().GetResult();
+        if (recordState)
+        {
+            RecordState(alias);
+        }
+
+        return new ValueTask<Outcome<T>>(outcome);
+    }
+
+    private async ValueTask<Outcome<T>> AwaitConfiguredRecordingAsync<T>(
+        ValueTask recording,
+        Outcome<T> outcome,
+        StrategyMetricAlias alias,
+        bool recordState)
+    {
+        await recording.ConfigureAwait(false);
         if (recordState)
         {
             RecordState(alias);

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -410,6 +410,7 @@ public class CircuitBreakerDynamicOptionsTests
 
             var execution = strategy.ExecuteAsync(continuation, context);
 
+            await Assert.That(execution.IsCompleted).IsTrue();
             await Assert.That(execution.IsCompletedSuccessfully).IsFalse();
             var thrown = await Assert.That(async () => await execution).Throws<InvalidOperationException>();
             await Assert.That(ReferenceEquals(thrown, predicateFailure)).IsTrue();

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using Kevlar.Internal;
+using Kevlar.Strategies;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
@@ -385,6 +387,37 @@ public class CircuitBreakerDynamicOptionsTests
         await Assert.That(ReferenceEquals(thrown, callbackFailure)).IsTrue();
         await Assert.That(observed).IsEqualTo(CircuitState.Open);
         await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Configured_Breaker_Returns_Synchronous_Processing_Failure_As_Faulted_ValueTask()
+    {
+        var predicateFailure = new InvalidOperationException("predicate");
+        var shield = Shield.When(_ => throw predicateFailure).CircuitBreaker(options =>
+        {
+            options.OnStateChangedAsync = static _ => ValueTask.CompletedTask;
+        });
+        var strategy = (CircuitBreakerStrategy)shield.Strategies.Single();
+        var context = KevlarContext.Rent(default, isSynchronous: false, TimeProvider.System, shieldName: null);
+
+        try
+        {
+            var continuation = new Continuation<int, object?>(
+                next: null,
+                static (_, _) => new ValueTask<Outcome<int>>(
+                    Outcome<int>.FromException(new ApplicationException("operation"))),
+                state: null);
+
+            var execution = strategy.ExecuteAsync(continuation, context);
+
+            await Assert.That(execution.IsCompletedSuccessfully).IsFalse();
+            var thrown = await Assert.That(async () => await execution).Throws<InvalidOperationException>();
+            await Assert.That(ReferenceEquals(thrown, predicateFailure)).IsTrue();
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Avoid async state-machine overhead when configured circuit-breaker entry, downstream execution, and outcome recording all complete synchronously.

Asynchronous transition callbacks and dynamic break-duration generation still use dedicated await paths when they actually suspend. Failure, cancellation, probe, metric, and publication behavior is preserved.

## Benchmark

BenchmarkDotNet v0.15.8, .NET 10.0.11, Windows 11, Intel i7-12700K, default job.

| Closed happy path | Before | After | Change | Allocation |
|---|---:|---:|---:|---:|
| Dynamic duration configured | 130.48 ns | 104.72 ns | 19.7% faster | 0 B |
| Async callback configured | 124.91 ns | 103.47 ns | 17.2% faster | 0 B |
| Plain circuit control | 92.31 ns | 92.36 ns | neutral | 0 B |

Command:

`dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*CircuitBreakerBenchmarks.Kevlar_ClosedHappyPath" "*CircuitBreakerBenchmarks.Kevlar_DynamicDurationConfigured" "*CircuitBreakerBenchmarks.Kevlar_AsyncCallbackConfigured"`

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` — 672 passed
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` — 2 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved circuit-breaker handling across synchronous and asynchronous operations.
* Prevented blocking while recording success or failure outcomes.
* Preserved cancellation behavior when probe operations are abandoned.
* Improved responsiveness by optimizing already-completed operations.
* Ensured synchronous predicate failures are surfaced asynchronously without losing the original exception.
* Improved reliability when recording circuit-breaker outcomes after successful or failed operations.
* Maintained consistent circuit state behavior across completed, pending, and cancelled executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Post-review validation

- Regression test confirms synchronous configured-path failures surface through a faulted ValueTask.
- Release build: clean.
- Unit tests: 673 passed.
- Allocation tests: 2 passed.
- BenchmarkDotNet after fix: plain 100.2 ns, dynamic duration 110.7 ns, async callback 108.0 ns; all 0 B allocated.
