### PR TITLE
feat(analyzers): detect ephemeral stateful shields

### DIFF
--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -19,6 +19,7 @@ Generated code is ignored.
 | `KEV001` | Warning | execution delegate ignores its `CancellationToken` |
 | `KEV002` | Warning | known multi-attempt hedging pipeline is passed to synchronous `Execute` |
 | `KEV003` | Warning | inner fallback makes retry, hedging, or circuit breaker unreachable |
+| `KEV004` | Warning | stateful shield or partition provider is constructed for one execution |
 
 ## KEV001: ignored execution cancellation
 
@@ -74,21 +75,51 @@ var shield = Shield.For<int>()
 No automatic code fix is supplied for `KEV002` or `KEV003`: changing sync control flow or strategy
 order can change application semantics.
 
+## KEV004: per-execution stateful shields
+
+Circuit breakers, rate limiters, concurrency limiters, and partition providers retain state between
+executions. Constructing one immediately before `Execute`, `ExecuteAsync`, or
+`ExecuteOutcomeAsync` discards that state after one call, so a circuit never accumulates failures
+and limiter capacity is not shared:
+
+```csharp
+// KEV004: a new circuit exists for only this call.
+await Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30))
+    .ExecuteAsync(ct => SendAsync(ct));
+
+// Clean: every call shares the same circuit.
+private readonly Shield _dependencyShield =
+    Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));
+
+await _dependencyShield.ExecuteAsync(ct => SendAsync(ct));
+```
+
+Store stateful shields in a field, singleton or keyed dependency-injection registration, or registry.
+Store `PartitionedShield<TKey>` and `PartitionedShield<TKey, TResult>` providers for the same reason:
+their retained per-key shields disappear when the provider is constructed per call.
+
+The rule is deliberately conservative. It reports inline construction and a stable local or local
+alias that has exactly one use in the same method or lambda. Fields, parameters, opaque factory
+results, locals with multiple uses, locals captured by nested lambdas, stateless-only pipelines,
+generated code, and assemblies ending in `.Test` or `.Tests` remain clean. Custom `Strategy`
+instances are not assumed to be stateful because that cannot be proven from their public contract.
+Test methods marked with standard TUnit, xUnit, NUnit, or MSTest attributes are also ignored.
+
 ## Suppression
 
 Suppress one reviewed site with ordinary C# warning pragmas and record why the analyzer cannot see
 the wider invariant:
 
 ```csharp
-#pragma warning disable KEV002 // Execution is unreachable in the synchronous deployment mode.
-var value = shield.Execute(_ => 1);
-#pragma warning restore KEV002
+#pragma warning disable KEV004 // This isolated circuit is intentional in a one-shot diagnostic.
+var value = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(1)).Execute(_ => 1);
+#pragma warning restore KEV004
 ```
 
 To suppress a rule project-wide, append its ID to `NoWarn`:
 
 ```xml
-<NoWarn>$(NoWarn);KEV002</NoWarn>
+<NoWarn>$(NoWarn);KEV004</NoWarn>
 ```
 
 Prefer a narrow pragma. Project-wide suppression can hide newly introduced unsafe call sites.

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -85,13 +85,16 @@ and limiter capacity is not shared:
 ```csharp
 // KEV004: a new circuit exists for only this call.
 await Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30))
-    .ExecuteAsync(ct => SendAsync(ct));
+    .ExecuteAsync(static _ => ValueTask.CompletedTask);
+```
 
+<!-- doc-test-declaration: split-before=await _dependencyShield -->
+```csharp
 // Clean: every call shares the same circuit.
-private readonly Shield _dependencyShield =
+private static readonly Shield _dependencyShield =
     Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));
 
-await _dependencyShield.ExecuteAsync(ct => SendAsync(ct));
+await _dependencyShield.ExecuteAsync(static _ => ValueTask.CompletedTask);
 ```
 
 Store stateful shields in a field, singleton or keyed dependency-injection registration, or registry.

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 KEV001 | Reliability | Warning | Execution delegate ignores its CancellationToken
 KEV002 | Reliability | Warning | Statically known multi-attempt hedging requires asynchronous execution
 KEV003 | Configuration | Warning | Fallback makes a reactive strategy unreachable
+KEV004 | Reliability | Warning | Stateful shield or partition provider is constructed per execution

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -8,8 +8,8 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Kevlar.Analyzers;
 
 /// <summary>
-/// Diagnoses statically provable Kevlar pipeline hazards: synchronous multi-attempt hedging and reactive
-/// strategies made unreachable by an inner fallback using the same handling clause.
+/// Diagnoses statically provable Kevlar pipeline hazards: synchronous multi-attempt hedging, reactive
+/// strategies made unreachable by an inner fallback, and per-execution construction of stateful shields.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
@@ -34,9 +34,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "A fallback inside retry, hedging, or circuit breaker under the same handling clause recovers every handled failure before the outer strategy can observe it. Kevlar rejects this pipeline at construction time.");
 
