### PR TITLE
feat(strategy): expose handling clauses

### DIFF
--- a/docs/docs/custom-strategies.md
+++ b/docs/docs/custom-strategies.md
@@ -81,6 +81,35 @@ public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
 
 The exception is only thrown once — at the pipeline boundary, back in the caller's frame, with its original stack trace intact.
 
+## Consume handling clauses
+
+Reactive custom strategies should use the shield's active handling clause instead of hard-coding exception filters. Pass a factory to `Use`; Kevlar invokes it once and supplies a `HandlingClause` that wraps the current `When`/`Or` clause, or `HandlingClause.Default` when none is active:
+
+<!-- doc-test-declaration: split-before=var shield -->
+```csharp
+public sealed class RetryOnceStrategy(HandlingClause handling) : Strategy
+{
+    protected override HandlingClause? Handling => handling;
+
+    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+        Continuation<T, TState> next, KevlarContext context)
+    {
+        var outcome = await next.InvokeAsync(context);
+        return handling.ShouldHandle(in outcome)
+            ? await next.InvokeAsync(context)
+            : outcome;
+    }
+}
+
+var shield = Shield
+    .When<HttpRequestException>()
+    .Use(clause => new RetryOnceStrategy(clause));
+```
+
+`ShouldHandle` works with exception and typed-result outcomes. The default handles any exception except `OperationCanceledException`. The existing `Use(Strategy)` overload remains the simpler choice for proactive strategies that do not inspect failures.
+
+Override `Strategy.Handling` when retaining the supplied clause, as above. This declaration lets Kevlar's unreachable-fallback validation and `Kevlar.Testing` custom strategy descriptors see the strategy's handling. A strategy with intentionally local rules may ignore the factory argument and implement those rules itself.
+
 ## Context properties
 
 `KevlarContext.Properties` is isolated per execution. A `KevlarKey<T>` is identified by both

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -69,6 +69,18 @@ This is why most chains only need one clause, written once at the top — and wh
 Timeouts, rate limits and concurrency limits don't care why something failed — they act on time and concurrency, not outcomes. Clauses only drive the reactive strategies.
 :::
 
+## Custom reactive strategies
+
+Custom strategies opt into ambient handling through the `Use` factory overload:
+
+<!-- doc-test-ignore: RetryOnceStrategy is defined on the Custom Strategies page. -->
+```csharp
+var shield = Shield.When<HttpRequestException>()
+    .Use(clause => new RetryOnceStrategy(clause));
+```
+
+The factory runs once and receives a `HandlingClause`. Call `clause.ShouldHandle(in outcome)` inside the strategy so exception and result rules stay aligned with the shield. See [Custom Strategies](custom-strategies.md#consume-handling-clauses) for a complete implementation.
+
 :::info Clauses survive lifting and composing
 `shield.For<T>()` carries an ambient exception clause into the typed shield, and `Shield.Compose(...)` keeps the last input's clause ambient — so strategies chained afterwards keep handling what you declared. Write a new clause any time you want different handling.
 :::

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -47,6 +47,16 @@ For the same reason there is no `Kevlar.Abstractions` package. Kevlar keeps its 
 
 And for testing, you don't need a mock: `Shield.Empty` is the no-op, and fault injection works better through a real shield with a [custom strategy](custom-strategies.md) — it exercises the actual engine. See [Testing Your Shields](testing.md).
 
+If your library ships a reactive custom strategy, accept its active handling through the `Use` factory rather than baking exception rules into the package:
+
+<!-- doc-test-ignore: LibraryRetryStrategy is supplied by the library author. -->
+```csharp
+var shield = Shield.When<HttpRequestException>()
+    .Use(clause => new LibraryRetryStrategy(clause));
+```
+
+Store the supplied `HandlingClause`, consult it for each `Outcome<T>`, and override `Strategy.Handling` so chain validation and `Kevlar.Testing` can inspect the declaration. Proactive custom strategies can keep using `Use(Strategy)`.
+
 ## Result-aware parameters
 
 If callers should be able to react to *result values* — retry on `null`, hedge on an error status — accept a `Shield<T>` instead:

--- a/src/Kevlar.Testing/CustomStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/CustomStrategyDescriptor.cs
@@ -3,9 +3,16 @@ namespace Kevlar.Testing;
 /// <summary>Diagnostic description of a caller-defined strategy.</summary>
 public sealed class CustomStrategyDescriptor : StrategyDescriptor
 {
-    internal CustomStrategyDescriptor(string description, Type strategyType)
-        : base(StrategyKind.Custom, description) => StrategyType = strategyType;
+    internal CustomStrategyDescriptor(string description, Type strategyType, HandlingClause? handling)
+        : base(StrategyKind.Custom, description)
+    {
+        StrategyType = strategyType;
+        Handling = handling;
+    }
 
     /// <summary>The caller-defined strategy type.</summary>
     public Type StrategyType { get; }
+
+    /// <summary>The strategy's declared handling clause, or <see langword="null"/> when proactive.</summary>
+    public HandlingClause? Handling { get; }
 }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -22,6 +22,7 @@ Kevlar.Testing.ConcurrencyLimitStrategyDescriptor
 Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.MaxConcurrency.get -> int
 Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.MaxQueue.get -> int
 Kevlar.Testing.CustomStrategyDescriptor
+Kevlar.Testing.CustomStrategyDescriptor.Handling.get -> Kevlar.HandlingClause?
 Kevlar.Testing.CustomStrategyDescriptor.StrategyType.get -> System.Type!
 Kevlar.Testing.FallbackStrategyDescriptor
 Kevlar.Testing.FallbackStrategyDescriptor.HasNotification.get -> bool

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -85,7 +85,10 @@ public static class ShieldDescriptorExtensions
                 description,
                 fallback.ResultType,
                 fallback.HasNotification),
