### PR TITLE
feat(http): add standard hedging handler

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/HttpStandardHedgingBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HttpStandardHedgingBenchmarks.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>Standard endpoint-aware HTTP hedging registration overhead.</summary>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class HttpStandardHedgingBenchmarks
+{
+    private ServiceProvider _services = null!;
+    private HttpClient _manual = null!;
+    private HttpClient _standard = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient("manual")
+            .ConfigurePrimaryHttpMessageHandler(static () => new SuccessHandler())
+            .AddShield(CreateOuterShield(), CreateHandlerOptions());
+        services.AddHttpClient("standard")
+            .ConfigurePrimaryHttpMessageHandler(static () => new SuccessHandler())
+            .AddStandardHedgingShield(static options =>
+            {
+                options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.invalid")));
+                options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.invalid")));
+            });
+        _services = services.BuildServiceProvider();
+        var factory = _services.GetRequiredService<IHttpClientFactory>();
+        _manual = factory.CreateClient("manual");
+        _standard = factory.CreateClient("standard");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _manual.Dispose();
+        _standard.Dispose();
+        _services.Dispose();
+    }
+
+    [BenchmarkCategory("HttpStandardHedgingHappy"), Benchmark(Baseline = true)]
+    public async Task ManualComposition()
+    {
+        using var response = await _manual.GetAsync("https://origin.invalid/");
+    }
+
+    [BenchmarkCategory("HttpStandardHedgingHappy"), Benchmark]
+    public async Task StandardRegistration()
+    {
+        using var response = await _standard.GetAsync("https://origin.invalid/");
+    }
+
+    private static Shield<HttpResponseMessage> CreateOuterShield() =>
+        Shield.Timeout(TimeSpan.FromSeconds(30))
+            .For<HttpResponseMessage>()
+            .When<HttpRequestException>()
+            .When<TimeoutExceededException>()
+            .When<ConcurrencyLimitExceededException>()
+            .When<CircuitOpenException>()
+            .WhenResult(HttpShield.IsTransient)
+            .Hedge(2, TimeSpan.FromSeconds(1));
+
+    private static ShieldHttpHandlerOptions CreateHandlerOptions()
+    {
+        var routing = new HttpEndpointRoutingOptions
+        {
+            ShieldFactory = static _ => HttpShield.WhenTransient()
+                .ConcurrencyLimit(10)
+                .CircuitBreaker(options =>
+                {
+                    options.FailureRatio = 0.5;
+                    options.MinimumThroughput = 10;
+                    options.SamplingWindow = TimeSpan.FromSeconds(30);
+                    options.BreakDuration = TimeSpan.FromSeconds(15);
+                })
+                .Timeout(TimeSpan.FromSeconds(10)),
+        };
+        routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.invalid")));
+        routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.invalid")));
+        return new ShieldHttpHandlerOptions { Routing = routing };
+    }
+
+    private sealed class SuccessHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+}

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -143,6 +143,31 @@ Route attempt 1, attempt 2, and so on across alternate authorities while preserv
 path and query:
 
 ```csharp
+services.AddHttpClient("routed")
+    .AddStandardHedgingShield(options =>
+    {
+        options.Endpoints.Add(new HttpEndpoint(new Uri("https://api-a.example"), weight: 3));
+        options.Endpoints.Add(new HttpEndpoint(new Uri("https://api-b.example"), weight: 1));
+        options.SelectionMode = HttpEndpointSelectionMode.Weighted;
+        options.MaxAttempts = 2;
+        options.HedgeDelay = TimeSpan.FromMilliseconds(500);
+    });
+```
+
+`AddStandardHedgingShield` installs a 30s total timeout and up to two hedged attempts. Each endpoint
+gets its own 10-concurrent/zero-queue limiter, 50%-over-30s circuit breaker (minimum 10 attempts,
+15s break), and 10s attempt timeout. Configure those defaults through `TotalTimeout`, `MaxAttempts`,
+`HedgeDelay`, `MaxConcurrency`, `MaxQueue`, `FailureRatio` or `ConsecutiveFailures`,
+`MinimumThroughput`, `SamplingWindow`, `BreakDuration`, and `AttemptTimeout`.
+
+The registration also exposes `ContentReplayPolicy`, `MaximumBufferSize`,
+`AllowUnsafeMethodReplay`, and `RequestFactory`. POST, PATCH, and custom methods still require the
+same explicit idempotency opt-in described above; registering the standard hedging pipeline does not
+make an unsafe operation safe to repeat.
+
+For a fully custom endpoint-aware pipeline, compose the outer and endpoint shields directly:
+
+```csharp
 var routing = new HttpEndpointRoutingOptions
 {
     SelectionMode = HttpEndpointSelectionMode.Ordered,
@@ -169,6 +194,7 @@ shield so every additional send goes through safe replay and routing.
 - **Superseded responses are handler-owned.** The handler disposes failed retry responses and losing hedge responses, including a loser that completes after the winner. A custom `OnRetry` response-disposal hook is unnecessary with `ShieldDelegatingHandler`; the hook that `HttpShield.Standard()` installs stays safe because `HttpResponseMessage.Dispose` is idempotent. The selected response remains caller-owned.
 - **Redirects remain transport-owned.** Each Kevlar attempt begins with the original absolute URI (or its routed authority). Normal `HttpClientHandler` redirect policy runs inside that attempt.
 - **State sharing depends on registration form.** Parameterless `AddStandardShield()`, its one-argument options callback, and `AddShield(shield)` build/capture one shield for that named client, so state survives handler rotation. Service-provider callbacks run once per `HttpClientFactory` handler lifetime and create fresh state unless they resolve and return shared state from DI.
+- **Standard hedging state is endpoint-local.** `AddStandardHedgingShield` creates one limiter and breaker per authority in each `HttpClientFactory` handler pipeline and reuses them across requests for that handler's lifetime.
 - **Compose with other handlers normally.** The Kevlar handler is a regular `DelegatingHandler`; ordering relative to your own handlers follows the usual `AddHttpMessageHandler` rules.
 
 :::tip Handling clause already done

--- a/src/Kevlar.Extensions.Grpc/ShieldUnaryClientInterceptor.cs
+++ b/src/Kevlar.Extensions.Grpc/ShieldUnaryClientInterceptor.cs
@@ -214,7 +214,8 @@ public sealed class ShieldUnaryClientInterceptor : Interceptor
                 && rpcException.StatusCode is (
                     StatusCode.DeadlineExceeded
                     or StatusCode.Cancelled
-                    or StatusCode.Unknown))
+                    or StatusCode.Unknown
+                    or StatusCode.Unavailable))
             {
                 return rpcException.StatusCode == StatusCode.DeadlineExceeded
                     ? rpcException

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -33,6 +33,44 @@ Kevlar.Extensions.Http.ShieldHttpHandlerOptions.RequestFactory.set -> void
 Kevlar.Extensions.Http.ShieldHttpHandlerOptions.Routing.get -> Kevlar.Extensions.Http.HttpEndpointRoutingOptions?
 Kevlar.Extensions.Http.ShieldHttpHandlerOptions.Routing.set -> void
 Kevlar.Extensions.Http.ShieldHttpHandlerOptions.ShieldHttpHandlerOptions() -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.AllowUnsafeMethodReplay.get -> bool
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.AllowUnsafeMethodReplay.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.AttemptTimeout.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.AttemptTimeout.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.BreakDuration.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.BreakDuration.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.ConsecutiveFailures.get -> int?
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.ConsecutiveFailures.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.ContentReplayPolicy.get -> Kevlar.Extensions.Http.HttpContentReplayPolicy
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.ContentReplayPolicy.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.Endpoints.get -> System.Collections.Generic.IList<Kevlar.Extensions.Http.HttpEndpoint!>!
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.FailureRatio.get -> double?
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.FailureRatio.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.HedgeDelay.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.HedgeDelay.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxAttempts.get -> int
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxAttempts.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxConcurrency.get -> int
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxConcurrency.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaximumBufferSize.get -> long
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaximumBufferSize.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxQueue.get -> int
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxQueue.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MinimumThroughput.get -> int
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.MinimumThroughput.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.RequestFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, int, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.Http.HttpRequestMessage!>>?
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.RequestFactory.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.SamplingWindow.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.SamplingWindow.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.Seed.get -> int
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.Seed.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.SelectionMode.get -> Kevlar.Extensions.Http.HttpEndpointSelectionMode
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.SelectionMode.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.StandardHedgingShieldOptions() -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.TotalTimeout.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.TotalTimeout.set -> void
+static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardHedgingShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<Kevlar.Extensions.Http.StandardHedgingShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Kevlar.Shield<System.Net.Http.HttpResponseMessage!>! shield, Kevlar.Extensions.Http.ShieldHttpHandlerOptions! options) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, Kevlar.Shield<System.Net.Http.HttpResponseMessage!>!>! shieldFactory, System.Func<System.IServiceProvider!, Kevlar.Extensions.Http.ShieldHttpHandlerOptions!>! optionsFactory) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Kevlar.Extensions.Http.StandardHttpShieldOptions

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -171,4 +171,118 @@ public static class ShieldHttpClientBuilderExtensions
 
         return snapshot;
     }
+
+    /// <summary>
+    /// Adds a standard endpoint-aware pipeline: total timeout, hedging, per-endpoint concurrency
+    /// limit and circuit breaker, then per-attempt timeout.
+    /// </summary>
+    public static IHttpClientBuilder AddStandardHedgingShield(
+        this IHttpClientBuilder builder,
+        Action<StandardHedgingShieldOptions> configure)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        var options = new StandardHedgingShieldOptions();
+        configure(options);
+        var shield = CreateHedgingShield(options);
+        var handlerOptions = CreateHandlerOptions(options);
+
+        return builder.AddHttpMessageHandler(() =>
+            new ShieldDelegatingHandler(shield, handlerOptions));
+    }
+
+    private static Shield<HttpResponseMessage> CreateHedgingShield(StandardHedgingShieldOptions options) =>
+        Shield.Timeout(options.TotalTimeout)
+            .For<HttpResponseMessage>()
+            .When<HttpRequestException>()
+            .When<TimeoutExceededException>()
+            .When<ConcurrencyLimitExceededException>()
+            .When<CircuitOpenException>()
+            .WhenResult(HttpShield.IsTransient)
+            .Hedge(options.MaxAttempts, options.HedgeDelay);
+
+    private static ShieldHttpHandlerOptions CreateHandlerOptions(StandardHedgingShieldOptions options)
+    {
+        if (!Enum.IsDefined(typeof(HttpEndpointSelectionMode), options.SelectionMode))
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "The endpoint selection mode is invalid.");
+        }
+
+        if (!Enum.IsDefined(typeof(HttpContentReplayPolicy), options.ContentReplayPolicy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "ContentReplayPolicy is invalid.");
+        }
+
+        if (options.MaximumBufferSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "MaximumBufferSize must be positive.");
+        }
+
+        if (options.Endpoints.Count == 0)
+        {
+            throw new ArgumentException("Standard hedging requires at least one endpoint.", nameof(options));
+        }
+
+        if (options.Endpoints.Any(static endpoint => endpoint is null))
+        {
+            throw new ArgumentException("Endpoints cannot contain null.", nameof(options));
+        }
+
+        var routing = new HttpEndpointRoutingOptions
+        {
+            SelectionMode = options.SelectionMode,
+            Seed = options.Seed,
+            ShieldFactory = CreateEndpointShieldFactory(options),
+        };
+        foreach (var endpoint in options.Endpoints)
+        {
+            routing.Endpoints.Add(endpoint);
+        }
+
+        return new ShieldHttpHandlerOptions
+        {
+            ContentReplayPolicy = options.ContentReplayPolicy,
+            MaximumBufferSize = options.MaximumBufferSize,
+            AllowUnsafeMethodReplay = options.AllowUnsafeMethodReplay,
+            RequestFactory = options.RequestFactory,
+            Routing = routing,
+        };
+    }
+
+    private static Func<Uri, Shield<HttpResponseMessage>> CreateEndpointShieldFactory(
+        StandardHedgingShieldOptions options)
+    {
+        var maxConcurrency = options.MaxConcurrency;
+        var maxQueue = options.MaxQueue;
+        var consecutiveFailures = options.ConsecutiveFailures;
+        var failureRatio = options.FailureRatio;
+        var minimumThroughput = options.MinimumThroughput;
+        var samplingWindow = options.SamplingWindow;
+        var breakDuration = options.BreakDuration;
+        var attemptTimeout = options.AttemptTimeout;
+
+        Shield<HttpResponseMessage> CreateEndpointShield(Uri _) =>
+            HttpShield.WhenTransient()
+                .ConcurrencyLimit(maxConcurrency, maxQueue)
+                .CircuitBreaker(circuitBreaker =>
+                {
+                    circuitBreaker.ConsecutiveFailures = consecutiveFailures;
+                    circuitBreaker.FailureRatio = failureRatio;
+                    circuitBreaker.MinimumThroughput = minimumThroughput;
+                    circuitBreaker.SamplingWindow = samplingWindow;
+                    circuitBreaker.BreakDuration = breakDuration;
+                })
+                .Timeout(attemptTimeout);
+
+        _ = CreateEndpointShield(null!);
+        return CreateEndpointShield;
+    }
 }

--- a/src/Kevlar.Extensions.Http/StandardHedgingShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHedgingShieldOptions.cs
@@ -1,0 +1,68 @@
+namespace Kevlar.Extensions.Http;
+
+/// <summary>Configures the standard endpoint-aware HTTP hedging pipeline.</summary>
+public sealed class StandardHedgingShieldOptions
+{
+    /// <summary>The maximum duration of the complete request. Default 30 seconds.</summary>
+    public TimeSpan TotalTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Total attempts including the original. Default 2.</summary>
+    public int MaxAttempts { get; set; } = 2;
+
+    /// <summary>The delay before another hedged attempt starts. Default 1 second.</summary>
+    public TimeSpan HedgeDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>The maximum duration of each endpoint attempt. Default 10 seconds.</summary>
+    public TimeSpan AttemptTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Maximum concurrent attempts per endpoint. Default 10.</summary>
+    public int MaxConcurrency { get; set; } = 10;
+
+    /// <summary>Maximum attempts queued per endpoint. Default 0.</summary>
+    public int MaxQueue { get; set; }
+
+    /// <summary>Trips each endpoint circuit after this many consecutive transient failures.</summary>
+    public int? ConsecutiveFailures { get; set; }
+
+    /// <summary>
+    /// Trips each endpoint circuit when its transient-failure ratio reaches this value.
+    /// Default 0.5. Set to <see langword="null"/> when using <see cref="ConsecutiveFailures"/>.
+    /// </summary>
+    public double? FailureRatio { get; set; } = 0.5;
+
+    /// <summary>Minimum endpoint attempts sampled before failure-ratio breaking. Default 10.</summary>
+    public int MinimumThroughput { get; set; } = 10;
+
+    /// <summary>The endpoint circuit sampling window. Default 30 seconds.</summary>
+    public TimeSpan SamplingWindow { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>How long an endpoint circuit remains open. Default 15 seconds.</summary>
+    public TimeSpan BreakDuration { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>The endpoint ordering algorithm.</summary>
+    public HttpEndpointSelectionMode SelectionMode { get; set; }
+
+    /// <summary>The deterministic seed used by weighted endpoint ordering.</summary>
+    public int Seed { get; set; }
+
+    /// <summary>The endpoint authorities available to attempts. At least one is required.</summary>
+    public IList<HttpEndpoint> Endpoints { get; } = new List<HttpEndpoint>();
+
+    /// <summary>The request-content replay policy. The default never buffers caller content.</summary>
+    public HttpContentReplayPolicy ContentReplayPolicy { get; set; }
+
+    /// <summary>The maximum buffered request-content size. Defaults to 1 MiB.</summary>
+    public long MaximumBufferSize { get; set; } = 1024 * 1024;
+
+    /// <summary>
+    /// Explicitly permits another attempt for methods other than GET, HEAD, OPTIONS, TRACE, PUT,
+    /// and DELETE. A request factory also counts as explicit opt-in.
+    /// </summary>
+    public bool AllowUnsafeMethodReplay { get; set; }
+
+    /// <summary>
+    /// Optionally creates a fresh complete request for each zero-based attempt. Returned requests
+    /// are owned and disposed by the handler; returning the original request preserves caller ownership.
+    /// </summary>
+    public Func<HttpRequestMessage, int, CancellationToken, ValueTask<HttpRequestMessage>>? RequestFactory { get; set; }
+}

--- a/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
@@ -220,6 +220,30 @@ public class GrpcResilienceTests
     }
 
     [Test]
+    public async Task Expired_Grpc_Deadline_Normalizes_Transport_Unavailable()
+    {
+        var response = new TaskCompletionSource<TestReply>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var trailers = new Metadata { { "selected", "true" } };
+        var invoker = new DelegateCallInvoker((_, _) => Call(response.Task))
+            .Intercept(new ShieldUnaryClientInterceptor(Shield.Empty));
+        var client = new Resilience.ResilienceClient(invoker);
+        using var call = client.UnaryAsync(
+            new TestRequest(),
+            deadline: DateTime.UtcNow.AddMilliseconds(50));
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        response.SetException(new RpcException(
+            new Status(StatusCode.Unavailable, "transport cancellation race"),
+            trailers));
+
+        var exception = await Assert.That(async () => await call.ResponseAsync)
+            .Throws<RpcException>();
+
+        await Assert.That(exception!.StatusCode).IsEqualTo(StatusCode.DeadlineExceeded);
+        await Assert.That(exception.Trailers.GetValue("selected")).IsEqualTo("true");
+    }
+
+    [Test]
     public async Task Deadline_Admission_Cutoff_Preserves_The_Failed_Attempt_Metadata()
     {
         var response = new TaskCompletionSource<TestReply>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Kevlar.IntegrationTests;
 
@@ -386,6 +387,255 @@ public class HttpReplayTests
     }
 
     [Test]
+    public async Task Standard_Hedging_Routes_And_Isolates_Endpoint_Breakers()
+    {
+        var calls = new System.Collections.Concurrent.ConcurrentDictionary<string, int>(
+            StringComparer.Ordinal);
+        var transport = new RecordingHandler((_, request, _) =>
+        {
+            var host = request.RequestUri!.Host;
+            _ = calls.AddOrUpdate(host, 1, static (_, current) => current + 1);
+            return Task.FromResult(new HttpResponseMessage(
+                host == "first.example" ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
+        });
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.HedgeDelay = Timeout.InfiniteTimeSpan;
+            options.ConsecutiveFailures = 1;
+            options.FailureRatio = null;
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+
+        using var first = await client.GetAsync("https://origin.example/api");
+        using var second = await client.GetAsync("https://origin.example/api");
+
+        await Assert.That(first.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(second.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(calls["first.example"]).IsEqualTo(1);
+        await Assert.That(calls["second.example"]).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Standard_Hedging_Attempt_Timeout_Advances_To_Next_Endpoint()
+    {
+        var timedOut = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var transport = new RecordingHandler(async (_, request, cancellationToken) =>
+        {
+            if (request.RequestUri!.Host == "first.example")
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    timedOut.TrySetResult();
+                    throw;
+                }
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.HedgeDelay = Timeout.InfiniteTimeSpan;
+            options.AttemptTimeout = TimeSpan.FromMilliseconds(20);
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+
+        using var response = await client.GetAsync("https://origin.example/api")
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await timedOut.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(transport.Attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Standard_Hedging_Propagates_Caller_Cancellation()
+    {
+        var transport = new RecordingHandler(async (_, _, cancellationToken) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.HedgeDelay = TimeSpan.Zero;
+            options.TotalTimeout = TimeSpan.FromMinutes(1);
+            options.AttemptTimeout = TimeSpan.FromMinutes(1);
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var cancellation = new CancellationTokenSource();
+
+        var send = client.GetAsync("https://origin.example/api", cancellation.Token);
+        await Task.Delay(20);
+        cancellation.Cancel();
+
+        var exception = await Assert.That(async () => await send).Throws<OperationCanceledException>();
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
+    public async Task Standard_Hedging_Total_Timeout_Covers_All_Attempts()
+    {
+        var transport = new RecordingHandler(async (_, _, cancellationToken) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.HedgeDelay = TimeSpan.Zero;
+            options.TotalTimeout = TimeSpan.FromSeconds(1);
+            options.AttemptTimeout = TimeSpan.FromMinutes(1);
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+
+        _ = await Assert.That(async () => await client.GetAsync("https://origin.example/api"))
+            .Throws<TimeoutExceededException>();
+
+        await Assert.That(transport.Attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Standard_Hedging_Explicitly_Replays_Unsafe_Content_And_Disposes_Failure()
+    {
+        var failedContent = new TrackingContent("failed");
+        var bodies = new List<string>();
+        var transport = new RecordingHandler(async (_, request, _) =>
+        {
+            bodies.Add(await request.Content!.ReadAsStringAsync());
+            return request.RequestUri!.Host == "first.example"
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = failedContent }
+                : new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.HedgeDelay = Timeout.InfiniteTimeSpan;
+            options.ContentReplayPolicy = HttpContentReplayPolicy.Buffer;
+            options.AllowUnsafeMethodReplay = true;
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+
+        using var response = await client.SendAsync(request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(bodies).IsEquivalentTo(["payload", "payload"]);
+        await Assert.That(failedContent.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Standard_Hedging_Rejects_Unsafe_Replay_Without_Explicit_Opt_In()
+    {
+        var failedContent = new TrackingContent("failed");
+        var transport = new RecordingHandler((_, _, _) => Task.FromResult(
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = failedContent }));
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.HedgeDelay = Timeout.InfiniteTimeSpan;
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+
+        _ = await Assert.That(async () => await client.SendAsync(request))
+            .Throws<HttpRequestReplayException>();
+
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+        await Assert.That(failedContent.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Standard_Hedging_Uses_Second_Endpoint_When_First_Is_Concurrency_Limited()
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var hosts = new System.Collections.Concurrent.ConcurrentBag<string>();
+        var transport = new RecordingHandler(async (_, request, cancellationToken) =>
+        {
+            hosts.Add(request.RequestUri!.Host);
+            if (request.RequestUri.Host == "first.example")
+            {
+                firstStarted.TrySetResult();
+                await release.Task.WaitAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.HedgeDelay = Timeout.InfiniteTimeSpan;
+            options.MaxConcurrency = 1;
+            options.MaxQueue = 0;
+            options.TotalTimeout = TimeSpan.FromMinutes(1);
+            options.AttemptTimeout = TimeSpan.FromMinutes(1);
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+
+        var holding = client.GetAsync("https://origin.example/holding");
+        await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        using var overflow = await client.GetAsync("https://origin.example/overflow")
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        release.TrySetResult();
+        using var held = await holding.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(overflow.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(held.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(hosts.Count(static host => host == "first.example")).IsEqualTo(1);
+        await Assert.That(hosts.Count(static host => host == "second.example")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Standard_Hedging_Uses_Weighted_Endpoint_Selection()
+    {
+        var hosts = new List<string>();
+        var transport = new RecordingHandler((_, request, _) =>
+        {
+            hosts.Add(request.RequestUri!.Host);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        using var services = CreateStandardHedgingServices(transport, options =>
+        {
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example"), 5));
+            options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example"), 1));
+            options.SelectionMode = HttpEndpointSelectionMode.Weighted;
+            options.Seed = 1729;
+            options.MaxAttempts = 1;
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+
+        for (var index = 0; index < 32; index++)
+        {
+            using var response = await client.GetAsync($"https://origin.example/{index}");
+        }
+
+        await Assert.That(hosts.Distinct().Count()).IsEqualTo(2);
+        await Assert.That(hosts.Count(static host => host == "first.example"))
+            .IsGreaterThan(hosts.Count(static host => host == "second.example"));
+    }
+
+    [Test]
     public async Task Weighted_Routing_Is_Deterministic_For_A_Seed()
     {
         var first = await WeightedSequence(1729);
@@ -589,6 +839,17 @@ public class HttpReplayTests
         }
 
         return new ShieldHttpHandlerOptions { Routing = routing };
+    }
+
+    private static ServiceProvider CreateStandardHedgingServices(
+        HttpMessageHandler transport,
+        Action<StandardHedgingShieldOptions> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient("standard-hedging")
+            .ConfigurePrimaryHttpMessageHandler(() => transport)
+            .AddStandardHedgingShield(configure);
+        return services.BuildServiceProvider();
     }
 
     private static HttpMessageInvoker CreateInvoker(

--- a/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
@@ -178,4 +178,30 @@ public class HttpResilienceTests
         await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("factory ok");
         await Assert.That(server.CallCount).IsEqualTo(2);
     }
+
+    [Test]
+    public async Task HttpClientFactory_Standard_Hedging_Routes_Across_Loopback_Endpoints()
+    {
+        await using var failing = FlakyHttpServer.Start((_, context) =>
+            FlakyHttpServer.Respond(context, 503));
+        await using var healthy = FlakyHttpServer.Start((_, context) =>
+            FlakyHttpServer.Respond(context, 200, "hedged ok"));
+        using var services = new ServiceCollection()
+            .AddHttpClient("hedged-backend")
+            .AddStandardHedgingShield(options =>
+            {
+                options.Endpoints.Add(new HttpEndpoint(new Uri(failing.Url)));
+                options.Endpoints.Add(new HttpEndpoint(new Uri(healthy.Url)));
+                options.HedgeDelay = Timeout.InfiniteTimeSpan;
+            })
+            .Services
+            .BuildServiceProvider();
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("hedged-backend");
+
+        using var response = await client.GetAsync("http://origin.invalid/path?q=1");
+
+        await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("hedged ok");
+        await Assert.That(failing.CallCount).IsEqualTo(1);
+        await Assert.That(healthy.CallCount).IsEqualTo(1);
+    }
 }

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -607,6 +607,13 @@ public class HttpContractTests
         await Assert.That(() => builder.AddStandardShield(
                 (Action<IServiceProvider, StandardHttpShieldOptions>)null!))
             .Throws<ArgumentNullException>();
+        await Assert.That(() => ShieldHttpClientBuilderExtensions.AddStandardHedgingShield(
+                nullBuilder!, _ => { }))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => builder.AddStandardHedgingShield(null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => builder.AddStandardHedgingShield(_ => { }))
+            .Throws<ArgumentException>();
     }
 
     private static HttpClient CreateClient(HttpMessageHandler inner, Shield<HttpResponseMessage> shield) =>


### PR DESCRIPTION
Closes #127.

## What changed

- add `AddStandardHedgingShield` and bindable `StandardHedgingShieldOptions`
- compose total timeout and hedging with endpoint-local concurrency limits, circuit breakers, and attempt timeouts
- preserve safe replay rules, ordered/weighted routing, state isolation, and exact response/request disposal
- document the one-line registration and add HTTP benchmarks

## Validation

- `dotnet build Kevlar.slnx -c Release --no-restore`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` — 680 passed
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` — 117 passed
- `npm run build` in `docs/`
- `Verify-Packages.ps1` — layout, consumers, analyzers, trimmed and single-file publish passed; NativeAOT remains Linux-CI-only
- `Verify-DocSnippets.ps1` — 99 snippets compiled and documented behavior executed

## Benchmark

ShortRun, .NET 10, HTTP happy path:

| Method | Mean | Allocated |
|---|---:|---:|
| Manual composition | 1.964 us | 3.41 KB |
| Standard registration | 1.977 us (1.01x) | 3.41 KB (1.00x) |