### PR TITLE
feat(limiters): add rejection hooks

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/ConcurrencyLimitBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/ConcurrencyLimitBenchmarks.cs
@@ -14,6 +14,12 @@ namespace Kevlar.Benchmarks;
 public class ConcurrencyLimitBenchmarks
 {
     private static readonly Shield KevlarConcurrency = Shield.ConcurrencyLimit(1024);
+    private static readonly Shield KevlarConcurrencyWithHooks = Shield.ConcurrencyLimit(options =>
+    {
+        options.MaxConcurrency = 1024;
+        options.OnRejected = static _ => { };
+        options.OnRejectedAsync = static _ => ValueTask.CompletedTask;
+    });
 
     private static readonly ResiliencePipeline PollyConcurrency = new ResiliencePipelineBuilder()
         .AddConcurrencyLimiter(1024)
@@ -24,4 +30,8 @@ public class ConcurrencyLimitBenchmarks
 
     [BenchmarkCategory("Uncontended"), Benchmark]
     public ValueTask<int> Polly_Uncontended() => PollyConcurrency.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("Uncontended"), Benchmark]
+    public ValueTask<int> Kevlar_WithHooks_Uncontended() =>
+        KevlarConcurrencyWithHooks.ExecuteAsync(static _ => new ValueTask<int>(42));
 }

--- a/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
@@ -16,6 +16,13 @@ namespace Kevlar.Benchmarks;
 public class RateLimitBenchmarks
 {
     private static readonly Shield KevlarRateLimit = Shield.RateLimit(1_000_000_000, TimeSpan.FromSeconds(1));
+    private static readonly Shield KevlarRateLimitWithHooks = Shield.RateLimit(options =>
+    {
+        options.Permits = 1_000_000_000;
+        options.Window = TimeSpan.FromSeconds(1);
+        options.OnRejected = static _ => { };
+        options.OnRejectedAsync = static _ => ValueTask.CompletedTask;
+    });
 
     private static readonly ResiliencePipeline PollyRateLimit = new ResiliencePipelineBuilder()
         .AddRateLimiter(new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
@@ -31,4 +38,8 @@ public class RateLimitBenchmarks
 
     [BenchmarkCategory("Uncontended"), Benchmark]
     public ValueTask<int> Polly_Uncontended() => PollyRateLimit.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("Uncontended"), Benchmark]
+    public ValueTask<int> Kevlar_WithHooks_Uncontended() =>
+        KevlarRateLimitWithHooks.ExecuteAsync(static _ => new ValueTask<int>(42));
 }

--- a/docs/docs/strategies/concurrency-limit.md
+++ b/docs/docs/strategies/concurrency-limit.md
@@ -13,6 +13,9 @@ Shield.ConcurrencyLimit(o =>
 {
     o.MaxConcurrency = 10;   // default 10
     o.MaxQueue = 20;         // default 0 — reject immediately when full
+    o.OnRejected = rejection =>
+        logger.LogWarning("Concurrency limit {Limit} rejected work", rejection.MaxConcurrency);
+    o.OnRejectedAsync = static _ => ValueTask.CompletedTask;
 });
 ```
 
@@ -22,10 +25,25 @@ Shield.ConcurrencyLimit(o =>
 |---|---|---|
 | `MaxConcurrency` | `10` | Executions allowed to run simultaneously |
 | `MaxQueue` | `0` | Executions allowed to wait for a slot; `0` = reject immediately when all slots are busy |
+| `OnRejected` | — | Synchronous notification for an actual rejection |
+| `OnRejectedAsync` | — | Awaited notification after `OnRejected` |
 
 Total capacity is `MaxConcurrency + MaxQueue`. Anything beyond that fails **immediately** with `ConcurrencyLimitExceededException` — the overflow check happens before any waiting, so rejection is instant and allocation-light.
 
+For an actual rejection, Kevlar publishes current limiter state and rejection metrics, invokes
+`OnRejected`, awaits `OnRejectedAsync`, then surfaces `ConcurrencyLimitExceededException`. The
+event includes the configured concurrency/queue limits, strategy index, and `KevlarContext`.
+A synchronous callback failure skips the asynchronous callback; either callback's failure replaces
+the limiter exception and preserves its exception instance.
+
+Callback contexts are pooled. Do not retain `ConcurrencyLimitRejectedEvent.Context` after the
+synchronous callback or returned `ValueTask` completes. Hooks run outside limiter locks and may run
+concurrently or re-enter the same shield; captured state must be thread-safe.
+
 Cancelling a queued execution frees its queue place when the asynchronous wait observes cancellation. `CancellationTokenSource.Cancel()` can return before that continuation updates accounting, so await the cancelled execution before assuming the place is reusable. If cancellation races a slot grant, the wait either cancels or acquires the slot; both paths update queue and running accounting exactly once, so later executions see the full capacity after the admitted work drains.
+
+Queued cancellation is not rejection and invokes neither rejection hook. A pre-cancelled caller is
+stopped at the shield boundary before the limiter runs.
 
 ## Why concurrency limits
 

--- a/docs/docs/strategies/rate-limit.md
+++ b/docs/docs/strategies/rate-limit.md
@@ -15,6 +15,9 @@ Shield.RateLimit(o =>
     o.Window = TimeSpan.FromSeconds(1);    // default 1s
     o.Burst = 200;                         // default: same as Permits
     o.QueueLimit = 20;                     // default 0
+    o.OnRejected = rejection =>
+        logger.LogWarning("Rate limited; retry after {RetryAfter}", rejection.RetryAfter);
+    o.OnRejectedAsync = static _ => ValueTask.CompletedTask;
 });
 ```
 