-            _ => new CustomStrategyDescriptor(description, strategy.GetType()),
+            _ => new CustomStrategyDescriptor(
+                description,
+                strategy.GetType(),
+                strategy.ReactiveJudge is { } judge ? new HandlingClause(judge) : null),
         };
     }
 

--- a/src/Kevlar/HandlingClause.cs
+++ b/src/Kevlar/HandlingClause.cs
@@ -1,0 +1,24 @@
+using Kevlar.Internal;
+
+namespace Kevlar;
+
+/// <summary>
+/// Decides whether an outcome is a handled failure. Custom reactive strategies receive the
+/// active clause through a <c>Use</c> factory and should consult it instead of duplicating filters.
+/// </summary>
+public readonly struct HandlingClause
+{
+    private readonly OutcomeJudge? _judge;
+
+    internal HandlingClause(OutcomeJudge judge) => _judge = judge;
+
+    /// <summary>
+    /// The default handling clause: any exception except <see cref="OperationCanceledException"/>.
+    /// </summary>
+    public static HandlingClause Default { get; } = new(OutcomeJudge.Default);
+
+    internal OutcomeJudge Judge => _judge ?? OutcomeJudge.Default;
+
+    /// <summary>Returns whether <paramref name="outcome"/> is a handled failure.</summary>
+    public bool ShouldHandle<T>(in Outcome<T> outcome) => Judge.ShouldHandle(in outcome);
+}

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace Kevlar.Internal;
 
 /// <summary>
@@ -53,12 +51,11 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
             return _exceptionPredicate?.Invoke(exception) ?? false;
         }
 
-        if (_resultPredicate is null)
+        if (_resultPredicate is null || typeof(T) != typeof(TResult))
         {
             return false;
         }
 