+    /// <summary>The KEV004 rule.</summary>
+    public static readonly DiagnosticDescriptor EphemeralStatefulShieldRule = new(
+        id: "KEV004",
+        title: "Stateful shield is constructed per execution",
+        messageFormat: "'{0}' creates resilience state for one execution. Store and reuse the shield or partition provider as a field, singleton/keyed DI registration, or registry entry.",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Circuit breakers, rate limiters, concurrency limiters, and partition providers must outlive individual executions so their resilience state is retained and shared.");
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        ImmutableArray.Create(SynchronousHedgingRule, UnreachableReactiveStrategyRule);
+        ImmutableArray.Create(
+            SynchronousHedgingRule,
+            UnreachableReactiveStrategyRule,
+            EphemeralStatefulShieldRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -95,6 +108,170 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 invocation.Syntax.GetLocation(),
                 reactiveStrategy));
         }
+
+        if (!knownTypes.IsTestAssembly
+            && !IsTestContext(context.ContainingSymbol)
+            && IsExecution(invocation.TargetMethod, knownTypes)
+            && TryFindEphemeralStatefulConstruction(
+                GetReceiver(invocation),
+                context,
+                knownTypes,
+                visitedLocals: null,
+                out var statefulComponent,
+                out var location))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                EphemeralStatefulShieldRule,
+                location,
+                statefulComponent));
+        }
+    }
+
+    private static bool TryFindEphemeralStatefulConstruction(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals,
+        out string? statefulComponent,
+        out Location? location)
+    {
+        operation = Unwrap(operation);
+
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedLocals.Add(localReference.Local)
+                || !TryGetSingleUseInitializer(localReference, context, out var initializer))
+            {
+                statefulComponent = null;
+                location = null;
+                return false;
+            }
+
+            var found = TryFindEphemeralStatefulConstruction(
+                initializer,
+                context,
+                knownTypes,
+                visitedLocals,
+                out statefulComponent,
+                out location);
+            visitedLocals.Remove(localReference.Local);
+            return found;
+        }
+
+        if (operation is IConditionalAccessOperation conditionalAccess)
+        {
+            return TryFindEphemeralStatefulConstruction(
+                conditionalAccess.Operation,
+                context,
+                knownTypes,
+                visitedLocals,
+                out statefulComponent,
+                out location);
+        }
+
+        if (operation is not IInvocationOperation invocation)
+        {
+            statefulComponent = null;
+            location = null;
+            return false;
+        }
+
+        var method = Normalize(invocation.TargetMethod);
+        if (IsStatefulStrategy(method, knownTypes))
+        {
+            statefulComponent = method.Name;
+            location = invocation.Syntax.GetLocation();
+            return true;
+        }
+
+        if (method.Name == "GetShield" && knownTypes.IsPartitionedShield(method.ContainingType))
+        {
+            return TryFindEphemeralPartitionProvider(
+                GetReceiver(invocation),
+                context,
+                knownTypes,
+                visitedLocals,
+                out statefulComponent,
+                out location);
+        }
+
+        if (!IsKevlarFluentMethod(method, knownTypes))
+        {
+            statefulComponent = null;
+            location = null;
+            return false;
+        }
+
+        if (IsCompositionBoundary(method, knownTypes))
+        {
+            foreach (var argument in invocation.Arguments)
+            {
+                if (TryFindEphemeralStatefulConstruction(
+                    argument.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out statefulComponent,
+                    out location))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return TryFindEphemeralStatefulConstruction(
+            GetReceiver(invocation),
+            context,
+            knownTypes,
+            visitedLocals,
+            out statefulComponent,
+            out location);
+    }
+
+    private static bool TryFindEphemeralPartitionProvider(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals,
+        out string? statefulComponent,
+        out Location? location)
+    {
+        operation = Unwrap(operation);
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedLocals.Add(localReference.Local)
+                || !TryGetSingleUseInitializer(localReference, context, out var initializer))
+            {
+                statefulComponent = null;
+                location = null;
+                return false;
+            }
+
+            var found = TryFindEphemeralPartitionProvider(
+                initializer,
+                context,
+                knownTypes,
+                visitedLocals,
+                out statefulComponent,
+                out location);
+            visitedLocals.Remove(localReference.Local);
+            return found;
+        }
+
+        if (operation is IObjectCreationOperation creation
+            && creation.Type is INamedTypeSymbol type
+            && knownTypes.IsPartitionedShield(type))
+        {
+            statefulComponent = "PartitionedShield";
+            location = creation.Syntax.GetLocation();
+            return true;
+        }
+
+        statefulComponent = null;
+        location = null;
+        return false;
     }
 
     private static bool FindInPipeline(
@@ -931,6 +1108,69 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return initializer is not null;
     }
 