@@ -26,12 +29,25 @@ Shield.RateLimit(o =>
 | `Window` | `1s` | The replenishment window |
 | `Burst` | = `Permits` | Bucket capacity: how far above the steady rate a burst may spike |
 | `QueueLimit` | `0` | How many executions may *wait* for a permit instead of being rejected immediately |
+| `OnRejected` | — | Synchronous notification for an actual rejection |
+| `OnRejectedAsync` | — | Awaited notification after `OnRejected` |
 
 ## Rejection vs queueing
 
 With `QueueLimit = 0`, an execution that finds the bucket empty fails immediately with `RateLimitExceededException`. The exception carries `RetryAfter` — an estimate of when a permit will next be available — which pairs naturally with an outer retry's `DelayGenerator`.
 
 With `QueueLimit > 0`, up to that many executions reserve a future permit and **wait** for it instead of failing. Beyond the queue limit, rejections resume.
+
+For an actual rejection, Kevlar records rejection metrics, invokes `OnRejected`, awaits
+`OnRejectedAsync`, then surfaces `RateLimitExceededException`. The event includes `RetryAfter`,
+the configured permit/window/burst/queue values, the strategy index, and `KevlarContext`.
+A synchronous callback failure skips the asynchronous callback; either callback's failure replaces
+the limiter exception and preserves its exception instance. Queued cancellation is cancellation,
+not rejection, so it invokes neither hook.
+
+Callback contexts are pooled. Do not retain `RateLimitRejectedEvent.Context` after the synchronous
+callback or returned `ValueTask` completes. Hooks run outside limiter locks and may run concurrently
+or re-enter the same shield; captured state must be thread-safe.
 
 :::note Queueing is reservation-based, not FIFO
 Queued executions each sleep until their reserved permit replenishes; there's no fairness ordering among waiters.

--- a/src/Kevlar.Testing/ConcurrencyLimitStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/ConcurrencyLimitStrategyDescriptor.cs
@@ -3,11 +3,16 @@ namespace Kevlar.Testing;
 /// <summary>Read-only concurrency limiter configuration.</summary>
 public sealed class ConcurrencyLimitStrategyDescriptor : StrategyDescriptor
 {
-    internal ConcurrencyLimitStrategyDescriptor(string description, int maxConcurrency, int maxQueue)
+    internal ConcurrencyLimitStrategyDescriptor(
+        string description,
+        int maxConcurrency,
+        int maxQueue,
+        bool hasNotification)
         : base(StrategyKind.ConcurrencyLimit, description)
     {
         MaxConcurrency = maxConcurrency;
         MaxQueue = maxQueue;
+        HasNotification = hasNotification;
     }
 
     /// <summary>The maximum concurrent executions.</summary>
@@ -15,4 +20,7 @@ public sealed class ConcurrencyLimitStrategyDescriptor : StrategyDescriptor
 
     /// <summary>The maximum wait queue size.</summary>
     public int MaxQueue { get; }
+
+    /// <summary>Whether synchronous or asynchronous rejection notifications are configured.</summary>
+    public bool HasNotification { get; }
 }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -142,3 +142,5 @@ Kevlar.Testing.TelemetryRecorder.TelemetryRecorder(bool captureMetrics = true) -
 Kevlar.Testing.TelemetryRecorder.WaitForCallbackCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Kevlar.Testing.TelemetryRecorder.WaitForMetricCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 static Kevlar.Testing.ShieldExecutionExtensions.WaitForPendingAsync(this System.Threading.Tasks.Task! execution, System.Func<bool>! workStarted, string! workDescription, int maxYields = 100, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.RateLimitStrategyDescriptor.HasNotification.get -> bool

--- a/src/Kevlar.Testing/RateLimitStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/RateLimitStrategyDescriptor.cs
@@ -8,13 +8,15 @@ public sealed class RateLimitStrategyDescriptor : StrategyDescriptor
         int permits,
         TimeSpan window,
         int burst,
-        int queueLimit)
+        int queueLimit,
+        bool hasNotification)
         : base(StrategyKind.RateLimit, description)
     {
         Permits = permits;
         Window = window;
         Burst = burst;
         QueueLimit = queueLimit;
+        HasNotification = hasNotification;
     }
 
     /// <summary>Permits replenished per window.</summary>