-        Debug.Assert(typeof(T) == typeof(TResult), "Typed strategies only execute inside a matching Shield<TResult>.");
         var predicate = (Func<T, bool>)(object)_resultPredicate;
         return predicate(outcome.Result!);
     }

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,3 +1,13 @@
+Kevlar.HandlingClause
+Kevlar.HandlingClause.HandlingClause() -> void
+Kevlar.HandlingClause.ShouldHandle<T>(in Kevlar.Outcome<T> outcome) -> bool
+static Kevlar.HandlingClause.Default.get -> Kevlar.HandlingClause
+static Kevlar.Shield.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.Use(this Kevlar.Shield! shield, System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield!
+Kevlar.Shield<TResult>.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield!
+Kevlar.ShieldBuilder<TResult>.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield<TResult>!
+virtual Kevlar.Strategy.Handling.get -> Kevlar.HandlingClause?
 Kevlar.CircuitBreakerBreakDurationEvent
 Kevlar.CircuitBreakerBreakDurationEvent.CircuitBreakerBreakDurationEvent() -> void
 Kevlar.CircuitBreakerBreakDurationEvent.Context.get -> Kevlar.KevlarContext!

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -96,6 +96,12 @@ public sealed class Shield
     /// <summary>Starts a pipeline with a custom <see cref="Strategy"/> implementation.</summary>
     public static Shield Use(Strategy strategy) => ShieldExtensions.Use(Empty, strategy);
 
+    /// <summary>
+    /// Starts a pipeline with a custom strategy created from the default handling clause.
+    /// The factory runs once when the strategy is appended.
+    /// </summary>
+    public static Shield Use(Func<HandlingClause, Strategy> factory) => ShieldExtensions.Use(Empty, factory);
+
     /// <summary>Starts a handling clause: subsequent reactive strategies act on exceptions of type <typeparamref name="TException"/>.</summary>
     public static ShieldBuilder When<TException>()
         where TException : Exception

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -86,6 +86,9 @@ public sealed class ShieldBuilder
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
     public Shield Hedge(Action<HedgingOptions> configure) => Seal().Hedge(configure);
 
+    /// <summary>Creates and appends a custom strategy using the accumulated handling clause.</summary>
+    public Shield Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);
+
     /// <summary>
     /// Runs <paramref name="fallback"/> in place of handled failures. Applies to void executions
     /// only; result-returning executions need <c>Shield.For&lt;T&gt;().Fallback(…)</c>.

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -114,6 +114,9 @@ public sealed class ShieldBuilder<TResult>
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
     public Shield<TResult> Hedge(Action<HedgingOptions> configure) => Seal().Hedge(configure);
 
+    /// <summary>Creates and appends a custom strategy using the accumulated handling clause.</summary>
+    public Shield<TResult> Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);
+
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
     public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>>? onFallback = null) => Seal().Fallback(fallbackValue, onFallback);
 

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -149,6 +149,19 @@ public static class ShieldExtensions
     }
 
     /// <summary>
+    /// Appends a custom strategy created from the active handling clause. The factory runs once;
+    /// reactive custom strategies should retain and consult the supplied clause.
+    /// </summary>
+    public static Shield Use(this Shield shield, Func<HandlingClause, Strategy> factory)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfNull(factory, nameof(factory));
+        var strategy = factory(new HandlingClause(shield.JudgeOrDefault))
+            ?? throw new InvalidOperationException("The strategy factory returned null.");
+        return shield.Append(strategy);
+    }
+
+    /// <summary>
     /// Wraps <paramref name="inner"/> inside <paramref name="outer"/>: the outer shield's strategies
     /// run first. The first non-null name and time provider win; the last handling clause stays ambient.
     /// </summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -236,6 +236,18 @@ public sealed class Shield<TResult>
         return Append(strategy);
     }
 
+    /// <summary>
+    /// Appends a custom strategy created from the active handling clause. The factory runs once;
+    /// reactive custom strategies should retain and consult the supplied clause.
+    /// </summary>
+    public Shield<TResult> Use(Func<HandlingClause, Strategy> factory)
+    {
+        Throw.IfNull(factory, nameof(factory));
+        var strategy = factory(new HandlingClause(JudgeOrDefault))
+            ?? throw new InvalidOperationException("The strategy factory returned null.");
+        return Append(strategy);
+    }
+
     // ── Composition ─────────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -24,6 +24,13 @@ public abstract class Strategy
     internal virtual bool InvokesContinuationAtMostOnce => false;
 
     /// <summary>
+    /// The handling clause this reactive strategy acts on, or <see langword="null"/> for a
+    /// proactive strategy. Override this when the strategy receives a clause through a
+    /// <c>Use</c> factory so chain validation and testing descriptors can inspect it.
+    /// </summary>
+    protected virtual HandlingClause? Handling => null;
+
+    /// <summary>
     /// Executes the strategy around the rest of the pipeline.
     /// </summary>
     /// <typeparam name="T">The result type of the execution.</typeparam>
