### PR TITLE
feat(http): configure standard shield

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/HttpReplayBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HttpReplayBenchmarks.cs
@@ -15,6 +15,10 @@ public class HttpReplayBenchmarks
         Shield<HttpResponseMessage>.Empty,
         new ShieldHttpHandlerOptions(),
         retry: false);
+    private readonly HttpMessageInvoker _standard = CreateInvoker(
+        HttpShield.Standard(),
+        new ShieldHttpHandlerOptions(),
+        retry: false);
     private readonly HttpMessageInvoker _buffered = CreateInvoker(
         HttpShield.WhenTransient().Retry(1, Backoff.None),
         new ShieldHttpHandlerOptions
@@ -40,6 +44,13 @@ public class HttpReplayBenchmarks
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://benchmark.invalid/");
         using var response = await _direct.SendAsync(request, CancellationToken.None);
+    }
+
+    [BenchmarkCategory("HttpNoContent"), Benchmark]
+    public async Task Standard_NoContent()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://benchmark.invalid/");
+        using var response = await _standard.SendAsync(request, CancellationToken.None);
     }
 
     [BenchmarkCategory("HttpBufferedRetry"), Benchmark]

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -24,6 +24,51 @@ services.AddHttpClient("api")
 3. **Circuit breaker** — sampling mode: opens at a 50% failure ratio over a 30s window (minimum 10 calls), breaks for 15s
 4. **10s attempt timeout** per individual try
 