+    private static bool TryGetSingleUseInitializer(
+        ILocalReferenceOperation localReference,
+        OperationAnalysisContext context,
+        out IOperation? initializer)
+    {
+        if (!TryGetStableInitializer(localReference, context, out initializer))
+        {
+            return false;
+        }
+
+        var declaration = localReference.Local.DeclaringSyntaxReferences[0]
+            .GetSyntax(context.CancellationToken);
+        var declarationScope = GetExecutableScope(declaration, context.CancellationToken);
+        var referenceScope = GetExecutableScope(localReference.Syntax, context.CancellationToken);
+        if (!SameSyntax(declarationScope, referenceScope))
+        {
+            initializer = null;
+            return false;
+        }
+
+        var semanticModel = context.Operation.SemanticModel;
+        if (semanticModel is null)
+        {
+            initializer = null;
+            return false;
+        }
+
+        var referenceCount = 0;
+        foreach (var identifier in declarationScope.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText == localReference.Local.Name
+                && SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol,
+                    localReference.Local)
+                && ++referenceCount > 1)
+            {
+                initializer = null;
+                return false;
+            }
+        }
+
+        return referenceCount == 1;
+    }
+
+    private static SyntaxNode GetExecutableScope(SyntaxNode syntax, CancellationToken cancellationToken)
+    {
+        for (SyntaxNode? current = syntax; current is not null; current = current.Parent)
+        {
+            if (current is AnonymousFunctionExpressionSyntax
+                or LocalFunctionStatementSyntax
+                or BaseMethodDeclarationSyntax
+                or AccessorDeclarationSyntax)
+            {
+                return current;
+            }
+        }
+
+        return syntax.SyntaxTree.GetRoot(cancellationToken);
+    }
+
+    private static bool SameSyntax(SyntaxNode left, SyntaxNode right) =>
+        left.SyntaxTree == right.SyntaxTree && left.Span == right.Span;
+
     private static bool IsEscapingArrayReference(
         IdentifierNameSyntax identifier,
         SyntaxNode permittedReference)
@@ -1042,6 +1282,40 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static IMethodSymbol Normalize(IMethodSymbol method) =>
         (method.ReducedFrom ?? method).OriginalDefinition;
 