@@ -39,7 +46,7 @@ public abstract class Strategy
     public virtual string Describe() => GetType().Name;
 
     /// <summary>The handling clause this reactive strategy acts on; null for proactive strategies.</summary>
-    internal virtual OutcomeJudge? ReactiveJudge => null;
+    internal virtual OutcomeJudge? ReactiveJudge => Handling?.Judge;
 
     /// <summary>Marks fallback strategies for chain-order validation.</summary>
     internal virtual bool IsFallback => false;

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -148,6 +148,22 @@ public class PipelineDescriptorTests
 
         await Assert.That(custom.StrategyType).IsEqualTo(typeof(PassThroughStrategy));
         await Assert.That(custom.Description).IsEqualTo("pass-through");
+        await Assert.That(custom.Handling).IsNull();
+    }
+
+    [Test]
+    public async Task Custom_Strategy_Descriptor_Exposes_Declared_Handling()
+    {
+        var custom = Shield.When<ArgumentException>()
+            .Use(clause => new HandlingAwareStrategy(clause))
+            .GetDescriptor()
+            .AssertContainsSingle<CustomStrategyDescriptor>();
+
+        await Assert.That(custom.Handling.HasValue).IsTrue();
+        await Assert.That(custom.Handling!.Value.ShouldHandle(
+            Outcome<int>.FromException(new ArgumentException()))).IsTrue();
+        await Assert.That(custom.Handling.Value.ShouldHandle(
+            Outcome<int>.FromException(new InvalidOperationException()))).IsFalse();
     }
 
     [Test]