+Customize those stages without rebuilding the pipeline:
+
+```csharp
+services.AddHttpClient("api")
+    .AddStandardShield(options =>
+    {
+        options.TotalTimeout.Timeout = TimeSpan.FromSeconds(20);
+        options.Retry.MaxRetries = 2;
+        options.CircuitBreaker.FailureRatio = 0.25;
+        options.ConcurrencyLimit = new ConcurrencyLimitOptions
+        {
+            MaxConcurrency = 100,
+            MaxQueue = 20,
+        };
+        options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(5);
+        options.Handler.ContentReplayPolicy = HttpContentReplayPolicy.Buffer;
+        options.Handler.MaximumBufferSize = 256 * 1024;
+    });
+```
+
+`StandardHttpShieldOptions` exposes the total timeout, typed retry options, circuit breaker,
+optional concurrency limiter, attempt timeout, and handler replay/routing options. Invalid strategy
+values fail while the registration is built; handler replay/routing values fail when
+`HttpClientFactory` builds its handler pipeline, before a request is sent.
+
+For dependency-aware setup, use the service-provider overload:
+
+```csharp
+services.AddSingleton(new ConcurrencyLimitOptions
+{
+    MaxConcurrency = 100,
+    MaxQueue = 20,
+});
+services.AddHttpClient("api")
+    .AddStandardShield((serviceProvider, options) =>
+    {
+        options.ConcurrencyLimit =
+            serviceProvider.GetRequiredService<ConcurrencyLimitOptions>();
+    });
+```
+
+The one-argument callback runs during registration and its shield is shared across handler
+rotations, matching parameterless `AddStandardShield()`. The service-provider callback runs once
+per `HttpClientFactory` handler lifetime and creates fresh strategy state for that lifetime.
+
 ## Bring your own pipeline
 
 ```csharp
@@ -123,7 +168,7 @@ shield so every additional send goes through safe replay and routing.
 
 - **Superseded responses are handler-owned.** The handler disposes failed retry responses and losing hedge responses, including a loser that completes after the winner. A custom `OnRetry` response-disposal hook is unnecessary with `ShieldDelegatingHandler`; the hook that `HttpShield.Standard()` installs stays safe because `HttpResponseMessage.Dispose` is idempotent. The selected response remains caller-owned.
 - **Redirects remain transport-owned.** Each Kevlar attempt begins with the original absolute URI (or its routed authority). Normal `HttpClientHandler` redirect policy runs inside that attempt.
-- **State sharing applies per registration.** `AddStandardShield` and `AddShield(shield)` build/capture one shield for that named client — every request through `"api"` shares the same circuit breaker, which is what makes the breaker meaningful. The factory overload runs once when `HttpClientFactory` creates a handler pipeline, receives that pipeline's service provider, and runs again only when the handler lifetime expires; return a shared instance, e.g. from the registry, to keep one circuit across lifetimes.
+- **State sharing depends on registration form.** Parameterless `AddStandardShield()`, its one-argument options callback, and `AddShield(shield)` build/capture one shield for that named client, so state survives handler rotation. Service-provider callbacks run once per `HttpClientFactory` handler lifetime and create fresh state unless they resolve and return shared state from DI.
 - **Compose with other handlers normally.** The Kevlar handler is a regular `DelegatingHandler`; ordering relative to your own handlers follows the usual `AddHttpMessageHandler` rules.
 
 :::tip Handling clause already done

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -30,26 +30,33 @@ public static class HttpShield
     /// disposed) → circuit breaker (50% failure ratio over 30s, minimum 10 calls, 15s break) →
     /// 10s per-attempt timeout.
     /// </summary>
-    public static Shield<HttpResponseMessage> Standard() =>
-        Shield.Timeout(TimeSpan.FromSeconds(30))
+    public static Shield<HttpResponseMessage> Standard() => Standard(new StandardHttpShieldOptions());
+
+    /// <summary>Builds the standard HTTP pipeline from <paramref name="options"/>.</summary>
+    public static Shield<HttpResponseMessage> Standard(StandardHttpShieldOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        Validate(options);
+
+        var shield = Shield.Timeout(timeout => Copy(options.TotalTimeout, timeout))
             .For<HttpResponseMessage>()
             .When<HttpRequestException>()
             .When<TimeoutExceededException>()
             .WhenResult(IsTransient)
-            .Retry(options =>
-            {
-                options.MaxRetries = 3;
-                options.DelayGenerator = RetryAfter;
-                options.OnRetry = static retry => retry.Outcome.Result?.Dispose();
-            })
-            .CircuitBreaker(options =>
-            {
-                options.FailureRatio = 0.5;
-                options.MinimumThroughput = 10;
-                options.SamplingWindow = TimeSpan.FromSeconds(30);
-                options.BreakDuration = TimeSpan.FromSeconds(15);
-            })
-            .Timeout(TimeSpan.FromSeconds(10));
+            .Retry(retry => Copy(options.Retry, retry))
+            .CircuitBreaker(circuitBreaker => Copy(options.CircuitBreaker, circuitBreaker));
+
+        if (options.ConcurrencyLimit is { } concurrencyLimit)
+        {
+            shield = shield.ConcurrencyLimit(target => Copy(concurrencyLimit, target));
+        }
+
+        return shield.Timeout(timeout => Copy(options.AttemptTimeout, timeout));
+    }
 
     /// <summary>
     /// A <see cref="RetryOptions{TResult}.DelayGenerator"/> honouring the response's
@@ -81,5 +88,86 @@ public static class HttpShield
         }
 
         return suggested is { } value && value > retry.Delay ? value : null;
+    }
+
+    private static void Validate(StandardHttpShieldOptions options)
+    {
+        ValidateTimeout(options.TotalTimeout, nameof(StandardHttpShieldOptions.TotalTimeout));
+        ValidateTimeout(options.AttemptTimeout, nameof(StandardHttpShieldOptions.AttemptTimeout));
+
+        if (options.Retry is null)
+        {
+            throw new ArgumentException("StandardHttpShieldOptions.Retry cannot be null.", nameof(options));
+        }
+
+        if (options.CircuitBreaker is null)
+        {
+            throw new ArgumentException("StandardHttpShieldOptions.CircuitBreaker cannot be null.", nameof(options));
+        }
+
+        if (options.Handler is null)
+        {
+            throw new ArgumentException("StandardHttpShieldOptions.Handler cannot be null.", nameof(options));
+        }
+    }
+
+    private static void ValidateTimeout(TimeoutOptions? timeout, string propertyName)
+    {
+        if (timeout is null)
+        {
+            throw new ArgumentException($"StandardHttpShieldOptions.{propertyName} cannot be null.", "options");
+        }
+
+        if (timeout.Timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                "options",
+                $"StandardHttpShieldOptions.{propertyName}.Timeout must be positive.");
+        }
+    }
+
+    private static void Copy(TimeoutOptions source, TimeoutOptions target)
+    {
+        target.Timeout = source.Timeout;
+        target.TimeoutGenerator = source.TimeoutGenerator;
+        target.OnTimeout = source.OnTimeout;
+        target.OnTimeoutAsync = source.OnTimeoutAsync;
+    }
+
+    private static void Copy(
+        RetryOptions<HttpResponseMessage> source,
+        RetryOptions<HttpResponseMessage> target)
+    {
+        var onRetry = source.OnRetry;
+        target.MaxRetries = source.MaxRetries;
+        target.Backoff = source.Backoff;
+        target.MaxDelay = source.MaxDelay;
+        target.DelayGenerator = source.DelayGenerator;
+        target.DelayGeneratorAsync = source.DelayGeneratorAsync;
+        target.OnRetry = retry =>
+        {
+            retry.Outcome.Result?.Dispose();
+            onRetry?.Invoke(retry);
+        };
+        target.OnRetryAsync = source.OnRetryAsync;
+    }
+
+    private static void Copy(CircuitBreakerOptions source, CircuitBreakerOptions target)
+    {
+        target.ConsecutiveFailures = source.ConsecutiveFailures;
+        target.FailureRatio = source.FailureRatio;
+        target.MinimumThroughput = source.MinimumThroughput;
+        target.SamplingWindow = source.SamplingWindow;
+        target.BreakDuration = source.BreakDuration;
+        target.BreakDurationGenerator = source.BreakDurationGenerator;
+        target.Monitor = source.Monitor;
+        target.OnStateChanged = source.OnStateChanged;
+        target.OnStateChangedAsync = source.OnStateChangedAsync;
+    }
+
+    private static void Copy(ConcurrencyLimitOptions source, ConcurrencyLimitOptions target)
+    {
+        target.MaxConcurrency = source.MaxConcurrency;
+        target.MaxQueue = source.MaxQueue;
     }
 }

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -35,3 +35,20 @@ Kevlar.Extensions.Http.ShieldHttpHandlerOptions.Routing.set -> void
 Kevlar.Extensions.Http.ShieldHttpHandlerOptions.ShieldHttpHandlerOptions() -> void
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Kevlar.Shield<System.Net.Http.HttpResponseMessage!>! shield, Kevlar.Extensions.Http.ShieldHttpHandlerOptions! options) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, Kevlar.Shield<System.Net.Http.HttpResponseMessage!>!>! shieldFactory, System.Func<System.IServiceProvider!, Kevlar.Extensions.Http.ShieldHttpHandlerOptions!>! optionsFactory) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+Kevlar.Extensions.Http.StandardHttpShieldOptions
+Kevlar.Extensions.Http.StandardHttpShieldOptions.AttemptTimeout.get -> Kevlar.TimeoutOptions!
+Kevlar.Extensions.Http.StandardHttpShieldOptions.AttemptTimeout.set -> void
+Kevlar.Extensions.Http.StandardHttpShieldOptions.CircuitBreaker.get -> Kevlar.CircuitBreakerOptions!
+Kevlar.Extensions.Http.StandardHttpShieldOptions.CircuitBreaker.set -> void
+Kevlar.Extensions.Http.StandardHttpShieldOptions.ConcurrencyLimit.get -> Kevlar.ConcurrencyLimitOptions?
+Kevlar.Extensions.Http.StandardHttpShieldOptions.ConcurrencyLimit.set -> void
+Kevlar.Extensions.Http.StandardHttpShieldOptions.Handler.get -> Kevlar.Extensions.Http.ShieldHttpHandlerOptions!
+Kevlar.Extensions.Http.StandardHttpShieldOptions.Handler.set -> void
+Kevlar.Extensions.Http.StandardHttpShieldOptions.Retry.get -> Kevlar.RetryOptions<System.Net.Http.HttpResponseMessage!>!
+Kevlar.Extensions.Http.StandardHttpShieldOptions.Retry.set -> void
+Kevlar.Extensions.Http.StandardHttpShieldOptions.StandardHttpShieldOptions() -> void
+Kevlar.Extensions.Http.StandardHttpShieldOptions.TotalTimeout.get -> Kevlar.TimeoutOptions!
+Kevlar.Extensions.Http.StandardHttpShieldOptions.TotalTimeout.set -> void
+static Kevlar.Extensions.Http.HttpShield.Standard(Kevlar.Extensions.Http.StandardHttpShieldOptions! options) -> Kevlar.Shield<System.Net.Http.HttpResponseMessage!>!
+static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<Kevlar.Extensions.Http.StandardHttpShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<System.IServiceProvider!, Kevlar.Extensions.Http.StandardHttpShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -86,15 +86,89 @@ public static class ShieldHttpClientBuilderExtensions
             new ShieldDelegatingHandler(shieldFactory(services), optionsFactory(services)));
     }
 
-    /// <summary>Sends this client's requests through <see cref="HttpShield.Standard"/>.</summary>
+    /// <summary>Sends this client's requests through <see cref="HttpShield.Standard()"/>.</summary>
     public static IHttpClientBuilder AddStandardShield(this IHttpClientBuilder builder)
+        => AddStandardShield(builder, static _ => { });
+
+    /// <summary>Configures and adds one shared standard shield for this client registration.</summary>
+    public static IHttpClientBuilder AddStandardShield(
+        this IHttpClientBuilder builder,
+        Action<StandardHttpShieldOptions> configure)
     {
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
 
-        var shield = HttpShield.Standard();
-        return builder.AddHttpMessageHandler(() => new ShieldDelegatingHandler(shield));
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        var options = new StandardHttpShieldOptions();
+        configure(options);
+        var shield = HttpShield.Standard(options);
+        var handlerOptions = Snapshot(options.Handler);
+        return builder.AddHttpMessageHandler(() => new ShieldDelegatingHandler(shield, handlerOptions));
+    }
+
+    /// <summary>
+    /// Configures and adds a standard shield using the handler pipeline's service provider.
+    /// Configuration and shield creation run once per handler lifetime.
+    /// </summary>
+    public static IHttpClientBuilder AddStandardShield(
+        this IHttpClientBuilder builder,
+        Action<IServiceProvider, StandardHttpShieldOptions> configure)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        return builder.AddHttpMessageHandler(services =>
+        {
+            var options = new StandardHttpShieldOptions();
+            configure(services, options);
+            return new ShieldDelegatingHandler(HttpShield.Standard(options), Snapshot(options.Handler));
+        });
+    }
+
+    private static ShieldHttpHandlerOptions Snapshot(ShieldHttpHandlerOptions source)
+    {
+        var snapshot = new ShieldHttpHandlerOptions
+        {
+            ContentReplayPolicy = source.ContentReplayPolicy,
+            MaximumBufferSize = source.MaximumBufferSize,
+            AllowUnsafeMethodReplay = source.AllowUnsafeMethodReplay,
+            RequestFactory = source.RequestFactory,
+            Routing = Snapshot(source.Routing),
+        };
+        return snapshot;
+    }
+
+    private static HttpEndpointRoutingOptions? Snapshot(HttpEndpointRoutingOptions? source)
+    {
+        if (source is null)
+        {
+            return null;
+        }
+
+        var snapshot = new HttpEndpointRoutingOptions
+        {
+            SelectionMode = source.SelectionMode,
+            Seed = source.Seed,
+            ShieldFactory = source.ShieldFactory,
+        };
+        foreach (var endpoint in source.Endpoints)
+        {
+            snapshot.Endpoints.Add(endpoint);
+        }
+
+        return snapshot;
     }
 }

--- a/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
@@ -1,0 +1,41 @@
+namespace Kevlar.Extensions.Http;
+
+/// <summary>Configures the standard HTTP resilience pipeline and its request handler.</summary>
+public sealed class StandardHttpShieldOptions
+{
+    /// <summary>Configures the outer total timeout. Defaults to 30 seconds.</summary>
+    public TimeoutOptions TotalTimeout { get; set; } = new();
+
+    /// <summary>
+    /// Configures transient retries. Defaults to three jittered exponential retries that honour
+    /// <c>Retry-After</c> headers. Superseded responses are always disposed before notifications run.
+    /// </summary>
+    public RetryOptions<HttpResponseMessage> Retry { get; set; } = new()
+    {
+        DelayGenerator = HttpShield.RetryAfter,
+    };
+
+    /// <summary>
+    /// Configures the circuit breaker. Defaults to a 50% failure ratio over 30 seconds, with a
+    /// minimum throughput of 10 and a 15-second break.
+    /// </summary>
+    public CircuitBreakerOptions CircuitBreaker { get; set; } = new()
+    {
+        FailureRatio = 0.5,
+    };
+
+    /// <summary>
+    /// Optionally configures a concurrency limiter between the circuit breaker and attempt
+    /// timeout. The limiter is disabled when this property is <see langword="null"/>.
+    /// </summary>
+    public ConcurrencyLimitOptions? ConcurrencyLimit { get; set; }
+
+    /// <summary>Configures the per-attempt timeout. Defaults to 10 seconds.</summary>
+    public TimeoutOptions AttemptTimeout { get; set; } = new()
+    {
+        Timeout = TimeSpan.FromSeconds(10),
+    };
+
+    /// <summary>Configures request replay and optional endpoint routing.</summary>
+    public ShieldHttpHandlerOptions Handler { get; set; } = new();
+}

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -92,6 +92,151 @@ public class HttpContractTests
             "Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
 
     [Test]
+    public async Task Configured_Standard_Has_Custom_Stages()
+    {
+        var options = new StandardHttpShieldOptions
+        {
+            TotalTimeout = new TimeoutOptions { Timeout = TimeSpan.FromSeconds(20) },
+            Retry = new RetryOptions<HttpResponseMessage>
+            {
+                MaxRetries = 1,
+                Backoff = Backoff.None,
+                DelayGenerator = HttpShield.RetryAfter,
+            },
+            CircuitBreaker = new CircuitBreakerOptions
+            {
+                ConsecutiveFailures = 8,
+                BreakDuration = TimeSpan.FromSeconds(5),
+            },
+            ConcurrencyLimit = new ConcurrencyLimitOptions
+            {
+                MaxConcurrency = 12,
+                MaxQueue = 4,
+            },
+            AttemptTimeout = new TimeoutOptions { Timeout = TimeSpan.FromSeconds(3) },
+        };
+
+        await Assert.That(HttpShield.Standard(options).ToString()).IsEqualTo(
+            "Timeout(20s) → Retry(1, no delay) → CircuitBreaker(8 consecutive, break 5s) → ConcurrencyLimit(12, queue 4) → Timeout(3s)");
+    }
+
+    [Test]
+    public async Task Configured_Standard_Replays_Buffered_Unsafe_Requests()
+    {
+        var calls = 0;
+        var bodies = new List<string>();
+        using var inner = new DelegateHandler(async (request, cancellationToken) =>
+        {
+            calls++;
+            bodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(
+                calls == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK);
+        });
+        using var services = new ServiceCollection()
+            .AddHttpClient("configured-standard")
+            .ConfigurePrimaryHttpMessageHandler(() => inner)
+            .AddStandardShield(options =>
+            {
+                options.Retry.MaxRetries = 1;
+                options.Retry.Backoff = Backoff.None;
+                options.CircuitBreaker.ConsecutiveFailures = 100;
+                options.CircuitBreaker.FailureRatio = null;
+                options.Handler.ContentReplayPolicy = HttpContentReplayPolicy.Buffer;
+                options.Handler.AllowUnsafeMethodReplay = true;
+            })
+            .Services
+            .BuildServiceProvider();
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("configured-standard");
+        using var content = new StringContent("payload");
+        using var response = await client.PostAsync("http://localhost/test", content);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(calls).IsEqualTo(2);
+        await Assert.That(bodies).IsEquivalentTo(["payload", "payload"]);
+    }
+
+    [Test]
+    public async Task Standard_ServiceProvider_Configuration_Runs_Once_Per_Handler_Lifetime()
+    {
+        var marker = new Marker();
+        var configureCalls = 0;
+        using var services = new ServiceCollection()
+            .AddSingleton(marker)
+            .AddHttpClient("configured-standard-factory")
+            .ConfigurePrimaryHttpMessageHandler(() => new DelegateHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK))))
+            .AddStandardShield((provider, options) =>
+            {
+                configureCalls++;
+                if (!ReferenceEquals(provider.GetRequiredService<Marker>(), marker))
+                {
+                    throw new InvalidOperationException("Unexpected service provider.");
+                }
+
+                options.Retry.MaxRetries = 0;
+            })
+            .Services
+            .BuildServiceProvider();
+        var factory = services.GetRequiredService<IHttpClientFactory>();
+
+        using var firstClient = factory.CreateClient("configured-standard-factory");
+        using var secondClient = factory.CreateClient("configured-standard-factory");
+        using var first = await firstClient.GetAsync("http://localhost/first");
+        using var second = await secondClient.GetAsync("http://localhost/second");
+
+        await Assert.That(configureCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Configured_Standard_Enforces_Optional_Concurrency_Limit()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var services = new ServiceCollection()
+            .AddHttpClient("limited-standard")
+            .ConfigurePrimaryHttpMessageHandler(() => new DelegateHandler(async (_, _) =>
+            {
+                entered.TrySetResult();
+                await release.Task;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }))
+            .AddStandardShield(options =>
+            {
+                options.Retry.MaxRetries = 0;
+                options.ConcurrencyLimit = new ConcurrencyLimitOptions
+                {
+                    MaxConcurrency = 1,
+                    MaxQueue = 0,
+                };
+            })
+            .Services
+            .BuildServiceProvider();
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("limited-standard");
+        var first = client.GetAsync("http://localhost/first");
+        await entered.Task;
+
+        await Assert.That(async () => await client.GetAsync("http://localhost/second"))
+            .Throws<ConcurrencyLimitExceededException>();
+
+        release.SetResult();
+        using var response = await first;
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Standard_Configuration_Rejects_Invalid_Options_Immediately()
+    {
+        var builder = new ServiceCollection().AddHttpClient("invalid-standard");
+
+        var exception = await Assert.That(() => builder.AddStandardShield(options =>
+        {
+            options.AttemptTimeout.Timeout = TimeSpan.Zero;
+        })).Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(exception!.Message).Contains("AttemptTimeout.Timeout");
+    }
+
+    [Test]
     public async Task Standard_Disposes_Superseded_Responses_But_Not_The_Winner()
     {
         var timeProvider = new RetrySignalingFakeTimeProvider();
@@ -447,6 +592,7 @@ public class HttpContractTests
         var services = new ServiceCollection();
         var builder = services.AddHttpClient("guards");
 
+        await Assert.That(() => HttpShield.Standard(null!)).Throws<ArgumentNullException>();
         await Assert.That(() => new ShieldDelegatingHandler(null!)).Throws<ArgumentNullException>();
         await Assert.That(() => ShieldHttpClientBuilderExtensions.AddShield(nullBuilder!, Shield<HttpResponseMessage>.Empty))
             .Throws<ArgumentNullException>();
@@ -455,6 +601,11 @@ public class HttpContractTests
         await Assert.That(() => builder.AddShield((Func<IServiceProvider, Shield<HttpResponseMessage>>)null!))
             .Throws<ArgumentNullException>();
         await Assert.That(() => ShieldHttpClientBuilderExtensions.AddStandardShield(nullBuilder!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => builder.AddStandardShield((Action<StandardHttpShieldOptions>)null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => builder.AddStandardShield(
+                (Action<IServiceProvider, StandardHttpShieldOptions>)null!))
             .Throws<ArgumentNullException>();
     }
 


### PR DESCRIPTION
## Summary
- expose `StandardHttpShieldOptions` for every standard pipeline stage
- add registration-time and service-provider-aware `AddStandardShield` callbacks
- snapshot handler configuration while preserving documented shield state lifetimes
- document configuration and add an HTTP baseline benchmark

## Benchmark
| Case | Mean | Allocated |
|---|---:|---:|
| Before | 500.674 ns | 600 B |
| After | 508.168 ns | 600 B |

The 1.5% mean difference is within overlapping confidence intervals; allocation is unchanged.

## Test plan
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (678 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (108 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (5 passed)
- `npm run build --prefix docs`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-issue126`
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local`

Closes #126