@@ -28,4 +30,7 @@ public sealed class RateLimitStrategyDescriptor : StrategyDescriptor
 
     /// <summary>The maximum wait queue size.</summary>
     public int QueueLimit { get; }
+
+    /// <summary>Whether synchronous or asynchronous rejection notifications are configured.</summary>
+    public bool HasNotification { get; }
 }

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -69,11 +69,13 @@ public static class ShieldDescriptorExtensions
                 rateLimit.Permits,
                 rateLimit.Window,
                 rateLimit.Burst,
-                rateLimit.QueueLimit),
+                rateLimit.QueueLimit,
+                rateLimit.HasNotification),
             ConcurrencyLimitStrategy concurrency => new ConcurrencyLimitStrategyDescriptor(
                 description,
                 concurrency.MaxConcurrency,
-                concurrency.MaxQueue),
+                concurrency.MaxQueue,
+                concurrency.HasNotification),
             HedgingStrategy hedging => new HedgingStrategyDescriptor(
                 description,
                 hedging.MaxAttempts,

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -104,3 +104,30 @@ Kevlar.HedgingOptions.OnHedgeAsync.get -> System.Func<Kevlar.HedgeEvent, System.
 Kevlar.HedgingOptions.OnHedgeAsync.set -> void
 static Kevlar.HedgeActionGenerator.Create(System.Func<Kevlar.HedgeActionGeneratorEvent, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>?>! generator) -> Kevlar.HedgeActionGenerator!
 static Kevlar.HedgeActionGenerator.Create<TResult>(System.Func<Kevlar.HedgeActionGeneratorEvent<TResult>, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>?>! generator) -> Kevlar.HedgeActionGenerator!
+Kevlar.ConcurrencyLimitOptions.OnRejected.get -> System.Action<Kevlar.ConcurrencyLimitRejectedEvent>?
+Kevlar.ConcurrencyLimitOptions.OnRejected.set -> void
+Kevlar.ConcurrencyLimitOptions.OnRejectedAsync.get -> System.Func<Kevlar.ConcurrencyLimitRejectedEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.ConcurrencyLimitOptions.OnRejectedAsync.set -> void
+Kevlar.ConcurrencyLimitRejectedEvent
+Kevlar.ConcurrencyLimitRejectedEvent.ConcurrencyLimitRejectedEvent() -> void
+Kevlar.ConcurrencyLimitRejectedEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.ConcurrencyLimitRejectedEvent.MaxConcurrency.get -> int
+Kevlar.ConcurrencyLimitRejectedEvent.MaxQueue.get -> int
+Kevlar.ConcurrencyLimitRejectedEvent.StrategyIndex.get -> int
+Kevlar.RateLimitOptions.OnRejected.get -> System.Action<Kevlar.RateLimitRejectedEvent>?
+Kevlar.RateLimitOptions.OnRejected.set -> void
+Kevlar.RateLimitOptions.OnRejectedAsync.get -> System.Func<Kevlar.RateLimitRejectedEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.RateLimitOptions.OnRejectedAsync.set -> void
+Kevlar.RateLimitRejectedEvent
+Kevlar.RateLimitRejectedEvent.RateLimitRejectedEvent() -> void
+Kevlar.RateLimitRejectedEvent.Burst.get -> int
+Kevlar.RateLimitRejectedEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.RateLimitRejectedEvent.Permits.get -> int
+Kevlar.RateLimitRejectedEvent.QueueLimit.get -> int
+Kevlar.RateLimitRejectedEvent.RetryAfter.get -> System.TimeSpan?
+Kevlar.RateLimitRejectedEvent.StrategyIndex.get -> int
+Kevlar.RateLimitRejectedEvent.Window.get -> System.TimeSpan
+Kevlar.ShieldBuilder.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield!
+Kevlar.ShieldBuilder.RateLimit(System.Action<Kevlar.RateLimitOptions!>! configure) -> Kevlar.Shield!
+Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.RateLimit(System.Action<Kevlar.RateLimitOptions!>! configure) -> Kevlar.Shield<TResult>!

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -106,8 +106,14 @@ public sealed class ShieldBuilder
     /// <summary>Limits throughput. The handling clauses remain ambient for later strategies.</summary>
     public Shield RateLimit(int permits, TimeSpan perWindow) => Seal().RateLimit(permits, perWindow);
 
+    /// <summary>Adds a configured rate limit. The handling clauses remain ambient for later strategies.</summary>
+    public Shield RateLimit(Action<RateLimitOptions> configure) => Seal().RateLimit(configure);
+
     /// <summary>Caps concurrency. The handling clauses remain ambient for later strategies.</summary>
     public Shield ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) => Seal().ConcurrencyLimit(maxConcurrency, maxQueue);