@@ -243,6 +259,15 @@ public class PipelineDescriptorTests
     private sealed class PassThroughStrategy : Strategy
     {
         public override string Describe() => "pass-through";
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
+    }
+
+    private sealed class HandlingAwareStrategy(HandlingClause handling) : Strategy
+    {
+        protected override HandlingClause? Handling => handling;
 
         public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
             Continuation<T, TState> next,

--- a/tests/Kevlar.Tests/CustomStrategyContractTests.cs
+++ b/tests/Kevlar.Tests/CustomStrategyContractTests.cs
@@ -212,8 +212,79 @@ public class CustomStrategyContractTests
     [Test]
     public async Task Use_Rejects_Null_Strategies()
     {
-        await Assert.That(() => Shield.Use(null!)).Throws<ArgumentNullException>();
-        await Assert.That(() => Shield<int>.Empty.Use(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => Shield.Use((Strategy)null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => Shield<int>.Empty.Use((Strategy)null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Use_Factory_Receives_The_Active_Exception_Handling_Clause_Once()
+    {
+        HandlingClause? captured = null;
+        var factoryCalls = 0;
+
+        var shield = Shield.When<ArgumentException>().Use(clause =>
+        {
+            factoryCalls++;
+            captured = clause;
+            return PassThroughStrategy.Instance;
+        });
+
+        await Assert.That(factoryCalls).IsEqualTo(1);
+        await Assert.That(captured.HasValue).IsTrue();
+        await Assert.That(captured!.Value.ShouldHandle(Outcome<int>.FromException(new ArgumentException()))).IsTrue();
+        await Assert.That(captured.Value.ShouldHandle(Outcome<int>.FromException(new InvalidOperationException()))).IsFalse();
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Use_Factory_Receives_Default_And_Typed_Result_Handling()
+    {
+        HandlingClause untyped = default;
+        HandlingClause typed = default;
+
+        _ = Shield.Use(clause =>
+        {
+            untyped = clause;
+            return PassThroughStrategy.Instance;
+        });
+        _ = Shield.For<int>().WhenResult(0).Use(clause =>
+        {
+            typed = clause;
+            return PassThroughStrategy.Instance;
+        });
+
+        await Assert.That(untyped.ShouldHandle(Outcome<int>.FromException(new InvalidOperationException()))).IsTrue();
+        await Assert.That(untyped.ShouldHandle(Outcome<int>.FromException(new OperationCanceledException()))).IsFalse();
+        await Assert.That(untyped.ShouldHandle(Outcome<int>.FromResult(0))).IsFalse();
+        await Assert.That(typed.ShouldHandle(Outcome<int>.FromResult(0))).IsTrue();
+        await Assert.That(typed.ShouldHandle(Outcome<int>.FromResult(1))).IsFalse();
+        await Assert.That(HandlingClause.Default.ShouldHandle(
+            Outcome<int>.FromException(new InvalidOperationException()))).IsTrue();
+    }
+
+    [Test]
+    public async Task Use_Factory_Is_Available_On_Typed_Shields_And_Rejects_Null()
+    {
+        var shield = Shield<int>.Empty.Use(_ => PassThroughStrategy.Instance);
+
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(42))).IsEqualTo(42);
+        await Assert.That(() => Shield.Empty.Use((Func<HandlingClause, Strategy>)null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => Shield.Empty.Use(_ => null!)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Declared_Handling_Participates_In_Chain_Validation()
+    {
+        await Assert.That(() =>
+        {
+            _ = Shield.For<int>()
+                .When<ArgumentException>()
+                .Use(clause => new HandlingAwareStrategy(clause))
+                .Fallback(0);
+        }).Throws<InvalidOperationException>();
     }
 
     [Test]
@@ -356,6 +427,15 @@ public class CustomStrategyContractTests
             Interlocked.Increment(ref _invocations);
             return next.InvokeAsync(context);
         }
+    }
+
+    private sealed class HandlingAwareStrategy(HandlingClause handling) : Strategy
+    {
+        protected override HandlingClause? Handling => handling;
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
     }
 
     private sealed class DescribedStrategy : Strategy

--- a/tests/Kevlar.Tests/CustomStrategyContractTests.cs
+++ b/tests/Kevlar.Tests/CustomStrategyContractTests.cs
@@ -260,6 +260,7 @@ public class CustomStrategyContractTests
         await Assert.That(untyped.ShouldHandle(Outcome<int>.FromResult(0))).IsFalse();
         await Assert.That(typed.ShouldHandle(Outcome<int>.FromResult(0))).IsTrue();
         await Assert.That(typed.ShouldHandle(Outcome<int>.FromResult(1))).IsFalse();
+        await Assert.That(typed.ShouldHandle(Outcome<string>.FromResult("0"))).IsFalse();
         await Assert.That(HandlingClause.Default.ShouldHandle(
             Outcome<int>.FromException(new InvalidOperationException()))).IsTrue();
     }

--- a/tests/Kevlar.Tests/OptionsValidationTests.cs
+++ b/tests/Kevlar.Tests/OptionsValidationTests.cs
@@ -110,7 +110,7 @@ public class OptionsValidationTests
         await Assert.That(() => Shield.Compose(shield, null!)).Throws<ArgumentNullException>();
         await Assert.That(() => shield.Wrap((Shield)null!)).Throws<ArgumentNullException>();
         await Assert.That(() => shield.Wrap((Shield<int>)null!)).Throws<ArgumentNullException>();
-        await Assert.That(() => shield.Use(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => shield.Use((Strategy)null!)).Throws<ArgumentNullException>();
         await Assert.That(() => shield.WithName(null!)).Throws<ArgumentNullException>();
         await Assert.That(() => shield.WithTimeProvider(null!)).Throws<ArgumentNullException>();
     }


### PR DESCRIPTION
## Summary
- expose `HandlingClause` as a readonly wrapper over Kevlar's existing `OutcomeJudge`, including shared default semantics
- add clause-aware `Use` factories on static, untyped, typed, and builder surfaces
- let custom reactive strategies declare `Strategy.Handling` for chain validation and `Kevlar.Testing` descriptors
- document handling guidance for custom strategies and library authors

## Declaration hook decision
Implemented the public protected `Strategy.Handling` hook in this PR. It maps directly to the existing internal judge, catches unreachable fallback chains, and surfaces as `CustomStrategyDescriptor.Handling` without exposing predicates.

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m`
- [x] `dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m`
- [x] `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m`
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m`
- [x] `npm run build --prefix docs`

Closes #165
