### PR TITLE
docs(api): standardize named arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@
 
 Use four-space indentation, file-scoped namespaces, braces on new lines, and modern C# patterns. Public types and members use `PascalCase`; locals and parameters use `camelCase`; private fields use `_camelCase`. Name one primary type per file. Keep hot paths zero-allocation where practical; benchmark unavoidable allocation changes. Nullable reference types and implicit usings are enabled, `LangVersion` is `latest`, and warnings fail the build. Document public APIs with XML comments. No repository-specific formatter is configured; match nearby code and keep `dotnet build` clean.
 
+In C# examples across the README, docs, and XML comments, the first shorthand-strategy argument may be positional when the method name makes its meaning clear. Name every later numeric, duration, or boolean argument. Name both `CircuitBreaker` shorthand arguments (`consecutiveFailures:` and `breakDuration:`) because its first argument is not self-explanatory.
+
 ## Testing Guidelines
 
 Tests use TUnit with `[Test]` methods and names such as `Exponential_Respects_MaxDelay`. Put focused behavior tests in `Kevlar.Tests`, cross-component scenarios in `Kevlar.IntegrationTests`, and diagnostic cases in `Kevlar.Analyzers.Tests`. Add regression tests for bug fixes and edge cases. No fixed coverage threshold is configured; meaningful behavioral coverage is expected.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ using Kevlar;
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))
     .Retry(3)
-    .CircuitBreaker(5, breakDuration: TimeSpan.FromSeconds(30));
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 
 var user = await shield.ExecuteAsync(
     ct => LoadUserAsync(id, ct), cancellationToken);
@@ -66,7 +66,7 @@ var search = Shield.For<HttpResponseMessage>()
     .OrResult(response => (int)response.StatusCode is 429 or >= 500)
     .Fallback((outcome, ct) => cache.GetCachedResultsAsync(ct))
     .Retry(3)
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 ```
 
 The clause applies to the reactive strategies that follow it. Typed shields keep result handling
@@ -80,7 +80,7 @@ The first strategy is the outermost, just like ASP.NET middleware:
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))  // total budget
     .Retry(3)                           // retry within that budget
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30))
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30))
     .Timeout(TimeSpan.FromSeconds(5));  // budget for each attempt
 ```
 

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -41,7 +41,7 @@ Synchronous `Execute` throws for a shield containing a hedge with a known `MaxAt
 one, so use `ExecuteAsync` or remove hedging:
 
 ```csharp
-var hedged = Shield.Hedge(2, TimeSpan.FromMilliseconds(50));
+var hedged = Shield.Hedge(2, delay: TimeSpan.FromMilliseconds(50));
 
 var value = await hedged.ExecuteAsync(ct => LoadAsync(ct));   // clean
 ```
@@ -84,7 +84,7 @@ and limiter capacity is not shared:
 
 ```csharp
 // KEV004: a new circuit exists for only this call.
-await Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30))
+await Shield.CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30))
     .ExecuteAsync(static _ => ValueTask.CompletedTask);
 ```
 
@@ -92,7 +92,7 @@ await Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30))
 ```csharp
 // Clean: every call shares the same circuit.
 private static readonly Shield _dependencyShield =
-    Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));
+    Shield.CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 
 await _dependencyShield.ExecuteAsync(static _ => ValueTask.CompletedTask);
 ```
@@ -115,7 +115,7 @@ the wider invariant:
 
 ```csharp
 #pragma warning disable KEV004 // This isolated circuit is intentional in a one-shot diagnostic.
-var value = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(1)).Execute(_ => 1);
+var value = Shield.CircuitBreaker(consecutiveFailures: 1, breakDuration: TimeSpan.FromSeconds(1)).Execute(_ => 1);
 #pragma warning restore KEV004
 ```
 

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -12,7 +12,7 @@ sidebar_position: 5
 Shield
     .Timeout(TimeSpan.FromSeconds(30))   // 1. total budget around everything below
     .Retry(3)                            // 2. retries happen inside that budget
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30))  // 3. breaker sees each attempt
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30))  // 3. breaker sees each attempt
     .Timeout(TimeSpan.FromSeconds(5));   // 4. each individual attempt gets 5s
 ```
 
