### PR TITLE
refactor(builders)!: enforce clause grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased
+
+### Breaking changes
+
+Handling clauses now use one spelling per position. `When…` starts a clause on `Shield` or
+`Shield<TResult>`; only `Or…` continues it on a builder. `Shield.For<TResult>()` now returns
+`Shield<TResult>` directly.
+
+| Before | After |
+|---|---|
+| `Shield.When<A>().When<B>()` | `Shield.When<A>().Or<B>()` |
+| `Shield.For<T>().Or<A>()` | `Shield.For<T>().When<A>()` |
+| `ShieldBuilder<T> builder = Shield.For<T>()` | `Shield<T> shield = Shield.For<T>()` |

--- a/benchmarks/Kevlar.Benchmarks/HttpStandardHedgingBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HttpStandardHedgingBenchmarks.cs
@@ -60,10 +60,10 @@ public class HttpStandardHedgingBenchmarks
         Shield.Timeout(TimeSpan.FromSeconds(30))
             .For<HttpResponseMessage>()
             .When<HttpRequestException>()
-            .When<TimeoutExceededException>()
-            .When<ConcurrencyLimitExceededException>()
-            .When<CircuitOpenException>()
-            .WhenResult(HttpShield.IsTransient)
+            .Or<TimeoutExceededException>()
+            .Or<ConcurrencyLimitExceededException>()
+            .Or<CircuitOpenException>()
+            .OrResult(HttpShield.IsTransient)
             .Hedge(2, TimeSpan.FromSeconds(1));
 
     private static ShieldHttpHandlerOptions CreateHandlerOptions()

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -72,7 +72,7 @@ Want to treat certain *results* as failures too (HTTP 500s, say)? Lift into a ty
 ```csharp
 var http = Shield.For<HttpResponseMessage>()
     .When<HttpRequestException>()
-    .WhenResult(r => (int)r.StatusCode >= 500)
+    .OrResult(r => (int)r.StatusCode >= 500)
     .Retry(3);
 ```
 

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -27,7 +27,9 @@ var shield = Shield
 - `When<TException>()` starts a clause matching `TException` and anything derived from it. `When<TException>(predicate)` narrows it further, and `When(predicate)` matches on any exception.
 - `Or<TException>()` / `Or<TException>(predicate)` / `OrWhen(predicate)` add alternatives to the clause. All alternatives OR together.
 
-Both builders speak the same grammar. `When…` and `Or…` are interchangeable — the convention is `When` for the first clause and `Or` for each addition: `When<A>().Or<B>().OrWhen(...)`.
+Clause position determines the vocabulary: `When…` starts a clause on a shield, while `Or…`
+continues that clause on the returned builder. The compiler therefore enforces
+`When<A>().Or<B>().OrWhen(...)`.
 
 ## Result clauses
 
@@ -36,7 +38,7 @@ Sometimes failure isn't an exception — it's a well-formed response you don't l
 ```csharp
 var http = Shield.For<HttpResponseMessage>()
     .When<HttpRequestException>()
-    .WhenResult(r => (int)r.StatusCode >= 500)
+    .OrResult(r => (int)r.StatusCode >= 500)
     .Retry(3);
 ```
 

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -56,7 +56,7 @@ Kevlar:
 var shield = Shield.For<HttpResponseMessage>()
     .Timeout(TimeSpan.FromSeconds(30))
     .When<HttpRequestException>()
-    .WhenResult(r => (int)r.StatusCode >= 500)
+    .OrResult(r => (int)r.StatusCode >= 500)
     .Retry(3)
     .CircuitBreaker(o => { o.FailureRatio = 0.5; o.MinimumThroughput = 20; o.BreakDuration = TimeSpan.FromSeconds(30); });
 

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -98,7 +98,7 @@ The ambient [handling clause](../handling-failures.md) — exceptions *and* hand
 ```csharp
 var http = Shield.For<HttpResponseMessage>()
     .When<HttpRequestException>()
-    .WhenResult(r => (int)r.StatusCode >= 500)
+    .OrResult(r => (int)r.StatusCode >= 500)
     .Fallback((outcome, ct) => new ValueTask<HttpResponseMessage>(CachedResponse()));
 ```
 
