### PR TITLE
feat(outcome): add Outcome<T>.TryGetResult

### DIFF
--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -111,14 +111,18 @@ When a failure is an expected outcome rather than an exceptional one, skip the t
 ```csharp
 Outcome<User> outcome = await shield.ExecuteOutcomeAsync(ct => LoadAsync(ct));
 
-if (!outcome.IsSuccess)
+if (outcome.TryGetResult(out var user))
 {
-    logger.LogError(outcome.Exception, "gave up loading user");
-    return cached;
+    return user;
 }
 
-return outcome.Result;
+logger.LogError(outcome.Exception, "gave up loading user");
+return cached;
 ```
+
+`TryGetResult` returns `true` exactly when the outcome succeeded. Its nullability annotation
+also tells flow analysis that a non-nullable result is available inside the success branch.
+Use `GetResultOrRethrow()` when you want the throwing path instead.
 
 No-throw execution also supports state-passing `ValueTask` and `Task` delegates. Use a static
 delegate to keep caller data out of a closure:

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -10,6 +10,10 @@ Reactive strategies — [retry](strategies/retry.md), [circuit breaker](strategi
 
 With no handling clause, the default is: **any exception except `OperationCanceledException`**. Cancellation isn't a fault; retrying it would fight the caller.
 
+When you execute with `ExecuteOutcomeAsync`, use `outcome.TryGetResult(out var result)` to
+consume a successful result without throwing. If it returns `false`, the final captured failure
+remains available through `outcome.Exception`.
+
 ## Exception clauses
 
 ```csharp

--- a/src/Kevlar/Outcome.cs
+++ b/src/Kevlar/Outcome.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using Kevlar.Internal;
 
@@ -25,7 +26,10 @@ public readonly struct Outcome<T>
     /// <summary>The captured exception, or <see langword="null"/> if the execution produced a result.</summary>
     public Exception? Exception => _exception?.Data[ExceptionProxyDataKey] as Exception ?? _exception;
 
-    /// <summary>The result value. Only meaningful when <see cref="Exception"/> is <see langword="null"/>.</summary>
+    /// <summary>
+    /// The result value. Only meaningful when <see cref="Exception"/> is <see langword="null"/>.
+    /// For flow-analysis-friendly access, use <see cref="TryGetResult(out T)"/>.
+    /// </summary>
     public T? Result => _result;
 
     /// <summary><see langword="true"/> when the execution produced a result rather than an exception.</summary>
@@ -39,6 +43,23 @@ public readonly struct Outcome<T>
     {
         Throw.IfNull(exception, nameof(exception));
         return new Outcome<T>(default, exception);
+    }
+
+    /// <summary>Tries to get the result without throwing the captured exception.</summary>
+    /// <param name="result">
+    /// The result value when the outcome is successful; otherwise, the default value of <typeparamref name="T"/>.
+    /// </param>
+    /// <returns><see langword="true"/> when the execution produced a result; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetResult([MaybeNullWhen(false)] out T result)
+    {
+        if (IsSuccess)
+        {
+            result = _result!;
+            return true;
+        }
+
+        result = default;
+        return false;
     }
 
     /// <summary>

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -9,6 +9,7 @@ Kevlar.CircuitBreakerOptions.BreakDurationGenerator.get -> System.Func<Kevlar.Ci
 Kevlar.CircuitBreakerOptions.BreakDurationGenerator.set -> void
 Kevlar.CircuitBreakerOptions.OnStateChangedAsync.get -> System.Func<Kevlar.CircuitStateChangedEvent, System.Threading.Tasks.ValueTask>?
 Kevlar.CircuitBreakerOptions.OnStateChangedAsync.set -> void
+Kevlar.Outcome<T>.TryGetResult(out T result) -> bool
 Kevlar.Shield.ExecuteOutcomeAsync<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
 Kevlar.Shield<TResult>.ExecuteOutcomeAsync<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<TResult>>
 Kevlar.TimeoutOptions.OnTimeoutAsync.get -> System.Func<Kevlar.TimeoutEvent, System.Threading.Tasks.ValueTask>?

--- a/tests/Kevlar.Tests/OutcomeAndContextTests.cs
+++ b/tests/Kevlar.Tests/OutcomeAndContextTests.cs
@@ -2,6 +2,9 @@ namespace Kevlar.Tests;
 
 public class OutcomeAndContextTests
 {
+    private const string ExceptionProxyDataKey =
+        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
+
     [Test]
     public async Task FromResult_Is_Success()
     {
@@ -57,6 +60,47 @@ public class OutcomeAndContextTests
             await Assert.That(ReferenceEquals(caught, original)).IsTrue();
             await Assert.That(caught.StackTrace!.Contains(nameof(ThrowOriginal))).IsTrue();
         }
+    }
+
+    [Test]
+    public async Task TryGetResult_Returns_Value_For_Successful_Outcomes()
+    {
+        var valueOutcome = Outcome<int>.FromResult(42);
+        var referenceOutcome = Outcome<string>.FromResult("value");
+
+        await Assert.That(valueOutcome.TryGetResult(out var value)).IsTrue();
+        await Assert.That(value).IsEqualTo(42);
+        await Assert.That(referenceOutcome.TryGetResult(out var reference)).IsTrue();
+        await Assert.That(reference).IsEqualTo("value");
+        await Assert.That(GetLength(referenceOutcome)).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task TryGetResult_Returns_Default_And_Preserves_Exception_For_Failures()
+    {
+        var exception = new InvalidOperationException("boom");
+        var valueOutcome = Outcome<int>.FromException(exception);
+        var referenceOutcome = Outcome<string>.FromException(exception);
+
+        await Assert.That(valueOutcome.TryGetResult(out var value)).IsFalse();
+        await Assert.That(value).IsEqualTo(default);
+        await Assert.That(valueOutcome.Exception).IsSameReferenceAs(exception);
+        await Assert.That(referenceOutcome.TryGetResult(out var reference)).IsFalse();
+        await Assert.That(reference).IsNull();
+        await Assert.That(referenceOutcome.Exception).IsSameReferenceAs(exception);
+    }
+
+    [Test]
+    public async Task TryGetResult_Preserves_Proxy_Exception_Unwrapping()
+    {
+        var original = new InvalidOperationException("original");
+        var proxy = new Exception("proxy");
+        proxy.Data[ExceptionProxyDataKey] = original;
+        var outcome = Outcome<int>.FromException(proxy);
+
+        await Assert.That(outcome.TryGetResult(out var result)).IsFalse();
+        await Assert.That(result).IsEqualTo(default);
+        await Assert.That(outcome.Exception).IsSameReferenceAs(original);
     }
 
     [Test]
@@ -250,6 +294,9 @@ public class OutcomeAndContextTests
     }
 
     private static void ThrowOriginal() => throw new InvalidOperationException("boom");
+
+    private static int GetLength(Outcome<string> outcome) =>
+        outcome.TryGetResult(out var result) ? result.Length : -1;
 
     private sealed class CustomValue
     {


### PR DESCRIPTION
## Summary
- add `Outcome<T>.TryGetResult` with `MaybeNullWhen(false)` flow annotation
- cover value, reference, failure, and proxy-exception outcomes
- document no-throw outcome consumption

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (734 passed)
- [x] `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (118 passed)
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (47 passed)
- [x] `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (5 passed)
- [x] `npm run build --prefix docs`

## Benchmark
`OverheadBenchmarks.Kevlar_EmptyOutcomeState` on .NET 10.0.11:

| Revision | Mean | Allocated |
| --- | ---: | ---: |
| `origin/main` | 7.997 ns | 0 B |
| this branch | 7.680 ns | 0 B |

No existing-path throughput or allocation regression.

Closes #163