### PR TITLE
feat(analyzers): add KEV005 fallback check

### DIFF
--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -20,6 +20,7 @@ Generated code is ignored.
 | `KEV002` | Warning | known multi-attempt hedging pipeline is passed to synchronous `Execute` |
 | `KEV003` | Warning | inner fallback makes retry, hedging, or circuit breaker unreachable |
 | `KEV004` | Warning | stateful shield or partition provider is constructed for one execution |
+| `KEV005` | Warning | void fallback is executed with a result-returning delegate |
 
 ## KEV001: ignored execution cancellation
 
@@ -107,6 +108,34 @@ results, locals with multiple uses, locals captured by nested lambdas, stateless
 generated code, and assemblies ending in `.Test` or `.Tests` remain clean. Custom `Strategy`
 instances are not assumed to be stateful because that cannot be proven from their public contract.
 Test methods marked with standard TUnit, xUnit, NUnit, or MSTest attributes are also ignored.
+
+## KEV005: void fallback with a result
+
+A fallback on non-generic `Shield` can recover void executions only. If that shield executes a
+result-returning delegate, the fallback cannot produce the required value and fails at runtime when
+it handles an outcome:
+
+```csharp
+var voidShield = Shield.Retry(3)
+    .Fallback(static _ => ValueTask.CompletedTask);
+
+var value = await voidShield.ExecuteAsync(static _ => new ValueTask<int>(42)); // KEV005
+```
+
+Build a result-aware shield and use its typed fallback overload instead:
+
+```csharp
+var resultShield = Shield.For<int>()
+    .Retry(3)
+    .Fallback(-1);
+
+var value = await resultShield.ExecuteAsync(static _ => new ValueTask<int>(42));
+```
+
+The rule recognizes same-expression chains and stable local aliases for synchronous, asynchronous,
+outcome-returning, context-aware, and `Task<T>` execution overloads. It deliberately skips
+parameters, returned shields, reassigned locals, and fields because their construction cannot be
+proved by the current intraprocedural analysis.
 
 ## Suppression
 

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -24,7 +24,10 @@ var shield = Shield
 await shield.ExecuteAsync(ct => bus.PublishAsync(message, ct));
 ```
 
-A void fallback guards void executions only; executing a result-returning delegate through it fails with a descriptive error rather than inventing a default value.
+A void fallback guards void executions only; executing a result-returning delegate through it fails
+with a descriptive error rather than inventing a default value. The optional analyzer reports this
+mistake as [`KEV005`](../analyzers.md#kev005-void-fallback-with-a-result) when the pipeline is visible
+in the same expression or a stable local.
 
 ## Three shapes
 

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ KEV001 | Reliability | Warning | Execution delegate ignores its CancellationToke
 KEV002 | Reliability | Warning | Statically known multi-attempt hedging requires asynchronous execution
 KEV003 | Configuration | Warning | Fallback makes a reactive strategy unreachable
 KEV004 | Reliability | Warning | Stateful shield or partition provider is constructed per execution
+KEV005 | Configuration | Warning | Void fallback is used with a result-returning execution

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -9,7 +9,8 @@ namespace Kevlar.Analyzers;
 
 /// <summary>
 /// Diagnoses statically provable Kevlar pipeline hazards: synchronous multi-attempt hedging, reactive
-/// strategies made unreachable by an inner fallback, and per-execution construction of stateful shields.
+/// strategies made unreachable by an inner fallback, per-execution construction of stateful shields,
+/// and void fallbacks used for result-returning executions.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
@@ -44,12 +45,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "Circuit breakers, rate limiters, concurrency limiters, and partition providers must outlive individual executions so their resilience state is retained and shared.");
 
+    /// <summary>The KEV005 rule.</summary>
+    public static readonly DiagnosticDescriptor VoidFallbackResultExecutionRule = new(
+        id: "KEV005",
+        title: "Fallback on a non-generic Shield applies only to void executions",
+        messageFormat: "Fallback on a non-generic Shield applies only to void executions. For executions that return a value, build a result-aware shield with Shield.For<T>() and use its Fallback overloads.",
+        category: "Configuration",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A void fallback cannot produce a value for a result-returning execution and fails at runtime when it handles an outcome.");
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             SynchronousHedgingRule,
             UnreachableReactiveStrategyRule,
-            EphemeralStatefulShieldRule);
+            EphemeralStatefulShieldRule,
+            VoidFallbackResultExecutionRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -124,6 +136,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 EphemeralStatefulShieldRule,
                 location,
                 statefulComponent));
+        }
+
+        if (IsResultReturningExecution(invocation.TargetMethod, knownTypes)
+            && FindInPipeline(
+                GetReceiver(invocation),
+                context,
+                candidate => IsVoidFallback(candidate.TargetMethod, knownTypes),
+                knownTypes,
+                stopAtHandlingClause: false,
+                stopAtCompositionBoundary: false,
+                out _))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                VoidFallbackResultExecutionRule,
+                invocation.Syntax.GetLocation()));
         }
     }
 
@@ -1317,9 +1344,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsExecution(IMethodSymbol method, KnownTypes knownTypes)
     {
         method = Normalize(method);
-        return method.Name is "Execute" or "ExecuteAsync" or "ExecuteOutcomeAsync"
+        return (method.Name is "Execute" or "ExecuteAsync" or "ExecuteOutcomeAsync"
+                or "ExecuteWithContext" or "ExecuteWithContextAsync")
             && (knownTypes.IsShield(method.ContainingType)
                 || knownTypes.IsShieldTaskExtensions(method.ContainingType));
+    }
+
+    private static bool IsResultReturningExecution(IMethodSymbol method, KnownTypes knownTypes)
+    {
+        method = Normalize(method);
+        return IsExecution(method, knownTypes)
+            && !method.ReturnsVoid
+            && !knownTypes.IsNonGenericValueTask(method.ReturnType);
+    }
+
+    private static bool IsVoidFallback(IMethodSymbol method, KnownTypes knownTypes)
+    {
+        method = Normalize(method);
+        return method.Name is "Fallback" or "FallbackWithNotifications"
+            && method.ReturnType is INamedTypeSymbol returnType
+            && knownTypes.IsUntypedShield(returnType)
+            && IsKevlarFluentMethod(method, knownTypes);
     }
 
     private static bool IsStatefulStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
@@ -1410,6 +1455,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         private readonly INamedTypeSymbol? _shieldTaskExtensions;
         private readonly INamedTypeSymbol? _partitionedShield;
         private readonly INamedTypeSymbol? _partitionedShieldOfT;
+        private readonly INamedTypeSymbol? _valueTask;
 
         internal KnownTypes(Compilation compilation)
         {
@@ -1421,6 +1467,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             _shieldTaskExtensions = compilation.GetTypeByMetadataName("Kevlar.ShieldTaskExtensions");
             _partitionedShield = compilation.GetTypeByMetadataName("Kevlar.PartitionedShield`1");
             _partitionedShieldOfT = compilation.GetTypeByMetadataName("Kevlar.PartitionedShield`2");