+    private static bool IsExecution(IMethodSymbol method, KnownTypes knownTypes)
+    {
+        method = Normalize(method);
+        return method.Name is "Execute" or "ExecuteAsync" or "ExecuteOutcomeAsync"
+            && (knownTypes.IsShield(method.ContainingType)
+                || knownTypes.IsShieldTaskExtensions(method.ContainingType));
+    }
+
+    private static bool IsStatefulStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
+        method.Name is "CircuitBreaker" or "RateLimit" or "ConcurrencyLimit"
+        && IsKevlarFluentMethod(method, knownTypes);
+
+    private static bool IsTestContext(ISymbol? symbol)
+    {
+        for (var current = symbol; current is not null; current = current.ContainingSymbol)
+        {
+            foreach (var attribute in current.GetAttributes())
+            {
+                var attributeType = attribute.AttributeClass;
+                if (attributeType is not null
+                    && attributeType.Name is "TestAttribute" or "FactAttribute" or "TheoryAttribute" or "TestMethodAttribute"
+                    && attributeType.ContainingNamespace.ToDisplayString() is "TUnit.Core"
+                        or "Xunit"
+                        or "NUnit.Framework"
+                        or "Microsoft.VisualStudio.TestTools.UnitTesting")
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private static bool IsSynchronousExecute(IMethodSymbol method, KnownTypes knownTypes)
     {
         method = Normalize(method);
@@ -1101,6 +1375,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         private readonly INamedTypeSymbol? _shieldBuilder;
         private readonly INamedTypeSymbol? _shieldBuilderOfT;
         private readonly INamedTypeSymbol? _shieldExtensions;
+        private readonly INamedTypeSymbol? _shieldTaskExtensions;
+        private readonly INamedTypeSymbol? _partitionedShield;
+        private readonly INamedTypeSymbol? _partitionedShieldOfT;
 
         internal KnownTypes(Compilation compilation)
         {
@@ -1109,7 +1386,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             _shieldBuilder = compilation.GetTypeByMetadataName("Kevlar.ShieldBuilder");
             _shieldBuilderOfT = compilation.GetTypeByMetadataName("Kevlar.ShieldBuilder`1");
             _shieldExtensions = compilation.GetTypeByMetadataName("Kevlar.ShieldExtensions");
+            _shieldTaskExtensions = compilation.GetTypeByMetadataName("Kevlar.ShieldTaskExtensions");
+            _partitionedShield = compilation.GetTypeByMetadataName("Kevlar.PartitionedShield`1");
+            _partitionedShieldOfT = compilation.GetTypeByMetadataName("Kevlar.PartitionedShield`2");
+            var assemblyName = compilation.AssemblyName;
+            IsTestAssembly = assemblyName is not null
+                && (assemblyName.EndsWith(".Test", StringComparison.OrdinalIgnoreCase)
+                    || assemblyName.EndsWith(".Tests", StringComparison.OrdinalIgnoreCase));
         }
+
+        internal bool IsTestAssembly { get; }
 
         internal bool IsShield(INamedTypeSymbol type) =>
             Is(type, _shield) || Is(type, _shieldOfT);
@@ -1118,6 +1404,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             Is(type, _shieldBuilder) || Is(type, _shieldBuilderOfT);
 
         internal bool IsShieldExtensions(INamedTypeSymbol type) => Is(type, _shieldExtensions);
+
+        internal bool IsShieldTaskExtensions(INamedTypeSymbol type) => Is(type, _shieldTaskExtensions);
+
+        internal bool IsPartitionedShield(INamedTypeSymbol type) =>
+            Is(type, _partitionedShield) || Is(type, _partitionedShieldOfT);
 
         private static bool Is(INamedTypeSymbol type, INamedTypeSymbol? expected) =>
             expected is not null

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1066,6 +1066,19 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         ILocalReferenceOperation localReference,
         OperationAnalysisContext context,
         out IOperation? initializer)
+        => TryGetInitializer(localReference, context, requireSingleUse: false, out initializer);
+
+    private static bool TryGetSingleUseInitializer(
+        ILocalReferenceOperation localReference,
+        OperationAnalysisContext context,
+        out IOperation? initializer)
+        => TryGetInitializer(localReference, context, requireSingleUse: true, out initializer);
+
+    private static bool TryGetInitializer(
+        ILocalReferenceOperation localReference,
+        OperationAnalysisContext context,
+        bool requireSingleUse,
+        out IOperation? initializer)
     {
         var local = localReference.Local;
         var declarations = local.DeclaringSyntaxReferences;
@@ -1086,50 +1099,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        var scope = (SyntaxNode?)declarator.FirstAncestorOrSelf<BlockSyntax>()
-            ?? declarator.SyntaxTree.GetRoot(context.CancellationToken);
-
-        foreach (var identifier in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
-        {
-            if (identifier.Identifier.ValueText == local.Name
-                && SymbolEqualityComparer.Default.Equals(
-                    semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol,
-                    local)
-                && (IsWritten(identifier)
-                    || local.Type is IArrayTypeSymbol
-                        && IsEscapingArrayReference(identifier, localReference.Syntax)))
-            {
-                initializer = null;
-                return false;
-            }
-        }
-
-        initializer = semanticModel.GetOperation(initializerSyntax, context.CancellationToken);
-        return initializer is not null;
-    }
-
-    private static bool TryGetSingleUseInitializer(
-        ILocalReferenceOperation localReference,
-        OperationAnalysisContext context,
-        out IOperation? initializer)
-    {
-        if (!TryGetStableInitializer(localReference, context, out initializer))
-        {
-            return false;
-        }
-
-        var declaration = localReference.Local.DeclaringSyntaxReferences[0]
-            .GetSyntax(context.CancellationToken);
-        var declarationScope = GetExecutableScope(declaration, context.CancellationToken);
-        var referenceScope = GetExecutableScope(localReference.Syntax, context.CancellationToken);
-        if (!SameSyntax(declarationScope, referenceScope))
-        {
-            initializer = null;
-            return false;
-        }
-
-        var semanticModel = context.Operation.SemanticModel;
-        if (semanticModel is null)
+        var declarationScope = GetExecutableScope(declarator, context.CancellationToken);
+        if (requireSingleUse
+            && !SameSyntax(
+                declarationScope,
+                GetExecutableScope(localReference.Syntax, context.CancellationToken)))
         {
             initializer = null;
             return false;
@@ -1138,18 +1112,31 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         var referenceCount = 0;
         foreach (var identifier in declarationScope.DescendantNodes().OfType<IdentifierNameSyntax>())
         {
-            if (identifier.Identifier.ValueText == localReference.Local.Name
+            if (identifier.Identifier.ValueText == local.Name
                 && SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol,
-                    localReference.Local)
-                && ++referenceCount > 1)
+                    local))
             {
-                initializer = null;
-                return false;
+                referenceCount++;
+                if (IsWritten(identifier)
+                    || local.Type is IArrayTypeSymbol
+                        && IsEscapingArrayReference(identifier, localReference.Syntax)
+                    || requireSingleUse && referenceCount > 1)
+                {
+                    initializer = null;
+                    return false;
+                }
             }
         }
 
-        return referenceCount == 1;
+        if (requireSingleUse && referenceCount != 1)
+        {
+            initializer = null;
+            return false;
+        }
+
+        initializer = semanticModel.GetOperation(initializerSyntax, context.CancellationToken);
+        return initializer is not null;
     }
 
     private static SyntaxNode GetExecutableScope(SyntaxNode syntax, CancellationToken cancellationToken)
@@ -1159,7 +1146,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             if (current is AnonymousFunctionExpressionSyntax
                 or LocalFunctionStatementSyntax
                 or BaseMethodDeclarationSyntax
-                or AccessorDeclarationSyntax)
+                or AccessorDeclarationSyntax
+                or ArrowExpressionClauseSyntax
+                or PropertyDeclarationSyntax
+                or IndexerDeclarationSyntax)
             {
                 return current;
             }
@@ -1303,7 +1293,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 var attributeType = attribute.AttributeClass;
                 if (attributeType is not null
                     && attributeType.Name is "TestAttribute" or "FactAttribute" or "TheoryAttribute" or "TestMethodAttribute"
-                    && attributeType.ContainingNamespace.ToDisplayString() is "TUnit.Core"
+                    && attributeType.ContainingNamespace?.ToDisplayString() is "TUnit.Core"
                         or "Xunit"
                         or "NUnit.Framework"
                         or "Microsoft.VisualStudio.TestTools.UnitTesting")

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -170,6 +170,48 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 out location);
         }
 
