### PR TITLE
feat(rate-limit): add framework adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Testing package tests
         run: dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename testing.trx --results-directory artifacts/test-results/testing
 
+      - name: Rate limiting adapter tests
+        run: dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --report-trx --report-trx-filename rate-limiting.trx --results-directory artifacts/test-results/rate-limiting
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -166,6 +169,9 @@ jobs:
 
       - name: Collect testing package coverage
         run: dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/testing.cobertura.xml --coverage-output-format cobertura
+
+      - name: Collect rate limiting adapter coverage
+        run: dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/rate-limiting.cobertura.xml --coverage-output-format cobertura
 
       - name: Merge coverage reports
         run: dotnet reportgenerator '-reports:artifacts/coverage/raw/*.cobertura.xml' '-targetdir:artifacts/coverage/report' '-reporttypes:Cobertura;Html'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.11" />
     <PackageVersion Include="Grpc.Core.Api" Version="2.83.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.83.0" />
 

--- a/Kevlar.slnx
+++ b/Kevlar.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj" />
     <Project Path="src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj" />
     <Project Path="src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj" />
+    <Project Path="src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj" />
     <Project Path="src/Kevlar/Kevlar.csproj" />
     <Project Path="src/Kevlar.Analyzers/Kevlar.Analyzers.csproj" />
     <Project Path="src/Kevlar.Testing/Kevlar.Testing.csproj" />
@@ -16,6 +17,7 @@
     <Project Path="tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj" />
     <Project Path="tests/Kevlar.AllocationTests/Kevlar.AllocationTests.csproj" />
     <Project Path="tests/Kevlar.IntegrationTests/Kevlar.IntegrationTests.csproj" />
+    <Project Path="tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj" />
     <Project Path="tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj" />
     <Project Path="tests/Kevlar.Tests/Kevlar.Tests.csproj" />
     <Project Path="tests/Kevlar.Analyzers.Tests/Kevlar.Analyzers.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ One clause up top decides what "failure" means for every strategy below it — e
 | `Kevlar.Extensions.DependencyInjection` | Named shields, config-bound shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
 | `Kevlar.Extensions.Grpc` | Unary gRPC client interceptor, transient-status helpers, named-shield DI integration |
+| `Kevlar.Extensions.RateLimiting` | `System.Threading.RateLimiting` and custom lease-acquisition adapters |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |
 | `Kevlar.Testing` | Pipeline descriptors, shape assertions, and deterministic fake-time helpers |
 

--- a/benchmarks/Kevlar.Benchmarks/Kevlar.Benchmarks.csproj
+++ b/benchmarks/Kevlar.Benchmarks/Kevlar.Benchmarks.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\Kevlar.Extensions.DependencyInjection\Kevlar.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.Http\Kevlar.Extensions.Http.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.Grpc\Kevlar.Extensions.Grpc.csproj" />
+    <ProjectReference Include="..\..\src\Kevlar.Extensions.RateLimiting\Kevlar.Extensions.RateLimiting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
@@ -1,6 +1,7 @@
 using System.Threading.RateLimiting;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using Kevlar.Extensions.RateLimiting;
 using Polly;
 
 namespace Kevlar.Benchmarks;
@@ -23,6 +24,13 @@ public class RateLimitBenchmarks
         options.OnRejected = static _ => { };
         options.OnRejectedAsync = static _ => ValueTask.CompletedTask;
     });
+    private static readonly FixedWindowRateLimiter FrameworkLimiter = new(new FixedWindowRateLimiterOptions
+    {
+        PermitLimit = 1_000_000_000,
+        Window = TimeSpan.FromSeconds(1),
+        QueueLimit = 0,
+    });
+    private static readonly Shield KevlarFrameworkRateLimit = Shield.Empty.RateLimit(FrameworkLimiter);
 
     private static readonly ResiliencePipeline PollyRateLimit = new ResiliencePipelineBuilder()
         .AddRateLimiter(new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
@@ -42,4 +50,8 @@ public class RateLimitBenchmarks
     [BenchmarkCategory("Uncontended"), Benchmark]
     public ValueTask<int> Kevlar_WithHooks_Uncontended() =>
         KevlarRateLimitWithHooks.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("Uncontended"), Benchmark]
+    public ValueTask<int> Kevlar_FrameworkAdapter_Uncontended() =>
+        KevlarFrameworkRateLimit.ExecuteAsync(static _ => new ValueTask<int>(42));
 }

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -38,6 +38,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 | `Kevlar.Chaos` | Opt-in latency, fault, typed outcome and custom behavior injection |
 | `Kevlar.Extensions.DependencyInjection` | Named shields + `IKevlarRegistry` for Microsoft DI |
 | `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
+| `Kevlar.Extensions.RateLimiting` | `System.Threading.RateLimiting` and custom lease-acquisition adapters |
 | `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |
 
 ## Where to next?

