### PR TITLE
refactor(retry)!: split typed retry options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 | `Shield.When<A>().When<B>()` | `Shield.When<A>().Or<B>()` |
 | `Shield.For<T>().Or<A>()` | `Shield.For<T>().When<A>()` |
 | `ShieldBuilder<T> builder = Shield.For<T>()` | `Shield<T> shield = Shield.For<T>()` |
+
+- `RetryOptions<TResult>` no longer inherits `RetryOptions`. Both types retain the same scalar
+  property names and defaults, but helpers that accepted `RetryOptions` must configure typed retry
+  options separately. Typed callback getters now return the exact delegates assigned to them.

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -65,6 +65,11 @@ Shield.Retry(o =>
 
 Order per retry: retry metrics are recorded → backoff computes the delay → `MaxDelay` clamps it → `DelayGenerator` may override it → the awaited `DelayGeneratorAsync` may override that result → `OnRetry`/`OnRetryAsync` see the final delay → sleep. Both generators ignore `null` and negative results, and `MaxDelay` clamps each override.
 
+`RetryOptions` and `RetryOptions<T>` are standalone sibling types. Both expose the same
+`MaxRetries`, `Backoff`, and `MaxDelay` settings, while their callback properties use distinct
+`RetryEvent` and `RetryEvent<T>` delegates. Configure shared scalar defaults in each options
+lambda; a `RetryOptions<T>` instance is not assignable to `RetryOptions`.
+
 Async generators receive the caller token through `e.Context.CancellationToken`. If cancellation
 arrives while a generator is awaiting, notification hooks still run after it completes, then the
 next attempt is suppressed and caller cancellation surfaces. A generator exception surfaces with

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -61,8 +61,14 @@ Kevlar.Shield.InvokesContinuationAtMostOnce.get -> bool
 virtual Kevlar.Strategy.IsDuplicateReferenceUnsafe.get -> bool
 Kevlar.RetryOptions.DelayGeneratorAsync.get -> System.Func<Kevlar.RetryEvent, System.Threading.Tasks.ValueTask<System.TimeSpan?>>?
 Kevlar.RetryOptions.DelayGeneratorAsync.set -> void
+Kevlar.RetryOptions<TResult>.Backoff.get -> Kevlar.Backoff!
+Kevlar.RetryOptions<TResult>.Backoff.set -> void
 Kevlar.RetryOptions<TResult>.DelayGeneratorAsync.get -> System.Func<Kevlar.RetryEvent<TResult>, System.Threading.Tasks.ValueTask<System.TimeSpan?>>?
 Kevlar.RetryOptions<TResult>.DelayGeneratorAsync.set -> void
+Kevlar.RetryOptions<TResult>.MaxDelay.get -> System.TimeSpan?
+Kevlar.RetryOptions<TResult>.MaxDelay.set -> void
+Kevlar.RetryOptions<TResult>.MaxRetries.get -> int
+Kevlar.RetryOptions<TResult>.MaxRetries.set -> void
 Kevlar.FallbackEvent
 Kevlar.FallbackEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.FallbackEvent.Exception.get -> System.Exception!

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -83,7 +83,7 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new RetryOptions<TResult>();
         configure(options);
-        return Append(new RetryStrategy(options, JudgeOrDefault));
+        return Append(RetryStrategy.Create(options, JudgeOrDefault));
     }
 
     /// <summary>Retries handled outcomes indefinitely.</summary>

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -51,66 +51,51 @@ public class RetryOptions
 /// Result-typed configuration for a retry strategy on a <see cref="Shield{TResult}"/>: the events
 /// carry a typed <see cref="Outcome{TResult}"/> instead of a boxed <see cref="object"/> result.
 /// </summary>
