### PR TITLE
perf(strategies): fast-path sync completion

### DIFF
--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -48,7 +48,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     public override string Describe() =>
         _maxQueue > 0 ? $"ConcurrencyLimit({_maxConcurrency}, queue {_maxQueue})" : $"ConcurrencyLimit({_maxConcurrency})";
 
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         var alias = new StrategyMetricAlias(context.ShieldName, context.StrategyIndex);
         if (Interlocked.Increment(ref _pending) > _capacity)
@@ -56,106 +56,99 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             Interlocked.Decrement(ref _pending);
             RecordState(alias);
             KevlarMetrics.Rejection(context.ShieldName, "concurrency_limit");
-            return Outcome<T>.FromException(new ConcurrencyLimitExceededException());
+            return new ValueTask<Outcome<T>>(
+                Outcome<T>.FromException(new ConcurrencyLimitExceededException()));
         }
 
-        var queued = false;
         try
         {
             context.CancellationToken.ThrowIfCancellationRequested();
+            if (TryAcquirePermit())
+            {
+                return ExecuteAcquired(next, context, alias, queued: false);
+            }
+        }
+        catch (OperationCanceledException cancelled)
+        {
+            Interlocked.Decrement(ref _pending);
+            RecordState(alias);
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(NormalizeCancellation(cancelled, context)));
+        }
+
+        return ExecuteQueuedAsync(next, context, alias);
+    }
+
+    private async ValueTask<Outcome<T>> ExecuteQueuedAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        StrategyMetricAlias alias)
+    {
+        UpdateMetricsState(inflightDelta: 0, queuedDelta: 1);
+        Interlocked.Increment(ref _waiters);
+        try
+        {
             if (!TryAcquirePermit())
             {
-                queued = true;
-                UpdateMetricsState(inflightDelta: 0, queuedDelta: 1);
-                Interlocked.Increment(ref _waiters);
-                try
+                if (context.IsSynchronous)
                 {
-                    if (!TryAcquirePermit())
-                    {
-                        if (context.IsSynchronous)
-                        {
-                            RecordState(alias);
-                            _semaphore.Wait(context.CancellationToken);
-                        }
-                        else
-                        {
-                            using var waitCancellation = context.CancellationToken.CanBeCanceled
-                                ? CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken)
-                                : new CancellationTokenSource();
-                            var wait = _semaphore.WaitAsync(waitCancellation.Token);
-                            try
-                            {
-                                RecordState(alias);
-                            }
-                            catch (Exception publicationFailure)
-                            {
-                                waitCancellation.Cancel();
-                                try
-                                {
-                                    await wait.ConfigureAwait(false);
-                                    ReleasePermit();
-                                }
-                                catch (OperationCanceledException)
-                                {
-                                    // Cancellation withdrew the wait before it took a permit.
-                                }
-
-                                ExceptionDispatchInfo.Capture(publicationFailure).Throw();
-                            }
-
-                            await wait.ConfigureAwait(false);
-                        }
-                    }
+                    RecordState(alias);
+                    _semaphore.Wait(context.CancellationToken);
                 }
-                finally
+                else
                 {
-                    Interlocked.Decrement(ref _waiters);
+                    using var waitCancellation = context.CancellationToken.CanBeCanceled
+                        ? CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken)
+                        : new CancellationTokenSource();
+                    var wait = _semaphore.WaitAsync(waitCancellation.Token);
+                    try
+                    {
+                        RecordState(alias);
+                    }
+                    catch (Exception publicationFailure)
+                    {
+                        waitCancellation.Cancel();
+                        try
+                        {
+                            await wait.ConfigureAwait(false);
+                            ReleasePermit();
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Cancellation withdrew the wait before it took a permit.
+                        }
+
+                        ExceptionDispatchInfo.Capture(publicationFailure).Throw();
+                    }
+
+                    await wait.ConfigureAwait(false);
                 }
             }
         }
         catch (OperationCanceledException cancelled)
         {
-            if (context.CancellationToken.IsCancellationRequested
-                && cancelled.CancellationToken != context.CancellationToken)
-            {
-                cancelled = new OperationCanceledException(
-                    cancelled.Message,
-                    cancelled,
-                    context.CancellationToken);
-            }
-
-            Interlocked.Decrement(ref _pending);
-            if (queued)
-            {
-                UpdateMetricsState(inflightDelta: 0, queuedDelta: -1);
-            }
-
-            RecordState(alias);
-            return Outcome<T>.FromException(cancelled);
+            ReleaseQueued(alias);
+            return Outcome<T>.FromException(NormalizeCancellation(cancelled, context));
         }
         catch (Exception publicationFailure)
         {
-            Interlocked.Decrement(ref _pending);
-            if (queued)
-            {
-                UpdateMetricsState(inflightDelta: 0, queuedDelta: -1);
-            }
-
-            try
-            {
-                RecordState(alias);
-            }
-            catch (Exception correctionFailure)
-            {
-                publicationFailure = new AggregateException(
-                    publicationFailure,
-                    correctionFailure).Flatten();
-            }
-
+            ReleaseQueued(alias, publicationFailure);
             ExceptionDispatchInfo.Capture(publicationFailure).Throw();
             throw;
         }