@@ -40,7 +40,7 @@ not count as their timeout and does not invoke their `OnTimeout` callback.
 Use `Wrap` to put one shield around another, or `Compose` to stack several:
 
 ```csharp
-var breaker  = Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));   // built once — holds the circuit state
+var breaker  = Shield.CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));   // built once — holds the circuit state
 var reads    = Shield.Retry(3).Wrap(breaker);
 var writes   = Shield.Timeout(TimeSpan.FromSeconds(5)).Wrap(breaker);
 // reads and writes share ONE circuit: failures through either trip both.
@@ -82,7 +82,7 @@ A [handling clause](handling-failures.md) applies to the strategy it precedes *a
 Shield
     .When<HttpRequestException>()
     .Retry(3)                      // retries HttpRequestException
-    .CircuitBreaker(5, breakDur)   // breaker also counts HttpRequestException
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: breakDur)   // breaker also counts HttpRequestException
     .When<TimeoutExceededException>()
     .Fallback(...);                // fallback reacts to TimeoutExceededException only
 ```
@@ -110,7 +110,7 @@ Every shield describes itself — `ToString()` prints the pipeline, outermost fi
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))
     .Retry(3)
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30))
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30))
     .WithName("github");
 
 logger.LogInformation("using {Shield}", shield);

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -28,7 +28,7 @@ using Kevlar;
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))   // total budget for the whole operation
     .Retry(3)                            // exponential backoff + jitter, out of the box
