### PR TITLE
docs: streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,346 +1,126 @@
 # Kevlar
 
-**Fast, allocation-conscious resilience for .NET.** Retries, circuit breakers, timeouts, rate limiting, concurrency limiting, hedging and fallbacks — composed through one fluent Shield API.
+**Fast, allocation-conscious resilience for .NET.** Kevlar brings retries, circuit breakers,
+timeouts, rate limiting, concurrency limiting, hedging and fallbacks together in one fluent API.
+
+Resilience code should explain how a call is protected, not make you decode a framework. With
+Kevlar, you build an immutable `Shield`, reuse it, and use it with ordinary sync, `Task` or
+`ValueTask` delegates.
+
+[Documentation](https://thomhurst.github.io/Kevlar/docs/getting-started) ·
+[Strategies](https://thomhurst.github.io/Kevlar/docs/category/strategies) ·
+[Benchmarks](https://thomhurst.github.io/Kevlar/docs/benchmarks)
+
+## Get started
+
+```bash
+dotnet add package Kevlar
+```
 
 ```csharp
 using Kevlar;
 
 var shield = Shield
-    .Timeout(TimeSpan.FromSeconds(30))                    // total budget for the whole operation
-    .Retry(3)                                             // exponential backoff + jitter, out of the box
+    .Timeout(TimeSpan.FromSeconds(30))
+    .Retry(3)
     .CircuitBreaker(5, breakDuration: TimeSpan.FromSeconds(30));
 
-var user = await shield.ExecuteAsync(ct => LoadUserAsync(id, ct), cancellationToken);
+var user = await shield.ExecuteAsync(
+    ct => LoadUserAsync(id, ct), cancellationToken);
 ```
 
-Build a shield once, reuse it everywhere. Shields are **immutable and thread-safe**, and ordinary `Task`-returning methods flow straight in — no `ValueTask` wrapping.
+That reads in execution order: the 30-second timeout wraps the retries, which wrap the circuit
+breaker. `Retry(3)` uses exponential backoff with jitter by default. The cancellation token passed
+to your delegate is important—it is how timeouts and abandoned attempts stop the underlying work.
 
-And when the scenario stops being simple, the API doesn't change shape — it deepens. Typed handling clauses, options overloads and delegate hooks carry the same fluent chain all the way up:
-
-```csharp
-var monitor = new CircuitBreakerMonitor();
-
-var search = Shield.For<HttpResponseMessage>()
-    .When<HttpRequestException>()
-    .Or<TimeoutExceededException>()
-    .OrResult(r => (int)r.StatusCode is >= 500 or 429)               // results are failures too
-    .Fallback((outcome, ct) => cache.GetCachedResultsAsync(ct))      // last resort — sees exactly what failed
-    .Retry(o =>
-    {
-        o.MaxRetries = 4;
-        o.Backoff = Backoff.Exponential(TimeSpan.FromMilliseconds(200), maxDelay: TimeSpan.FromSeconds(5));
-        o.DelayGenerator = e => e.Outcome.Result?.Headers.RetryAfter?.Delta;   // server knows best…
-        o.MaxDelay = TimeSpan.FromSeconds(10);                                 // …within reason
-        o.OnRetry = e => logger.LogWarning("search retry {Attempt} in {Delay}", e.Attempt, e.Delay);
-    })
-    .CircuitBreaker(o =>
-    {
-        o.FailureRatio = 0.5;                            // open at ≥50% failures…
-        o.MinimumThroughput = 20;                        // …across ≥20 calls…
-        o.SamplingWindow = TimeSpan.FromSeconds(30);     // …in a rolling 30s window
-        o.Monitor = monitor;                             // ops handle: monitor.Isolate() / monitor.Reset()
-    })
-    .Hedge(maxAttempts: 2, delay: TimeSpan.FromMilliseconds(150))    // race a second attempt on slow p99s
-    .Timeout(TimeSpan.FromSeconds(2))                                // per-attempt budget
-    .WithName("search");                                             // tags metrics and ToString()
-```
-
-One clause up top decides what "failure" means for every strategy below it — exceptions and result values alike. The result is still just a `Shield<HttpResponseMessage>`: immutable, reusable, and it prints its own pipeline when you log it.
+Build shields once and reuse them. They are immutable and thread-safe. Reuse also matters for
+stateful strategies: calls made through the same shield share its circuit breaker and limiter state.
 
 ## Why Kevlar?
 
-- **Intuitive first.** `Shield.When<TimeoutException>().Retry(3)` reads like what it does. No context pooling ceremony, no predicate-builder classes, no options objects for the simple cases — and full options objects when you want them.
-- **Fast.** Outcomes flow between pipeline layers as structs instead of thrown exceptions; contexts are pooled internally; state-passing overloads eliminate closures; `ValueTask` end to end.
-- **Production defaults.** `Shield.Retry(3)` gives you exponential backoff *with jitter* capped at 30s — the thing you'd have configured anyway.
-- **Hard to hold wrong.** Impossible chain orders throw at build time with the fix in the message, and the `Kevlar.Analyzers` package flags cancellation and pipeline hazards at compile time.
-- **Observable out of the box.** `shield.ToString()` prints the whole pipeline; every shield publishes metrics through a built-in `Meter` — no telemetry package, no setup.
-- **Composable.** Shields merge with `Wrap` and `Compose`, chain fluently, and stateful strategies (breakers, limiters) intentionally share their state wherever the same shield instance is reused.
-- **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net10.0` targets.
+- **The common case stays small.** Start with `Shield.Retry(3)`; use options and callbacks when the
+  situation genuinely needs them.
+- **Failures can be exceptions or results.** Retry an `HttpRequestException`, an HTTP 500 response,
+  or both, without changing the shape of the pipeline.
+- **Composition is explicit.** Chain strategies, or combine existing shields with `Wrap` and
+  `Compose`. The first strategy is always the outermost.
+- **It is designed for hot paths.** Struct outcomes, pooled contexts, state-passing overloads and
+  `ValueTask` keep overhead and allocations low. The repository publishes comparative
+  [BenchmarkDotNet results](https://thomhurst.github.io/Kevlar/docs/benchmarks).
+- **Production concerns are built in.** Shields support `TimeProvider`, describe their own pipeline,
+  and publish metrics through the `Kevlar` meter on .NET 8 and later. An optional analyzer catches
+  cancellation and pipeline mistakes at compile time.
+
+The core package targets `netstandard2.0` and `net10.0`.
+
+## Choose what counts as failure
+
+Reactive strategies handle any exception except `OperationCanceledException` by default. A
+handling clause lets you be more precise:
+
+```csharp
+var search = Shield.For<HttpResponseMessage>()
+    .When<HttpRequestException>()
+    .Or<TimeoutExceededException>()
+    .OrResult(response => (int)response.StatusCode is 429 or >= 500)
+    .Fallback((outcome, ct) => cache.GetCachedResultsAsync(ct))
+    .Retry(3)
+    .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+```
+
+The clause applies to the reactive strategies that follow it. Typed shields keep result handling
+strongly typed, including callback events and `Outcome<T>` values.
+
+## Compose protection in reading order
+
+The first strategy is the outermost, just like ASP.NET middleware:
+
+```csharp
+var shield = Shield
+    .Timeout(TimeSpan.FromSeconds(30))  // total budget
+    .Retry(3)                           // retry within that budget
+    .CircuitBreaker(5, TimeSpan.FromSeconds(30))
+    .Timeout(TimeSpan.FromSeconds(5));  // budget for each attempt
+```
+
+This rule makes the important questions visible: is a timeout per attempt or for the whole call?
+Does fallback wrap retry? Are two clients meant to share one circuit? See
+[composition](https://thomhurst.github.io/Kevlar/docs/composition) for `Wrap`, `Compose` and the
+state-sharing rules.
+
+## HTTP and dependency injection
+
+`Kevlar.Extensions.Http` provides a ready-to-use `HttpClientFactory` pipeline:
+
+```csharp
+services.AddHttpClient("api")
+    .AddStandardShield();
+```
+
+The standard shield has a 30-second total timeout, three jittered retries that honour
+`Retry-After`, a circuit breaker, and a 10-second timeout per attempt. You can configure every
+part or supply your own shield. `Kevlar.Extensions.DependencyInjection` adds named,
+configuration-bound shields and `IKevlarRegistry`.
 
 ## Packages
 
-| Package | Purpose |
+| Package | What it adds |
 |---|---|
-| `Kevlar` | The core: all strategies |
-| `Kevlar.Chaos` | Opt-in latency, fault, typed outcome and custom behavior injection |
-| `Kevlar.Extensions.DependencyInjection` | Named shields, config-bound shields + `IKevlarRegistry` for Microsoft DI |
-| `Kevlar.Extensions.Http` | `HttpClientFactory` integration, transient-fault handling, `Retry-After` support |
-| `Kevlar.Extensions.Grpc` | Unary gRPC client interceptor, transient-status helpers, named-shield DI integration |
-| `Kevlar.Extensions.RateLimiting` | `System.Threading.RateLimiting` and custom lease-acquisition adapters |
-| `Kevlar.Analyzers` | Roslyn analyzers that catch resilience mistakes at compile time |
-| `Kevlar.Testing` | Pipeline descriptors, shape assertions, and deterministic fake-time helpers |
-
-## The five-minute tour
-
-### Handling clauses
-
-Tell reactive strategies (retry, circuit breaker, hedging, fallback) what counts as a failure — `When` starts a clause, `Or` extends it:
-
-```csharp
-// Exceptions
-var shield = Shield
-    .When<HttpRequestException>()
-    .Or<TimeoutExceededException>()
-    .OrWhen(ex => ex is IOException { Message: var m } && m.Contains("pipe"))
-    .Retry(5);
-
-// Results too — lift into a typed shield with For<T>
-var http = Shield.For<HttpResponseMessage>()
-    .When<HttpRequestException>()
-    .OrResult(r => (int)r.StatusCode >= 500)
-    .Retry(3);
-
-// The most common result check has a shorthand:
-Shield.For<User?>().WhenDefault().Retry(2);   // retry null results
-```
-
-With no handling clause, the default is: **any exception except `OperationCanceledException`**. A clause applies to the strategy it creates *and* to every reactive strategy chained after it — through `For<T>()`, `Wrap` and `Compose` too — until you write a new clause.
-
-### Retry
-
-```csharp
-Shield.Retry(3);                                          // exponential + jitter (250ms base, 30s cap)
-Shield.Retry(3, Backoff.Constant(TimeSpan.FromSeconds(1)));
-Shield.Retry(3, Backoff.Linear(TimeSpan.FromMilliseconds(500)));
-Shield.RetryForever(Backoff.Exponential(TimeSpan.FromSeconds(1), maxDelay: TimeSpan.FromMinutes(1)));
-
-Shield.Retry(o =>
-{
-    o.MaxRetries = 5;
-    o.Backoff = Backoff.Custom(attempt => TimeSpan.FromMilliseconds(100 * attempt));
-    o.MaxDelay = TimeSpan.FromSeconds(10);   // absolute cap — even over DelayGenerator output
-    o.OnRetry = e => logger.LogWarning(e.Exception, "Retry {Attempt} after {Delay}", e.Attempt, e.Delay);
-    o.DelayGenerator = e => /* return a TimeSpan to override the computed delay, or null */ null;
-    o.DelayGeneratorAsync = e => new ValueTask<TimeSpan?>(TimeSpan.Zero); // awaited override
-});
-```
-
-On a typed `Shield<T>`, retry events are typed too: `e.Outcome` is an `Outcome<T>` — no boxed `object` results, no casting.
-
-### Circuit breaker
-
-```csharp
-// Simple: open after N consecutive failures
-Shield.CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
-
-// Sampling: open when ≥50% of calls fail within a rolling window
-var monitor = new CircuitBreakerMonitor();
-Shield.CircuitBreaker(o =>
-{
-    o.FailureRatio = 0.5;
-    o.MinimumThroughput = 20;
-    o.SamplingWindow = TimeSpan.FromSeconds(30);
-    o.BreakDuration = TimeSpan.FromSeconds(15);
-    o.Monitor = monitor;                                  // observe + manual control
-    o.OnStateChanged = c => logger.LogWarning("Circuit {From} -> {To}", c.From, c.To);
-});
-
-_ = monitor.State;  // Closed / Open / HalfOpen / Isolated
-monitor.Isolate();  // force open (maintenance switch)
-monitor.Reset();    // close and clear metrics
-```
-
-Open circuits reject with `CircuitOpenException` (carrying `RetryAfter`). After the break duration, one probe execution decides whether to close or re-open.
-
-### Timeout
-
-```csharp
-Shield.Timeout(TimeSpan.FromSeconds(10));
-```
-
-Cooperative: the delegate receives a cancellation token that fires on timeout — always use the token you're handed (the `Kevlar.Analyzers` package warns when you don't). Exceeding the budget surfaces `TimeoutExceededException`, which retry clauses can handle.
-
-### Rate limit & concurrency limit
-
-```csharp
-Shield.RateLimit(100, perWindow: TimeSpan.FromSeconds(1));   // token bucket, burst = 100
-Shield.RateLimit(o => { o.Permits = 100; o.Window = TimeSpan.FromSeconds(1); o.QueueLimit = 20; });
-
-Shield.ConcurrencyLimit(maxConcurrency: 10, maxQueue: 20);   // the classic bulkhead pattern
-```
-
-Rejections throw `RateLimitExceededException` (with a `RetryAfter` estimate) and `ConcurrencyLimitExceededException`. With `QueueLimit > 0`, rate-limited executions wait for their reserved permit instead of failing.
-
-### Hedging
-
-```csharp
-// Fire a second attempt if the first hasn't answered within 100ms; fastest wins, losers are cancelled.
-Shield.Hedge(maxAttempts: 2, delay: TimeSpan.FromMilliseconds(100));
-```
-
-`Delay = TimeSpan.Zero` races all attempts at once; `Timeout.InfiniteTimeSpan` hedges only on failure. A handled failure always launches the next attempt immediately. Your delegate must be safe to invoke concurrently.
-
-### Fallback
-
-```csharp
-var shield = Shield.For<Config>()
-    .When<HttpRequestException>()
-    .Fallback(Config.Default);
-
-// Or compute it, with access to the typed failure:
-var computed = Shield.For<Config>()
-    .When<HttpRequestException>()
-    .Fallback((outcome, ct) =>
-    {
-        logger.LogError(outcome.Exception, "Using cached config");
-        return new ValueTask<Config>(cache.Get());
-    });
-
-// Void executions have their own fallback on the plain Shield:
-Shield.When<MessagingException>()
-    .Fallback((exception, ct) => deadLetter.PublishAsync(exception, ct));
-```
-
-For awaited audit or telemetry work, use `FallbackWithNotifications` with
-`FallbackOptions<T>.OnFallbackAsync`. The hook completes before recovery runs; hook failures keep
-their exact exception identity and skip the recovery factory. Notification hooks may be concurrent
-and reentrant, and their pooled `FallbackEvent.Context` must not be retained after completion.
-
-Fallback belongs **before** the strategies it recovers from (first = outermost). Chain it after a retry with the same clause and Kevlar throws at build time — that order silently disables the retry, so it refuses to build it.
-
-## Composition
-
-**The first strategy in a chain is the outermost** — the same rule as ASP.NET middleware:
-
-```csharp
-Shield
-    .Timeout(TimeSpan.FromSeconds(30))   // 1. total budget around everything below
-    .Retry(3)                            // 2. retries happen inside that budget
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30))
-    .Timeout(TimeSpan.FromSeconds(5));   // 4. each individual attempt gets 5s
-```
-
-Merge independently defined shields:
-
-```csharp
-var breaker  = Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));   // built once — holds the circuit state
-var reads    = Shield.Retry(3).Wrap(breaker);
-var writes   = Shield.Timeout(TimeSpan.FromSeconds(5)).Wrap(breaker);
-// reads and writes share ONE circuit: failures through either trip both.
-
-var combined = Shield.Compose(timeoutShield, retryShield, breakerShield);  // first = outermost
-```
-
-That's the state-sharing rule in one line: **strategy state lives with the shield instance that created it**. Reuse the instance to share a circuit or a rate limiter; build a new one for fresh state.
-
-Every shield describes itself — log it at startup:
-
-```csharp
-logger.LogInformation("using {Shield}", shield);
-// github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s)
-```
-
-## Executing
-
-```csharp
-await shield.ExecuteAsync(ct => FetchAsync(ct), cancellationToken);   // Task or ValueTask — both just work
-await shield.ExecuteAsync(ct => SaveAsync(ct), cancellationToken);    // async void
-shield.Execute(ct => ComputeSync(ct));                                // sync (same shield!)
-
-// Zero-closure hot path: thread your state instead of capturing it
-await shield.ExecuteAsync((client, id), static (s, ct) => s.client.GetUserAsync(s.id, ct), ct);
-
-// No-throw execution: inspect the outcome instead
-Outcome<User> outcome = await shield.ExecuteOutcomeAsync(ct => LoadAsync(ct));
-if (!outcome.IsSuccess) logger.LogError(outcome.Exception, "gave up");
-```
-
-The same shield serves any result type, sync or async. (One exception: hedging is inherently concurrent and requires async execution.)
-
-## Dependency injection
-
-<!-- doc-test-tail-declaration: split-before=public sealed class -->
-```csharp
-services.AddShield("github", Shield.Timeout(TimeSpan.FromSeconds(10)).Retry(3));
-services.AddShield<HttpResponseMessage>("downstream",
-    sp => HttpShield.WhenTransient().Retry(3).WithName("downstream"));
-
-// Or bind the whole shield from configuration — tunable without a redeploy:
-services.AddShield("github", builder.Configuration.GetSection("Resilience:GitHub"));
-
-// Consume via the registry…
-var shield = registry.GetShield("github");                       // IKevlarRegistry
-// …or as a keyed service
-public sealed class GitHubClient([FromKeyedServices("github")] Shield shield)
-{
-    public Shield Resilience { get; } = shield;
-}
-```
-
-## HTTP
-
-```csharp
-services.AddHttpClient("api")
-    .AddStandardShield();     // 30s total timeout → 3 jittered retries (honouring Retry-After,
-                              // disposing retried responses) → circuit breaker → 10s attempt timeout
-
-// Or bring your own:
-services.AddHttpClient("api")
-    .AddShield(HttpShield.WhenTransient()        // HttpRequestException, attempt timeouts, 5xx, 408, 429
-        .Retry(o => { o.MaxRetries = 4; o.DelayGenerator = HttpShield.RetryAfter; })
-        .CircuitBreaker(o => o.FailureRatio = 0.5));
-```
-
-## Observability
-
-On .NET 8+ every shield publishes metrics through a `Meter` named `"Kevlar"` with zero configuration — executions, retries, timeouts, hedges, fallbacks, rejections and circuit transitions, tagged with the shield's `WithName` name. Subscribe with `AddMeter(KevlarDiagnostics.MeterName)`.
-
-And `dotnet add package Kevlar.Analyzers` adds compile-time checks for ignored execution cancellation, synchronous hedging, and unreachable reactive strategies. See the [analyzer rule reference](docs/docs/analyzers.md).
-
-## Custom strategies
-
-Everything in Kevlar is a `Strategy` — middleware over an `Outcome<T>` pipeline. Write your own:
-
-<!-- doc-test-declaration: split-before=var shield -->
-```csharp
-public sealed class LoggingStrategy(ILogger logger) : Strategy
-{
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
-        Continuation<T, TState> next, KevlarContext context)
-    {
-        var start = context.TimeProvider.GetTimestamp();
-        var outcome = await next.InvokeAsync(context);
-        logger.LogInformation("{Shield} took {Elapsed}", context.ShieldName,
-            context.TimeProvider.GetElapsedTime(start));
-        return outcome;
-    }
-
-    public override string Describe() => "Logging";
-}
-
-var shield = Shield.Use(new LoggingStrategy(logger)).Retry(3);
-```
-
-Strategies return failures as outcomes rather than throwing, so outer strategies can react to them. Invoke `next` zero times (short-circuit), once (decorate), or many times (retry/hedge).
-
-## Testing your shields
-
-Every delay, timeout and time window runs on a `TimeProvider`:
-
-```csharp
-var time = new FakeTimeProvider();   // Microsoft.Extensions.TimeProvider.Testing
-var shield = Shield.Retry(3, Backoff.Constant(TimeSpan.FromSeconds(10))).WithTimeProvider(time);
-
-var pending = shield.ExecuteAsync(ct => FlakyAsync(ct)).AsTask();
-time.Advance(TimeSpan.FromSeconds(10));                  // no real waiting in tests
-```
-
-## Coming from Polly?
-
-| Polly v8 | Kevlar |
-|---|---|
-| `new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions { … }).Build()` | `Shield.Retry(3)` |
-| `ShouldHandle = new PredicateBuilder().Handle<T>()` | `Shield.When<T>().…` (ambient for the whole chain) |
-| `ResiliencePipeline` / `ResiliencePipeline<T>` | `Shield` / `Shield<T>` |
-| `ResilienceContextPool.Shared.Get(...)` + `Return` | automatic — contexts are pooled internally |
-| `BrokenCircuitException` | `CircuitOpenException` (with `RetryAfter`) |
-| `TimeoutRejectedException` | `TimeoutExceededException` |
-| `CircuitBreakerManualControl` + `StateProvider` | one `CircuitBreakerMonitor` |
-| `AddConcurrencyLimiter(10, 20)` | `Shield.ConcurrencyLimit(10, maxQueue: 20)` |
-| Delegates must return `ValueTask` | `Task`-returning methods flow straight in |
-| Retry default: constant 2s, no jitter | exponential + jitter, 30s cap |
-| First strategy added is outermost | same rule — pipelines translate 1:1 |
-
-## Performance
-
-Kevlar is benchmarked against Polly v8 across every strategy on every merge to `main` — happy paths, failure paths, and composed pipelines. The results are published automatically to the [Benchmarks page](https://thomhurst.github.io/Kevlar/docs/benchmarks) in the docs.
+| [`Kevlar`](https://www.nuget.org/packages/Kevlar) | Core strategies and the Shield API |
+| [`Kevlar.Chaos`](https://www.nuget.org/packages/Kevlar.Chaos) | Controlled latency, faults, outcomes and custom behaviour |
+| [`Kevlar.Extensions.DependencyInjection`](https://www.nuget.org/packages/Kevlar.Extensions.DependencyInjection) | Named and configuration-bound shields for Microsoft DI |
+| [`Kevlar.Extensions.Http`](https://www.nuget.org/packages/Kevlar.Extensions.Http) | `HttpClientFactory` integration, request replay and transient-fault handling |
+| [`Kevlar.Extensions.Grpc`](https://www.nuget.org/packages/Kevlar.Extensions.Grpc) | gRPC client resilience for unary and streaming calls |
+| [`Kevlar.Extensions.RateLimiting`](https://www.nuget.org/packages/Kevlar.Extensions.RateLimiting) | Adapters for `System.Threading.RateLimiting` and custom leases |
+| [`Kevlar.Analyzers`](https://www.nuget.org/packages/Kevlar.Analyzers) | Compile-time checks for common resilience mistakes |
+| [`Kevlar.Testing`](https://www.nuget.org/packages/Kevlar.Testing) | Pipeline assertions, state snapshots and deterministic time helpers |
+
+## Where next?
+
+- Follow the [getting-started guide](https://thomhurst.github.io/Kevlar/docs/getting-started).
+- Browse the [strategy reference](https://thomhurst.github.io/Kevlar/docs/category/strategies).
+- Add [HTTP resilience](https://thomhurst.github.io/Kevlar/docs/http),
+  [dependency injection](https://thomhurst.github.io/Kevlar/docs/dependency-injection), or
+  [observability](https://thomhurst.github.io/Kevlar/docs/observability).
+- Moving from Polly? The [migration guide](https://thomhurst.github.io/Kevlar/docs/polly-migration)
+  maps the concepts side by side.


### PR DESCRIPTION
## Summary

- streamline the README from roughly 1,900 words to about 635
- lead with installation, the core API, and the pipeline mental model
- correct outdated dependency and gRPC descriptions
- keep package, integration, benchmark, and migration links easy to find

## Motivation

The README had grown into a compact reference manual. This keeps it useful as a concise introduction while directing readers to the full documentation for advanced details.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `./scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local` (95 snippets compiled and documented behavior executed)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the README with a concise product overview and clearer getting-started guidance.
  * Added documentation covering failure handling, composition, HTTP and dependency-injection integration, package offerings, and next steps.
  * Updated examples to highlight reusable shields, execution-order composition, typed results, and standard HTTP pipelines.
  * Removed outdated or overly detailed sections on strategies, observability, testing, migration, and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->