### PR TITLE
test(benchmarks): align Polly comparisons

### DIFF
--- a/.github/scripts/benchmark_docs.py
+++ b/.github/scripts/benchmark_docs.py
@@ -47,8 +47,8 @@ _SECTIONS = {
     "CircuitBreakerBenchmarks": (
         "Circuit breaker",
         3,
-        "Success bookkeeping while closed, and the fast-fail rejection cost while open "
-        "(thrown exception included).",
+        "Ratio/sampling bookkeeping while closed, and the fast-fail rejection cost while "
+        "manually isolated (thrown exception included).",
     ),
     "HedgingBenchmarks": (
         "Hedging",
@@ -63,7 +63,7 @@ _SECTIONS = {
     "RateLimitBenchmarks": (
         "Rate limit",
         6,
-        "Uncontended permit acquisition — every call is admitted.",
+        "Uncontended token-bucket permit acquisition — every call is admitted.",
     ),
     "ConcurrencyLimitBenchmarks": (
         "Concurrency limit",
@@ -94,14 +94,21 @@ _SCENARIO_LABELS = {
     ("TimeoutBenchmarks", "HappyPath"): "Timeout(10 s) — completes instantly",
     ("CircuitBreakerBenchmarks", "ClosedHappyPath"): "Closed circuit — success",
     ("CircuitBreakerBenchmarks", "OpenFastFail"): "Open circuit — fast-fail rejection",
+    ("CircuitBreakerBenchmarks", "RatioClosedHappyPath"): "Ratio breaker, closed — success",
+    ("CircuitBreakerBenchmarks", "IsolatedFastFail"): "Isolated circuit — fast-fail rejection",
     ("HedgingBenchmarks", "PrimaryWins"): "Hedge(2) — primary wins",
     ("FallbackBenchmarks", "PassThrough"): "Fallback — not triggered",
     ("FallbackBenchmarks", "Triggered"): "Fallback — triggered by exception",
     ("RateLimitBenchmarks", "Uncontended"): "Rate limit — uncontended acquire",
+    ("RateLimitBenchmarks", "TokenBucketUncontended"): "Token bucket — uncontended acquire",
     ("ConcurrencyLimitBenchmarks", "Uncontended"): "Concurrency limit — uncontended",
     ("TypedResultBenchmarks", "ResultJudged"): "Typed retry — result judged, no retry",
     ("PipelineBenchmarks", "TimeoutRetryBreaker"): "Timeout → Retry → Circuit breaker",
     ("PipelineBenchmarks", "FiveStrategyChain"): "Five-strategy chain",
+    ("PipelineBenchmarks", "RatioTimeoutRetryBreaker"): "Timeout → Retry → ratio breaker",
+    ("PipelineBenchmarks", "TokenBucketRatioFiveStrategyChain"): (
+        "Token bucket → Timeout → Retry → ratio breaker → Concurrency limit"
+    ),
 }
 
 

--- a/.github/scripts/stress_docs.py
+++ b/.github/scripts/stress_docs.py
@@ -63,7 +63,7 @@ def build_page(data, commit):
         "",
         "# Stress tests",
         "",
-        "Kevlar and [Polly v8](https://github.com/App-vNext/Polly) run the same composed timeout, retry, and circuit-breaker workload under sustained parallel load. The two phases run one after another in a single process, so they use the same GitHub runner.",
+        "Kevlar and [Polly v8](https://github.com/App-vNext/Polly) run the same composed timeout, retry, and circuit-breaker workload under sustained parallel load. Alternating measurement rounds run in a single process, so they use the same GitHub runner while balancing early- and late-run conditions.",
         "",
         f"*Last updated {timestamp}{suffix}.*",
         "",
@@ -94,7 +94,9 @@ def build_page(data, commit):
         "",
         "## Method",
         "",
-        f"- {data['workers']} parallel workers; {fmt_duration(data['totalDuration'])} total measured time, split equally between libraries.",
+        f"- {data['workers']} parallel workers; "
+        f"{fmt_duration(data['totalDuration'])} total measured time, split equally "
+        f"between libraries across {data.get('measurementRounds', 1)} alternating rounds.",
         f"- Each pipeline warmed for {fmt_duration(data['warmup'])} before measurement.",
         "- Each operation returns `42` successfully through Timeout(10 s) → Retry(3, no delay) → CircuitBreaker(10% over 30 s, min 100, break 5 s).",
         "- Process-wide allocation counters include all worker threads. GC counts are captured separately for each phase.",

--- a/benchmarks/Kevlar.Benchmarks/CircuitBreakerBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/CircuitBreakerBenchmarks.cs
@@ -14,59 +14,81 @@ namespace Kevlar.Benchmarks;
 [CategoriesColumn]
 public class CircuitBreakerBenchmarks
 {
-    private static readonly Shield KevlarBreaker = Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));
+    private const double FailureRatio = 0.1;
+    private const int MinimumThroughput = 100;
+    private static readonly TimeSpan SamplingWindow = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan BreakDuration = TimeSpan.FromSeconds(5);
+
+    private static readonly Shield KevlarBreaker = Shield.CircuitBreaker(ConfigureKevlarRatioBreaker);
     private static readonly Shield KevlarDynamicDurationBreaker = Shield.CircuitBreaker(options =>
     {
-        options.ConsecutiveFailures = 5;
-        options.BreakDurationGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(30));
+        ConfigureKevlarRatioBreaker(options);
+        options.BreakDurationGenerator = static _ => new ValueTask<TimeSpan>(BreakDuration);
     });
     private static readonly Shield KevlarAsyncCallbackBreaker = Shield.CircuitBreaker(options =>
     {
-        options.ConsecutiveFailures = 5;
+        ConfigureKevlarRatioBreaker(options);
         options.OnStateChangedAsync = static _ => default;
     });
-    private static readonly Shield KevlarOpenBreaker = Shield.CircuitBreaker(1, TimeSpan.FromDays(1));
+
+    private static readonly CircuitBreakerMonitor KevlarManualControl = new();
+    private static readonly Shield KevlarOpenBreaker = Shield.CircuitBreaker(options =>
+    {
+        ConfigureKevlarRatioBreaker(options);
+        options.Monitor = KevlarManualControl;
+    });
 
     private static readonly ResiliencePipeline PollyBreaker = new ResiliencePipelineBuilder()
-        .AddCircuitBreaker(new CircuitBreakerStrategyOptions())
+        .AddCircuitBreaker(CreatePollyRatioBreakerOptions())
         .Build();
 
     private static readonly CircuitBreakerManualControl PollyManualControl = new();
     private static readonly ResiliencePipeline PollyOpenBreaker = new ResiliencePipelineBuilder()
-        .AddCircuitBreaker(new CircuitBreakerStrategyOptions { ManualControl = PollyManualControl })
+        .AddCircuitBreaker(CreatePollyRatioBreakerOptions(PollyManualControl))
         .Build();
 
-    [GlobalSetup(Target = nameof(Kevlar_OpenFastFail))]
-    public async Task TripKevlarBreaker()
-    {
-        try
-        {
-            await KevlarOpenBreaker.ExecuteAsync(static _ => throw new InvalidOperationException("trip"));
-        }
-        catch (InvalidOperationException)
-        {
-        }
-    }
+    [GlobalSetup(Target = nameof(Kevlar_IsolatedFastFail))]
+    public ValueTask IsolateKevlarBreaker() => KevlarManualControl.IsolateAsync();
 
-    [GlobalSetup(Target = nameof(Polly_OpenFastFail))]
+    [GlobalSetup(Target = nameof(Polly_IsolatedFastFail))]
     public Task IsolatePollyBreaker() => PollyManualControl.IsolateAsync();
 
-    [BenchmarkCategory("ClosedHappyPath"), Benchmark(Baseline = true)]
-    public ValueTask<int> Kevlar_ClosedHappyPath() => KevlarBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
+    private static void ConfigureKevlarRatioBreaker(CircuitBreakerOptions options)
+    {
+        options.FailureRatio = FailureRatio;
+        options.MinimumThroughput = MinimumThroughput;
+        options.SamplingWindow = SamplingWindow;
+        options.BreakDuration = BreakDuration;
+    }
 
-    [BenchmarkCategory("ClosedHappyPath"), Benchmark]
-    public ValueTask<int> Polly_ClosedHappyPath() => PollyBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
+    private static CircuitBreakerStrategyOptions CreatePollyRatioBreakerOptions(
+        CircuitBreakerManualControl? manualControl = null) => new()
+        {
+            FailureRatio = FailureRatio,
+            MinimumThroughput = MinimumThroughput,
+            SamplingDuration = SamplingWindow,
+            BreakDuration = BreakDuration,
+            ManualControl = manualControl,
+        };
 
-    [BenchmarkCategory("ClosedHappyPath"), Benchmark]
+    [BenchmarkCategory("RatioClosedHappyPath"), Benchmark(Baseline = true)]
+    public ValueTask<int> Kevlar_RatioClosedHappyPath() =>
+        KevlarBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("RatioClosedHappyPath"), Benchmark]
+    public ValueTask<int> Polly_RatioClosedHappyPath() =>
+        PollyBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("RatioClosedHappyPath"), Benchmark]
     public ValueTask<int> Kevlar_DynamicDurationConfigured() =>
         KevlarDynamicDurationBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("ClosedHappyPath"), Benchmark]