+
+    /// <summary>Adds a configured concurrency limit. The handling clauses remain ambient for later strategies.</summary>
+    public Shield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);
 
     private Shield Seal() =>
         new(_parent.Strategies, new ExceptionJudge(Combine(_predicates)), _parent.Name, _parent.Time);

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -146,8 +146,14 @@ public sealed class ShieldBuilder<TResult>
     /// <summary>Limits throughput. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> RateLimit(int permits, TimeSpan perWindow) => Seal().RateLimit(permits, perWindow);
 
+    /// <summary>Adds a configured rate limit. The handling clauses remain ambient for later strategies.</summary>
+    public Shield<TResult> RateLimit(Action<RateLimitOptions> configure) => Seal().RateLimit(configure);
+
     /// <summary>Caps concurrency. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) => Seal().ConcurrencyLimit(maxConcurrency, maxQueue);
+
+    /// <summary>Adds a configured concurrency limit. The handling clauses remain ambient for later strategies.</summary>
+    public Shield<TResult> ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);
 
     private Shield<TResult> Seal()
     {

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitOptions.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitOptions.cs
@@ -5,6 +5,11 @@ namespace Kevlar;
 /// <see cref="MaxConcurrency"/> executions run at once, with up to <see cref="MaxQueue"/>
 /// more waiting; anything beyond that is rejected immediately.
 /// </summary>
+/// <remarks>
+/// When an execution is rejected, rejection metrics are recorded, <see cref="OnRejected"/> runs,
+/// and then <see cref="OnRejectedAsync"/> runs and is awaited. A callback failure replaces the
+/// <see cref="ConcurrencyLimitExceededException"/> that would otherwise be returned.
+/// </remarks>
 public sealed class ConcurrencyLimitOptions
 {
     /// <summary>Maximum concurrent executions. Default 10.</summary>
@@ -12,4 +17,10 @@ public sealed class ConcurrencyLimitOptions
 
     /// <summary>Maximum executions allowed to wait for a slot. Default 0 (reject immediately when full).</summary>
     public int MaxQueue { get; set; }
+
+    /// <summary>Invoked synchronously when an execution is rejected.</summary>
+    public Action<ConcurrencyLimitRejectedEvent>? OnRejected { get; set; }
+
+    /// <summary>Invoked and awaited after <see cref="OnRejected"/> when an execution is rejected.</summary>
+    public Func<ConcurrencyLimitRejectedEvent, ValueTask>? OnRejectedAsync { get; set; }
 }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitRejectedEvent.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitRejectedEvent.cs
@@ -1,0 +1,32 @@
+namespace Kevlar;
+
+/// <summary>Describes an execution rejected by the built-in concurrency limiter.</summary>
+public readonly struct ConcurrencyLimitRejectedEvent
+{
+    internal ConcurrencyLimitRejectedEvent(
+        int maxConcurrency,
+        int maxQueue,
+        int strategyIndex,
+        KevlarContext context)
+    {
+        MaxConcurrency = maxConcurrency;
+        MaxQueue = maxQueue;
+        StrategyIndex = strategyIndex;
+        Context = context;
+    }
+
+    /// <summary>The configured maximum concurrent executions.</summary>
+    public int MaxConcurrency { get; }
+
+    /// <summary>The configured maximum wait queue size.</summary>
+    public int MaxQueue { get; }
+
+    /// <summary>The zero-based position of this strategy in the executing shield.</summary>
+    public int StrategyIndex { get; }
+
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it after synchronous and
+    /// asynchronous rejection callbacks complete.
+    /// </summary>
+    public KevlarContext Context { get; }
+}

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -12,6 +12,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly int _maxConcurrency;
     private readonly int _maxQueue;
     private readonly long _capacity;
+    private readonly Action<ConcurrencyLimitRejectedEvent>? _onRejected;
+    private readonly Func<ConcurrencyLimitRejectedEvent, ValueTask>? _onRejectedAsync;
     private int _available;
     private int _waiters;
     private StrategyMetricAlias[] _metricsAliasSnapshot = [];
@@ -25,6 +27,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     internal int MaxConcurrency => _maxConcurrency;
 
     internal int MaxQueue => _maxQueue;
+
+    internal bool HasNotification => _onRejected is not null || _onRejectedAsync is not null;
 
     internal (int Available, int Running, int Queued) CaptureState()
     {
@@ -43,6 +47,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         _maxQueue = options.MaxQueue;
         _capacity = options.MaxConcurrency + (long)options.MaxQueue;
         _available = options.MaxConcurrency;
+        _onRejected = options.OnRejected;
+        _onRejectedAsync = options.OnRejectedAsync;
     }
 
     public override string Describe() =>
@@ -56,8 +62,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             Interlocked.Decrement(ref _pending);
             RecordState(alias);
             KevlarMetrics.Rejection(context.ShieldName, "concurrency_limit");
-            return new ValueTask<Outcome<T>>(
-                Outcome<T>.FromException(new ConcurrencyLimitExceededException()));
+            return RejectAsync<T>(context);
         }
 
         try