+        finally
+        {
+            Interlocked.Decrement(ref _waiters);
+        }
 
+        return await ExecuteAcquired(next, context, alias, queued: true).ConfigureAwait(false);
+    }
+
+    private ValueTask<Outcome<T>> ExecuteAcquired<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        StrategyMetricAlias alias,
+        bool queued)
+    {
         UpdateMetricsState(inflightDelta: 1, queuedDelta: queued ? -1 : 0);
         try
         {
@@ -181,18 +174,66 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             throw;
         }
 
+        var execution = next.InvokeAsync(context);
+        if (!execution.IsCompletedSuccessfully)
+        {
+            return AwaitExecutionAsync(execution, alias);
+        }
+
+        var outcome = execution.Result;
+        CompleteExecution(alias);
+        return new ValueTask<Outcome<T>>(outcome);
+    }
+
+    private async ValueTask<Outcome<T>> AwaitExecutionAsync<T>(
+        ValueTask<Outcome<T>> execution,
+        StrategyMetricAlias alias)
+    {
         try
         {
-            return await next.InvokeAsync(context).ConfigureAwait(false);
+            return await execution.ConfigureAwait(false);
         }
         finally
         {
-            UpdateMetricsState(inflightDelta: -1, queuedDelta: 0);
-            ReleasePermit();
-            Interlocked.Decrement(ref _pending);
-            RecordState(alias);
+            CompleteExecution(alias);
         }
     }
+
+    private void CompleteExecution(StrategyMetricAlias alias)
+    {
+        UpdateMetricsState(inflightDelta: -1, queuedDelta: 0);
+        ReleasePermit();
+        Interlocked.Decrement(ref _pending);
+        RecordState(alias);
+    }
+
+    private void ReleaseQueued(
+        StrategyMetricAlias alias,
+        Exception? publicationFailure = null)
+    {
+        Interlocked.Decrement(ref _pending);
+        UpdateMetricsState(inflightDelta: 0, queuedDelta: -1);
+
+        try
+        {
+            RecordState(alias);
+        }
+        catch (Exception correctionFailure) when (publicationFailure is not null)
+        {
+            throw new AggregateException(publicationFailure, correctionFailure).Flatten();
+        }
+    }
+
+    private static OperationCanceledException NormalizeCancellation(
+        OperationCanceledException cancelled,
+        KevlarContext context) =>
+        context.CancellationToken.IsCancellationRequested
+        && cancelled.CancellationToken != context.CancellationToken
+            ? new OperationCanceledException(
+                cancelled.Message,
+                cancelled,
+                context.CancellationToken)
+            : cancelled;
 
     private bool TryAcquirePermit()
     {

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -52,18 +52,40 @@ internal sealed class RetryStrategy : Strategy
             : $"Retry({_maxRetries}, {_backoff}{cap})";
     }
 
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    {
+        var execution = next.InvokeAsync(context);
+        var firstOutcomeShouldRetry = false;
+        if (execution.IsCompletedSuccessfully)
+        {
+            var outcome = execution.Result;
+            if (!ShouldRetry(in outcome, retriesUsed: 0, context))
+            {
+                return new ValueTask<Outcome<T>>(outcome);
+            }
+
+            firstOutcomeShouldRetry = true;
+        }
+
+        return ExecuteCoreAsync(next, context, execution, firstOutcomeShouldRetry);
+    }
+
+    private async ValueTask<Outcome<T>> ExecuteCoreAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context,
+        ValueTask<Outcome<T>> execution,
+        bool firstOutcomeShouldRetry)
     {
         for (var retriesUsed = 0; ; retriesUsed++)
         {
-            var outcome = await next.InvokeAsync(context).ConfigureAwait(false);
+            var outcome = await execution.ConfigureAwait(false);
 
-            if (retriesUsed >= _maxRetries
-                || !_judge.ShouldHandle(in outcome)
-                || context.CancellationToken.IsCancellationRequested)
+            if (!firstOutcomeShouldRetry && !ShouldRetry(in outcome, retriesUsed, context))
             {
                 return outcome;
             }
+
+            firstOutcomeShouldRetry = false;
 
             var attempt = retriesUsed + 1;
             KevlarMetrics.Retry(context.ShieldName);
@@ -119,8 +141,15 @@ internal sealed class RetryStrategy : Strategy
                     return Outcome<T>.FromException(cancelled);
                 }
             }