+    [BenchmarkCategory("RatioClosedHappyPath"), Benchmark]
     public ValueTask<int> Kevlar_AsyncCallbackConfigured() =>
         KevlarAsyncCallbackBreaker.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("OpenFastFail"), Benchmark(Baseline = true)]
-    public async ValueTask<bool> Kevlar_OpenFastFail()
+    [BenchmarkCategory("IsolatedFastFail"), Benchmark(Baseline = true)]
+    public async ValueTask<bool> Kevlar_IsolatedFastFail()
     {
         try
         {
@@ -79,8 +101,8 @@ public class CircuitBreakerBenchmarks
         }
     }
 
-    [BenchmarkCategory("OpenFastFail"), Benchmark]
-    public async ValueTask<bool> Polly_OpenFastFail()
+    [BenchmarkCategory("IsolatedFastFail"), Benchmark]
+    public async ValueTask<bool> Polly_IsolatedFastFail()
     {
         try
         {

--- a/benchmarks/Kevlar.Benchmarks/PipelineBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/PipelineBenchmarks.cs
@@ -18,46 +18,74 @@ namespace Kevlar.Benchmarks;
 [CategoriesColumn]
 public class PipelineBenchmarks
 {
+    private const double FailureRatio = 0.1;
+    private const int MinimumThroughput = 100;
+    private static readonly TimeSpan SamplingWindow = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan BreakDuration = TimeSpan.FromSeconds(5);
+
     private static readonly Shield KevlarTrio = Shield
         .Timeout(TimeSpan.FromSeconds(10))
-        .Retry(3)
-        .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+        .Retry(3, Backoff.None)
+        .CircuitBreaker(ConfigureKevlarRatioBreaker);
 
     private static readonly Shield KevlarDeep = Shield
         .RateLimit(1_000_000_000, TimeSpan.FromSeconds(1))
         .Timeout(TimeSpan.FromSeconds(10))
-        .Retry(3)
-        .CircuitBreaker(5, TimeSpan.FromSeconds(30))
+        .Retry(3, Backoff.None)
+        .CircuitBreaker(ConfigureKevlarRatioBreaker)
         .ConcurrencyLimit(1024);
 
     private static readonly ResiliencePipeline PollyTrio = new ResiliencePipelineBuilder()
         .AddTimeout(new TimeoutStrategyOptions { Timeout = TimeSpan.FromSeconds(10) })
-        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3 })
-        .AddCircuitBreaker(new CircuitBreakerStrategyOptions())
+        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })
+        .AddCircuitBreaker(CreatePollyRatioBreakerOptions())
         .Build();
 
     private static readonly ResiliencePipeline PollyDeep = new ResiliencePipelineBuilder()