@@ -76,6 +81,57 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         }
 
         return ExecuteQueuedAsync(next, context, alias);
+    }
+
+    private ValueTask<Outcome<T>> RejectAsync<T>(KevlarContext context)
+    {
+        var rejection = new ConcurrencyLimitExceededException();
+        if (_onRejected is null && _onRejectedAsync is null)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+        }
+
+        var rejectedEvent = new ConcurrencyLimitRejectedEvent(
+            _maxConcurrency,
+            _maxQueue,
+            context.StrategyIndex,
+            context);
+        try
+        {
+            _onRejected?.Invoke(rejectedEvent);
+            if (_onRejectedAsync is null)
+            {
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+            }
+
+            var notification = _onRejectedAsync(rejectedEvent);
+            if (notification.IsCompletedSuccessfully)
+            {
+                notification.GetAwaiter().GetResult();
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+            }
+
+            return AwaitRejectionAsync<T>(notification, rejection);
+        }
+        catch (Exception callbackFailure)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(callbackFailure));
+        }
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitRejectionAsync<T>(
+        ValueTask notification,
+        ConcurrencyLimitExceededException rejection)
+    {
+        try
+        {
+            await notification.ConfigureAwait(false);
+            return Outcome<T>.FromException(rejection);
+        }
+        catch (Exception callbackFailure)
+        {
+            return Outcome<T>.FromException(callbackFailure);
+        }
     }
 
     private async ValueTask<Outcome<T>> ExecuteQueuedAsync<T, TState>(

--- a/src/Kevlar/Strategies/RateLimit/RateLimitOptions.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitOptions.cs
@@ -4,6 +4,11 @@ namespace Kevlar;
 /// Configuration for a token-bucket rate limit strategy: <see cref="Permits"/> executions per
 /// <see cref="Window"/>, with bursts up to <see cref="Burst"/> and optional queueing.
 /// </summary>
+/// <remarks>
+/// When an execution is rejected, rejection metrics are recorded, <see cref="OnRejected"/> runs,
+/// and then <see cref="OnRejectedAsync"/> runs and is awaited. A callback failure replaces the
+/// <see cref="RateLimitExceededException"/> that would otherwise be returned.
+/// </remarks>
 public sealed class RateLimitOptions
 {
     /// <summary>Sustained number of executions allowed per <see cref="Window"/>. Default 100.</summary>
@@ -20,4 +25,10 @@ public sealed class RateLimitOptions
     /// Waiting executions are delayed until their reserved permit is replenished. Default 0.
     /// </summary>
     public int QueueLimit { get; set; }
+
+    /// <summary>Invoked synchronously when an execution is rejected.</summary>
+    public Action<RateLimitRejectedEvent>? OnRejected { get; set; }
+
+    /// <summary>Invoked and awaited after <see cref="OnRejected"/> when an execution is rejected.</summary>
+    public Func<RateLimitRejectedEvent, ValueTask>? OnRejectedAsync { get; set; }
 }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitRejectedEvent.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitRejectedEvent.cs
@@ -1,0 +1,47 @@
+namespace Kevlar;
+
+/// <summary>Describes an execution rejected by the built-in rate limiter.</summary>
+public readonly struct RateLimitRejectedEvent
+{
+    internal RateLimitRejectedEvent(
+        TimeSpan? retryAfter,
+        int permits,
+        TimeSpan window,
+        int burst,
+        int queueLimit,
+        int strategyIndex,
+        KevlarContext context)
+    {
+        RetryAfter = retryAfter;
+        Permits = permits;
+        Window = window;
+        Burst = burst;
+        QueueLimit = queueLimit;
+        StrategyIndex = strategyIndex;
+        Context = context;
+    }
+
+    /// <summary>The estimated delay before another execution can be admitted, when available.</summary>
+    public TimeSpan? RetryAfter { get; }
+
+    /// <summary>The configured permits replenished per <see cref="Window"/>.</summary>
+    public int Permits { get; }
+
+    /// <summary>The configured replenishment window.</summary>
+    public TimeSpan Window { get; }
+
+    /// <summary>The configured maximum burst capacity.</summary>
+    public int Burst { get; }
+
+    /// <summary>The configured maximum wait queue size.</summary>
+    public int QueueLimit { get; }
+
+    /// <summary>The zero-based position of this strategy in the executing shield.</summary>
+    public int StrategyIndex { get; }
+
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it after synchronous and
+    /// asynchronous rejection callbacks complete.
+    /// </summary>
+    public KevlarContext Context { get; }
+}

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -25,6 +25,8 @@ internal sealed class RateLimitStrategy : Strategy
     private readonly int _queueLimit;
     private readonly double _timestampUnitsPerPermit;
     private readonly double _burstTolerance;
+    private readonly Action<RateLimitRejectedEvent>? _onRejected;
+    private readonly Func<RateLimitRejectedEvent, ValueTask>? _onRejectedAsync;
     private readonly Lock _metricsPublicationGate = new();
     private readonly HashSet<StrategyMetricAlias> _metricsAliases = [];
     private readonly object _queueGate = new();
@@ -48,6 +50,8 @@ internal sealed class RateLimitStrategy : Strategy
 
     internal int QueueLimit => _queueLimit;
 
+    internal bool HasNotification => _onRejected is not null || _onRejectedAsync is not null;
+
     public RateLimitStrategy(RateLimitOptions options)
     {
         Throw.IfOutOfRange(options.Permits <= 0, nameof(options), "Permits must be positive.");
@@ -61,6 +65,8 @@ internal sealed class RateLimitStrategy : Strategy
         _queueLimit = options.QueueLimit;
         _timestampUnitsPerPermit = options.Window.TotalSeconds * Stopwatch.Frequency / options.Permits;
         _burstTolerance = (_burst - 1) * _timestampUnitsPerPermit;
+        _onRejected = options.OnRejected;
+        _onRejectedAsync = options.OnRejectedAsync;
     }
 
     public override string Describe()
@@ -75,12 +81,67 @@ internal sealed class RateLimitStrategy : Strategy
         if (!TryAcquireAndRecord(context, out var reservation, out var retryAfter))
         {
             KevlarMetrics.Rejection(context.ShieldName, "rate_limit");
-            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(new RateLimitExceededException(retryAfter)));
+            return RejectAsync<T>(context, retryAfter);
         }
 
         return reservation is null
             ? next.InvokeAsync(context)
             : ExecuteReservedAsync(next, context, reservation);