+
+            execution = next.InvokeAsync(context);
         }
     }
+
+    private bool ShouldRetry<T>(in Outcome<T> outcome, int retriesUsed, KevlarContext context) =>
+        retriesUsed < _maxRetries
+        && _judge.ShouldHandle(in outcome)
+        && !context.CancellationToken.IsCancellationRequested;
 
     private TimeSpan ApplyGeneratedDelay(TimeSpan current, TimeSpan? generated)
     {

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -64,6 +64,7 @@ internal sealed class RetryStrategy : Strategy
                 return new ValueTask<Outcome<T>>(outcome);
             }
 
+            execution = new ValueTask<Outcome<T>>(outcome);
             firstOutcomeShouldRetry = true;
         }
 

--- a/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
@@ -1,9 +1,25 @@
+using System.Threading.Tasks.Sources;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
 
 public class RetryEdgeCaseTests
 {
+    [Test]
+    public async Task Retry_Consumes_Source_Backed_Synchronous_Outcomes_Once()
+    {
+        var strategy = new SourceBackedResultStrategy();
+        var shield = Shield.For<int>()
+            .WhenResult(0)
+            .Retry(1, Backoff.None)
+            .Use(strategy);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(-1));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(strategy.Invocations).IsEqualTo(2);
+    }
+
     [Test]
     public async Task RetryForever_Keeps_Retrying_Until_Success()
     {
@@ -319,5 +335,44 @@ public class RetryEdgeCaseTests
                 ? new InvalidOperationException($"attempt {attempts}")
                 : new ApplicationException("final");
         })).Throws<ApplicationException>().WithMessage("final");
+    }
+
+    private sealed class SourceBackedResultStrategy : Strategy
+    {
+        private int _invocations;
+
+        public int Invocations => Volatile.Read(ref _invocations);
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            var invocation = Interlocked.Increment(ref _invocations);
+            var outcome = Outcome<T>.FromResult((T)(object)(invocation == 1 ? 0 : 42));
+            return new ValueTask<Outcome<T>>(new SingleConsumptionSource<T>(outcome), 0);
+        }
+    }
+
+    private sealed class SingleConsumptionSource<T>(Outcome<T> outcome) : IValueTaskSource<Outcome<T>>
+    {
+        private int _consumptionCount;
+
+        public Outcome<T> GetResult(short token)
+        {
+            if (Interlocked.Increment(ref _consumptionCount) != 1)
+            {
+                throw new InvalidOperationException("ValueTask source consumed more than once.");
+            }
+
+            return outcome;
+        }
+
+        public ValueTaskSourceStatus GetStatus(short token) => ValueTaskSourceStatus.Succeeded;
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) => throw new InvalidOperationException("Source completed synchronously.");
     }
 }


### PR DESCRIPTION
## Summary

Split retry and concurrency-limit execution into synchronous-completion fast paths plus asynchronous slow paths.

Retry avoids entering its async loop when the first outcome does not need handling. Concurrency limiting avoids its async state machine for uncontended acquisition and synchronously completed downstream execution. Queuing, cancellation, metric rollback, and exception ordering remain on explicit slow paths.

## Benchmark

BenchmarkDotNet v0.15.8, .NET 10.0.11, Windows 11, Intel i7-12700K, default job.

| Happy path | Before | After | Change | Allocation |
|---|---:|---:|---:|---:|
| Retry | 95.30 ns | 66.17 ns | 30.6% faster | 0 B |
| Concurrency limit, uncontended | 111.5 ns | 100.8 ns | 9.6% faster | 0 B |

Polly comparisons in the after run measured 148.22 ns / 24 B for retry and 129.0 ns / 40 B for concurrency limiting.

Command:

`dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*RetryBenchmarks.Kevlar_HappyPath" "*RetryBenchmarks.Polly_HappyPath" "*ConcurrencyLimitBenchmarks*"`

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` — 672 passed, repeated three times after final refactor
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` — 2 passed
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` — 5 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency-limit handling for queued operations, cancellation, permit release, and metric-recording failures.
  * Fixed retry handling for synchronously completed, source-backed results to ensure each outcome is consumed correctly.
  * Improved consistency when operations complete through different execution paths.

* **Performance**
  * Reduced unnecessary asynchronous waiting when operations complete synchronously.

* **Tests**
  * Added coverage for retry behavior involving single-consumption asynchronous results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->