-        .AddRateLimiter(new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        .AddRateLimiter(new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
         {
-            PermitLimit = 1_000_000_000,
-            Window = TimeSpan.FromSeconds(1),
+            TokenLimit = 1_000_000_000,
+            TokensPerPeriod = 1_000_000_000,
+            ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+            AutoReplenishment = true,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
             QueueLimit = 0,
         }))
         .AddTimeout(new TimeoutStrategyOptions { Timeout = TimeSpan.FromSeconds(10) })
-        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3 })
-        .AddCircuitBreaker(new CircuitBreakerStrategyOptions())
+        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })
+        .AddCircuitBreaker(CreatePollyRatioBreakerOptions())
         .AddConcurrencyLimiter(1024)
         .Build();
 
-    [BenchmarkCategory("TimeoutRetryBreaker"), Benchmark(Baseline = true)]
-    public ValueTask<int> Kevlar_TimeoutRetryBreaker() => KevlarTrio.ExecuteAsync(static _ => new ValueTask<int>(42));
+    private static void ConfigureKevlarRatioBreaker(CircuitBreakerOptions options)
+    {
+        options.FailureRatio = FailureRatio;
+        options.MinimumThroughput = MinimumThroughput;
+        options.SamplingWindow = SamplingWindow;
+        options.BreakDuration = BreakDuration;
+    }
 