-public sealed class RetryOptions<TResult> : RetryOptions
+/// <remarks>
+/// <see cref="RetryOptions{TResult}"/> and <see cref="RetryOptions"/> are standalone sibling types.
+/// Their callback properties expose distinct delegate types and preserve the delegates assigned
+/// to them.
+/// Before each retry, callbacks run in this order: <see cref="DelayGenerator"/>,
+/// <see cref="DelayGeneratorAsync"/>, <see cref="OnRetry"/>, then <see cref="OnRetryAsync"/>.
+/// If the caller's cancellation token is cancelled by the time the callbacks complete, the retry
+/// stops and surfaces caller cancellation.
+/// </remarks>
+public sealed class RetryOptions<TResult>
 {
-    private Action<RetryEvent<TResult>>? _onRetry;
-    private Func<RetryEvent<TResult>, ValueTask>? _onRetryAsync;
-    private Func<RetryEvent<TResult>, TimeSpan?>? _delayGenerator;
-    private Func<RetryEvent<TResult>, ValueTask<TimeSpan?>>? _delayGeneratorAsync;
+    /// <summary>
+    /// Maximum number of retries after the initial attempt. The default is 3
+    /// (up to 4 total executions). Use <see cref="int.MaxValue"/> to retry forever.
+    /// </summary>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>The delay computation between attempts. Defaults to <see cref="Backoff.Default"/>.</summary>
+    public Backoff Backoff { get; set; } = Backoff.Default;
+
+    /// <summary>
+    /// An absolute upper bound applied to every delay, including delays produced by
+    /// <see cref="DelayGenerator"/> (so a huge <c>Retry-After</c> header cannot stall the pipeline).
+    /// </summary>
+    public TimeSpan? MaxDelay { get; set; }
 
     /// <summary>Invoked synchronously before each retry sleeps, with the typed handled outcome.</summary>
-    public new Action<RetryEvent<TResult>>? OnRetry
-    {
-        get => _onRetry;
-        set
-        {
-            _onRetry = value;
-            base.OnRetry = value is null ? null : untyped => value(new RetryEvent<TResult>(untyped));
-        }
-    }
+    public Action<RetryEvent<TResult>>? OnRetry { get; set; }
 
     /// <summary>Invoked and awaited before each retry sleeps, with the typed handled outcome.</summary>
-    public new Func<RetryEvent<TResult>, ValueTask>? OnRetryAsync
-    {
-        get => _onRetryAsync;
-        set
-        {
-            _onRetryAsync = value;
-            base.OnRetryAsync = value is null ? null : untyped => value(new RetryEvent<TResult>(untyped));
-        }
-    }
+    public Func<RetryEvent<TResult>, ValueTask>? OnRetryAsync { get; set; }
 
     /// <summary>
     /// Overrides the computed delay for a specific retry, with the typed handled outcome.
     /// Return a non-null value to replace the backoff-computed delay;
-    /// <see cref="RetryOptions.MaxDelay"/> still caps the returned value.
+    /// <see cref="MaxDelay"/> still caps the returned value.
     /// </summary>
-    public new Func<RetryEvent<TResult>, TimeSpan?>? DelayGenerator
-    {
-        get => _delayGenerator;
-        set
-        {
-            _delayGenerator = value;
-            base.DelayGenerator = value is null ? null : untyped => value(new RetryEvent<TResult>(untyped));
-        }
-    }
+    public Func<RetryEvent<TResult>, TimeSpan?>? DelayGenerator { get; set; }
 
     /// <summary>
     /// Asynchronously overrides the delay for a specific retry, with the typed handled outcome.
-    /// Receives the delay after the synchronous generator and <see cref="RetryOptions.MaxDelay"/>
+    /// Receives the delay after the synchronous generator and <see cref="MaxDelay"/>
     /// have been applied. Return a non-null value to replace it; the maximum still applies.
     /// </summary>
-    public new Func<RetryEvent<TResult>, ValueTask<TimeSpan?>>? DelayGeneratorAsync
-    {
-        get => _delayGeneratorAsync;
-        set
-        {
-            _delayGeneratorAsync = value;
-            base.DelayGeneratorAsync = value is null
-                ? null
-                : untyped => value(new RetryEvent<TResult>(untyped));
-        }
-    }
+    public Func<RetryEvent<TResult>, ValueTask<TimeSpan?>>? DelayGeneratorAsync { get; set; }
 }
 
 /// <summary>Describes a retry that is about to happen.</summary>

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -14,20 +14,61 @@ internal sealed class RetryStrategy : Strategy
     private readonly Func<RetryEvent, ValueTask<TimeSpan?>>? _delayGeneratorAsync;
 
     public RetryStrategy(RetryOptions options, OutcomeJudge judge)