@@ -126,7 +126,7 @@ Fallback is usually **outermost** — the last line of defence after retries and
 ```csharp
 var shield = Shield.For<Quote>()
     .When<HttpRequestException>()
-    .When<CircuitOpenException>()    // catch the breaker's rejection too
+    .Or<CircuitOpenException>()      // catch the breaker's rejection too
     .Fallback(Quote.Unavailable)
     .Retry(3)
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1382,7 +1382,6 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool StartsHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
         (method.Name is "When" or "WhenResult" or "WhenDefault")
         && (knownTypes.IsShield(method.ContainingType)
-            || knownTypes.IsShieldBuilder(method.ContainingType)
             || knownTypes.IsShieldExtensions(method.ContainingType));
 
     private static bool IsCompositionBoundary(IMethodSymbol method, KnownTypes knownTypes) =>

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -21,8 +21,8 @@ public static class HttpShield
     public static ShieldBuilder<HttpResponseMessage> WhenTransient() =>
         Shield.For<HttpResponseMessage>()
             .When<HttpRequestException>()
-            .When<TimeoutExceededException>()
-            .WhenResult(IsTransient);
+            .Or<TimeoutExceededException>()
+            .OrResult(IsTransient);
 
     /// <summary>
     /// A production-ready pipeline, outermost first: 30s total timeout → 3 retries with
@@ -45,8 +45,8 @@ public static class HttpShield
         var shield = Shield.Timeout(timeout => Copy(options.TotalTimeout, timeout))
             .For<HttpResponseMessage>()
             .When<HttpRequestException>()
-            .When<TimeoutExceededException>()
-            .WhenResult(IsTransient)
+            .Or<TimeoutExceededException>()
+            .OrResult(IsTransient)
             .Retry(retry => Copy(options.Retry, retry))
             .CircuitBreaker(circuitBreaker => Copy(options.CircuitBreaker, circuitBreaker));
 

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -334,10 +334,10 @@ public static class ShieldHttpClientBuilderExtensions
         Shield.Timeout(options.TotalTimeout)
             .For<HttpResponseMessage>()
             .When<HttpRequestException>()
-            .When<TimeoutExceededException>()
-            .When<ConcurrencyLimitExceededException>()
-            .When<CircuitOpenException>()
-            .WhenResult(HttpShield.IsTransient)
+            .Or<TimeoutExceededException>()
+            .Or<ConcurrencyLimitExceededException>()
+            .Or<CircuitOpenException>()
+            .OrResult(HttpShield.IsTransient)
             .Hedge(options.MaxAttempts, options.HedgeDelay);
 
     private static ShieldHttpHandlerOptions CreateHandlerOptions(StandardHedgingShieldOptions options)

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -132,3 +132,14 @@ Kevlar.ShieldBuilder.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptio
 Kevlar.ShieldBuilder.RateLimit(System.Action<Kevlar.RateLimitOptions!>! configure) -> Kevlar.Shield!
 Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.RateLimit(System.Action<Kevlar.RateLimitOptions!>! configure) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder.When(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder!
+*REMOVED*Kevlar.ShieldBuilder.When<TException>() -> Kevlar.ShieldBuilder!
+*REMOVED*Kevlar.ShieldBuilder.When<TException>(System.Func<TException!, bool>! predicate) -> Kevlar.ShieldBuilder!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.When(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.When<TException>() -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.When<TException>(System.Func<TException!, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.WhenDefault() -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.WhenResult(System.Func<TResult, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.WhenResult(TResult result) -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*static Kevlar.Shield.For<TResult>() -> Kevlar.ShieldBuilder<TResult>!
+static Kevlar.Shield.For<TResult>() -> Kevlar.Shield<TResult>!

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -109,8 +109,8 @@ public sealed class Shield
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>.</summary>
     public static ShieldBuilder When(Func<Exception, bool> predicate) => ShieldExtensions.When(Empty, predicate);
 
-    /// <summary>Starts building a result-aware shield for executions returning <typeparamref name="TResult"/>.</summary>
-    public static ShieldBuilder<TResult> For<TResult>() => new(Shield<TResult>.Empty);
+    /// <summary>Starts a result-aware shield for executions returning <typeparamref name="TResult"/>.</summary>
+    public static Shield<TResult> For<TResult>() => Shield<TResult>.Empty;
 
     /// <summary>
     /// Merges shields into one pipeline. The first shield is the outermost. Stateful strategies

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -9,8 +9,8 @@ namespace Kevlar;
 /// here and to reactive strategies chained afterwards, until replaced by a new clause.
 /// </summary>
 /// <remarks>
-/// <c>When…</c> and <c>Or…</c> are interchangeable; the convention is <c>When</c> for the first
-/// clause and <c>Or</c> for each additional one: <c>Shield.When&lt;A&gt;().Or&lt;B&gt;().Retry(3)</c>.
+/// Start a clause with <c>When…</c> on a shield, then continue it with <c>Or…</c> on this builder:
+/// <c>Shield.When&lt;A&gt;().Or&lt;B&gt;().Retry(3)</c>.
 /// </remarks>
 public sealed class ShieldBuilder
 {
@@ -42,19 +42,6 @@ public sealed class ShieldBuilder
         Throw.IfNull(predicate, nameof(predicate));
         return Or(predicate);
     }
-
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/>. Interchangeable with <see cref="Or{TException}()"/>.</summary>
-    public ShieldBuilder When<TException>()
-        where TException : Exception
-        => Or<TException>();
-
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder When<TException>(Func<TException, bool> predicate)
-        where TException : Exception
-        => Or(predicate);
-
-    /// <summary>Also handle exceptions matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder When(Func<Exception, bool> predicate) => OrWhen(predicate);
 
     private ShieldBuilder Or(Func<Exception, bool> predicate)
     {

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -4,13 +4,12 @@ namespace Kevlar;
 
 /// <summary>
 /// Accumulates exception and result handling clauses for a <see cref="Shield{TResult}"/> chain.
-/// Obtained via <c>Shield.For&lt;T&gt;()</c> or the <c>When</c>/<c>WhenResult</c> methods on
-/// <see cref="Shield{TResult}"/>; finished by adding a strategy. The clauses become the shield's
-/// ambient handling for the strategy added here and reactive strategies chained afterwards.
+/// Obtained via the <c>When</c>/<c>WhenResult</c> methods on <see cref="Shield{TResult}"/> and
+/// finished by adding a strategy. The clauses become the shield's ambient handling for the
+/// strategy added here and reactive strategies chained afterwards.
 /// </summary>
 /// <remarks>
-/// <c>When…</c> and <c>Or…</c> are interchangeable; the convention is <c>When</c> for the first
-/// clause and <c>Or</c> for each additional one:
+/// Start a clause with <c>When…</c> on a shield, then continue it with <c>Or…</c> on this builder:
 /// <c>Shield.For&lt;T&gt;().When&lt;A&gt;().OrResult(r =&gt; …).Retry(3)</c>.
 /// </remarks>
 public sealed class ShieldBuilder<TResult>
@@ -21,16 +20,16 @@ public sealed class ShieldBuilder<TResult>
 
     internal ShieldBuilder(Shield<TResult> parent) => _parent = parent;
 
-    /// <summary>Handle exceptions of type <typeparamref name="TException"/>.</summary>
-    public ShieldBuilder<TResult> When<TException>()
+    /// <summary>Also handle exceptions of type <typeparamref name="TException"/>.</summary>
+    public ShieldBuilder<TResult> Or<TException>()
         where TException : Exception
     {
         _exceptionPredicates.Add(static exception => exception is TException);
         return this;
     }
 
-    /// <summary>Handle exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> When<TException>(Func<TException, bool> predicate)
+    /// <summary>Also handle exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
+    public ShieldBuilder<TResult> Or<TException>(Func<TException, bool> predicate)
         where TException : Exception
     {
         Throw.IfNull(predicate, nameof(predicate));
@@ -38,57 +37,35 @@ public sealed class ShieldBuilder<TResult>
         return this;
     }
 
-    /// <summary>Handle exceptions matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> When(Func<Exception, bool> predicate)
+    /// <summary>Also handle exceptions matching <paramref name="predicate"/>.</summary>
+    public ShieldBuilder<TResult> OrWhen(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         _exceptionPredicates.Add(predicate);
         return this;
     }
 
-    /// <summary>Handle results matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> WhenResult(Func<TResult, bool> predicate)
+    /// <summary>Also handle results matching <paramref name="predicate"/>.</summary>
+    public ShieldBuilder<TResult> OrResult(Func<TResult, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         _resultPredicates.Add(predicate);
         return this;
     }
 
-    /// <summary>Handle results equal to <paramref name="result"/>.</summary>
-    public ShieldBuilder<TResult> WhenResult(TResult result)
+    /// <summary>Also handle results equal to <paramref name="result"/>.</summary>
+    public ShieldBuilder<TResult> OrResult(TResult result)
     {
         _resultPredicates.Add(candidate => EqualityComparer<TResult>.Default.Equals(candidate, result));
         return this;
     }
 
-    /// <summary>Handle results equal to <c>default</c> — <see langword="null"/> for reference types.</summary>
-    public ShieldBuilder<TResult> WhenDefault()
+    /// <summary>Also handle results equal to <c>default</c> — <see langword="null"/> for reference types.</summary>
+    public ShieldBuilder<TResult> OrDefault()
     {
         _resultPredicates.Add(static candidate => EqualityComparer<TResult>.Default.Equals(candidate, default!));
         return this;
     }
-
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/>. Interchangeable with <see cref="When{TException}()"/>.</summary>
-    public ShieldBuilder<TResult> Or<TException>()
-        where TException : Exception
-        => When<TException>();
-
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> Or<TException>(Func<TException, bool> predicate)
-        where TException : Exception
-        => When(predicate);
-
-    /// <summary>Also handle exceptions matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> OrWhen(Func<Exception, bool> predicate) => When(predicate);
-
-    /// <summary>Also handle results matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> OrResult(Func<TResult, bool> predicate) => WhenResult(predicate);
-
-    /// <summary>Also handle results equal to <paramref name="result"/>.</summary>
-    public ShieldBuilder<TResult> OrResult(TResult result) => WhenResult(result);
-
-    /// <summary>Also handle results equal to <c>default</c> — <see langword="null"/> for reference types.</summary>
-    public ShieldBuilder<TResult> OrDefault() => WhenDefault();
 
     /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
     public Shield<TResult> Retry(int maxRetries = 3) => Seal().Retry(maxRetries);
@@ -157,11 +134,6 @@ public sealed class ShieldBuilder<TResult>
 
     private Shield<TResult> Seal()
     {
-        if (_exceptionPredicates.Count == 0 && _resultPredicates.Count == 0)
-        {
-            return _parent;
-        }
-
         var exceptionPredicate = _exceptionPredicates.Count == 0 ? null : ShieldBuilder.Combine(_exceptionPredicates);
         var resultPredicate = CombineResults(_resultPredicates);
         var judge = new TypedJudge<TResult>(exceptionPredicate, resultPredicate);

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -41,24 +41,24 @@ public sealed class Shield<TResult>
     /// <summary>Starts a handling clause: subsequent reactive strategies act on exceptions of type <typeparamref name="TException"/>.</summary>
     public ShieldBuilder<TResult> When<TException>()
         where TException : Exception
-        => new ShieldBuilder<TResult>(this).When<TException>();
+        => new ShieldBuilder<TResult>(this).Or<TException>();
 
     /// <summary>Starts a handling clause for exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
     public ShieldBuilder<TResult> When<TException>(Func<TException, bool> predicate)
         where TException : Exception
-        => new ShieldBuilder<TResult>(this).When(predicate);
+        => new ShieldBuilder<TResult>(this).Or(predicate);
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> When(Func<Exception, bool> predicate) => new ShieldBuilder<TResult>(this).When(predicate);
+    public ShieldBuilder<TResult> When(Func<Exception, bool> predicate) => new ShieldBuilder<TResult>(this).OrWhen(predicate);
 
     /// <summary>Starts a handling clause for results matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> WhenResult(Func<TResult, bool> predicate) => new ShieldBuilder<TResult>(this).WhenResult(predicate);
+    public ShieldBuilder<TResult> WhenResult(Func<TResult, bool> predicate) => new ShieldBuilder<TResult>(this).OrResult(predicate);
 
     /// <summary>Starts a handling clause for results equal to <paramref name="result"/>.</summary>
-    public ShieldBuilder<TResult> WhenResult(TResult result) => new ShieldBuilder<TResult>(this).WhenResult(result);
+    public ShieldBuilder<TResult> WhenResult(TResult result) => new ShieldBuilder<TResult>(this).OrResult(result);
 
     /// <summary>Starts a handling clause for results equal to <c>default</c> — <see langword="null"/> for reference types.</summary>
-    public ShieldBuilder<TResult> WhenDefault() => new ShieldBuilder<TResult>(this).WhenDefault();
+    public ShieldBuilder<TResult> WhenDefault() => new ShieldBuilder<TResult>(this).OrDefault();
 
     // ── Strategy chaining ───────────────────────────────────────────────────────────────
 

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -695,7 +695,7 @@ public class HttpReplayTests
             HttpShield.WhenTransient().CircuitBreaker(1, TimeSpan.FromHours(1));
         var routingPolicy = Shield.For<HttpResponseMessage>()
             .When<CircuitOpenException>()
-            .WhenResult(HttpShield.IsTransient)
+            .OrResult(HttpShield.IsTransient)
             .Hedge(2, TimeSpan.Zero);
         using var invoker = CreateInvoker(routingPolicy, options, transport);
 

--- a/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
@@ -27,8 +27,8 @@ public class HttpResilienceTests
         var shield = Shield.Timeout(TimeSpan.FromSeconds(30))
             .For<HttpResponseMessage>()
             .When<HttpRequestException>()
-            .When<TimeoutExceededException>()
-            .WhenResult(HttpShield.IsTransient)
+            .Or<TimeoutExceededException>()
+            .OrResult(HttpShield.IsTransient)
             .Retry(options =>
             {
                 options.MaxRetries = 3;
@@ -140,7 +140,7 @@ public class HttpResilienceTests
 
         var shield = Shield.For<HttpResponseMessage>()
             .When<HttpRequestException>()
-            .WhenResult(HttpShield.IsTransient)
+            .OrResult(HttpShield.IsTransient)
             .Hedge(maxAttempts: 2, delay: TimeSpan.FromMilliseconds(100));
 
         var stopwatch = Stopwatch.StartNew();

--- a/tests/Kevlar.Tests/NewApiTests.cs
+++ b/tests/Kevlar.Tests/NewApiTests.cs
@@ -9,6 +9,54 @@ namespace Kevlar.Tests;
 public class NewApiTests
 {
     [Test]
+    public async Task For_Returns_Typed_Shield_And_Builders_Expose_Only_Or_Continuations()
+    {
+        Shield<int> typed = Shield.For<int>();
+        await Assert.That(typed.GetType()).IsEqualTo(typeof(Shield<int>));
+
+        var untypedBuilderWhenMethods = typeof(ShieldBuilder)
+            .GetMethods(System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.DeclaredOnly)
+            .Where(static method => method.Name.StartsWith("When", StringComparison.Ordinal))
+            .Select(static method => method.Name)
+            .ToArray();
+        var typedBuilderWhenMethods = typeof(ShieldBuilder<int>)
+            .GetMethods(System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.DeclaredOnly)
+            .Where(static method => method.Name.StartsWith("When", StringComparison.Ordinal))
+            .Select(static method => method.Name)
+            .ToArray();
+        var shieldOrMethods = new[] { typeof(Shield), typeof(Shield<int>) }
+            .SelectMany(static type => type.GetMethods(
+                System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Static
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.DeclaredOnly))
+            .Where(static method => method.Name.StartsWith("Or", StringComparison.Ordinal))
+            .Select(static method => method.Name)
+            .ToArray();
+
+        await Assert.That(untypedBuilderWhenMethods).IsEmpty();
+        await Assert.That(typedBuilderWhenMethods).IsEmpty();
+        await Assert.That(shieldOrMethods).IsEmpty();
+
+        var attempts = 0;
+        var shield = Shield.For<int>().Retry(1, Backoff.None);
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return attempts == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException())
+                : new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task When_And_Or_Compose_On_The_Untyped_Builder()
     {
         var attempts = 0;

--- a/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
@@ -286,7 +286,7 @@ public class RetryEdgeCaseTests
         var attempts = 0;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .WhenResult(-1)
+            .OrResult(-1)
             .Retry(3, Backoff.None);
 
         var result = await shield.ExecuteAsync(_ =>


### PR DESCRIPTION
## Summary
- make `When…` shield-only clause entry points and `Or…` builder-only continuations
- return `Shield<TResult>` directly from `Shield.For<TResult>()`
- migrate repository examples and record the breaking migration table

## Breaking changes
- replace builder `.When…` continuations with `.Or…`
- replace `.Or…` immediately after `Shield.For<T>()` with `.When…`
- bind `Shield.For<T>()` to `Shield<T>`, not `ShieldBuilder<T>`

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release` (0 warnings)
- [x] unit tests (735/735)
- [x] integration tests (118/118)
- [x] analyzer tests (47/47)
- [x] `npm run build` (`docs/`)
- [x] package and run `scripts/Verify-DocSnippets.ps1` (95 snippets compiled; documented pipeline executed)

Closes #161