+        if (operation is IArrayCreationOperation { Initializer: { } arrayInitializer })
+        {
+            foreach (var element in arrayInitializer.ElementValues)
+            {
+                if (TryFindEphemeralStatefulConstruction(
+                    element,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out statefulComponent,
+                    out location))
+                {
+                    return true;
+                }
+            }
+
+            statefulComponent = null;
+            location = null;
+            return false;
+        }
+
+        if (operation?.Syntax is CollectionExpressionSyntax or SpreadElementSyntax)
+        {
+            foreach (var child in operation.ChildOperations)
+            {
+                if (TryFindEphemeralStatefulConstruction(
+                    child,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out statefulComponent,
+                    out location))
+                {
+                    return true;
+                }
+            }
+
+            statefulComponent = null;
+            location = null;
+            return false;
+        }
+
         if (operation is not IInvocationOperation invocation)
         {
             statefulComponent = null;

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Kevlar.Analyzers.PipelineHazardAnalyzer
 Kevlar.Analyzers.PipelineHazardAnalyzer.PipelineHazardAnalyzer() -> void
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.EphemeralStatefulShieldRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -9,6 +9,238 @@ namespace Kevlar.Analyzers.Tests;
 public class PipelineHazardAnalyzerTests
 {
     [Test]
+    public async Task KEV004_Flags_Inline_Stateful_Shields_For_All_Execution_Forms()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);",
+            "await Shield.RateLimit(10, TimeSpan.FromSeconds(1)).ExecuteAsync(_ => new ValueTask<int>(1));",
+            "await Shield.ConcurrencyLimit(2).ExecuteOutcomeAsync(_ => new ValueTask<int>(1));",
+            "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);",
+            "await Shield.For<int>().RateLimit(10, TimeSpan.FromSeconds(1)).ExecuteAsync(_ => new ValueTask<int>(1));",
+            "await Shield.For<int>().ConcurrencyLimit(2).ExecuteOutcomeAsync(_ => new ValueTask<int>(1));",
+            "await Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).ExecuteAsync(_ => Task.FromResult(1));",
+            "await Shield.For<int>().RateLimit(10, TimeSpan.FromSeconds(1)).ExecuteOutcomeAsync(_ => Task.FromResult(1));",
+            "Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => { });",
+            "_ = Shield.RateLimit(10, TimeSpan.FromSeconds(1)).Execute(1, (state, _) => state);",
+            "await Shield.ConcurrencyLimit(2).ExecuteAsync(_ => ValueTask.CompletedTask);",
+            "await Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).ExecuteAsync(1, (state, _) => Task.FromResult(state));",
+            "await Shield.RateLimit(10, TimeSpan.FromSeconds(1)).ExecuteOutcomeAsync(1, (state, _) => new ValueTask<int>(state));",
+            "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(1, (state, _) => state);",
+            "await Shield.For<int>().RateLimit(10, TimeSpan.FromSeconds(1)).ExecuteAsync(1, (state, _) => Task.FromResult(state));",
+            "await Shield.For<int>().ConcurrencyLimit(2).ExecuteOutcomeAsync(1, (state, _) => new ValueTask<int>(state));",
+        };
+
+        await AssertEachAsync(cases, "KEV004");
+    }
+
+    [Test]
+    public async Task KEV004_Flags_Single_Use_Locals_Aliases_And_Extension_Syntax()
+    {
+        var cases = new[]
+        {
+            "var shield = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)); _ = shield.Execute(_ => 1);",
+            "var shield = Shield.RateLimit(10, TimeSpan.FromSeconds(1)); var alias = shield; await alias.ExecuteAsync(_ => new ValueTask<int>(1));",
+            "_ = ShieldExtensions.ConcurrencyLimit(Shield.Empty, 2).Execute(_ => 1);",
+            "Func<ValueTask<int>> run = () => Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).ExecuteAsync(_ => new ValueTask<int>(1)); await run();",
+        };
+
+        await AssertEachAsync(cases, "KEV004");
+
+        var typeAlias = await AnalyzeSourceAsync("""
+            using KShield = Kevlar.Shield;
+
+            public class TestSubject
+            {
+                public int Run() => KShield.RateLimit(10, TimeSpan.FromSeconds(1)).Execute(_ => 1);
+            }
+            """);
+        await AssertRuleAsync(typeAlias, "KEV004");
+    }
+
+    [Test]
+    public async Task KEV004_Flags_Per_Execution_Partition_Providers()
+    {
+        var cases = new[]
+        {
+            "_ = new PartitionedShield<string>(_ => Shield.Empty).GetShield(\"tenant\").Execute(_ => 1);",
+            "await new PartitionedShield<string, int>(_ => Shield<int>.Empty).GetShield(\"tenant\").ExecuteAsync(_ => new ValueTask<int>(1));",
+            "var partitions = new PartitionedShield<string>(_ => Shield.Empty); await partitions.GetShield(\"tenant\").ExecuteOutcomeAsync(_ => new ValueTask<int>(1));",
+            "var partitions = new PartitionedShield<string>(_ => Shield.Empty); var shield = partitions.GetShield(\"tenant\"); _ = shield.Execute(_ => 1);",
+        };
+
+        await AssertEachAsync(cases, "KEV004");
+    }
+
+    [Test]
+    public async Task KEV004_Skips_Stateless_Reused_And_Ambiguous_Shields()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.Retry(2).Execute(_ => 1);",
+            "await Shield.Timeout(TimeSpan.FromSeconds(1)).ExecuteAsync(_ => new ValueTask<int>(1));",
+            "await Shield.For<int>().Fallback(0).ExecuteOutcomeAsync(_ => new ValueTask<int>(1));",
+            "var shield = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)); _ = shield.Execute(_ => 1); _ = shield.Execute(_ => 2);",
+            "var shield = CreateShield(); _ = shield.Execute(_ => 1);",
+            "var partitions = new PartitionedShield<string>(_ => Shield.Empty); _ = partitions.GetShield(\"one\"); _ = partitions.GetShield(\"two\").Execute(_ => 1);",
+            "var shield = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)); Func<int> run = () => shield.Execute(_ => 1); _ = run();",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(
+                body,
+                "private static Shield CreateShield() => Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1));");
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV004_Skips_Fields_Parameters_Factories_Registrations_And_Test_Assemblies()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private static readonly Shield Shared = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1));
+                private readonly PartitionedShield<string> _partitions = new(_ => Shield.Empty);
+
+                public int FromField() => Shared.Execute(_ => 1);
+                public int FromParameter(Shield shield) => shield.Execute(_ => 1);
+                public int FromPartitionField() => _partitions.GetShield("tenant").Execute(_ => 1);
+                public Shield Create() => Shield.RateLimit(10, TimeSpan.FromSeconds(1));
+                public void Configure() => Register(Shield.ConcurrencyLimit(2));
+                private static void Register(Shield shield) { }
+            }
+            """);
+        var testAssemblyDiagnostics = await AnalyzeBodyAsync(
+            "_ = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);",
+            assemblyName: "Sample.Tests");
+        var testMethodDiagnostics = await AnalyzeSourceAsync("""
+            namespace Xunit
+            {
+                public sealed class FactAttribute : Attribute { }
+            }
+
+            public sealed class TestSubject
+            {
+                [Xunit.Fact]
+                public int IsolatedExecution() =>
+                    Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+        await Assert.That(testAssemblyDiagnostics).IsEmpty();
+        await Assert.That(testMethodDiagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV004_Ignores_Lookalikes_Generated_Code_And_Malformed_Code()
+    {
+        var lookalike = await AnalyzeSourceAsync("""
+            public sealed class OtherShield
+            {
+                public static OtherShield CircuitBreaker() => new();
+                public int Execute(Func<CancellationToken, int> action) => action(default);
+            }
+
+            public class TestSubject
+            {
+                public int Run() => OtherShield.CircuitBreaker().Execute(_ => 1);
+            }
+            """);
+        var generated = await AnalyzeBodyAsync(
+            "_ = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);",
+            isGenerated: true);
+        var malformed = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public async Task RunAsync()
+                {
+                    await Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).ExecuteAsync(_ =>
+                }
+            }
+            """, allowCompilationErrors: true);
+
+        await Assert.That(lookalike).IsEmpty();
+        await Assert.That(generated).IsEmpty();
+        await Assert.That(malformed.Any(diagnostic => diagnostic.Id == "AD0001")).IsFalse();
+    }
+
+    [Test]
+    public async Task KEV004_Diagnostic_Contract_Location_And_Suppression_Are_Exact()
+    {
+        const string construction = "Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1))";
+        var source = $$"""
+            public class TestSubject
+            {
+                public int Run() => {{construction}}.Execute(_ => 1);
+            }
+            """;
+        var diagnostics = await AnalyzeSourceAsync(source);
+        var suppressed = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public int Run()
+                {
+            #pragma warning disable KEV004 // Isolated execution is intentional.
+                    return Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);
+            #pragma warning restore KEV004
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        var diagnostic = diagnostics[0];
+        await Assert.That(diagnostic.Id).IsEqualTo("KEV004");
+        await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            "'CircuitBreaker' creates resilience state for one execution. Store and reuse the shield or partition provider as a field, singleton/keyed DI registration, or registry entry.");
+        await Assert.That(diagnostic.Location.SourceSpan.Start)
+            .IsEqualTo(CreateSource(source).IndexOf(construction, StringComparison.Ordinal));
+        await Assert.That(diagnostic.Location.SourceSpan.Length).IsEqualTo(construction.Length);
+        await Assert.That(suppressed).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV004_Concurrent_Analyzer_Runs_Are_Deterministic()
+    {
+        var source = CreateSource("""
+            public class TestSubject
+            {
+                public async Task RunAsync()
+                {
+                    _ = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);
+                    await Shield.RateLimit(10, TimeSpan.FromSeconds(1)).ExecuteAsync(_ => new ValueTask<int>(1));
+                    await new PartitionedShield<string>(_ => Shield.Empty).GetShield("tenant").ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+                }
+            }
+            """);
+        var compilation = CreateCompilation(source);
+        var runs = await Task.WhenAll(Enumerable.Range(0, 16)
+            .Select(_ => GetAnalyzerDiagnosticsAsync(compilation)));
+        var expected = runs[0]
+            .Where(diagnostic => diagnostic.Id == "KEV004")
+            .Select(diagnostic => diagnostic.Location.SourceSpan)
+            .OrderBy(span => span.Start)
+            .ToArray();
+
+        await Assert.That(expected.Length).IsEqualTo(3);
+        foreach (var run in runs)
+        {
+            var actual = run
+                .Where(diagnostic => diagnostic.Id == "KEV004")
+                .Select(diagnostic => diagnostic.Location.SourceSpan)
+                .OrderBy(span => span.Start)
+                .ToArray();
+            if (!expected.SequenceEqual(actual))
+            {
+                throw new InvalidOperationException("Concurrent analyzer runs produced different KEV004 spans.");
+            }
+        }
+    }
+
+    [Test]
     public async Task KEV002_Flags_Known_Hedging_Shields_Used_Synchronously()
     {
         var cases = new[]
@@ -211,24 +443,39 @@ public class PipelineHazardAnalyzerTests
     private static Task<ImmutableArray<Diagnostic>> AnalyzeBodyAsync(
         string body,
         string members = "",
-        bool isGenerated = false) =>
+        bool isGenerated = false,
+        string assemblyName = "PipelineHazardAnalyzerTestSubject") =>
         AnalyzeSourceAsync($$"""
             public class TestSubject
             {
                 {{members}}
 
-                public void Run()
+                public async Task RunAsync()
                 {
                     {{body}}
                 }
             }
-            """, isGenerated);
+            """, isGenerated, assemblyName: assemblyName);
 
     private static async Task<ImmutableArray<Diagnostic>> AnalyzeSourceAsync(
         string declarations,
-        bool isGenerated = false)
+        bool isGenerated = false,
+        bool allowCompilationErrors = false,
+        string assemblyName = "PipelineHazardAnalyzerTestSubject")
     {
-        var source = (isGenerated ? "// <auto-generated/>\n" : string.Empty) + $$"""
+        var source = CreateSource(declarations, isGenerated);
+        var compilation = CreateCompilation(source, assemblyName);
+        var errors = compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        if (!allowCompilationErrors && errors.Length > 0)
+        {
+            throw new InvalidOperationException("Test source does not compile: " + string.Join("; ", errors.Select(static error => error.ToString())));
+        }
+
+        return await GetAnalyzerDiagnosticsAsync(compilation);
+    }
+
+    private static string CreateSource(string declarations, bool isGenerated = false) =>
+        (isGenerated ? "// <auto-generated/>\n" : string.Empty) + $$"""
             using System;
             using System.Threading;
             using System.Threading.Tasks;
@@ -236,23 +483,24 @@ public class PipelineHazardAnalyzerTests
 
             {{declarations}}
             """;
+
+    private static CSharpCompilation CreateCompilation(
+        string source,
+        string assemblyName = "PipelineHazardAnalyzerTestSubject")
+    {
         var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
             .Split(Path.PathSeparator)
             .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
             .Append(MetadataReference.CreateFromFile(typeof(Shield).Assembly.Location));
-        var compilation = CSharpCompilation.Create(
-            "PipelineHazardAnalyzerTestSubject",
+        return CSharpCompilation.Create(
+            assemblyName,
             [CSharpSyntaxTree.ParseText(source)],
             references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-        var errors = compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
-        if (errors.Length > 0)
-        {
-            throw new InvalidOperationException("Test source does not compile: " + string.Join("; ", errors.Select(static error => error.ToString())));
-        }
+    }
 
-        return await compilation
+    private static Task<ImmutableArray<Diagnostic>> GetAnalyzerDiagnosticsAsync(CSharpCompilation compilation) =>
+        compilation
             .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new PipelineHazardAnalyzer()))
             .GetAnalyzerDiagnosticsAsync();
-    }
 }

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -161,10 +161,19 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """, allowCompilationErrors: true);
+        var malformedAttribute = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                [MissingTest]
+                public int Run() =>
+                    Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).Execute(_ => 1);
+            }
+            """, allowCompilationErrors: true);
 
         await Assert.That(lookalike).IsEmpty();
         await Assert.That(generated).IsEmpty();
         await Assert.That(malformed.Any(diagnostic => diagnostic.Id == "AD0001")).IsFalse();
+        await Assert.That(malformedAttribute.Any(diagnostic => diagnostic.Id == "AD0001")).IsFalse();
     }
 
     [Test]
@@ -233,10 +242,7 @@ public class PipelineHazardAnalyzerTests
                 .Select(diagnostic => diagnostic.Location.SourceSpan)
                 .OrderBy(span => span.Start)
                 .ToArray();
-            if (!expected.SequenceEqual(actual))
-            {
-                throw new InvalidOperationException("Concurrent analyzer runs produced different KEV004 spans.");
-            }
+            await Assert.That(actual).IsEquivalentTo(expected);
         }
     }
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -59,6 +59,21 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV004_Flags_Stateful_Composition_Operands()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.Empty.Wrap(Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1))).Execute(_ => 1);",
+            "_ = Shield.Compose(Shield.Empty, Shield.RateLimit(10, TimeSpan.FromSeconds(1))).Execute(_ => 1);",
+            "_ = Shield.Compose([Shield.ConcurrencyLimit(2)]).Execute(_ => 1);",
+            "_ = Shield.Compose([.. new[] { Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)) }]).Execute(_ => 1);",
+            "var parts = new[] { Shield.RateLimit(10, TimeSpan.FromSeconds(1)) }; _ = Shield.Compose(parts).Execute(_ => 1);",
+        };
+
+        await AssertEachAsync(cases, "KEV004");
+    }
+
+    [Test]
     public async Task KEV004_Flags_Per_Execution_Partition_Providers()
     {
         var cases = new[]


### PR DESCRIPTION
## Summary

- add KEV004 for inline and provably single-use circuit-breaker, rate-limit, and concurrency-limit shields
- detect directly constructed and single-use `PartitionedShield` providers
- keep fields, parameters, reused/captured locals, factories, registrations, stateless chains, generated code, test assemblies, and standard test methods clean
- document diagnostic contract, safe lifetimes, and suppression

## Test plan

- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release -- --timeout 5m` (46 passed)
- [x] `dotnet build Kevlar.slnx -c Release -p:Version=0.0.0-issue116`
- [x] `dotnet pack Kevlar.slnx -c Release --no-build -p:Version=0.0.0-issue116`
- [x] `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-issue116`
- [x] `npm ci` and `npm run build` from `docs/`

Local package verification passed package layout, net8/net10 consumers, analyzer consumer, win-x64 trimming, and single-file publish. NativeAOT is explicitly Linux-only in the repository verifier and will run in CI.

Closes #116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analyzer warning KEV004 for stateful shields or partition providers created per execution.
  * Detects affected circuit breakers, rate limiters, concurrency limiters, and partitioned providers across supported execution patterns.
  * Excludes test scenarios and recognized safe or reusable configurations.

* **Documentation**
  * Added guidance, suppression examples, and project-wide configuration options for KEV004.
  * Documented the new reliability warning and warning severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->