+        : this(
+            options.MaxRetries,
+            options.Backoff,
+            options.MaxDelay,
+            judge,
+            options.OnRetry,
+            options.OnRetryAsync,
+            options.DelayGenerator,
+            options.DelayGeneratorAsync)
     {
-        Throw.IfOutOfRange(options.MaxRetries < 0, nameof(options), "MaxRetries must not be negative.");
-        Throw.IfNull(options.Backoff, nameof(options));
-        Throw.IfOutOfRange(options.MaxDelay.HasValue && options.MaxDelay.Value < TimeSpan.Zero, nameof(options.MaxDelay), "MaxDelay must not be negative.");
-        Throw.IfOutOfRange(options.MaxDelay > DelayHelper.MaximumDelay, nameof(options.MaxDelay), "MaxDelay exceeds the runtime timer limit.");
+    }
+
+    private RetryStrategy(
+        int maxRetries,
+        Backoff backoff,
+        TimeSpan? maxDelay,
+        OutcomeJudge judge,
+        Action<RetryEvent>? onRetry,
+        Func<RetryEvent, ValueTask>? onRetryAsync,
+        Func<RetryEvent, TimeSpan?>? delayGenerator,
+        Func<RetryEvent, ValueTask<TimeSpan?>>? delayGeneratorAsync)
+    {
+        Throw.IfOutOfRange(maxRetries < 0, "options", "MaxRetries must not be negative.");
+        Throw.IfNull(backoff, "options");
+        Throw.IfOutOfRange(maxDelay.HasValue && maxDelay.Value < TimeSpan.Zero, "MaxDelay", "MaxDelay must not be negative.");
+        Throw.IfOutOfRange(maxDelay > DelayHelper.MaximumDelay, "MaxDelay", "MaxDelay exceeds the runtime timer limit.");
 
         _judge = judge;
-        _maxRetries = options.MaxRetries;
-        _backoff = options.Backoff;
-        _maxDelay = options.MaxDelay;
-        _onRetry = options.OnRetry;
-        _onRetryAsync = options.OnRetryAsync;
-        _delayGenerator = options.DelayGenerator;
-        _delayGeneratorAsync = options.DelayGeneratorAsync;
+        _maxRetries = maxRetries;
+        _backoff = backoff;
+        _maxDelay = maxDelay;
+        _onRetry = onRetry;
+        _onRetryAsync = onRetryAsync;
+        _delayGenerator = delayGenerator;
+        _delayGeneratorAsync = delayGeneratorAsync;
+    }
+
+    internal static RetryStrategy Create<TResult>(RetryOptions<TResult> options, OutcomeJudge judge)
+    {
+        var onRetry = options.OnRetry;
+        var onRetryAsync = options.OnRetryAsync;
+        var delayGenerator = options.DelayGenerator;
+        var delayGeneratorAsync = options.DelayGeneratorAsync;
+
+        return new RetryStrategy(
+            options.MaxRetries,
+            options.Backoff,
+            options.MaxDelay,
+            judge,
+            onRetry is null ? null : retry => onRetry(new RetryEvent<TResult>(retry)),
+            onRetryAsync is null ? null : retry => onRetryAsync(new RetryEvent<TResult>(retry)),
+            delayGenerator is null ? null : retry => delayGenerator(new RetryEvent<TResult>(retry)),
+            delayGeneratorAsync is null
+                ? null
+                : retry => delayGeneratorAsync(new RetryEvent<TResult>(retry)));
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;

--- a/tests/Kevlar.Tests/NewApiTests.cs
+++ b/tests/Kevlar.Tests/NewApiTests.cs
@@ -197,26 +197,82 @@ public class NewApiTests
     }
 
     [Test]
-    public async Task Typed_Retry_Callbacks_Can_All_Be_Cleared()
+    public async Task Retry_Option_Types_Are_Siblings_And_Preserve_Delegate_Identity()
     {
-        var options = new RetryOptions<int>
+        Action<RetryEvent> untypedOnRetry = static _ => { };
+        Func<RetryEvent, ValueTask> untypedOnRetryAsync = static _ => ValueTask.CompletedTask;
+        Func<RetryEvent, TimeSpan?> untypedDelayGenerator = static _ => TimeSpan.Zero;
+        Func<RetryEvent, ValueTask<TimeSpan?>> untypedDelayGeneratorAsync =
+            static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero);
+        Action<RetryEvent<int>> typedOnRetry = static _ => { };
+        Func<RetryEvent<int>, ValueTask> typedOnRetryAsync = static _ => ValueTask.CompletedTask;
+        Func<RetryEvent<int>, TimeSpan?> typedDelayGenerator = static _ => TimeSpan.Zero;
+        Func<RetryEvent<int>, ValueTask<TimeSpan?>> typedDelayGeneratorAsync =
+            static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero);
+
+        var untyped = new RetryOptions
         {
-            OnRetry = static _ => { },
-            OnRetryAsync = static _ => ValueTask.CompletedTask,
-            DelayGenerator = static _ => TimeSpan.Zero,
-            DelayGeneratorAsync = static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero),
+            OnRetry = untypedOnRetry,
+            OnRetryAsync = untypedOnRetryAsync,
+            DelayGenerator = untypedDelayGenerator,
+            DelayGeneratorAsync = untypedDelayGeneratorAsync,
+        };
+        var typed = new RetryOptions<int>
+        {
+            OnRetry = typedOnRetry,
+            OnRetryAsync = typedOnRetryAsync,
+            DelayGenerator = typedDelayGenerator,
+            DelayGeneratorAsync = typedDelayGeneratorAsync,
         };
 