-    [BenchmarkCategory("TimeoutRetryBreaker"), Benchmark]
-    public ValueTask<int> Polly_TimeoutRetryBreaker() => PollyTrio.ExecuteAsync(static _ => new ValueTask<int>(42));
+    private static CircuitBreakerStrategyOptions CreatePollyRatioBreakerOptions() => new()
+    {
+        FailureRatio = FailureRatio,
+        MinimumThroughput = MinimumThroughput,
+        SamplingDuration = SamplingWindow,
+        BreakDuration = BreakDuration,
+    };
 
-    [BenchmarkCategory("FiveStrategyChain"), Benchmark(Baseline = true)]
-    public ValueTask<int> Kevlar_FiveStrategyChain() => KevlarDeep.ExecuteAsync(static _ => new ValueTask<int>(42));
+    [BenchmarkCategory("RatioTimeoutRetryBreaker"), Benchmark(Baseline = true)]
+    public ValueTask<int> Kevlar_RatioTimeoutRetryBreaker() =>
+        KevlarTrio.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("FiveStrategyChain"), Benchmark]
-    public ValueTask<int> Polly_FiveStrategyChain() => PollyDeep.ExecuteAsync(static _ => new ValueTask<int>(42));
+    [BenchmarkCategory("RatioTimeoutRetryBreaker"), Benchmark]
+    public ValueTask<int> Polly_RatioTimeoutRetryBreaker() =>
+        PollyTrio.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("TokenBucketRatioFiveStrategyChain"), Benchmark(Baseline = true)]
+    public ValueTask<int> Kevlar_TokenBucketRatioFiveStrategyChain() =>
+        KevlarDeep.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("TokenBucketRatioFiveStrategyChain"), Benchmark]
+    public ValueTask<int> Polly_TokenBucketRatioFiveStrategyChain() =>
+        PollyDeep.ExecuteAsync(static _ => new ValueTask<int>(42));
 }

--- a/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
@@ -25,21 +25,26 @@ public class RateLimitBenchmarks
     });
 
     private static readonly ResiliencePipeline PollyRateLimit = new ResiliencePipelineBuilder()
-        .AddRateLimiter(new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        .AddRateLimiter(new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
         {
-            PermitLimit = 1_000_000_000,
-            Window = TimeSpan.FromSeconds(1),
+            TokenLimit = 1_000_000_000,
+            TokensPerPeriod = 1_000_000_000,
+            ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+            AutoReplenishment = true,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
             QueueLimit = 0,
         }))
         .Build();
 
-    [BenchmarkCategory("Uncontended"), Benchmark(Baseline = true)]
-    public ValueTask<int> Kevlar_Uncontended() => KevlarRateLimit.ExecuteAsync(static _ => new ValueTask<int>(42));
+    [BenchmarkCategory("TokenBucketUncontended"), Benchmark(Baseline = true)]
+    public ValueTask<int> Kevlar_TokenBucketUncontended() =>
+        KevlarRateLimit.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("Uncontended"), Benchmark]
-    public ValueTask<int> Polly_Uncontended() => PollyRateLimit.ExecuteAsync(static _ => new ValueTask<int>(42));
+    [BenchmarkCategory("TokenBucketUncontended"), Benchmark]
+    public ValueTask<int> Polly_TokenBucketUncontended() =>
+        PollyRateLimit.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("Uncontended"), Benchmark]
+    [BenchmarkCategory("TokenBucketUncontended"), Benchmark]
     public ValueTask<int> Kevlar_WithHooks_Uncontended() =>
         KevlarRateLimitWithHooks.ExecuteAsync(static _ => new ValueTask<int>(42));
 }

--- a/benchmarks/Kevlar.Benchmarks/RetryBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/RetryBenchmarks.cs
@@ -17,7 +17,7 @@ public class RetryBenchmarks
 {
     private static readonly InvalidOperationException RecoverableError = new("transient");
 
-    private static readonly Shield KevlarRetry = Shield.Retry(3);
+    private static readonly Shield KevlarRetry = Shield.Retry(3, Backoff.None);
     private static readonly Shield KevlarRetryNoBackoff = Shield.Retry(options =>
     {
         options.MaxRetries = 3;
@@ -25,7 +25,7 @@ public class RetryBenchmarks
     });
 
     private static readonly ResiliencePipeline PollyRetry = new ResiliencePipelineBuilder()
-        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3 })
+        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })
         .Build();
     private static readonly ResiliencePipeline PollyRetryNoBackoff = new ResiliencePipelineBuilder()
         .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })

