### PR TITLE
feat(telemetry): add structured events

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/StructuredEventBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/StructuredEventBenchmarks.cs
@@ -1,0 +1,41 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>Structured event overhead for synchronously completing execution paths.</summary>
+[MemoryDiagnoser]
+public class StructuredEventBenchmarks
+{
+    private static readonly Shield Empty = Shield.Empty.WithName("benchmark");
+    private static readonly Shield Retry = Shield.Retry(0, Backoff.None).WithName("benchmark");
+
+    private IDisposable? _subscription;
+
+    [Params(false, true)]
+    public bool ListenerEnabled { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (ListenerEnabled)
+        {
+            _subscription = KevlarDiagnostics.Subscribe(new NoOpListener());
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _subscription?.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public ValueTask<int> EmptyShield() => Empty.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [Benchmark]
+    public ValueTask<int> RetryHappyPath() => Retry.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    private sealed class NoOpListener : KevlarEventListener
+    {
+        public override void OnEvent<T>(in KevlarEvent<T> telemetryEvent)
+        {
+        }
+    }
+}

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -4,7 +4,8 @@ sidebar_position: 11
 
 # Observability
 
-Shields are observable without any setup: they describe themselves as strings, publish metrics through a built-in `Meter`, and an analyzer package catches the most common resilience mistake at compile time.
+Shields describe themselves as strings, publish metrics through a built-in `Meter`, expose an
+optional structured event stream, and ship an analyzer package for common resilience mistakes.
 
 ## Pipeline descriptions
 
@@ -23,6 +24,60 @@ Console.WriteLine(shield);
 ```
 
 Log it once at startup and every incident review starts from the actual configuration, not the configuration someone remembers. Custom strategies participate by overriding `Strategy.Describe()`.
+
+## Structured events
+
+Subscribe once to the process-wide event stream for request-level diagnostics without wiring every
+strategy callback:
+
+<!-- doc-test-declaration -->
+```csharp
+public sealed class ApplicationEventListener : KevlarEventListener
+{
+    public static IDisposable Subscribe() =>
+        KevlarDiagnostics.Subscribe(new ApplicationEventListener());
+
+    public override bool IsEnabled(KevlarEventKind kind) =>
+        kind == KevlarEventKind.ExecutionCompleted;
+
+    public override void OnEvent<T>(in KevlarEvent<T> telemetryEvent)
+    {
+        Console.WriteLine(
+            $"{telemetryEvent.ShieldName}: {telemetryEvent.OutcomeClassification} " +
+            $"in {telemetryEvent.Duration.TotalMilliseconds:F1} ms");
+    }
+}
+```
+
+Every public call emits `ExecutionStarted` followed by `ExecutionCompleted`, including empty
+shields, synchronous calls, outcome-returning calls, and calls cancelled before dispatch. A
+completion carries `Success`, `Failure`, or `Canceled`; metrics still record exactly one execution,
+so subscribing does not double-count it. The generic `KevlarEvent<T>` preserves value-type results
+without boxing. Read `Outcome` only when `HasOutcome` is true; use `OutcomeClassification` when a
+bounded, result-free value is sufficient.
+
+Callbacks are synchronous and run in subscription order. Concurrent executions may invoke the
+same listener concurrently, so listeners must be thread-safe. Reentrant shield execution and
+subscription disposal are supported. Listener and filter exceptions are suppressed and cannot
+change pipeline outcomes or stop later listeners. Disposal stops future delivery but does not
+interrupt an in-progress callback.
+
+`KevlarEvent<T>` and its `Context` are callback-scoped. Never retain or mutate the context or its
+properties: the context returns to a pool immediately after completion delivery. Operation
+metadata added with `ExecuteWithContext` is readable from `telemetryEvent.Context.Properties`
+during the callback. Shield names, event kinds, strategy kinds, strategy indexes, attempts,
+severity, outcome classification, and duration are bounded schema fields; application property
+values are not automatically promoted to metric dimensions.
+
+BenchmarkDotNet `ShortRun` results on .NET 10.0.11, Windows 11, and an Intel Core i7-12700K:
+
+| Pipeline | Listener off | No-op listener | Allocated |
+|---|---:|---:|---:|
+| Empty shield | 3.6 ns | 108.1 ns | 0 B |
+| Retry happy path | 63.1 ns | 117.5 ns | 0 B |
+
+The pre-change empty-shield baseline was 3.7 ns, within the disabled result's confidence interval.
+These figures measure synchronous no-op delivery, not logging or exporter cost.
 
 ## Metrics
 
@@ -100,4 +155,8 @@ and suppression guidance.
 
 ## Callbacks
 
-Strategy callbacks provide request-level logging where configured. Retry, circuit breaker, timeout, and result-aware fallback expose synchronous and asynchronous callbacks. Hedging exposes a synchronous callback only. Concurrency limit and rate limit expose no callback APIs. Each callback is documented on its [strategy page](/docs/category/strategies). Metrics tell you *how much*; callbacks give you the *which request* detail.
+Strategy callbacks provide targeted notifications where configured. The structured event stream is
+the single subscription point for cross-strategy request diagnostics; individual callbacks remain
+useful when application behavior must run at one specific boundary. Each callback is documented on
+its [strategy page](/docs/category/strategies). Metrics tell you *how much*; structured events and
+callbacks provide the *which request* detail.

--- a/src/Kevlar/Internal/KevlarEventSource.cs
+++ b/src/Kevlar/Internal/KevlarEventSource.cs
@@ -1,0 +1,121 @@
+namespace Kevlar.Internal;
+
+internal static class KevlarEventSource
+{
+    private static readonly object Gate = new();
+    private static Entry[] _entries = [];
+
+    public static bool Enabled => Volatile.Read(ref _entries).Length != 0;
+
+    public static IDisposable Subscribe(KevlarEventListener listener)
+    {
+        var entry = new Entry(listener);
+        lock (Gate)
+        {
+            var current = _entries;
+            var updated = new Entry[current.Length + 1];
+            Array.Copy(current, updated, current.Length);
+            updated[current.Length] = entry;
+            Volatile.Write(ref _entries, updated);
+        }
+
+        return new Subscription(entry);
+    }
+
+    public static void ExecutionStarted<T>(KevlarContext context)
+    {
+        var telemetryEvent = new KevlarEvent<T>(
+            KevlarEventKind.ExecutionStarted,
+            KevlarEventSeverity.Debug,
+            KevlarStrategyKind.None,
+            strategyIndex: -1,
+            attempt: 0,
+            duration: TimeSpan.Zero,
+            handled: false,
+            outcome: default,
+            hasOutcome: false,
+            context);
+        Publish(in telemetryEvent);
+    }
+
+    public static void ExecutionCompleted<T>(
+        KevlarContext context,
+        in Outcome<T> outcome,
+        TimeSpan duration)
+    {
+        var telemetryEvent = new KevlarEvent<T>(
+            KevlarEventKind.ExecutionCompleted,
+            outcome.IsSuccess ? KevlarEventSeverity.Information : KevlarEventSeverity.Error,
+            KevlarStrategyKind.None,
+            strategyIndex: -1,
+            attempt: 0,
+            duration,
+            handled: false,
+            outcome,
+            hasOutcome: true,
+            context);
+        Publish(in telemetryEvent);
+    }
+
+    private static void Publish<T>(in KevlarEvent<T> telemetryEvent)
+    {
+        var snapshot = Volatile.Read(ref _entries);
+        foreach (var entry in snapshot)
+        {
+            try
+            {
+                if (entry.Listener.IsEnabled(telemetryEvent.Kind))
+                {
+                    entry.Listener.OnEvent(in telemetryEvent);
+                }
+            }
+            catch
+            {
+                // Telemetry must never alter pipeline behavior or prevent later listeners.
+            }
+        }
+    }
+
+    private static void Unsubscribe(Entry entry)
+    {
+        lock (Gate)
+        {
+            var current = _entries;
+            var index = Array.IndexOf(current, entry);
+            if (index < 0)
+            {
+                return;
+            }
+
+            if (current.Length == 1)
+            {
+                Volatile.Write(ref _entries, []);
+                return;
+            }
+
+            var updated = new Entry[current.Length - 1];
+            Array.Copy(current, 0, updated, 0, index);
+            Array.Copy(current, index + 1, updated, index, current.Length - index - 1);
+            Volatile.Write(ref _entries, updated);
+        }
+    }
+
+    private sealed class Entry(KevlarEventListener listener)
+    {
+        public KevlarEventListener Listener { get; } = listener;
+    }
+
+    private sealed class Subscription(Entry entry) : IDisposable
+    {
+        private Entry? _entry = entry;
+
+        public void Dispose()
+        {
+            var removed = Interlocked.Exchange(ref _entry, null);
+            if (removed is not null)
+            {
+                Unsubscribe(removed);
+            }
+        }
+    }
+}

--- a/src/Kevlar/Internal/ShieldEngine.cs
+++ b/src/Kevlar/Internal/ShieldEngine.cs
@@ -11,6 +11,11 @@ internal static class ShieldEngine
         Func<TState, CancellationToken, ValueTask<T>> action,
         CancellationToken cancellationToken)
     {
+        if (KevlarEventSource.Enabled)
+        {
+            return ExecuteObservedAsync(head, timeProvider, shieldName, state, action, cancellationToken);
+        }
+
         var startedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
         if (cancellationToken.IsCancellationRequested)
         {
@@ -65,6 +70,11 @@ internal static class ShieldEngine
         Func<TState, CancellationToken, ValueTask<T>> action,
         CancellationToken cancellationToken)
     {
+        if (KevlarEventSource.Enabled)
+        {
+            return ExecuteObservedOutcomeAsync(head, timeProvider, shieldName, state, action, cancellationToken);
+        }
+
         var startedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
         if (cancellationToken.IsCancellationRequested)
         {
@@ -117,6 +127,18 @@ internal static class ShieldEngine
         Func<TState, KevlarContext, ValueTask<T>> action,
         CancellationToken cancellationToken)
     {
+        if (KevlarEventSource.Enabled)
+        {
+            return ExecuteObservedWithContextAsync(
+                head,
+                timeProvider,
+                shieldName,
+                state,
+                initializeProperties,
+                action,
+                cancellationToken);
+        }
+
         var startedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
         if (cancellationToken.IsCancellationRequested)
         {
@@ -156,6 +178,11 @@ internal static class ShieldEngine
         Func<TState, CancellationToken, T> action,
         CancellationToken cancellationToken)
     {
+        if (KevlarEventSource.Enabled)
+        {
+            return ExecuteObservedSync(head, timeProvider, shieldName, state, action, cancellationToken);
+        }
+
         var startedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
         if (cancellationToken.IsCancellationRequested)
         {
@@ -205,6 +232,18 @@ internal static class ShieldEngine
         Func<TState, KevlarContext, T> action,
         CancellationToken cancellationToken)
     {
+        if (KevlarEventSource.Enabled)
+        {
+            return ExecuteObservedWithContextSync(
+                head,
+                timeProvider,
+                shieldName,
+                state,
+                initializeProperties,
+                action,
+                cancellationToken);
+        }
+
         var startedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
         if (cancellationToken.IsCancellationRequested)
         {
@@ -238,6 +277,285 @@ internal static class ShieldEngine
             KevlarContext.Return(context);
         }
     }
+
+    private static ValueTask<T> ExecuteObservedAsync<T, TState>(
+        StrategyNode? head,
+        TimeProvider timeProvider,
+        string? shieldName,
+        TState state,
+        Func<TState, CancellationToken, ValueTask<T>> action,
+        CancellationToken cancellationToken)
+    {
+        var metricsStartedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
+        var context = KevlarContext.Rent(cancellationToken, isSynchronous: false, timeProvider, shieldName);
+        var eventStartedAt = StartEventDuration();
+        KevlarEventSource.ExecutionStarted<T>(context);
+
+        ValueTask<Outcome<T>> pipeline;
+        if (cancellationToken.IsCancellationRequested)
+        {
+            pipeline = new ValueTask<Outcome<T>>(Outcome<T>.FromException(
+                new OperationCanceledException(cancellationToken)));
+        }
+        else
+        {
+            pipeline = RunAsync(head, state, action, context);
+        }
+
+        if (!pipeline.IsCompletedSuccessfully)
+        {
+            return AwaitObservedAsync(pipeline, context, eventStartedAt, metricsStartedAt);
+        }
+
+        var outcome = pipeline.Result;
+        try
+        {
+            CompleteObservedExecution(context, in outcome, eventStartedAt, metricsStartedAt);
+            return outcome.IsSuccess ? new ValueTask<T>(outcome.Result!) : Rethrow(outcome);
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    private static ValueTask<Outcome<T>> ExecuteObservedOutcomeAsync<T, TState>(
+        StrategyNode? head,
+        TimeProvider timeProvider,
+        string? shieldName,
+        TState state,
+        Func<TState, CancellationToken, ValueTask<T>> action,
+        CancellationToken cancellationToken)
+    {
+        var metricsStartedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
+        var context = KevlarContext.Rent(cancellationToken, isSynchronous: false, timeProvider, shieldName);
+        var eventStartedAt = StartEventDuration();
+        KevlarEventSource.ExecutionStarted<T>(context);
+
+        ValueTask<Outcome<T>> pipeline;
+        if (cancellationToken.IsCancellationRequested)
+        {
+            pipeline = new ValueTask<Outcome<T>>(Outcome<T>.FromException(
+                new OperationCanceledException(cancellationToken)));
+        }
+        else
+        {
+            pipeline = RunAsync(head, state, action, context);
+        }
+
+        if (!pipeline.IsCompletedSuccessfully)
+        {
+            return AwaitObservedOutcomeAsync(pipeline, context, eventStartedAt, metricsStartedAt);
+        }
+
+        var outcome = pipeline.Result;
+        try
+        {
+            CompleteObservedExecution(context, in outcome, eventStartedAt, metricsStartedAt);
+            return new ValueTask<Outcome<T>>(outcome);
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    private static ValueTask<T> ExecuteObservedWithContextAsync<T, TState>(
+        StrategyNode? head,
+        TimeProvider timeProvider,
+        string? shieldName,
+        TState state,
+        Action<TState, KevlarProperties> initializeProperties,
+        Func<TState, KevlarContext, ValueTask<T>> action,
+        CancellationToken cancellationToken)
+    {
+        var metricsStartedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
+        var context = KevlarContext.Rent(cancellationToken, isSynchronous: false, timeProvider, shieldName);
+        var eventStartedAt = StartEventDuration();
+        if (cancellationToken.IsCancellationRequested)
+        {
+            KevlarEventSource.ExecutionStarted<T>(context);
+            var canceled = Outcome<T>.FromException(new OperationCanceledException(cancellationToken));
+            try
+            {
+                CompleteObservedExecution(context, in canceled, eventStartedAt, metricsStartedAt);
+                return Rethrow(canceled);
+            }
+            finally
+            {
+                KevlarContext.Return(context);
+            }
+        }
+
+        try
+        {
+            initializeProperties(state, context.Properties);
+        }
+        catch (Exception exception)
+        {
+            KevlarEventSource.ExecutionStarted<T>(context);
+            var failed = Outcome<T>.FromException(exception);
+            try
+            {
+                CompleteObservedExecution(context, in failed, eventStartedAt, metricsStartedAt);
+            }
+            finally
+            {
+                KevlarContext.Return(context);
+            }
+
+            throw;
+        }
+
+        KevlarEventSource.ExecutionStarted<T>(context);
+        var pipeline = RunWithContextAsync(head, state, action, context);
+        if (!pipeline.IsCompletedSuccessfully)
+        {
+            return AwaitObservedAsync(pipeline, context, eventStartedAt, metricsStartedAt);
+        }
+
+        var outcome = pipeline.Result;
+        try
+        {
+            CompleteObservedExecution(context, in outcome, eventStartedAt, metricsStartedAt);
+            return outcome.IsSuccess ? new ValueTask<T>(outcome.Result!) : Rethrow(outcome);
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    private static T ExecuteObservedSync<T, TState>(
+        StrategyNode? head,
+        TimeProvider timeProvider,
+        string? shieldName,
+        TState state,
+        Func<TState, CancellationToken, T> action,
+        CancellationToken cancellationToken)
+    {
+        var metricsStartedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
+        var context = KevlarContext.Rent(cancellationToken, isSynchronous: true, timeProvider, shieldName);
+        var eventStartedAt = StartEventDuration();
+        try
+        {
+            KevlarEventSource.ExecutionStarted<T>(context);
+            var outcome = cancellationToken.IsCancellationRequested
+                ? Outcome<T>.FromException(new OperationCanceledException(cancellationToken))
+                : GetSyncOutcome(RunSync(head, state, action, context));
+            CompleteObservedExecution(context, in outcome, eventStartedAt, metricsStartedAt);
+            return outcome.GetResultOrRethrowInternal();
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    private static T ExecuteObservedWithContextSync<T, TState>(
+        StrategyNode? head,
+        TimeProvider timeProvider,
+        string? shieldName,
+        TState state,
+        Action<TState, KevlarProperties> initializeProperties,
+        Func<TState, KevlarContext, T> action,
+        CancellationToken cancellationToken)
+    {
+        var metricsStartedAt = KevlarMetrics.DurationEnabled ? KevlarMetrics.StartDuration() : 0;
+        var context = KevlarContext.Rent(cancellationToken, isSynchronous: true, timeProvider, shieldName);
+        var eventStartedAt = StartEventDuration();
+        try
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                KevlarEventSource.ExecutionStarted<T>(context);
+                var canceled = Outcome<T>.FromException(new OperationCanceledException(cancellationToken));
+                CompleteObservedExecution(context, in canceled, eventStartedAt, metricsStartedAt);
+                return canceled.GetResultOrRethrowInternal();
+            }
+
+            try
+            {
+                initializeProperties(state, context.Properties);
+            }
+            catch (Exception exception)
+            {
+                KevlarEventSource.ExecutionStarted<T>(context);
+                var failed = Outcome<T>.FromException(exception);
+                CompleteObservedExecution(context, in failed, eventStartedAt, metricsStartedAt);
+                throw;
+            }
+
+            KevlarEventSource.ExecutionStarted<T>(context);
+            var outcome = GetSyncOutcome(RunWithContextSync(head, state, action, context));
+            CompleteObservedExecution(context, in outcome, eventStartedAt, metricsStartedAt);
+            return outcome.GetResultOrRethrowInternal();
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    private static Outcome<T> GetSyncOutcome<T>(ValueTask<Outcome<T>> pipeline) =>
+        pipeline.IsCompletedSuccessfully
+            ? pipeline.Result
+            : pipeline.AsTask().GetAwaiter().GetResult();
+
+    private static async ValueTask<T> AwaitObservedAsync<T>(
+        ValueTask<Outcome<T>> pipeline,
+        KevlarContext context,
+        long eventStartedAt,
+        long metricsStartedAt)
+    {
+        try
+        {
+            var outcome = await pipeline.ConfigureAwait(false);
+            CompleteObservedExecution(context, in outcome, eventStartedAt, metricsStartedAt);
+            return outcome.GetResultOrRethrowInternal();
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitObservedOutcomeAsync<T>(
+        ValueTask<Outcome<T>> pipeline,
+        KevlarContext context,
+        long eventStartedAt,
+        long metricsStartedAt)
+    {
+        try
+        {
+            var outcome = await pipeline.ConfigureAwait(false);
+            CompleteObservedExecution(context, in outcome, eventStartedAt, metricsStartedAt);
+            return outcome;
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    private static void CompleteObservedExecution<T>(
+        KevlarContext context,
+        in Outcome<T> outcome,
+        long eventStartedAt,
+        long metricsStartedAt)
+    {
+        KevlarEventSource.ExecutionCompleted(
+            context,
+            in outcome,
+            GetEventDuration(eventStartedAt));
+        RecordExecution(metricsStartedAt, context.ShieldName, outcome.IsSuccess);
+    }
+
+    private static long StartEventDuration() => System.Diagnostics.Stopwatch.GetTimestamp();
+
+    private static TimeSpan GetEventDuration(long startedAt) => TimeSpan.FromSeconds(
+        (System.Diagnostics.Stopwatch.GetTimestamp() - startedAt)
+        / (double)System.Diagnostics.Stopwatch.Frequency);
 
     private static ValueTask<Outcome<T>> RunAsync<T, TState>(
         StrategyNode? head,

--- a/src/Kevlar/KevlarDiagnostics.cs
+++ b/src/Kevlar/KevlarDiagnostics.cs
@@ -31,4 +31,15 @@ public static class KevlarDiagnostics
 {
     /// <summary>The name of Kevlar's <c>Meter</c>.</summary>
     public const string MeterName = "Kevlar";
+
+    /// <summary>
+    /// Subscribes <paramref name="listener"/> to the process-wide structured event stream.
+    /// Dispose the returned subscription to stop delivery. Subscriptions are invoked in
+    /// registration order; disposal does not interrupt a callback already in progress.
+    /// </summary>
+    public static IDisposable Subscribe(KevlarEventListener listener)
+    {
+        Internal.Throw.IfNull(listener, nameof(listener));
+        return Internal.KevlarEventSource.Subscribe(listener);
+    }
 }

--- a/src/Kevlar/KevlarEvent.cs
+++ b/src/Kevlar/KevlarEvent.cs
@@ -1,0 +1,94 @@
+namespace Kevlar;
+
+/// <summary>
+/// A structured lifecycle or strategy event. The event and its <see cref="Context"/> are valid
+/// only for the duration of <see cref="KevlarEventListener.OnEvent{T}"/> and must not be retained.
+/// </summary>
+/// <typeparam name="T">The execution result type, preserved without boxing.</typeparam>
+public readonly struct KevlarEvent<T>
+{
+    private readonly KevlarContext? _context;
+    private readonly Outcome<T> _outcome;
+
+    internal KevlarEvent(
+        KevlarEventKind kind,
+        KevlarEventSeverity severity,
+        KevlarStrategyKind strategyKind,
+        int strategyIndex,
+        int attempt,
+        TimeSpan duration,
+        bool handled,
+        Outcome<T> outcome,
+        bool hasOutcome,
+        KevlarContext context)
+    {
+        Kind = kind;
+        Severity = severity;
+        StrategyKind = strategyKind;
+        StrategyIndex = strategyIndex;
+        Attempt = attempt;
+        Duration = duration;
+        Handled = handled;
+        _outcome = outcome;
+        HasOutcome = hasOutcome;
+        _context = context;
+    }
+
+    /// <summary>The event identity.</summary>
+    public KevlarEventKind Kind { get; }
+
+    /// <summary>The suggested event severity.</summary>
+    public KevlarEventSeverity Severity { get; }
+
+    /// <summary>The shield name, or <see langword="null"/> for an unnamed shield.</summary>
+    public string? ShieldName => _context?.ShieldName;
+
+    /// <summary>The bounded strategy identity, or <see cref="KevlarStrategyKind.None"/> for execution events.</summary>
+    public KevlarStrategyKind StrategyKind { get; }
+
+    /// <summary>The zero-based pipeline position, or -1 for execution events.</summary>
+    public int StrategyIndex { get; }
+
+    /// <summary>The zero-based attempt number.</summary>
+    public int Attempt { get; }
+
+    /// <summary>Elapsed time associated with this event; zero when no duration applies.</summary>
+    public TimeSpan Duration { get; }
+
+    /// <summary>Whether a strategy handled the associated outcome.</summary>
+    public bool Handled { get; }
+
+    /// <summary>Whether this event carries an <see cref="Outcome"/>.</summary>
+    public bool HasOutcome { get; }
+
+    /// <summary>A bounded classification that does not expose or format result values.</summary>
+    public KevlarOutcomeClassification OutcomeClassification => !HasOutcome
+        ? KevlarOutcomeClassification.None
+        : _outcome.IsSuccess
+            ? KevlarOutcomeClassification.Success
+            : _outcome.Exception is OperationCanceledException
+                ? KevlarOutcomeClassification.Canceled
+                : KevlarOutcomeClassification.Failure;
+
+    /// <summary>
+    /// The typed outcome. Access is valid only when <see cref="HasOutcome"/> is
+    /// <see langword="true"/>.
+    /// </summary>
+    public Outcome<T> Outcome => HasOutcome
+        ? _outcome
+        : throw new InvalidOperationException("This event does not carry an outcome.");
+
+    /// <summary>
+    /// The pooled execution context. Read it only during the listener callback; do not mutate or
+    /// retain it or its properties.
+    /// </summary>
+    public KevlarContext Context => _context
+        ?? throw new InvalidOperationException("The event is not initialized.");
+
+    /// <summary>Attempts to retrieve the typed outcome without boxing its result.</summary>
+    public bool TryGetOutcome(out Outcome<T> outcome)
+    {
+        outcome = _outcome;
+        return HasOutcome;
+    }
+}

--- a/src/Kevlar/KevlarEventKind.cs
+++ b/src/Kevlar/KevlarEventKind.cs
@@ -1,0 +1,32 @@
+namespace Kevlar;
+
+/// <summary>Identifies a structured event emitted by Kevlar.</summary>
+public enum KevlarEventKind
+{
+    /// <summary>A public shield execution is starting.</summary>
+    ExecutionStarted,
+
+    /// <summary>A public shield execution completed.</summary>
+    ExecutionCompleted,
+
+    /// <summary>A retry was scheduled.</summary>
+    RetryScheduled,
+
+    /// <summary>A timeout elapsed.</summary>
+    Timeout,
+
+    /// <summary>An additional hedge attempt started.</summary>
+    HedgeStarted,
+
+    /// <summary>A fallback replaced a handled outcome.</summary>
+    Fallback,
+
+    /// <summary>A circuit breaker changed state.</summary>
+    CircuitStateChanged,
+
+    /// <summary>A rate limiter rejected an execution.</summary>
+    RateLimitRejected,
+
+    /// <summary>A concurrency limiter rejected an execution.</summary>
+    ConcurrencyLimitRejected,
+}

--- a/src/Kevlar/KevlarEventListener.cs
+++ b/src/Kevlar/KevlarEventListener.cs
@@ -1,0 +1,16 @@
+namespace Kevlar;
+
+/// <summary>Receives the unified stream of structured Kevlar events.</summary>
+/// <remarks>
+/// Callbacks run synchronously in subscription order and may run concurrently for concurrent
+/// executions. Implementations must be thread-safe. Reentrancy is supported. Listener exceptions
+/// are suppressed so telemetry cannot alter execution behavior.
+/// </remarks>
+public abstract class KevlarEventListener
+{
+    /// <summary>Returns whether this listener wants events of <paramref name="kind"/>.</summary>
+    public virtual bool IsEnabled(KevlarEventKind kind) => true;
+
+    /// <summary>Receives an event while preserving its result type.</summary>
+    public abstract void OnEvent<T>(in KevlarEvent<T> telemetryEvent);
+}

--- a/src/Kevlar/KevlarEventSeverity.cs
+++ b/src/Kevlar/KevlarEventSeverity.cs
@@ -1,0 +1,17 @@
+namespace Kevlar;
+
+/// <summary>Suggested severity for a structured Kevlar event.</summary>
+public enum KevlarEventSeverity
+{
+    /// <summary>Detailed diagnostic information.</summary>
+    Debug,
+
+    /// <summary>Normal lifecycle information.</summary>
+    Information,
+
+    /// <summary>A handled or potentially disruptive condition.</summary>
+    Warning,
+
+    /// <summary>An execution failure.</summary>
+    Error,
+}

--- a/src/Kevlar/KevlarOutcomeClassification.cs
+++ b/src/Kevlar/KevlarOutcomeClassification.cs
@@ -1,0 +1,17 @@
+namespace Kevlar;
+
+/// <summary>Safe, bounded classification of an event's outcome.</summary>
+public enum KevlarOutcomeClassification
+{
+    /// <summary>The event has no outcome.</summary>
+    None,
+
+    /// <summary>The execution produced a result.</summary>
+    Success,
+
+    /// <summary>The execution failed with an exception.</summary>
+    Failure,
+
+    /// <summary>The execution was canceled.</summary>
+    Canceled,
+}

--- a/src/Kevlar/KevlarStrategyKind.cs
+++ b/src/Kevlar/KevlarStrategyKind.cs
@@ -1,0 +1,29 @@
+namespace Kevlar;
+
+/// <summary>Bounded identity of the strategy associated with a structured event.</summary>
+public enum KevlarStrategyKind
+{
+    /// <summary>The event belongs to the public execution rather than a strategy.</summary>
+    None,
+
+    /// <summary>A retry strategy.</summary>
+    Retry,
+
+    /// <summary>A timeout strategy.</summary>
+    Timeout,
+
+    /// <summary>A hedging strategy.</summary>
+    Hedging,
+
+    /// <summary>A fallback strategy.</summary>
+    Fallback,
+
+    /// <summary>A circuit-breaker strategy.</summary>
+    CircuitBreaker,
+
+    /// <summary>A rate-limit strategy.</summary>
+    RateLimit,
+
+    /// <summary>A concurrency-limit strategy.</summary>
+    ConcurrencyLimit,
+}

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -56,6 +56,55 @@ Kevlar.Shield<TResult>.ExecuteWithContextAsync<TState>(TState state, System.Acti
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<T, TState>(this Kevlar.Shield! shield, TState state, System.Action<TState, Kevlar.KevlarProperties!>! initializeProperties, System.Func<TState, Kevlar.KevlarContext!, System.Threading.Tasks.Task<T>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<TResult, TState>(this Kevlar.Shield<TResult>! shield, TState state, System.Action<TState, Kevlar.KevlarProperties!>! initializeProperties, System.Func<TState, Kevlar.KevlarContext!, System.Threading.Tasks.Task<TResult>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<TState>(this Kevlar.Shield! shield, TState state, System.Action<TState, Kevlar.KevlarProperties!>! initializeProperties, System.Func<TState, Kevlar.KevlarContext!, System.Threading.Tasks.Task!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+abstract Kevlar.KevlarEventListener.OnEvent<T>(in Kevlar.KevlarEvent<T> telemetryEvent) -> void
+Kevlar.KevlarEvent<T>
+Kevlar.KevlarEvent<T>.Attempt.get -> int
+Kevlar.KevlarEvent<T>.Context.get -> Kevlar.KevlarContext!
+Kevlar.KevlarEvent<T>.Duration.get -> System.TimeSpan
+Kevlar.KevlarEvent<T>.Handled.get -> bool
+Kevlar.KevlarEvent<T>.HasOutcome.get -> bool
+Kevlar.KevlarEvent<T>.KevlarEvent() -> void
+Kevlar.KevlarEvent<T>.Kind.get -> Kevlar.KevlarEventKind
+Kevlar.KevlarEvent<T>.Outcome.get -> Kevlar.Outcome<T>
+Kevlar.KevlarEvent<T>.OutcomeClassification.get -> Kevlar.KevlarOutcomeClassification
+Kevlar.KevlarEvent<T>.Severity.get -> Kevlar.KevlarEventSeverity
+Kevlar.KevlarEvent<T>.ShieldName.get -> string?
+Kevlar.KevlarEvent<T>.StrategyIndex.get -> int
+Kevlar.KevlarEvent<T>.StrategyKind.get -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarEvent<T>.TryGetOutcome(out Kevlar.Outcome<T> outcome) -> bool
+Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.CircuitStateChanged = 6 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.ConcurrencyLimitRejected = 8 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.ExecutionCompleted = 1 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.ExecutionStarted = 0 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.Fallback = 5 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.HedgeStarted = 4 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.RateLimitRejected = 7 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.RetryScheduled = 2 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventKind.Timeout = 3 -> Kevlar.KevlarEventKind
+Kevlar.KevlarEventListener
+Kevlar.KevlarEventListener.KevlarEventListener() -> void
+Kevlar.KevlarEventSeverity
+Kevlar.KevlarEventSeverity.Debug = 0 -> Kevlar.KevlarEventSeverity
+Kevlar.KevlarEventSeverity.Error = 3 -> Kevlar.KevlarEventSeverity
+Kevlar.KevlarEventSeverity.Information = 1 -> Kevlar.KevlarEventSeverity
+Kevlar.KevlarEventSeverity.Warning = 2 -> Kevlar.KevlarEventSeverity
+Kevlar.KevlarOutcomeClassification
+Kevlar.KevlarOutcomeClassification.Canceled = 3 -> Kevlar.KevlarOutcomeClassification
+Kevlar.KevlarOutcomeClassification.Failure = 2 -> Kevlar.KevlarOutcomeClassification
+Kevlar.KevlarOutcomeClassification.None = 0 -> Kevlar.KevlarOutcomeClassification
+Kevlar.KevlarOutcomeClassification.Success = 1 -> Kevlar.KevlarOutcomeClassification
+Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.CircuitBreaker = 5 -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.ConcurrencyLimit = 7 -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.Fallback = 4 -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.Hedging = 3 -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.None = 0 -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.RateLimit = 6 -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.Retry = 1 -> Kevlar.KevlarStrategyKind
+Kevlar.KevlarStrategyKind.Timeout = 2 -> Kevlar.KevlarStrategyKind
+static Kevlar.KevlarDiagnostics.Subscribe(Kevlar.KevlarEventListener! listener) -> System.IDisposable!
+virtual Kevlar.KevlarEventListener.IsEnabled(Kevlar.KevlarEventKind kind) -> bool
 Kevlar.Shield.InvokesContinuationAtMostOnce.get -> bool
 virtual Kevlar.Strategy.IsDuplicateReferenceUnsafe.get -> bool
 Kevlar.RetryOptions.DelayGeneratorAsync.get -> System.Func<Kevlar.RetryEvent, System.Threading.Tasks.ValueTask<System.TimeSpan?>>?

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -103,6 +103,7 @@ public class AllocationBudgetTests
     private readonly Counter _retryCounter = new();
     private readonly Counter _asyncDelayRetryCounter = new();
     private readonly ParallelHedgeState _parallelHedgeState = new();
+    private readonly NoOpEventListener _eventListener = new();
     private readonly int _metadataValue = 42;
 
     public AllocationBudgetTests() => _ = _partitioned.GetShield(42);
@@ -196,6 +197,15 @@ public class AllocationBudgetTests
             test._rateLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("concurrency state metrics", this, static test =>
             test._concurrencyLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+    }
+
+    [Test]
+    public void Structured_Execution_Events_Allocate_Zero_Bytes_Per_Operation()
+    {
+        using var subscription = KevlarDiagnostics.Subscribe(_eventListener);
+
+        AssertZero("structured execution events", this, static test =>
+            test._empty.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
     }
 
     /// <summary>Verifies bounded allocations for failure and parallel execution paths.</summary>
@@ -294,6 +304,13 @@ public class AllocationBudgetTests
     private sealed class Counter
     {
         public int Value;
+    }
+
+    private sealed class NoOpEventListener : KevlarEventListener
+    {
+        public override void OnEvent<T>(in KevlarEvent<T> telemetryEvent)
+        {
+        }
     }
 
     private sealed class ParallelHedgeState

--- a/tests/Kevlar.Tests/StructuredTelemetryTests.cs
+++ b/tests/Kevlar.Tests/StructuredTelemetryTests.cs
@@ -1,0 +1,234 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+namespace Kevlar.Tests;
+
+[NotInParallel]
+public class StructuredTelemetryTests
+{
+    private static readonly KevlarKey<int> OperationId = new("operation-id");
+
+    [Test]
+    public async Task Execution_Lifecycle_Is_Typed_Ordered_And_Correlated()
+    {
+        var listener = new RecordingListener();
+        using var subscription = KevlarDiagnostics.Subscribe(listener);
+        var shield = Shield.Retry(0, Backoff.None).WithName("orders");
+
+        var result = await shield.ExecuteWithContextAsync(
+            42,
+            static (value, properties) => properties.Set(OperationId, value),
+            static (_, context) => new ValueTask<int>(context.Properties.GetOrDefault(OperationId)));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(listener.Events.Count).IsEqualTo(2);
+        await Assert.That(listener.Events[0]).IsEqualTo(new RecordedEvent(
+            KevlarEventKind.ExecutionStarted,
+            KevlarEventSeverity.Debug,
+            KevlarOutcomeClassification.None,
+            "orders",
+            -1,
+            0,
+            false,
+            typeof(int),
+            42));
+        await Assert.That(listener.Events[1] with { Duration = TimeSpan.Zero }).IsEqualTo(new RecordedEvent(
+            KevlarEventKind.ExecutionCompleted,
+            KevlarEventSeverity.Information,
+            KevlarOutcomeClassification.Success,
+            "orders",
+            -1,
+            0,
+            true,
+            typeof(int),
+            42));
+        await Assert.That(listener.Events[1].Duration).IsGreaterThanOrEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
+    public async Task Failure_And_PreCancellation_Are_Classified()
+    {
+        var listener = new RecordingListener();
+        using var subscription = KevlarDiagnostics.Subscribe(listener);
+        var failure = new InvalidOperationException("failure");
+        var initialized = false;
+
+        var failed = await Shield.Empty.ExecuteOutcomeAsync<int>(_ => throw failure);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var canceled = await Shield.Empty.ExecuteOutcomeAsync<int>(
+            static _ => new ValueTask<int>(42),
+            cancellation.Token);
+        await Assert.That(async () => await Shield.Empty.ExecuteWithContextAsync(
+                42,
+                (_, _) => initialized = true,
+                static (_, _) => new ValueTask<int>(42),
+                cancellation.Token))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(ReferenceEquals(failed.Exception, failure)).IsTrue();
+        await Assert.That(canceled.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(initialized).IsFalse();
+        await Assert.That(listener.Events
+            .Where(static item => item.Kind == KevlarEventKind.ExecutionCompleted)
+            .Select(static item => item.Outcome)
+            .ToArray()).IsEquivalentTo([
+                KevlarOutcomeClassification.Failure,
+                KevlarOutcomeClassification.Canceled,
+                KevlarOutcomeClassification.Canceled,
+            ]);
+    }
+
+    [Test]
+    public async Task Listener_Faults_Do_Not_Change_Execution_Or_Block_Other_Listeners()
+    {
+        var faulting = new CallbackListener(static _ => throw new InvalidOperationException("listener"));
+        var recording = new RecordingListener();
+        using var first = KevlarDiagnostics.Subscribe(faulting);
+        using var second = KevlarDiagnostics.Subscribe(recording);
+
+        var result = await Shield.Empty.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(faulting.Calls).IsEqualTo(2);
+        await Assert.That(recording.Events.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Subscriptions_Are_Reentrant_Concurrent_And_Disposable()
+    {
+        var nested = 0;
+        var order = new ConcurrentQueue<KevlarEventKind>();
+        var listener = new CallbackListener(kind =>
+        {
+            order.Enqueue(kind);
+            if (kind == KevlarEventKind.ExecutionStarted
+                && Interlocked.CompareExchange(ref nested, 1, 0) == 0)
+            {
+                _ = Shield.Empty.Execute(static _ => 1);
+            }
+        });
+        var subscription = KevlarDiagnostics.Subscribe(listener);
+
+        _ = Shield.Empty.Execute(static _ => 1);
+        await Assert.That(order.ToArray()).IsEquivalentTo([
+            KevlarEventKind.ExecutionStarted,
+            KevlarEventKind.ExecutionStarted,
+            KevlarEventKind.ExecutionCompleted,
+            KevlarEventKind.ExecutionCompleted,
+        ]);
+
+        Parallel.For(0, 100, static _ => Shield.Empty.Execute(static _ => 1));
+        subscription.Dispose();
+        _ = Shield.Empty.Execute(static _ => 1);
+
+        await Assert.That(listener.Calls).IsEqualTo(204);
+    }
+
+    [Test]
+    public async Task Listener_Filter_And_Null_Guard_Are_Immediate()
+    {
+        var listener = new RecordingListener(KevlarEventKind.ExecutionCompleted);
+        using var subscription = KevlarDiagnostics.Subscribe(listener);
+
+        _ = Shield.Empty.Execute(static _ => 1);
+
+        await Assert.That(listener.Events.Select(static item => item.Kind).ToArray())
+            .IsEquivalentTo([KevlarEventKind.ExecutionCompleted]);
+        await Assert.That(() => KevlarDiagnostics.Subscribe(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Void_Executions_Use_The_Generic_Event_Path()
+    {
+        var listener = new RecordingListener();
+        using var subscription = KevlarDiagnostics.Subscribe(listener);
+
+        await Shield.Empty.ExecuteAsync(static _ => ValueTask.CompletedTask);
+
+        await Assert.That(listener.Events.Count).IsEqualTo(2);
+        await Assert.That(listener.Events[1].Outcome).IsEqualTo(KevlarOutcomeClassification.Success);
+    }
+
+    [Test]
+    public async Task Structured_Events_Do_Not_Double_Count_Execution_Metrics()
+    {
+        var executions = 0L;
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == KevlarDiagnostics.MeterName
+                    && instrument.Name == "kevlar.executions")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+            Interlocked.Add(ref executions, measurement));
+        meterListener.Start();
+        using var subscription = KevlarDiagnostics.Subscribe(new RecordingListener());
+
+        _ = Shield.Empty.Execute(static _ => 1);
+        _ = await Shield.Empty.ExecuteOutcomeAsync<int>(static _ =>
+            throw new InvalidOperationException());
+
+        await Assert.That(executions).IsEqualTo(2);
+    }
+
+    private sealed class RecordingListener(KevlarEventKind? enabledKind = null) : KevlarEventListener
+    {
+        public List<RecordedEvent> Events { get; } = [];
+
+        public override bool IsEnabled(KevlarEventKind kind) => enabledKind is null || enabledKind == kind;
+
+        public override void OnEvent<T>(in KevlarEvent<T> telemetryEvent)
+        {
+            var operationId = telemetryEvent.Context.Properties.GetOrDefault(OperationId);
+            lock (Events)
+            {
+                Events.Add(new RecordedEvent(
+                    telemetryEvent.Kind,
+                    telemetryEvent.Severity,
+                    telemetryEvent.OutcomeClassification,
+                    telemetryEvent.ShieldName,
+                    telemetryEvent.StrategyIndex,
+                    telemetryEvent.Attempt,
+                    telemetryEvent.HasOutcome,
+                    typeof(T),
+                    operationId)
+                {
+                    Duration = telemetryEvent.Duration,
+                });
+            }
+        }
+    }
+
+    private sealed class CallbackListener(Action<KevlarEventKind> callback) : KevlarEventListener
+    {
+        private int _calls;
+
+        public int Calls => Volatile.Read(ref _calls);
+
+        public override void OnEvent<T>(in KevlarEvent<T> telemetryEvent)
+        {
+            Interlocked.Increment(ref _calls);
+            callback(telemetryEvent.Kind);
+        }
+    }
+
+    private sealed record RecordedEvent(
+        KevlarEventKind Kind,
+        KevlarEventSeverity Severity,
+        KevlarOutcomeClassification Outcome,
+        string? ShieldName,
+        int StrategyIndex,
+        int Attempt,
+        bool HasOutcome,
+        Type ResultType,
+        int OperationId)
+    {
+        public TimeSpan Duration { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a process-wide typed structured event subscription surface
- emit ordered execution start/completion events across sync, async, outcome, empty, and pre-cancelled paths
- isolate listener faults and support concurrent, reentrant, disposable subscriptions
- preserve typed outcomes and zero-allocation disabled/enabled happy paths
- document schema, pooled-context lifetime, ordering, and benchmark cost

## Benchmark
| Case | Mean | Allocated |
|---|---:|---:|
| Empty, before | 3.724 ns | 0 B |
| Empty, listener off | 3.597 ns | 0 B |
| Empty, no-op listener | 108.081 ns | 0 B |
| Retry, listener off | 63.127 ns | 0 B |
| Retry, no-op listener | 117.510 ns | 0 B |

The disabled empty-path confidence intervals overlap; no material regression was measured.

## Test plan
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (692 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (118 passed)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (4 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (5 passed)
- `npm run build --prefix docs`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-issue132r1` (102 snippets)
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/verify-issue132r1 -Version 0.0.0-issue132r1`

Windows NativeAOT is explicitly unsupported by the verifier; Linux CI owns that check.

Closes #132