--- a/docs/docs/strategies/rate-limit.md
+++ b/docs/docs/strategies/rate-limit.md
@@ -21,6 +21,58 @@ Shield.RateLimit(o =>
 });
 ```
 
+## System.Threading.RateLimiting adapters
+
+Install `Kevlar.Extensions.RateLimiting` to reuse a framework limiter without adding that dependency
+to Kevlar core:
+
+```shell
+dotnet add package Kevlar.Extensions.RateLimiting
+```
+
+```csharp
+using Kevlar.Extensions.RateLimiting;
+using System.Threading.RateLimiting;
+
+using var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+{
+    PermitLimit = 100,
+    Window = TimeSpan.FromSeconds(1),
+    QueueLimit = 20,
+    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+});
+
+var shield = Shield.Empty.RateLimit(limiter, options =>
+{
+    options.PermitCount = 1;
+    options.OnRejected = rejection =>
+        Console.WriteLine(rejection.RetryAfter);
+});
+
+await shield.ExecuteAsync(static _ => ValueTask.CompletedTask);
+```
+
+The caller owns the `RateLimiter`; the adapter never disposes it. Every returned `RateLimitLease`
+is held until the protected execution completes and is then disposed exactly once. Rejected lease
+metadata is copied before disposal. `MetadataName.RetryAfter` becomes
+`RateLimitExceededException.RetryAfter`, and the complete immutable snapshot is available from
+`RateLimiterRejectedEvent.Metadata`.
+
+Fixed-window, sliding-window, concurrency, chained, and custom limiters all use the same adapter.
+For a limiter owned behind another abstraction, supply asynchronous acquisition directly:
+
+<!-- doc-test-ignore: AcquireTenantLeaseAsync is supplied by the application's limiter abstraction. -->
+```csharp
+var shield = Shield.Empty.RateLimit(
+    static (permitCount, context) =>
+        AcquireTenantLeaseAsync(permitCount, context.CancellationToken));
+```
+
+The delegate must return a fresh acquired or rejected lease for each call. Rejection metrics and
+hooks follow the built-in contract: metric first, then `OnRejected`, then awaited
+`OnRejectedAsync`; a hook failure replaces `RateLimitExceededException`. Cancellation while
+queued is cancellation, not rejection, so hooks do not run.
+
 ## Options
 
 | Option | Default | What it does |

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -108,9 +108,9 @@ capturing replenished availability.
 
 ## Repository quality gates
 
-Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, analyzer, and testing-package suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
+Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, analyzer, testing-package, and rate-limiting-adapter suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
 
-The Linux coverage job merges all six suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
+The Linux coverage job merges all seven suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
 
 Core strategy mutation testing runs every Monday at 03:23 UTC and on demand. It uses the checked-in Stryker configuration, keeps 74% as the report reference, and treats the aggregate score as informational because timing-sensitive mutants make it nondeterministic. Operational Stryker failures still fail the workflow. Superseded runs are cancelled, and completed runs publish HTML and JSON reports as the `mutation-report` artifact. The audited initial survivors and threshold policy are recorded in `.github/mutation-baseline.md`. Run the test and mutation checks locally with:
 
@@ -123,6 +123,7 @@ dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --t
 dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
+dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict
 $coverageRoot = (New-Item -ItemType Directory -Force artifacts/coverage/raw).FullName
 dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/unit.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/chaos.cobertura.xml" --coverage-output-format cobertura
@@ -130,6 +131,7 @@ dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --t
 dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/integration.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/analyzers.cobertura.xml" --coverage-output-format cobertura
 dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/testing.cobertura.xml" --coverage-output-format cobertura
+dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 1 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output "$coverageRoot/rate-limiting.cobertura.xml" --coverage-output-format cobertura
 dotnet reportgenerator '-reports:artifacts/coverage/raw/*.cobertura.xml' '-targetdir:artifacts/coverage/report' '-reporttypes:Cobertura;Html'
 ./.github/scripts/Assert-Coverage.ps1 -Report artifacts/coverage/report/Cobertura.xml -MinimumLinePercent 92 -MinimumBranchPercent 86
 Push-Location src/Kevlar

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -29,6 +29,7 @@ $requiredPackages = @(
     'Kevlar.Extensions.DependencyInjection'
     'Kevlar.Extensions.Grpc'
     'Kevlar.Extensions.Http'
+    'Kevlar.Extensions.RateLimiting'
     'Kevlar.Testing'
 )
 
@@ -186,10 +187,12 @@ $builder = [Text.StringBuilder]::new()
 [void]$builder.AppendLine('using Kevlar.Extensions.DependencyInjection;')
 [void]$builder.AppendLine('using Kevlar.Extensions.Grpc;')
 [void]$builder.AppendLine('using Kevlar.Extensions.Http;')
+[void]$builder.AppendLine('using Kevlar.Extensions.RateLimiting;')
 [void]$builder.AppendLine('using Kevlar.Testing;')
 [void]$builder.AppendLine('using Microsoft.Extensions.DependencyInjection;')
 [void]$builder.AppendLine('using Microsoft.Extensions.Time.Testing;')
 [void]$builder.AppendLine('using Microsoft.Extensions.Logging;')
+[void]$builder.AppendLine('using System.Threading.RateLimiting;')
 [void]$builder.AppendLine('using OpenTelemetry.Metrics;')
 [void]$builder.AppendLine('using Polly;')
 [void]$builder.AppendLine('using Polly.CircuitBreaker;')

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -105,6 +105,10 @@ $expectedDependencies = @{
         'net10.0' = @('Kevlar', 'Microsoft.Extensions.Http')
         '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Http')
     }
+    'Kevlar.Extensions.RateLimiting' = @{
+        'net10.0' = @('Kevlar', 'System.Threading.RateLimiting')
+        '.NETStandard2.0' = @('Kevlar', 'System.Threading.RateLimiting')
+    }
     'Kevlar.Chaos' = @{
         'net10.0' = @('Kevlar')
         'net8.0' = @('Kevlar')
@@ -272,9 +276,11 @@ using Kevlar.Chaos;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Grpc;
 using Kevlar.Extensions.Http;
+using Kevlar.Extensions.RateLimiting;
 using Kevlar.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.Metrics;
+using System.Threading.RateLimiting;
 
 var shield = Shield.Empty;
 var descriptor = shield.GetDescriptor();
@@ -317,6 +323,16 @@ IServiceCollection services = new ServiceCollection();
 services.AddShield("consumer", shield);
 services.AddHttpClient("consumer").AddStandardShield();
 _ = new ShieldUnaryClientInterceptor(GrpcShield.WhenTransient().Retry(1));
+using var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+{
+    PermitLimit = 1,
+    QueueLimit = 0,
+    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+});
+if (await Shield.Empty.RateLimit(limiter).ExecuteAsync(static _ => new ValueTask<int>(42)) != 42)
+{
+    throw new InvalidOperationException("Rate limiting adapter execution failed.");
+}
 Console.WriteLine("Kevlar package consumer passed.");
 '@
 
@@ -337,6 +353,7 @@ Console.WriteLine("Kevlar package consumer passed.");
     <PackageReference Include="Kevlar.Chaos" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
+    <PackageReference Include="Kevlar.Extensions.RateLimiting" Version="$Version" />
     <PackageReference Include="Kevlar.Testing" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Grpc" Version="$Version" />
   </ItemGroup>

--- a/scripts/Verify-PublishCompatibility.ps1
+++ b/scripts/Verify-PublishCompatibility.ps1
@@ -113,6 +113,7 @@ try
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Grpc" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
+    <PackageReference Include="Kevlar.Extensions.RateLimiting" Version="$Version" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="$ConfigurationVersion" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$DependencyInjectionVersion" />
   </ItemGroup>
@@ -127,8 +128,10 @@ using Kevlar.Chaos;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Grpc;
 using Kevlar.Extensions.Http;
+using Kevlar.Extensions.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.RateLimiting;
 
 var untyped = Shield.Empty;
 if (untyped.Execute(static _ => 42) != 42
@@ -171,7 +174,15 @@ var isolated = await Shield.ConcurrencyLimit(1).ExecuteAsync(static _ => new Val
 var hedged = await Shield.Hedge(2, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
 var fallback = await Shield.For<int>().When<InvalidOperationException>().Fallback(42)
     .ExecuteAsync<int>(static _ => throw new InvalidOperationException());
-if (retried + timed + broken + limited + isolated + hedged + fallback != 294)
+using var frameworkLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+{
+    PermitLimit = 1,
+    QueueLimit = 0,
+    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+});
+var adapted = await Shield.Empty.RateLimit(frameworkLimiter)
+    .ExecuteAsync(static _ => new ValueTask<int>(42));
+if (retried + timed + broken + limited + isolated + hedged + fallback + adapted != 336)
 {
     throw new InvalidOperationException("Built-in strategy execution failed.");
 }

--- a/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
+++ b/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <RootNamespace>Kevlar.Extensions.RateLimiting</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <Description>System.Threading.RateLimiting adapters for Kevlar shields, including custom asynchronous lease acquisition.</Description>
+    <PackageTags>resilience;rate-limiting;system-threading-ratelimiting;kevlar</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <PackageReference Include="System.Threading.RateLimiting" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kevlar.Extensions.RateLimiting/PublicAPI.Shipped.txt
+++ b/src/Kevlar.Extensions.RateLimiting/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Kevlar.Extensions.RateLimiting/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.RateLimiting/PublicAPI.Unshipped.txt
@@ -1,0 +1,23 @@
+#nullable enable
+Kevlar.Extensions.RateLimiting.RateLimitLeaseAcquirer
+virtual Kevlar.Extensions.RateLimiting.RateLimitLeaseAcquirer.Invoke(int permitCount, Kevlar.KevlarContext! context) -> System.Threading.Tasks.ValueTask<System.Threading.RateLimiting.RateLimitLease!>
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions.OnRejected.get -> System.Action<Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent>?
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions.OnRejected.set -> void
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions.OnRejectedAsync.get -> System.Func<Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions.OnRejectedAsync.set -> void
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions.PermitCount.get -> int
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions.PermitCount.set -> void
+Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions.RateLimiterAdapterOptions() -> void
+Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent
+Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent.RateLimiterRejectedEvent() -> void
+Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!
+Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent.PermitCount.get -> int
+Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent.RetryAfter.get -> System.TimeSpan?
+Kevlar.Extensions.RateLimiting.RateLimiterRejectedEvent.StrategyIndex.get -> int
+Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions
+static Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions.RateLimit(this Kevlar.Shield! shield, Kevlar.Extensions.RateLimiting.RateLimitLeaseAcquirer! acquireLease, System.Action<Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions!>? configure = null) -> Kevlar.Shield!
+static Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions.RateLimit(this Kevlar.Shield! shield, System.Threading.RateLimiting.RateLimiter! limiter, System.Action<Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions!>? configure = null) -> Kevlar.Shield!
+static Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions.RateLimit<TResult>(this Kevlar.Shield<TResult>! shield, Kevlar.Extensions.RateLimiting.RateLimitLeaseAcquirer! acquireLease, System.Action<Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions!>? configure = null) -> Kevlar.Shield<TResult>!
+static Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions.RateLimit<TResult>(this Kevlar.Shield<TResult>! shield, System.Threading.RateLimiting.RateLimiter! limiter, System.Action<Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions!>? configure = null) -> Kevlar.Shield<TResult>!

--- a/src/Kevlar.Extensions.RateLimiting/RateLimitLeaseAcquirer.cs
+++ b/src/Kevlar.Extensions.RateLimiting/RateLimitLeaseAcquirer.cs
@@ -1,0 +1,11 @@
+using System.Threading.RateLimiting;
+
+namespace Kevlar.Extensions.RateLimiting;
+
+/// <summary>Acquires a rate-limit lease for one shield execution.</summary>
+/// <param name="permitCount">The configured number of permits requested per execution.</param>
+/// <param name="context">The current execution context, including its cancellation token.</param>
+/// <returns>The acquired or rejected lease. The adapter disposes it exactly once.</returns>
+public delegate ValueTask<RateLimitLease> RateLimitLeaseAcquirer(
+    int permitCount,
+    KevlarContext context);

--- a/src/Kevlar.Extensions.RateLimiting/RateLimiterAdapterOptions.cs
+++ b/src/Kevlar.Extensions.RateLimiting/RateLimiterAdapterOptions.cs
@@ -1,0 +1,19 @@
+namespace Kevlar.Extensions.RateLimiting;
+
+/// <summary>Configuration for a framework or delegate-backed rate-limiter adapter.</summary>
+/// <remarks>
+/// Rejections record the standard Kevlar rejection metric, invoke <see cref="OnRejected"/>, then
+/// invoke and await <see cref="OnRejectedAsync"/>. A callback failure replaces the
+/// <see cref="RateLimitExceededException"/> that would otherwise be returned.
+/// </remarks>
+public sealed class RateLimiterAdapterOptions
+{
+    /// <summary>The number of permits acquired for each execution. Default 1.</summary>
+    public int PermitCount { get; set; } = 1;
+
+    /// <summary>Invoked synchronously when a lease rejects an execution.</summary>
+    public Action<RateLimiterRejectedEvent>? OnRejected { get; set; }
+
+    /// <summary>Invoked and awaited after <see cref="OnRejected"/> for a rejected lease.</summary>
+    public Func<RateLimiterRejectedEvent, ValueTask>? OnRejectedAsync { get; set; }
+}

--- a/src/Kevlar.Extensions.RateLimiting/RateLimiterRejectedEvent.cs
+++ b/src/Kevlar.Extensions.RateLimiting/RateLimiterRejectedEvent.cs
@@ -1,0 +1,37 @@
+namespace Kevlar.Extensions.RateLimiting;
+
+/// <summary>Describes an execution rejected by an adapted rate limiter.</summary>
+public readonly struct RateLimiterRejectedEvent
+{
+    internal RateLimiterRejectedEvent(
+        TimeSpan? retryAfter,
+        IReadOnlyDictionary<string, object?> metadata,
+        int permitCount,
+        int strategyIndex,
+        KevlarContext context)
+    {
+        RetryAfter = retryAfter;
+        Metadata = metadata;
+        PermitCount = permitCount;
+        StrategyIndex = strategyIndex;
+        Context = context;
+    }
+
+    /// <summary>The lease-provided delay before another acquisition should be attempted.</summary>
+    public TimeSpan? RetryAfter { get; }
+
+    /// <summary>An immutable snapshot of all metadata supplied by the rejected lease.</summary>
+    public IReadOnlyDictionary<string, object?> Metadata { get; }
+
+    /// <summary>The number of permits requested for the execution.</summary>
+    public int PermitCount { get; }
+
+    /// <summary>The zero-based position of this strategy in the executing shield.</summary>
+    public int StrategyIndex { get; }
+
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it after synchronous and
+    /// asynchronous rejection callbacks complete.
+    /// </summary>
+    public KevlarContext Context { get; }
+}

--- a/src/Kevlar.Extensions.RateLimiting/RateLimiterStrategy.cs
+++ b/src/Kevlar.Extensions.RateLimiting/RateLimiterStrategy.cs
@@ -1,0 +1,257 @@
+using System.Collections.ObjectModel;
+using System.Threading.RateLimiting;
+using Kevlar.Internal;
+
+namespace Kevlar.Extensions.RateLimiting;
+
+internal sealed class RateLimiterStrategy : Strategy
+{
+    private static readonly IReadOnlyDictionary<string, object?> EmptyMetadata =
+        new ReadOnlyDictionary<string, object?>(new Dictionary<string, object?>());
+
+    private readonly RateLimitLeaseAcquirer _acquireLease;
+    private readonly int _permitCount;
+    private readonly Action<RateLimiterRejectedEvent>? _onRejected;
+    private readonly Func<RateLimiterRejectedEvent, ValueTask>? _onRejectedAsync;
+    private readonly string _kind;
+
+    internal override bool InvokesContinuationAtMostOnce => true;
+
+    protected internal override bool IsDuplicateReferenceUnsafe => true;
+
+    internal RateLimiterStrategy(
+        RateLimitLeaseAcquirer acquireLease,
+        RateLimiterAdapterOptions options,
+        string kind)
+    {
+        if (options.PermitCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "PermitCount must be positive.");
+        }
+
+        _acquireLease = acquireLease;
+        _permitCount = options.PermitCount;
+        _onRejected = options.OnRejected;
+        _onRejectedAsync = options.OnRejectedAsync;
+        _kind = kind;
+    }
+
+    public override string Describe() => $"RateLimitAdapter({_kind}, permits {_permitCount})";
+
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        ValueTask<RateLimitLease> acquisition;
+        try
+        {
+            acquisition = _acquireLease(_permitCount, context);
+        }
+        catch (Exception exception)
+        {
+            return Failure<T>(exception);
+        }
+
+        if (!acquisition.IsCompletedSuccessfully)
+        {
+            return AwaitAcquisitionAsync(acquisition, next, context);
+        }
+
+        return ExecuteLease(acquisition.Result, next, context);
+    }
+
+    private async ValueTask<Outcome<T>> AwaitAcquisitionAsync<T, TState>(
+        ValueTask<RateLimitLease> acquisition,
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        RateLimitLease lease;
+        try
+        {
+            lease = await acquisition.ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            return Outcome<T>.FromException(exception);
+        }
+
+        return await ExecuteLease(lease, next, context).ConfigureAwait(false);
+    }
+
+    private ValueTask<Outcome<T>> ExecuteLease<T, TState>(
+        RateLimitLease lease,
+        Continuation<T, TState> next,
+        KevlarContext context)
+    {
+        if (context.CancellationToken.IsCancellationRequested)
+        {
+            return DisposeWithFailure<T>(
+                lease,
+                new OperationCanceledException(context.CancellationToken));
+        }
+
+        bool isAcquired;
+        try
+        {
+            isAcquired = lease.IsAcquired;
+        }
+        catch (Exception exception)
+        {
+            return DisposeWithFailure<T>(lease, exception);
+        }
+
+        if (!isAcquired)
+        {
+            return RejectLease<T>(lease, context);
+        }
+
+        ValueTask<Outcome<T>> execution;
+        try
+        {
+            execution = next.InvokeAsync(context);
+        }
+        catch (Exception exception)
+        {
+            return DisposeWithFailure<T>(lease, exception);
+        }
+
+        if (!execution.IsCompletedSuccessfully)
+        {
+            return AwaitExecutionAsync(execution, lease);
+        }
+
+        var outcome = execution.Result;
+        try
+        {
+            lease.Dispose();
+        }
+        catch (Exception exception)
+        {
+            return Failure<T>(exception);
+        }
+
+        return new ValueTask<Outcome<T>>(outcome);
+    }
+
+    private ValueTask<Outcome<T>> RejectLease<T>(RateLimitLease lease, KevlarContext context)
+    {
+        TimeSpan? retryAfter;
+        IReadOnlyDictionary<string, object?> metadata;
+        try
+        {
+            retryAfter = lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan value)
+                ? value
+                : null;
+            metadata = SnapshotMetadata(lease);
+        }
+        catch (Exception exception)
+        {
+            return DisposeWithFailure<T>(lease, exception);
+        }
+
+        try
+        {
+            lease.Dispose();
+        }
+        catch (Exception exception)
+        {
+            return Failure<T>(exception);
+        }
+
+        KevlarMetrics.Rejection(context.ShieldName, "rate_limit");
+        var rejection = new RateLimitExceededException(retryAfter);
+        if (_onRejected is null && _onRejectedAsync is null)
+        {
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+        }
+
+        var rejectedEvent = new RateLimiterRejectedEvent(
+            retryAfter,
+            metadata,
+            _permitCount,
+            context.StrategyIndex,
+            context);
+        try
+        {
+            _onRejected?.Invoke(rejectedEvent);
+            if (_onRejectedAsync is null)
+            {
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+            }
+
+            var notification = _onRejectedAsync(rejectedEvent);
+            if (notification.IsCompletedSuccessfully)
+            {
+                notification.GetAwaiter().GetResult();
+                return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection));
+            }
+
+            return AwaitRejectionAsync<T>(notification, rejection);
+        }
+        catch (Exception callbackFailure)
+        {
+            return Failure<T>(callbackFailure);
+        }
+    }
+
+    private static IReadOnlyDictionary<string, object?> SnapshotMetadata(RateLimitLease lease)
+    {
+        Dictionary<string, object?>? snapshot = null;
+        foreach (var pair in lease.GetAllMetadata())
+        {
+            (snapshot ??= new Dictionary<string, object?>(StringComparer.Ordinal))[pair.Key] = pair.Value;
+        }
+
+        return snapshot is null
+            ? EmptyMetadata
+            : new ReadOnlyDictionary<string, object?>(snapshot);
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitExecutionAsync<T>(
+        ValueTask<Outcome<T>> execution,
+        RateLimitLease lease)
+    {
+        try
+        {
+            return await execution.ConfigureAwait(false);
+        }
+        finally
+        {
+            lease.Dispose();
+        }
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitRejectionAsync<T>(
+        ValueTask notification,
+        RateLimitExceededException rejection)
+    {
+        try
+        {
+            await notification.ConfigureAwait(false);
+            return Outcome<T>.FromException(rejection);
+        }
+        catch (Exception callbackFailure)
+        {
+            return Outcome<T>.FromException(callbackFailure);
+        }
+    }
+
+    private static ValueTask<Outcome<T>> DisposeWithFailure<T>(
+        RateLimitLease lease,
+        Exception failure)
+    {
+        try
+        {
+            lease.Dispose();
+        }
+        catch (Exception disposalFailure)
+        {
+            failure = new AggregateException(failure, disposalFailure).Flatten();
+        }
+
+        return Failure<T>(failure);
+    }
+
+    private static ValueTask<Outcome<T>> Failure<T>(Exception exception) =>
+        new(Outcome<T>.FromException(exception));
+}

--- a/src/Kevlar.Extensions.RateLimiting/ShieldRateLimiterExtensions.cs
+++ b/src/Kevlar.Extensions.RateLimiting/ShieldRateLimiterExtensions.cs
@@ -1,0 +1,99 @@
+using System.Threading.RateLimiting;
+
+namespace Kevlar.Extensions.RateLimiting;
+
+/// <summary>Adds System.Threading.RateLimiting-backed strategies to Kevlar shields.</summary>
+public static class ShieldRateLimiterExtensions
+{
+    /// <summary>Appends a strategy backed by <paramref name="limiter"/>.</summary>
+    public static Shield RateLimit(
+        this Shield shield,
+        RateLimiter limiter,
+        Action<RateLimiterAdapterOptions>? configure = null)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return shield.Use(CreateStrategy(limiter, configure));
+    }
+
+    /// <summary>Appends a strategy backed by caller-provided asynchronous lease acquisition.</summary>
+    public static Shield RateLimit(
+        this Shield shield,
+        RateLimitLeaseAcquirer acquireLease,
+        Action<RateLimiterAdapterOptions>? configure = null)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return shield.Use(CreateStrategy(acquireLease, configure));
+    }
+
+    /// <summary>Appends a strategy backed by <paramref name="limiter"/>.</summary>
+    public static Shield<TResult> RateLimit<TResult>(
+        this Shield<TResult> shield,
+        RateLimiter limiter,
+        Action<RateLimiterAdapterOptions>? configure = null)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return shield.Use(CreateStrategy(limiter, configure));
+    }
+
+    /// <summary>Appends a strategy backed by caller-provided asynchronous lease acquisition.</summary>
+    public static Shield<TResult> RateLimit<TResult>(
+        this Shield<TResult> shield,
+        RateLimitLeaseAcquirer acquireLease,
+        Action<RateLimiterAdapterOptions>? configure = null)
+    {
+        if (shield is null)
+        {
+            throw new ArgumentNullException(nameof(shield));
+        }
+
+        return shield.Use(CreateStrategy(acquireLease, configure));
+    }
+
+    private static Strategy CreateStrategy(
+        RateLimiter limiter,
+        Action<RateLimiterAdapterOptions>? configure)
+    {
+        if (limiter is null)
+        {
+            throw new ArgumentNullException(nameof(limiter));
+        }
+
+        var options = CreateOptions(configure);
+        return new RateLimiterStrategy(
+            (permitCount, context) => limiter.AcquireAsync(permitCount, context.CancellationToken),
+            options,
+            "framework");
+    }
+
+    private static Strategy CreateStrategy(
+        RateLimitLeaseAcquirer acquireLease,
+        Action<RateLimiterAdapterOptions>? configure)
+    {
+        if (acquireLease is null)
+        {
+            throw new ArgumentNullException(nameof(acquireLease));
+        }
+
+        return new RateLimiterStrategy(acquireLease, CreateOptions(configure), "delegate");
+    }
+
+    private static RateLimiterAdapterOptions CreateOptions(
+        Action<RateLimiterAdapterOptions>? configure)
+    {
+        var options = new RateLimiterAdapterOptions();
+        configure?.Invoke(options);
+        return options;
+    }
+}

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />
     <InternalsVisibleTo Include="Kevlar.Testing" />
+    <InternalsVisibleTo Include="Kevlar.Extensions.RateLimiting" />
   </ItemGroup>
 
 </Project>

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.Grpc" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.Http" VersionOverride="$(KevlarPackageVersion)" />
+    <PackageReference Include="Kevlar.Extensions.RateLimiting" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Testing" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />

--- a/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
+++ b/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kevlar.Extensions.RateLimiting\Kevlar.Extensions.RateLimiting.csproj" />
+    <ProjectReference Include="..\..\src\Kevlar.Testing\Kevlar.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Kevlar.Extensions.RateLimiting.Tests/RateLimiterAdapterTests.cs
+++ b/tests/Kevlar.Extensions.RateLimiting.Tests/RateLimiterAdapterTests.cs
@@ -1,0 +1,551 @@
+using System.Diagnostics.Metrics;
+using System.Threading.RateLimiting;
+using Kevlar.Extensions.RateLimiting;
+using Kevlar.Testing;
+
+namespace Kevlar.Extensions.RateLimiting.Tests;
+
+public class RateLimiterAdapterTests
+{
+    [Test]
+    public async Task Fixed_Window_Preserves_Retry_After_And_Hook_Order()
+    {
+        using var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 1,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = false,
+        });
+        using var listener = new RejectionListener("fixed-window");
+        var order = new List<string>();
+        RateLimiterRejectedEvent observed = default;
+        var shield = Shield.Empty
+            .RateLimit(limiter, options =>
+            {
+                options.OnRejected = rejection =>
+                {
+                    observed = rejection;
+                    order.Add(listener.Count == 1 ? "metric-sync" : "sync-before-metric");
+                };
+                options.OnRejectedAsync = async rejection =>
+                {
+                    await Task.Yield();
+                    await Assert.That(ReferenceEquals(rejection.Context, observed.Context)).IsTrue();
+                    order.Add("async");
+                };
+            })
+            .WithName("fixed-window");
+
+        await shield.ExecuteAsync(static _ => new ValueTask<int>(1));
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(2));
+
+        var exception = outcome.Exception as RateLimitExceededException;
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.RetryAfter).IsNotNull();
+        await Assert.That(exception.RetryAfter > TimeSpan.Zero).IsTrue();
+        await Assert.That(observed.RetryAfter).IsEqualTo(exception.RetryAfter);
+        await Assert.That(observed.Metadata.ContainsKey(MetadataName.RetryAfter.Name)).IsTrue();
+        await Assert.That(observed.PermitCount).IsEqualTo(1);
+        await Assert.That(observed.StrategyIndex).IsEqualTo(0);
+        await Assert.That(order.SequenceEqual(["metric-sync", "async"])).IsTrue();
+    }
+
+    [Test]
+    public async Task Sliding_Window_And_Chained_Limiters_Reject()
+    {
+        using var sliding = new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = 1,
+            Window = TimeSpan.FromMinutes(1),
+            SegmentsPerWindow = 2,
+            QueueLimit = 0,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = false,
+        });
+        await AssertRejectsSecondExecution(sliding);
+
+        using var first = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 1,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = false,
+        });
+        using var second = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = 1,
+            Window = TimeSpan.FromMinutes(1),
+            QueueLimit = 0,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = false,
+        });
+        using var chained = RateLimiter.CreateChained(first, second);
+        await AssertRejectsSecondExecution(chained);
+    }
+
+    [Test]
+    public async Task Concurrency_Limiter_Queues_Releases_And_Cancels()
+    {
+        using var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+        {
+            PermitLimit = 1,
+            QueueLimit = 1,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+        });
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var rejected = 0;
+        var shield = Shield.Empty.RateLimit(limiter, options =>
+            options.OnRejected = _ => rejected++);
+        var occupying = shield.ExecuteAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+            return 1;
+        }).AsTask();
+        await entered.Task;
+
+        using var cancellation = new CancellationTokenSource();
+        var queued = shield.ExecuteAsync(static _ => new ValueTask<int>(2), cancellation.Token).AsTask();
+        await Assert.That(queued.IsCompleted).IsFalse();
+        cancellation.Cancel();
+        await Assert.That(async () => await queued).Throws<OperationCanceledException>();
+        await Assert.That(rejected).IsEqualTo(0);
+
+        var replacement = shield.ExecuteAsync(static _ => new ValueTask<int>(3)).AsTask();
+        release.SetResult();
+        await Assert.That(await occupying).IsEqualTo(1);
+        await Assert.That(await replacement.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Delegate_Acquisition_Receives_Context_And_Disposes_Lease_Once()
+    {
+        var lease = new TrackingLease(isAcquired: true);
+        int observedPermitCount = 0;
+        string? observedName = null;
+        var shield = Shield.Empty
+            .RateLimit((permitCount, context) =>
+            {
+                observedPermitCount = permitCount;
+                observedName = context.ShieldName;
+                return new ValueTask<RateLimitLease>(lease);
+            }, options => options.PermitCount = 3)
+            .WithName("delegate-source");
+
+        await Assert.That(await shield.ExecuteAsync(static _ => new ValueTask<int>(42))).IsEqualTo(42);
+        await Assert.That(observedPermitCount).IsEqualTo(3);
+        await Assert.That(observedName).IsEqualTo("delegate-source");
+        await Assert.That(lease.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Custom_Limiter_Lease_Is_Held_Through_Async_Execution()
+    {
+        var lease = new TrackingLease(isAcquired: true);
+        using var limiter = new StubLimiter(_ => new ValueTask<RateLimitLease>(lease));
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield<int>.Empty.RateLimit(limiter);
+
+        var execution = shield.ExecuteAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+            return 42;
+        }).AsTask();
+        await entered.Task;
+        await Assert.That(lease.DisposeCount).IsEqualTo(0);
+
+        release.SetResult();
+        await Assert.That(await execution).IsEqualTo(42);
+        await Assert.That(lease.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Rejected_Custom_Lease_Snapshots_Metadata_Before_Disposal()
+    {
+        var retryAfter = TimeSpan.FromSeconds(7);
+        var lease = new TrackingLease(
+            isAcquired: false,
+            new Dictionary<string, object?>
+            {
+                [MetadataName.RetryAfter.Name] = retryAfter,
+                ["tenant"] = "alpha",
+            });
+        RateLimiterRejectedEvent observed = default;
+        using var limiter = new StubLimiter(_ => new ValueTask<RateLimitLease>(lease));
+        var shield = Shield.Empty.RateLimit(limiter, options =>
+            options.OnRejected = rejection => observed = rejection);
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(outcome.Exception).IsTypeOf<RateLimitExceededException>();
+        await Assert.That(((RateLimitExceededException)outcome.Exception!).RetryAfter).IsEqualTo(retryAfter);
+        await Assert.That(observed.Metadata["tenant"]).IsEqualTo("alpha");
+        await Assert.That(lease.DisposeCount).IsEqualTo(1);
+        await Assert.That(lease.MetadataReadAfterDispose).IsFalse();
+    }
+
+    [Test]
+    public async Task Callback_Failure_Replaces_Rejection_And_Skips_Later_Hook()
+    {
+        var callbackFailure = new InvalidOperationException("callback failed");
+        var asyncCalls = 0;
+        var shield = Shield.Empty.RateLimit(
+            static (_, _) => new ValueTask<RateLimitLease>(new TrackingLease(false)),
+            options =>
+            {
+                options.OnRejected = _ => throw callbackFailure;
+                options.OnRejectedAsync = _ =>
+                {
+                    asyncCalls++;
+                    return ValueTask.CompletedTask;
+                };
+            });
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, callbackFailure)).IsTrue();
+        await Assert.That(asyncCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Asynchronous_Callback_Failure_Replaces_Rejection()
+    {
+        var callbackFailure = new InvalidOperationException("async callback failed");
+        var shield = Shield.Empty.RateLimit(
+            static (_, _) => new ValueTask<RateLimitLease>(new TrackingLease(false)),
+            options => options.OnRejectedAsync = async _ =>
+            {
+                await Task.Yield();
+                throw callbackFailure;
+            });
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(ReferenceEquals(outcome.Exception, callbackFailure)).IsTrue();
+    }
+
+    [Test]
+    public async Task Completed_Asynchronous_Callback_Preserves_Rejection()
+    {
+        var shield = Shield.Empty.RateLimit(
+            static (_, _) => new ValueTask<RateLimitLease>(new TrackingLease(false)),
+            options => options.OnRejectedAsync = static _ => ValueTask.CompletedTask);
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(outcome.Exception).IsTypeOf<RateLimitExceededException>();
+    }
+
+    [Test]
+    public async Task Cancellation_Wins_Acquisition_Race_And_Disposes_Returned_Lease()
+    {
+        var acquisition = new TaskCompletionSource<RateLimitLease>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lease = new TrackingLease(isAcquired: true);
+        var invoked = false;
+        var rejections = 0;
+        var shield = Shield.Empty.RateLimit(
+            (_, _) => new ValueTask<RateLimitLease>(acquisition.Task),
+            options => options.OnRejected = _ => rejections++);
+        using var cancellation = new CancellationTokenSource();
+
+        var execution = shield.ExecuteAsync(_ =>
+        {
+            invoked = true;
+            return new ValueTask<int>(42);
+        }, cancellation.Token).AsTask();
+        cancellation.Cancel();
+        acquisition.SetResult(lease);
+
+        var exception = await Assert.That(async () => await execution)
+            .Throws<OperationCanceledException>();
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+        await Assert.That(invoked).IsFalse();
+        await Assert.That(rejections).IsEqualTo(0);
+        await Assert.That(lease.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Concurrent_Async_Executions_Dispose_Every_Lease_Once()
+    {
+        const int executionCount = 64;
+        var leases = new List<TrackingLease>();
+        var gate = new object();
+        var shield = Shield.Empty.RateLimit((_, _) =>
+        {
+            var lease = new TrackingLease(isAcquired: true);
+            lock (gate)
+            {
+                leases.Add(lease);
+            }
+
+            return new ValueTask<RateLimitLease>(lease);
+        });
+
+        var executions = Enumerable.Range(0, executionCount)
+            .Select(index => shield.ExecuteAsync(async _ =>
+            {
+                await Task.Yield();
+                return index;
+            }).AsTask());
+
+        await Task.WhenAll(executions);
+        await Assert.That(leases.Count).IsEqualTo(executionCount);
+        await Assert.That(leases.All(static lease => lease.DisposeCount == 1)).IsTrue();
+    }
+
+    [Test]
+    public async Task Description_Identifies_Source_Without_Exposing_Limiter()
+    {
+        using var limiter = new StubLimiter(static _ =>
+            new ValueTask<RateLimitLease>(new TrackingLease(true)));
+        var frameworkShield = Shield.Empty.RateLimit(limiter, options => options.PermitCount = 2);
+        var delegateShield = Shield<int>.Empty.RateLimit(static (_, _) =>
+            new ValueTask<RateLimitLease>(new TrackingLease(true)));
+
+        var frameworkDescriptor = frameworkShield.GetDescriptor()
+            .AssertContainsSingle<CustomStrategyDescriptor>();
+        var delegateDescriptor = delegateShield.GetDescriptor()
+            .AssertContainsSingle<CustomStrategyDescriptor>();
+
+        await Assert.That(frameworkDescriptor.Description).IsEqualTo(
+            "RateLimitAdapter(framework, permits 2)");
+        await Assert.That(delegateDescriptor.Description).IsEqualTo(
+            "RateLimitAdapter(delegate, permits 1)");
+        await Assert.That(frameworkDescriptor.Description.Contains(limiter.GetType().FullName!)).IsFalse();
+    }
+
+    [Test]
+    public async Task Acquisition_And_Lease_Failures_Are_Outcomes_And_Dispose_Once()
+    {
+        var synchronousFailure = new InvalidOperationException("sync acquire");
+        var synchronous = Shield.Empty.RateLimit((_, _) => throw synchronousFailure);
+        var synchronousOutcome = await synchronous.ExecuteOutcomeAsync(
+            static _ => new ValueTask<int>(42));
+        await Assert.That(ReferenceEquals(synchronousOutcome.Exception, synchronousFailure)).IsTrue();
+
+        var asynchronousFailure = new InvalidOperationException("async acquire");
+        var asynchronous = Shield.Empty.RateLimit((_, _) =>
+            ValueTask.FromException<RateLimitLease>(asynchronousFailure));
+        var asynchronousOutcome = await asynchronous.ExecuteOutcomeAsync(
+            static _ => new ValueTask<int>(42));
+        await Assert.That(ReferenceEquals(asynchronousOutcome.Exception, asynchronousFailure)).IsTrue();
+
+        var stateFailure = new InvalidOperationException("lease state");
+        var stateLease = new TrackingLease(true) { IsAcquiredFailure = stateFailure };
+        var stateShield = Shield.Empty.RateLimit((_, _) => new ValueTask<RateLimitLease>(stateLease));
+        var stateOutcome = await stateShield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+        await Assert.That(ReferenceEquals(stateOutcome.Exception, stateFailure)).IsTrue();
+        await Assert.That(stateLease.DisposeCount).IsEqualTo(1);
+
+        var metadataFailure = new InvalidOperationException("lease metadata");
+        var metadataLease = new TrackingLease(false) { MetadataFailure = metadataFailure };
+        var metadataShield = Shield.Empty.RateLimit((_, _) =>
+            new ValueTask<RateLimitLease>(metadataLease));
+        var metadataOutcome = await metadataShield.ExecuteOutcomeAsync(
+            static _ => new ValueTask<int>(42));
+        await Assert.That(ReferenceEquals(metadataOutcome.Exception, metadataFailure)).IsTrue();
+        await Assert.That(metadataLease.DisposeCount).IsEqualTo(1);
+
+        var disposalFailure = new InvalidOperationException("lease disposal");
+        var acquiredLease = new TrackingLease(true) { DisposalFailure = disposalFailure };
+        var acquiredShield = Shield.Empty.RateLimit((_, _) =>
+            new ValueTask<RateLimitLease>(acquiredLease));
+        var acquiredOutcome = await acquiredShield.ExecuteOutcomeAsync(
+            static _ => new ValueTask<int>(42));
+        await Assert.That(ReferenceEquals(acquiredOutcome.Exception, disposalFailure)).IsTrue();
+        await Assert.That(acquiredLease.DisposeCount).IsEqualTo(1);
+
+        var rejectedLease = new TrackingLease(false) { DisposalFailure = disposalFailure };
+        var rejectedShield = Shield.Empty.RateLimit((_, _) =>
+            new ValueTask<RateLimitLease>(rejectedLease));
+        var rejectedOutcome = await rejectedShield.ExecuteOutcomeAsync(
+            static _ => new ValueTask<int>(42));
+        await Assert.That(ReferenceEquals(rejectedOutcome.Exception, disposalFailure)).IsTrue();
+        await Assert.That(rejectedLease.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Disposal_Failure_Is_Aggregated_With_An_Earlier_Lease_Failure()
+    {
+        var stateFailure = new InvalidOperationException("lease state");
+        var disposalFailure = new InvalidOperationException("lease disposal");
+        var lease = new TrackingLease(true)
+        {
+            IsAcquiredFailure = stateFailure,
+            DisposalFailure = disposalFailure,
+        };
+        var shield = Shield.Empty.RateLimit((_, _) => new ValueTask<RateLimitLease>(lease));
+
+        var outcome = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+
+        var aggregate = outcome.Exception as AggregateException;
+        await Assert.That(aggregate).IsNotNull();
+        await Assert.That(aggregate!.InnerExceptions.Contains(stateFailure)).IsTrue();
+        await Assert.That(aggregate.InnerExceptions.Contains(disposalFailure)).IsTrue();
+        await Assert.That(lease.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Options_And_Duplicate_Strategy_Contracts_Are_Validated()
+    {
+        using var limiter = new StubLimiter(static _ =>
+            new ValueTask<RateLimitLease>(new TrackingLease(true)));
+
+        await Assert.That(() => Shield.Empty.RateLimit(
+            limiter,
+            options => options.PermitCount = 0)).Throws<ArgumentOutOfRangeException>();
+
+        var shield = Shield.Empty.RateLimit(limiter);
+        await Assert.That(shield.InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(() => Shield.Compose(shield, shield)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Null_Public_Arguments_Are_Rejected()
+    {
+        using var limiter = new StubLimiter(static _ =>
+            new ValueTask<RateLimitLease>(new TrackingLease(true)));
+        RateLimitLeaseAcquirer acquire = static (_, _) =>
+            new ValueTask<RateLimitLease>(new TrackingLease(true));
+
+        await Assert.That(() => ShieldRateLimiterExtensions.RateLimit(null!, limiter))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => ShieldRateLimiterExtensions.RateLimit(null!, acquire))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => ShieldRateLimiterExtensions.RateLimit<int>(null!, limiter))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => ShieldRateLimiterExtensions.RateLimit<int>(null!, acquire))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => Shield.Empty.RateLimit((RateLimiter)null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => Shield.Empty.RateLimit((RateLimitLeaseAcquirer)null!))
+            .Throws<ArgumentNullException>();
+    }
+
+    private static async Task AssertRejectsSecondExecution(RateLimiter limiter)
+    {
+        var shield = Shield.Empty.RateLimit(limiter);
+        await shield.ExecuteAsync(static _ => new ValueTask<int>(1));
+        await Assert.That(async () => await shield.ExecuteAsync(static _ => new ValueTask<int>(2)))
+            .Throws<RateLimitExceededException>();
+    }
+
+    private sealed class StubLimiter(
+        Func<CancellationToken, ValueTask<RateLimitLease>> acquire) : RateLimiter
+    {
+        public override TimeSpan? IdleDuration => null;
+
+        protected override RateLimitLease AttemptAcquireCore(int permitCount) =>
+            acquire(default).GetAwaiter().GetResult();
+
+        protected override ValueTask<RateLimitLease> AcquireAsyncCore(
+            int permitCount,
+            CancellationToken cancellationToken) => acquire(cancellationToken);
+
+        public override RateLimiterStatistics? GetStatistics() => null;
+    }
+
+    private sealed class TrackingLease : RateLimitLease
+    {
+        private readonly bool _isAcquired;
+        private readonly IReadOnlyDictionary<string, object?> _metadata;
+        private int _disposeCount;
+
+        public TrackingLease(
+            bool isAcquired,
+            IReadOnlyDictionary<string, object?>? metadata = null)
+        {
+            _isAcquired = isAcquired;
+            _metadata = metadata ?? new Dictionary<string, object?>();
+        }
+
+        public override bool IsAcquired => IsAcquiredFailure is null
+            ? _isAcquired
+            : throw IsAcquiredFailure;
+
+        public override IEnumerable<string> MetadataNames => _metadata.Keys;
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public Exception? IsAcquiredFailure { get; init; }
+
+        public Exception? MetadataFailure { get; init; }
+
+        public Exception? DisposalFailure { get; init; }
+
+        public bool MetadataReadAfterDispose { get; private set; }
+
+        public override bool TryGetMetadata(string metadataName, out object? metadata)
+        {
+            if (MetadataFailure is not null)
+            {
+                throw MetadataFailure;
+            }
+
+            MetadataReadAfterDispose |= DisposeCount > 0;
+            return _metadata.TryGetValue(metadataName, out metadata);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Interlocked.Increment(ref _disposeCount);
+            if (DisposalFailure is not null)
+            {
+                throw DisposalFailure;
+            }
+        }
+    }
+
+    private sealed class RejectionListener : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        private readonly string _shieldName;
+        private int _count;
+
+        public RejectionListener(string shieldName)
+        {
+            _shieldName = shieldName;
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == KevlarDiagnostics.MeterName
+                    && instrument.Name == "kevlar.rejections")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+            {
+                string? name = null;
+                string? kind = null;
+                foreach (var tag in tags)
+                {
+                    if (tag.Key == "kevlar.shield.name")
+                    {
+                        name = tag.Value as string;
+                    }
+                    else if (tag.Key == "kevlar.rejection.type")
+                    {
+                        kind = tag.Value as string;
+                    }
+                }
+
+                if (name == _shieldName && kind == "rate_limit")
+                {
+                    Interlocked.Add(ref _count, (int)measurement);
+                }
+            });
+            _listener.Start();
+        }
+
+        public int Count => Volatile.Read(ref _count);
+
+        public void Dispose() => _listener.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- add `Kevlar.Extensions.RateLimiting` for `System.Threading.RateLimiting.RateLimiter` and caller-supplied asynchronous lease acquisition
- preserve retry-after and immutable lease metadata, dispose every returned lease exactly once, and keep cancellation distinct from rejection
- use standard rejection metrics and sync/async hook ordering without adding framework dependencies to Kevlar core
- add package, trimming, docs, CI, coverage, race, and BenchmarkDotNet coverage

Closes #124
Part of #114

## Validation

- `dotnet build Kevlar.slnx -c Release` — 0 warnings
- full Release suites — 680 unit, 23 chaos, 5 netstandard, 108 integration, 38 analyzer, 31 testing, 16 adapter, 3 allocation tests passed
- adapter coverage — 98.5% lines, 100% branches
- `Verify-DocSnippets.ps1` — 99 snippets compiled; documented behavior passed
- `Verify-Packages.ps1` — package layout, net8/net10 consumers, trimmed and single-file publish passed; NativeAOT remains Linux-CI-only
- `npm run build` — Docusaurus production build passed

## Benchmark

BenchmarkDotNet v0.15.8, .NET 10.0.11, Windows 11, Intel i7-12700K, default job:

| Uncontended path | Mean | Allocation |
|---|---:|---:|
| Built-in Kevlar rate limiter | 97.03 ns | 0 B |
| Framework limiter adapter | 86.86 ns | 0 B |

Command: `dotnet run --project benchmarks/Kevlar.Benchmarks -c Release --no-build -- --filter "*RateLimitBenchmarks.Kevlar_Uncontended" "*RateLimitBenchmarks.Kevlar_FrameworkAdapter_Uncontended" --noOverwrite`