--- a/benchmarks/Kevlar.Benchmarks/TypedResultBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/TypedResultBenchmarks.cs
@@ -17,13 +17,14 @@ public class TypedResultBenchmarks
 {
     private static readonly Shield<int> KevlarResultRetry = Shield.For<int>()
         .WhenResult(-1)
-        .Retry(3);
+        .Retry(3, Backoff.None);
 
     private static readonly ResiliencePipeline<int> PollyResultRetry = new ResiliencePipelineBuilder<int>()
         .AddRetry(new RetryStrategyOptions<int>
         {
             ShouldHandle = new PredicateBuilder<int>().HandleResult(-1),
             MaxRetryAttempts = 3,
+            Delay = TimeSpan.Zero,
         })
         .Build();
 

--- a/benchmarks/Kevlar.StressTests/StressRunResult.cs
+++ b/benchmarks/Kevlar.StressTests/StressRunResult.cs
@@ -11,6 +11,7 @@ internal sealed record StressRunResult(
     int Workers,
     TimeSpan TotalDuration,
     TimeSpan Warmup,
+    int MeasurementRounds,
     long PeakWorkingSetBytes,
     IReadOnlyList<StressPhaseResult> Results);
 

--- a/benchmarks/Kevlar.StressTests/StressRunner.cs
+++ b/benchmarks/Kevlar.StressTests/StressRunner.cs
@@ -9,6 +9,8 @@ namespace Kevlar.StressTests;
 
 internal static class StressRunner
 {
+    private const int MeasurementRounds = 4;
+
     private static readonly Shield KevlarShield = Shield
         .Timeout(TimeSpan.FromSeconds(10))
         .Retry(3, Backoff.None)
@@ -34,19 +36,37 @@ internal static class StressRunner
 
     public static async Task<StressRunResult> RunAsync(StressOptions options)
     {
-        var phaseDuration = TimeSpan.FromTicks(options.Duration.Ticks / 2);
+        var phaseDuration = TimeSpan.FromTicks(options.Duration.Ticks / (MeasurementRounds * 2));
         Console.WriteLine(
-            $"Running {options.Workers} workers for {phaseDuration:g} per library " +
-            $"({options.Duration:g} total measured time).");
+            $"Running {options.Workers} workers for {MeasurementRounds} alternating rounds " +
+            $"of {phaseDuration:g} per library ({options.Duration:g} total measured time).");
 
         await WarmUpAsync("Polly", ExecutePollyAsync, options);
         await WarmUpAsync("Kevlar", ExecuteKevlarAsync, options);
 
-        var results = new[]
+        var phases = new List<StressPhaseResult>(MeasurementRounds * 2);
+        for (var round = 0; round < MeasurementRounds; round++)
         {
-            await MeasureAsync("Polly", ExecutePollyAsync, phaseDuration, options.Workers),
-            await MeasureAsync("Kevlar", ExecuteKevlarAsync, phaseDuration, options.Workers),
-        };
+            if (round % 2 == 0)
+            {
+                phases.Add(await MeasureAsync("Polly", ExecutePollyAsync, phaseDuration, options.Workers, round));
+                phases.Add(await MeasureAsync("Kevlar", ExecuteKevlarAsync, phaseDuration, options.Workers, round));
+            }
+            else
+            {
+                phases.Add(await MeasureAsync("Kevlar", ExecuteKevlarAsync, phaseDuration, options.Workers, round));
+                phases.Add(await MeasureAsync("Polly", ExecutePollyAsync, phaseDuration, options.Workers, round));
+            }
+        }
+
+        var results = new[] { Aggregate("Polly", phases), Aggregate("Kevlar", phases) };
+        foreach (var result in results)
+        {
+            Console.WriteLine(
+                $"{result.Library} total: {result.OperationsPerSecond:N0} ops/s, " +
+                $"{result.BytesPerOperation:N2} B/op, " +
+                $"{result.AllocatedBytes / 1_048_576d:N1} MiB allocated.");
+        }
 
         using var process = Process.GetCurrentProcess();
         process.Refresh();
@@ -59,6 +79,7 @@ internal static class StressRunner
             options.Workers,
             options.Duration,
             options.Warmup,
+            MeasurementRounds,
             process.PeakWorkingSet64,
             results);
     }