-    .CircuitBreaker(5, breakDuration: TimeSpan.FromSeconds(30));
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 
 var user = await shield.ExecuteAsync(ct => LoadUserAsync(id, ct), cancellationToken);
 ```

--- a/docs/docs/grpc.md
+++ b/docs/docs/grpc.md
@@ -28,7 +28,7 @@ using Kevlar.Extensions.Grpc;
 
 var shield = GrpcShield.WhenTransient()
     .Retry(3)
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 
 var client = new Orders.OrdersClient(
     channel.Intercept(new ShieldUnaryClientInterceptor(shield)));
@@ -90,7 +90,7 @@ services.AddShield(
     "orders-grpc",
     GrpcShield.WhenTransient()
         .Retry(3)
-        .CircuitBreaker(5, TimeSpan.FromSeconds(30)));
+        .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30)));
 
 services.AddGrpcClient<Orders.OrdersClient>(options =>
         options.Address = new Uri("https://orders.example"))

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -54,7 +54,7 @@ A clause applies to the strategy it creates *and* to every reactive strategy cha
 Shield
     .When<HttpRequestException>()      // clause #1
     .Retry(3)                            //   ← uses clause #1
-    .CircuitBreaker(5, breakDuration)    //   ← also clause #1
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: breakDuration)    //   ← also clause #1
     .When<TimeoutExceededException>()  // clause #2 replaces #1 from here on
     .Fallback(...);                      //   ← uses clause #2
 ```

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -254,14 +254,14 @@ var routing = new HttpEndpointRoutingOptions
 {
     SelectionMode = HttpEndpointSelectionMode.Ordered,
     ShieldFactory = endpoint => HttpShield.WhenTransient()
-        .CircuitBreaker(5, TimeSpan.FromSeconds(30)),
+        .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30)),
 };
 routing.Endpoints.Add(new HttpEndpoint(new Uri("https://api-a.example")));
 routing.Endpoints.Add(new HttpEndpoint(new Uri("https://api-b.example")));
 
 services.AddHttpClient("routed")
     .AddShield(
-        HttpShield.WhenTransient().Hedge(2, TimeSpan.Zero),
+        HttpShield.WhenTransient().Hedge(2, delay: TimeSpan.Zero),
         new ShieldHttpHandlerOptions { Routing = routing });
 ```
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -13,7 +13,7 @@ using Kevlar;
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))                    // total budget for the whole operation
     .Retry(3)                                             // exponential backoff + jitter, out of the box
-    .CircuitBreaker(5, breakDuration: TimeSpan.FromSeconds(30));
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 
 var user = await shield.ExecuteAsync(ct => LoadUserAsync(id, ct), cancellationToken);
 ```

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -32,7 +32,7 @@ var client = new ReportsClient(http,
     Shield
         .Timeout(TimeSpan.FromSeconds(30))
         .Retry(3)
-        .CircuitBreaker(5, TimeSpan.FromSeconds(30)));
+        .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30)));
 ```
 
 `Shield.Empty` executes the delegate directly with no strategies in between, so the null-coalescing default costs nothing and needs no branching at call sites.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -15,7 +15,7 @@ Shields are observable without any setup: they describe themselves as strings, p
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))
     .Retry(3)
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30))
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30))
     .WithName("github");
 
 Console.WriteLine(shield);

--- a/docs/docs/partitioning.md
+++ b/docs/docs/partitioning.md
@@ -11,7 +11,7 @@ tenant, shard, authority, or operation while placing an explicit bound on retain
 ```csharp
 var endpoints = new PartitionedShield<string>(
     endpoint => Shield.When<TimeoutException>()
-        .CircuitBreaker(5, TimeSpan.FromSeconds(30)),
+        .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30)),
     new PartitionedShieldOptions
     {
         MaximumPartitions = 500,
@@ -54,7 +54,7 @@ application service provider and the partition key.
 services.AddPartitionedShield<Uri>(
     "endpoints",
     (serviceProvider, endpoint) => Shield.When<HttpRequestException>()
-        .CircuitBreaker(5, TimeSpan.FromSeconds(30))
+        .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30))
         .WithName("outbound-endpoint"),
     options =>
     {
@@ -81,7 +81,7 @@ services.AddPartitionedShield<string, TenantResult>(
     "tenants",
     (serviceProvider, tenantId) => Shield.For<TenantResult>()
         .When<TimeoutException>()
-        .CircuitBreaker(3, TimeSpan.FromSeconds(20))
+        .CircuitBreaker(consecutiveFailures: 3, breakDuration: TimeSpan.FromSeconds(20))
         .WithName("tenant-operation"),
     options => options.MaximumPartitions = 5_000,
     StringComparer.Ordinal);

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -110,7 +110,7 @@ Transitions are delivered serially in state-change order: `OnStateChanged`, awai
 A breaker only protects a dependency if every call site hitting that dependency shares it. State lives with the shield instance:
 
 ```csharp
-var breaker = Shield.CircuitBreaker(5, TimeSpan.FromSeconds(30));   // ONE circuit
+var breaker = Shield.CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));   // ONE circuit
 var reads   = Shield.Retry(3).Wrap(breaker);
 var writes  = Shield.Timeout(TimeSpan.FromSeconds(5)).Wrap(breaker);
 // failures through either trip both

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -129,7 +129,7 @@ var shield = Shield.For<Quote>()
     .When<CircuitOpenException>()    // catch the breaker's rejection too
     .Fallback(Quote.Unavailable)
     .Retry(3)
-    .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 ```
 
 Note the clause: to fall back when the circuit is open, the fallback's handling clause must include `CircuitOpenException`.

--- a/docs/docs/strategies/rate-limit.md
+++ b/docs/docs/strategies/rate-limit.md
@@ -148,7 +148,7 @@ var polite = Shield
         o.MaxRetries = 3;
         o.DelayGenerator = e => (e.Exception as RateLimitExceededException)?.RetryAfter;
     })
-    .RateLimit(100, TimeSpan.FromSeconds(1));
+    .RateLimit(100, perWindow: TimeSpan.FromSeconds(1));
 ```
 
 :::warning Sync callers block


### PR DESCRIPTION
## Summary
- define named-argument guidance for shorthand strategy examples
- name both circuit-breaker arguments and every later numeric or duration argument
- confirm public shorthand parameter names need no breaking rename

## Test plan
- [x] `npm run build` (`docs/`)
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] pack local packages and run `scripts/Verify-DocSnippets.ps1` (95 snippets compiled; documented pipeline executed)

Closes #164