+            _valueTask = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask");
             var assemblyName = compilation.AssemblyName;
             IsTestAssembly = assemblyName is not null
                 && (assemblyName.EndsWith(".Test", StringComparison.OrdinalIgnoreCase)
@@ -1432,6 +1479,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         internal bool IsShield(INamedTypeSymbol type) =>
             Is(type, _shield) || Is(type, _shieldOfT);
 
+        internal bool IsUntypedShield(INamedTypeSymbol type) => Is(type, _shield);
+
         internal bool IsShieldBuilder(INamedTypeSymbol type) =>
             Is(type, _shieldBuilder) || Is(type, _shieldBuilderOfT);
 
@@ -1441,6 +1490,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         internal bool IsPartitionedShield(INamedTypeSymbol type) =>
             Is(type, _partitionedShield) || Is(type, _partitionedShieldOfT);
+
+        internal bool IsNonGenericValueTask(ITypeSymbol type) =>
+            type is INamedTypeSymbol namedType && Is(namedType, _valueTask);
 
         private static bool Is(INamedTypeSymbol type, INamedTypeSymbol? expected) =>
             expected is not null

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalys
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.UnreachableReactiveStrategyRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.VoidFallbackResultExecutionRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -262,6 +262,118 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV005_Flags_Inline_Void_Fallback_For_Each_Result_Execution_Method()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).Execute(static _ => 1);",
+            "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteAsync(static _ => new ValueTask<int>(1));",
+            "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteOutcomeAsync(static _ => new ValueTask<int>(1));",
+            "_ = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteWithContext(0, static (_, _) => { }, static (_, _) => 1);",
+            "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteWithContextAsync(0, static (_, _) => { }, static (_, _) => new ValueTask<int>(1));",
+        };
+
+        await AssertEachAsync(cases, "KEV005");
+    }
+
+    [Test]
+    public async Task KEV005_Flags_Task_Extensions_And_Transitional_Fallback_Overload()
+    {
+        var cases = new[]
+        {
+            "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteAsync(static _ => Task.FromResult(1));",
+            "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteOutcomeAsync(static _ => Task.FromResult(1));",
+            "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteWithContextAsync(0, static (_, _) => { }, static (_, _) => Task.FromResult(1));",
+            "_ = Shield.Empty.FallbackWithNotifications(static _ => ValueTask.CompletedTask, new FallbackOptions()).Execute(static _ => 1);",
+        };
+
+        await AssertEachAsync(cases, "KEV005");
+    }
+
+    [Test]
+    public async Task KEV005_Flags_Stable_Locals_Aliases_Builders_And_Result_Lifts()
+    {
+        var cases = new[]
+        {
+            "var shield = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); _ = shield.Execute(static _ => 1);",
+            "var shield = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); var alias = shield; _ = alias.Execute(static _ => 1);",
+            "var shield = Shield.When<InvalidOperationException>().Fallback(static (_, _) => ValueTask.CompletedTask); _ = shield.Execute(static _ => 1);",
+            "var shield = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); _ = shield.For<int>().Execute(static _ => 1);",
+            "_ = Shield.Empty.Wrap(Shield.Empty.Fallback(static _ => ValueTask.CompletedTask)).Execute(static _ => 1);",
+            "var fallback = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); _ = Shield.Compose(Shield.Empty, fallback).Execute(static _ => 1);",
+        };
+
+        await AssertEachAsync(cases, "KEV005");
+    }
+
+    [Test]
+    public async Task KEV005_Skips_Typed_Fallbacks_And_Void_Executions()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.For<int>().Fallback(0).Execute(static _ => 1);",
+            "Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).Execute(static _ => { });",
+            "await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteAsync(static _ => ValueTask.CompletedTask);",
+            "Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteWithContext(0, static (_, _) => { }, static (_, _) => { });",
+            "await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteWithContextAsync(0, static (_, _) => { }, static (_, _) => ValueTask.CompletedTask);",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body);
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV005_Defers_Fields_And_Skips_Escaped_Or_Unstable_Locals()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private static readonly Shield Shared = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask);
+
+                public int FromField() => Shared.Execute(static _ => 1);
+
+                public Shield Escape() => Shield.Empty.Fallback(static _ => ValueTask.CompletedTask);
+
+                public int FromParameter(Shield shield) => shield.Execute(static _ => 1);
+
+                public int Reassigned()
+                {
+                    var shield = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask);
+                    shield = Shield.Empty;
+                    return shield.Execute(static _ => 1);
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV005_Diagnostic_Contract_And_Suppression_Are_Exact()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            "_ = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).Execute(static _ => 1);");
+        var suppressed = await AnalyzeBodyAsync("""
+            #pragma warning disable KEV005 // Result use is validated elsewhere.
+            _ = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).Execute(static _ => 1);
+            #pragma warning restore KEV005
+            """);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        var diagnostic = diagnostics[0];
+        await Assert.That(diagnostic.Id).IsEqualTo("KEV005");
+        await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            "Fallback on a non-generic Shield applies only to void executions. " +
+            "For executions that return a value, build a result-aware shield with " +
+            "Shield.For<T>() and use its Fallback overloads.");
+        await Assert.That(suppressed).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV002_Flags_Known_Hedging_Shields_Used_Synchronously()
     {
         var cases = new[]


### PR DESCRIPTION
## Summary
- add KEV005 for void fallbacks used by provably result-returning executions
- cover fluent chains, stable locals/aliases, composition, context-aware methods, outcome methods, and Task<T> extensions
- document the diagnostic and track its analyzer/public API release entries

## Scope decision
Tier 3 field/property flow is deferred. Existing analyzer data flow proves stable local initializers only; inferring single-assignment members safely needs interprocedural/member-write analysis. Fields, properties, parameters, returned shields, and reassigned locals remain conservative false negatives.

## Test plan
- [x] KEV005 focused tests (6/6)
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release -- --timeout 5m` (53/53)
- [x] `dotnet build Kevlar.slnx -c Release` (0 warnings)
- [x] `npm run build` (`docs/`)
- [x] package and run `scripts/Verify-DocSnippets.ps1` (97 snippets compiled; documented pipeline executed)

Closes #160