@@ -81,7 +102,8 @@ internal static class StressRunner
         string library,
         Func<ValueTask<int>> operation,
         TimeSpan duration,
-        int workers)
+        int workers,
+        int round)
     {
         ForceCollection();
         var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
@@ -90,7 +112,7 @@ internal static class StressRunner
         var gen1Before = GC.CollectionCount(1);
         var gen2Before = GC.CollectionCount(2);
 
-        Console.WriteLine($"Measuring {library} for {duration:g}...");
+        Console.WriteLine($"Measuring {library}, round {round + 1}/{MeasurementRounds}, for {duration:g}...");
         var stopwatch = Stopwatch.StartNew();
         var operations = await RunWorkersAsync(operation, duration, workers);
         stopwatch.Stop();
@@ -114,9 +136,30 @@ internal static class StressRunner
             GC.CollectionCount(2) - gen2Before);
 
         Console.WriteLine(
-            $"{library}: {result.OperationsPerSecond:N0} ops/s, " +
+            $"{library} round {round + 1}: {result.OperationsPerSecond:N0} ops/s, " +
             $"{result.BytesPerOperation:N2} B/op, {result.AllocatedBytes / 1_048_576d:N1} MiB allocated.");
         return result;
+    }
+
+    private static StressPhaseResult Aggregate(string library, List<StressPhaseResult> phases)
+    {
+        var matching = phases.Where(result => result.Library == library).ToArray();
+        var operations = matching.Sum(result => result.Operations);
+        var elapsedSeconds = matching.Sum(result => result.ElapsedSeconds);
+        var allocatedBytes = matching.Sum(result => result.AllocatedBytes);
+
+        return new StressPhaseResult(
+            library,
+            operations,
+            elapsedSeconds,
+            operations / elapsedSeconds,
+            allocatedBytes,
+            allocatedBytes / (double)operations,
+            matching[0].ManagedBytesBefore,
+            matching[^1].ManagedBytesAfter,
+            matching.Sum(result => result.Gen0Collections),
+            matching.Sum(result => result.Gen1Collections),
+            matching.Sum(result => result.Gen2Collections));
     }
 
     private static async Task<long> RunWorkersAsync(


### PR DESCRIPTION
## Summary

- align Kevlar and Polly circuit-breaker benchmarks on the same ratio, sampling, throughput, and break settings
- compare manually isolated circuits on both sides and token-bucket rate limiters on both sides
- make retry delays explicitly zero wherever only strategy machinery is intended to be measured
- alternate and aggregate stress-test rounds so runner drift does not systematically penalize the second library
- give corrected scenarios new history keys so previous non-equivalent measurements are not mixed into published medians

## Motivation

The [15-minute stress run](https://github.com/thomhurst/Kevlar/actions/runs/32528341286/job/96915173985) measured Kevlar about 5.6% below Polly despite the published microbenchmarks favoring Kevlar. The stress workload itself used matching ratio breakers, while the published composed benchmarks compared Kevlar's consecutive-failure breaker with Polly's ratio breaker. The rate-limit comparison also used Kevlar's token-bucket/GCRA limiter against Polly's fixed-window limiter, and the stress harness always measured Polly first and Kevlar second.

This change makes the compared semantics explicit and symmetric and balances early/late runner conditions.

## Local benchmark check

BenchmarkDotNet short job, .NET 10.0.11, Windows, Intel Core Ultra 9 185H:

| Scenario | Kevlar | Polly | Allocation |
|---|---:|---:|---:|
| Ratio breaker, closed | 270 ns | 315 ns | 0 B / 24 B |
| Timeout → retry → ratio breaker | 454 ns | 1,236 ns | 0 B / 48 B |
| Five-strategy token-bucket/ratio chain | 572 ns | 1,203 ns | 0 B / 88 B |
| Token bucket, uncontended | 152 ns | 188 ns | 0 B / 0 B |

The short job is directional; the normal benchmark workflow remains the authoritative measurement.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` — 685 passed
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` — 3 passed
- BenchmarkDotNet dry validation — all 88 cases passed
- BenchmarkDotNet corrected 13-case dry and short runs passed
- 8-second alternating-round stress smoke test and both documentation generators passed