-        options.OnRetry = null;
-        options.OnRetryAsync = null;
-        options.DelayGenerator = null;
-        options.DelayGeneratorAsync = null;
+        await Assert.That(typeof(RetryOptions).BaseType).IsEqualTo(typeof(object));
+        await Assert.That(typeof(RetryOptions<int>).BaseType).IsEqualTo(typeof(object));
+        await Assert.That(typeof(RetryOptions).IsAssignableFrom(typeof(RetryOptions<int>))).IsFalse();
+        await Assert.That(ReferenceEquals(untyped.OnRetry, untypedOnRetry)).IsTrue();
+        await Assert.That(ReferenceEquals(untyped.OnRetryAsync, untypedOnRetryAsync)).IsTrue();
+        await Assert.That(ReferenceEquals(untyped.DelayGenerator, untypedDelayGenerator)).IsTrue();
+        await Assert.That(ReferenceEquals(untyped.DelayGeneratorAsync, untypedDelayGeneratorAsync)).IsTrue();
+        await Assert.That(ReferenceEquals(typed.OnRetry, typedOnRetry)).IsTrue();
+        await Assert.That(ReferenceEquals(typed.OnRetryAsync, typedOnRetryAsync)).IsTrue();
+        await Assert.That(ReferenceEquals(typed.DelayGenerator, typedDelayGenerator)).IsTrue();
+        await Assert.That(ReferenceEquals(typed.DelayGeneratorAsync, typedDelayGeneratorAsync)).IsTrue();
+    }
 
-        var untyped = (RetryOptions)options;
-        await Assert.That(ReferenceEquals(untyped.OnRetry, null)).IsTrue();
-        await Assert.That(ReferenceEquals(untyped.OnRetryAsync, null)).IsTrue();
-        await Assert.That(ReferenceEquals(untyped.DelayGenerator, null)).IsTrue();
-        await Assert.That(ReferenceEquals(untyped.DelayGeneratorAsync, null)).IsTrue();
+    [Test]
+    public async Task Typed_Retry_Callbacks_Keep_Their_Defined_Order()
+    {
+        var order = new List<string>();
+        var shield = Shield.For<int>()
+            .WhenResult(-1)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.DelayGenerator = _ =>
+                {
+                    order.Add("DelayGenerator");
+                    return TimeSpan.Zero;
+                };
+                options.DelayGeneratorAsync = _ =>
+                {
+                    order.Add("DelayGeneratorAsync");
+                    return new ValueTask<TimeSpan?>(TimeSpan.Zero);
+                };
+                options.OnRetry = _ => order.Add("OnRetry");
+                options.OnRetryAsync = _ =>
+                {
+                    order.Add("OnRetryAsync");
+                    return ValueTask.CompletedTask;
+                };
+            });
+
+        var attempts = 0;
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(attempts++ == 0 ? -1 : 42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(order).IsEquivalentTo(
+            ["DelayGenerator", "DelayGeneratorAsync", "OnRetry", "OnRetryAsync"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- make `RetryOptions` and `RetryOptions<TResult>` standalone sibling types
- keep scalar names/defaults while moving typed callback adaptation into strategy construction
- preserve assigned delegate identity and callback ordering
- document migration in retry guide and changelog

## Breaking change
`RetryOptions<TResult>` is no longer assignable to `RetryOptions`. Shared scalar defaults must be configured for typed options separately.

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (735 passed after rebase)
- [x] `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (118 passed)
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (47 passed)
- [x] `dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m` (31 passed after rebase)
- [x] `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (5 passed)
- [x] `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (3 passed)
- [x] `npm run build --prefix docs`

## Benchmark
`TypedResultBenchmarks.Kevlar_ResultJudged` on .NET 10.0.11, both revisions based on current `main`:

| Revision | Mean | Allocated |
| --- | ---: | ---: |
| `origin/main` | 66.78 ns | 0 B |
| this branch | 65.31 ns | 0 B |

No typed retry throughput or allocation regression.

Closes #162