+    }
+
+    private ValueTask<Outcome<T>> RejectAsync<T>(KevlarContext context, TimeSpan? retryAfter)
+    {
+        var rejection = new RateLimitExceededException(retryAfter);
+        if (_onRejected is null && _onRejectedAsync is null)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+        }
+
+        var rejectedEvent = new RateLimitRejectedEvent(
+            retryAfter,
+            _permits,
+            _window,
+            _burst,
+            _queueLimit,
+            context.StrategyIndex,
+            context);
+
+        try
+        {
+            _onRejected?.Invoke(rejectedEvent);
+            if (_onRejectedAsync is null)
+            {
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+            }
+
+            var notification = _onRejectedAsync(rejectedEvent);
+            if (notification.IsCompletedSuccessfully)
+            {
+                notification.GetAwaiter().GetResult();
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+            }
+
+            return AwaitRejectionAsync<T>(notification, rejection);
+        }
+        catch (Exception callbackFailure)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(callbackFailure));
+        }
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitRejectionAsync<T>(
+        ValueTask notification,
+        RateLimitExceededException rejection)
+    {
+        try
+        {
+            await notification.ConfigureAwait(false);
+            return Outcome<T>.FromException(rejection);
+        }
+        catch (Exception callbackFailure)
+        {
+            return Outcome<T>.FromException(callbackFailure);
+        }
     }
 
     private bool TryAcquireAndRecord(

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -50,7 +50,20 @@ public class AllocationBudgetTests
         .When<InvalidOperationException>()
         .Fallback(7);
     private readonly Shield _rateLimit = Shield.RateLimit(1_000_000_000, TimeSpan.FromSeconds(1));
+    private readonly Shield _rateLimitWithRejectionHooks = Shield.RateLimit(options =>
+    {
+        options.Permits = 1_000_000_000;
+        options.Window = TimeSpan.FromSeconds(1);
+        options.OnRejected = static _ => { };
+        options.OnRejectedAsync = static _ => ValueTask.CompletedTask;
+    });
     private readonly Shield _concurrencyLimit = Shield.ConcurrencyLimit(1024);
+    private readonly Shield _concurrencyLimitWithRejectionHooks = Shield.ConcurrencyLimit(options =>
+    {
+        options.MaxConcurrency = 1024;
+        options.OnRejected = static _ => { };
+        options.OnRejectedAsync = static _ => ValueTask.CompletedTask;
+    });
     private readonly Shield<int> _typedJudge = Shield.For<int>()
         .WhenResult(-1)
         .Retry(3, Backoff.None);
@@ -144,8 +157,12 @@ public class AllocationBudgetTests
             test._fallbackWithAsyncNotification.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("rate limit uncontended", this, static test =>
             test._rateLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("rate limit with rejection hooks uncontended", this, static test =>
+            test._rateLimitWithRejectionHooks.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("concurrency limit uncontended", this, static test =>
             test._concurrencyLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("concurrency limit with rejection hooks uncontended", this, static test =>
+            test._concurrencyLimitWithRejectionHooks.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("typed result judging", this, static test =>
             test._typedJudge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("composed pipeline", this, static test =>

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -37,8 +37,14 @@ public class PipelineDescriptorTests
                 options.Window = TimeSpan.FromSeconds(5);
                 options.Burst = 12;
                 options.QueueLimit = 3;
+                options.OnRejectedAsync = _ => default;
             })
-            .ConcurrencyLimit(6, maxQueue: 2)
+            .ConcurrencyLimit(options =>
+            {
+                options.MaxConcurrency = 6;
+                options.MaxQueue = 2;
+                options.OnRejected = _ => { };
+            })
             .Hedge(options =>
             {
                 options.MaxAttempts = 3;
@@ -87,10 +93,12 @@ public class PipelineDescriptorTests
         await Assert.That(rateLimit.Window).IsEqualTo(TimeSpan.FromSeconds(5));
         await Assert.That(rateLimit.Burst).IsEqualTo(12);
         await Assert.That(rateLimit.QueueLimit).IsEqualTo(3);
+        await Assert.That(rateLimit.HasNotification).IsTrue();
 
         var concurrency = descriptor.AssertContainsSingle<ConcurrencyLimitStrategyDescriptor>();
         await Assert.That(concurrency.MaxConcurrency).IsEqualTo(6);
         await Assert.That(concurrency.MaxQueue).IsEqualTo(2);
+        await Assert.That(concurrency.HasNotification).IsTrue();
 
         var hedge = descriptor.AssertContainsSingle<HedgingStrategyDescriptor>();
         await Assert.That(hedge.MaxAttempts).IsEqualTo(3);

--- a/tests/Kevlar.Tests/LimiterRejectionHookTests.cs
+++ b/tests/Kevlar.Tests/LimiterRejectionHookTests.cs
@@ -1,0 +1,211 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class LimiterRejectionHookTests
+{
+    [Test]
+    public async Task Rate_Limit_Hooks_Are_Ordered_And_Receive_Metadata()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var order = new List<string>();
+        RateLimitRejectedEvent observed = default;
+        string? observedShieldName = null;
+        var shield = Shield.For<int>()
+            .RateLimit(options =>
+            {
+                options.Permits = 1;
+                options.Window = TimeSpan.FromSeconds(2);
+                options.Burst = 1;
+                options.QueueLimit = 0;
+                options.OnRejected = rejection =>
+                {
+                    observed = rejection;
+                    observedShieldName = rejection.Context.ShieldName;
+                    order.Add("sync");
+                };
+                options.OnRejectedAsync = async rejection =>
+                {
+                    await Task.Yield();
+                    await Assert.That(ReferenceEquals(rejection.Context, observed.Context)).IsTrue();
+                    order.Add("async");
+                };
+            })
+            .WithName("orders")
+            .WithTimeProvider(fakeTime);
+
+        await shield.ExecuteAsync(static _ => new ValueTask<int>(1));
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(2));
+
+        await Assert.That(outcome.Exception).IsTypeOf<RateLimitExceededException>();
+        await Assert.That(order.SequenceEqual(["sync", "async"])).IsTrue();
+        await Assert.That(observed.RetryAfter).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(observed.Permits).IsEqualTo(1);
+        await Assert.That(observed.Window).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(observed.Burst).IsEqualTo(1);
+        await Assert.That(observed.QueueLimit).IsEqualTo(0);
+        await Assert.That(observed.StrategyIndex).IsEqualTo(0);
+        await Assert.That(observedShieldName).IsEqualTo("orders");
+    }
+
+    [Test]
+    public async Task Concurrency_Limit_Hooks_Are_Ordered_And_Receive_Metadata()
+    {
+        var order = new List<string>();
+        ConcurrencyLimitRejectedEvent observed = default;
+        string? observedShieldName = null;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .ConcurrencyLimit(options =>
+            {
+                options.MaxConcurrency = 1;
+                options.MaxQueue = 0;
+                options.OnRejected = rejection =>
+                {
+                    observed = rejection;
+                    observedShieldName = rejection.Context.ShieldName;
+                    order.Add("sync");
+                };
+                options.OnRejectedAsync = async rejection =>
+                {
+                    await Task.Yield();
+                    await Assert.That(ReferenceEquals(rejection.Context, observed.Context)).IsTrue();
+                    order.Add("async");
+                };
+            })
+            .WithName("bulkhead");
+
+        var running = shield.ExecuteAsync(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            return 1;
+        }).AsTask();
+        await started.Task;
+
+        await Assert.That(async () => await shield.ExecuteAsync(static _ => new ValueTask<int>(2)))
+            .Throws<ConcurrencyLimitExceededException>();
+
+        await Assert.That(order.SequenceEqual(["sync", "async"])).IsTrue();
+        await Assert.That(observed.MaxConcurrency).IsEqualTo(1);
+        await Assert.That(observed.MaxQueue).IsEqualTo(0);
+        await Assert.That(observed.StrategyIndex).IsEqualTo(0);
+        await Assert.That(observedShieldName).IsEqualTo("bulkhead");
+
+        release.SetResult();
+        await running;
+    }
+
+    [Test]
+    public async Task Synchronous_Rejection_Hook_Failure_Skips_Async_Hook()
+    {
+        var callbackFailure = new InvalidOperationException("sync rejection callback failed");
+        var asyncHooks = 0;
+        var shield = Shield.RateLimit(options =>
+        {
+            options.Permits = 1;
+            options.Window = TimeSpan.FromMinutes(1);
+            options.OnRejected = _ => throw callbackFailure;
+            options.OnRejectedAsync = _ =>
+            {
+                asyncHooks++;
+                return ValueTask.CompletedTask;
+            };
+        });
+
+        shield.Execute(static _ => 1);
+        var exception = await Assert.That(() => shield.Execute(static _ => 2))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(exception, callbackFailure)).IsTrue();
+        await Assert.That(asyncHooks).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Asynchronous_Rejection_Hook_Failure_Preserves_Exception()
+    {
+        var callbackFailure = new InvalidOperationException("async rejection callback failed");
+        var shield = Shield.ConcurrencyLimit(options =>
+        {
+            options.MaxConcurrency = 1;
+            options.OnRejectedAsync = _ => ValueTask.FromException(callbackFailure);
+        });
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var running = shield.ExecuteAsync(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            return 1;
+        }).AsTask();
+        await started.Task;
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(2));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, callbackFailure)).IsTrue();
+        release.SetResult();
+        await running;
+    }
+
+    [Test]
+    public async Task Queued_Cancellation_Does_Not_Invoke_Rejection_Hooks()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var rejections = 0;
+        var shield = Shield.RateLimit(options =>
+        {
+            options.Permits = 1;
+            options.Window = TimeSpan.FromSeconds(1);
+            options.QueueLimit = 1;
+            options.OnRejected = _ => rejections++;
+        }).WithTimeProvider(fakeTime);
+        using var cancellation = new CancellationTokenSource();
+
+        await shield.ExecuteAsync(static _ => new ValueTask<int>(0));
+        var queued = shield.ExecuteAsync(static _ => new ValueTask<int>(1), cancellation.Token).AsTask();
+        cancellation.Cancel();
+
+        await Assert.That(async () => await queued).Throws<OperationCanceledException>();
+        await Assert.That(rejections).IsEqualTo(0);
+
+        var replacement = shield.ExecuteAsync(static _ => new ValueTask<int>(2)).AsTask();
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+        await Assert.That(await replacement.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(2);
+        await Assert.That(rejections).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Concurrency_Queue_Cancellation_Does_Not_Invoke_Rejection_Hooks()
+    {
+        var rejections = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.ConcurrencyLimit(options =>
+        {
+            options.MaxConcurrency = 1;
+            options.MaxQueue = 1;
+            options.OnRejected = _ => rejections++;
+        });
+        using var cancellation = new CancellationTokenSource();
+        var running = shield.ExecuteAsync(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            return 1;
+        }).AsTask();
+        await started.Task;
+        var queued = shield.ExecuteAsync(static _ => new ValueTask<int>(2), cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+        await Assert.That(async () => await queued).Throws<OperationCanceledException>();
+        await Assert.That(rejections).IsEqualTo(0);
+
+        var replacement = shield.ExecuteAsync(static _ => new ValueTask<int>(3)).AsTask();
+        release.SetResult();
+        await Assert.That(await running).IsEqualTo(1);
+        await Assert.That(await replacement).IsEqualTo(3);
+        await Assert.That(rejections).IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Summary

- add synchronous and awaited asynchronous rejection hooks for built-in rate and concurrency limiters
- expose immutable rejection metadata, configured-builder overloads, and testing descriptors
- document callback ordering, failure/cancellation semantics, pooled context lifetime, and concurrency expectations

## Test plan

- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (679 passed)
- [x] `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (108 passed)
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (38 passed)
- [x] `dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m` (31 passed)
- [x] `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (3 passed)
- [x] `npm run build` in `docs/`

## Benchmarks

BenchmarkDotNet Short/InProcess, .NET 10, Windows 11. Default out-of-process toolchain failed locally before measurement because its generated working directory was removed; in-process runs completed normally.

| Uncontended path | `main` | This PR | Hooks configured | Allocation |
|---|---:|---:|---:|---:|
| Concurrency limit | 109.9 ns | 106.3 ns | 107.1 ns | 0 B/op |
| Rate limit | 100.5 ns | 102.8 ns | 100.2 ns | 0 B/op |

No material throughput regression; allocation gates remain zero.

Part of #114.

Closes #123
