### PR TITLE
feat(fallback)!: unify options configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Configure fallback notifications through `Fallback(..., configure)`. The pre-release `FallbackWithNotifications` methods and typed optional `onFallback` parameters were removed.
+- Configure fallback notifications through `Fallback(..., configure)`. The pre-release `FallbackWithNotifications` methods and typed optional `onFallback` parameters were removed. Migration-only error overloads prevent old positional callback lambdas from silently binding as options configurators.
 
 Handling clauses now use one spelling per position. `When…` starts a clause on `Shield` or
 `Shield<TResult>`; only `Or…` continues it on a builder. `Shield.For<TResult>()` now returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+- Configure fallback notifications through `Fallback(..., configure)`. The pre-release `FallbackWithNotifications` methods and typed optional `onFallback` parameters were removed.
+
 Handling clauses now use one spelling per position. `When…` starts a clause on `Shield` or
 `Shield<TResult>`; only `Or…` continues it on a builder. `Shield.For<TResult>()` now returns
 `Shield<TResult>` directly.

--- a/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
@@ -23,25 +23,19 @@ public class FallbackBenchmarks
 
     private static readonly Shield<int> KevlarSyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(7, static _ => { });
+        .Fallback(7, static options => options.OnFallback = static _ => { });
 
     private static readonly Shield<int> KevlarCompletedAsyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .FallbackWithNotifications(
+        .Fallback(
             7,
-            new FallbackOptions<int>
-            {
-                OnFallbackAsync = static _ => ValueTask.CompletedTask,
-            });
+            static options => options.OnFallbackAsync = static _ => ValueTask.CompletedTask);
 
     private static readonly Shield<int> KevlarYieldingAsyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .FallbackWithNotifications(
+        .Fallback(
             7,
-            new FallbackOptions<int>
-            {
-                OnFallbackAsync = static async _ => await Task.Yield(),
-            });
+            static options => options.OnFallbackAsync = static async _ => await Task.Yield());
 
     private static readonly ResiliencePipeline<int> PollyFallback = new ResiliencePipelineBuilder<int>()
         .AddFallback(new FallbackStrategyOptions<int>

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -47,35 +47,35 @@ in the same expression or a stable local.
 })
 ```
 
-Every overload takes an optional `onFallback` callback:
+Every overload also has an options configurator for fallback notifications:
 
 <!-- doc-test-ignore: Fluent fragment requires the typed builder introduced by the surrounding prose. -->
 ```csharp
 .Fallback(Config.Default,
-    onFallback: e => metrics.Increment("config.fallback"))
+    options => options.OnFallback = e => metrics.Increment("config.fallback"))
 ```
 
 The `FallbackEvent<T>` carries the failure that triggered it as a typed `Outcome<T>` — `Outcome.Exception` when an exception was handled, `Outcome.Result` when a result value was. No casting, no boxing.
 
-`onFallback` runs before the fallback value or factory. If the callback throws, its exact
+`OnFallback` runs before the fallback value or factory. If the callback throws, its exact
 exception becomes the pipeline outcome and the factory is not called. A later execution is
 unaffected. Async factory failures are likewise preserved as the pipeline outcome.
 
-## Awaited notifications
+## Notifications
 
-Use `FallbackWithNotifications` when notification work must be awaited:
+Configure both synchronous and awaited notification work in the same lambda:
 
 <!-- doc-test-ignore: Illustrative logger and audit dependencies are application services. -->
 ```csharp
 var shield = Shield.For<Config>()
     .When<HttpRequestException>()
-    .FallbackWithNotifications(
+    .Fallback(
         Config.Default,
-        new FallbackOptions<Config>
+        options =>
         {
-            OnFallback = e => logger.LogWarning(e.Outcome.Exception, "Using defaults"),
-            OnFallbackAsync = async e =>
-                await audit.RecordFallbackAsync(e.Outcome, e.Context.CancellationToken),
+            options.OnFallback = e => logger.LogWarning(e.Outcome.Exception, "Using defaults");
+            options.OnFallbackAsync = async e =>
+                await audit.RecordFallbackAsync(e.Outcome, e.Context.CancellationToken);
         });
 ```
 

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -55,6 +55,9 @@ Every overload also has an options configurator for fallback notifications:
     options => options.OnFallback = e => metrics.Increment("config.fallback"))
 ```
 
+Legacy positional notification callbacks intentionally fail compilation instead of being
+reinterpreted as configurators. Assign the callback to `options.OnFallback` as shown above.
+
 The `FallbackEvent<T>` carries the failure that triggered it as a typed `Outcome<T>` — `Outcome.Exception` when an exception was handled, `Outcome.Result` when a result value was. No casting, no boxing.
 
 `OnFallback` runs before the fallback value or factory. If the callback throws, its exact

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1361,7 +1361,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsVoidFallback(IMethodSymbol method, KnownTypes knownTypes)
     {
         method = Normalize(method);
-        return method.Name is "Fallback" or "FallbackWithNotifications"
+        return method.Name == "Fallback"
             && method.ReturnType is INamedTypeSymbol returnType
             && knownTypes.IsUntypedShield(returnType)
             && IsKevlarFluentMethod(method, knownTypes);

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -79,15 +79,27 @@ Kevlar.FallbackOptions<TResult>.OnFallback.get -> System.Action<Kevlar.FallbackE
 Kevlar.FallbackOptions<TResult>.OnFallback.set -> void
 Kevlar.FallbackOptions<TResult>.OnFallbackAsync.get -> System.Func<Kevlar.FallbackEvent<TResult>, System.Threading.Tasks.ValueTask>?
 Kevlar.FallbackOptions<TResult>.OnFallbackAsync.set -> void
-Kevlar.Shield<TResult>.FallbackWithNotifications(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.FallbackWithNotifications(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.FallbackWithNotifications(TResult fallbackValue, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder.FallbackWithNotifications(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!
-Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.FallbackWithNotifications(TResult fallbackValue, Kevlar.FallbackOptions<TResult>! options) -> Kevlar.Shield<TResult>!
-static Kevlar.ShieldExtensions.FallbackWithNotifications(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!
-static Kevlar.ShieldExtensions.FallbackWithNotifications(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, Kevlar.FallbackOptions! options) -> Kevlar.Shield!
+*REMOVED*Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.Shield<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
+Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
 Kevlar.HedgeActionGenerator
 Kevlar.HedgeActionGeneratorEvent
 Kevlar.HedgeActionGeneratorEvent.HedgeActionGeneratorEvent() -> void

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -86,17 +86,23 @@ Kevlar.FallbackOptions<TResult>.OnFallbackAsync.set -> void
 *REMOVED*Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -80,12 +80,12 @@ public sealed class ShieldBuilder
     public Shield Fallback(Func<Exception, CancellationToken, ValueTask> fallback) => Seal().Fallback(fallback);
 
     /// <summary>
-    /// Runs <paramref name="fallback"/> in place of handled failures and uses the configured
-    /// notifications. Applies to void executions only.
+    /// Runs <paramref name="fallback"/> in place of handled failures and configures notifications.
+    /// Applies to void executions only.
     /// </summary>
-    public Shield FallbackWithNotifications(
+    public Shield Fallback(
         Func<Exception, CancellationToken, ValueTask> fallback,
-        FallbackOptions options) => Seal().FallbackWithNotifications(fallback, options);
+        Action<FallbackOptions> configure) => Seal().Fallback(fallback, configure);
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>. The handling clauses remain ambient for later strategies.</summary>
     public Shield Timeout(TimeSpan timeout) => Seal().Timeout(timeout);

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -92,30 +92,30 @@ public sealed class ShieldBuilder<TResult>
     public Shield<TResult> Hedge(Action<HedgingOptions> configure) => Seal().Hedge(configure);
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
-    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>>? onFallback = null) => Seal().Fallback(fallbackValue, onFallback);
+    public Shield<TResult> Fallback(TResult fallbackValue) => Seal().Fallback(fallbackValue);
 
-    /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and uses the configured notifications.</summary>
-    public Shield<TResult> FallbackWithNotifications(TResult fallbackValue, FallbackOptions<TResult> options) =>
-        Seal().FallbackWithNotifications(fallbackValue, options);
+    /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
+    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure) =>
+        Seal().Fallback(fallbackValue, configure);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
-    public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null) => Seal().Fallback(fallback, onFallback);
+    public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback) => Seal().Fallback(fallback);
 
-    /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and uses the configured notifications.</summary>
-    public Shield<TResult> FallbackWithNotifications(
+    /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and configures notifications.</summary>
+    public Shield<TResult> Fallback(
         Func<CancellationToken, ValueTask<TResult>> fallback,
-        FallbackOptions<TResult> options) => Seal().FallbackWithNotifications(fallback, options);
+        Action<FallbackOptions<TResult>> configure) => Seal().Fallback(fallback, configure);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
-    public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null) => Seal().Fallback(fallback, onFallback);
+    public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback) => Seal().Fallback(fallback);
 
     /// <summary>
     /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives
-    /// the handled outcome, and uses the configured notifications.
+    /// the handled outcome, and configures notifications.
     /// </summary>
-    public Shield<TResult> FallbackWithNotifications(
+    public Shield<TResult> Fallback(
         Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
-        FallbackOptions<TResult> options) => Seal().FallbackWithNotifications(fallback, options);
+        Action<FallbackOptions<TResult>> configure) => Seal().Fallback(fallback, configure);
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> Timeout(TimeSpan timeout) => Seal().Timeout(timeout);

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -14,6 +14,9 @@ namespace Kevlar;
 /// </remarks>
 public sealed class ShieldBuilder<TResult>
 {
+    private const string LegacyFallbackCallbackMessage =
+        "Configure fallback notifications with Fallback(..., options => options.OnFallback = callback).";
+
     private readonly Shield<TResult> _parent;
     private readonly List<Func<Exception, bool>> _exceptionPredicates = [];
     private readonly List<Func<TResult, bool>> _resultPredicates = [];
@@ -94,12 +97,24 @@ public sealed class ShieldBuilder<TResult>
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
     public Shield<TResult> Fallback(TResult fallbackValue) => Seal().Fallback(fallbackValue);
 
+    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
+    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
+    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>> onFallback) =>
+        Seal().Fallback(fallbackValue, options => options.OnFallback = onFallback);
+
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
     public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure) =>
         Seal().Fallback(fallbackValue, configure);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
     public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback) => Seal().Fallback(fallback);
+
+    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
+    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
+    public Shield<TResult> Fallback(
+        Func<CancellationToken, ValueTask<TResult>> fallback,
+        Action<FallbackEvent<TResult>> onFallback) =>
+        Seal().Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and configures notifications.</summary>
     public Shield<TResult> Fallback(
@@ -108,6 +123,13 @@ public sealed class ShieldBuilder<TResult>
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
     public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback) => Seal().Fallback(fallback);
+
+    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
+    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
+    public Shield<TResult> Fallback(
+        Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
+        Action<FallbackEvent<TResult>> onFallback) =>
+        Seal().Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>
     /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -203,17 +203,20 @@ public static class ShieldExtensions
     }
 
     /// <summary>
-    /// Runs <paramref name="fallback"/> in place of handled failures and uses the configured
-    /// notifications. Applies to void executions only.
+    /// Runs <paramref name="fallback"/> in place of handled failures and configures notifications.
+    /// Applies to void executions only.
     /// </summary>
-    public static Shield FallbackWithNotifications(
+    /// <remarks>Runs <see cref="FallbackOptions.OnFallback"/>, then <see cref="FallbackOptions.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
+    public static Shield Fallback(
         this Shield shield,
         Func<Exception, CancellationToken, ValueTask> fallback,
-        FallbackOptions options)
+        Action<FallbackOptions> configure)
     {
         Throw.IfNull(shield, nameof(shield));
         Throw.IfNull(fallback, nameof(fallback));
-        Throw.IfNull(options, nameof(options));
+        Throw.IfNull(configure, nameof(configure));
+        var options = new FallbackOptions();
+        configure(options);
         return shield.Append(new VoidFallbackStrategy(
             fallback,
             shield.JudgeOrDefault,
@@ -233,17 +236,18 @@ public static class ShieldExtensions
     }
 
     /// <summary>
-    /// Runs <paramref name="fallback"/> in place of handled failures and uses the configured
-    /// notifications. Applies to void executions only.
+    /// Runs <paramref name="fallback"/> in place of handled failures and configures notifications.
+    /// Applies to void executions only.
     /// </summary>
-    public static Shield FallbackWithNotifications(
+    /// <remarks>Runs <see cref="FallbackOptions.OnFallback"/>, then <see cref="FallbackOptions.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
+    public static Shield Fallback(
         this Shield shield,
         Func<CancellationToken, ValueTask> fallback,
-        FallbackOptions options)
+        Action<FallbackOptions> configure)
     {
         Throw.IfNull(fallback, nameof(fallback));
-        Throw.IfNull(options, nameof(options));
-        return shield.FallbackWithNotifications((_, token) => fallback(token), options);
+        Throw.IfNull(configure, nameof(configure));
+        return shield.Fallback((_, token) => fallback(token), configure);
     }
 
     /// <summary>Returns a copy of this shield with a diagnostic name (surfaced as <see cref="KevlarContext.ShieldName"/>).</summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -11,6 +11,9 @@ namespace Kevlar;
 /// </summary>
 public sealed class Shield<TResult>
 {
+    private const string LegacyFallbackCallbackMessage =
+        "Configure fallback notifications with Fallback(..., options => options.OnFallback = callback).";
+
     internal readonly Strategy[] Strategies;
     internal readonly StrategyNode? Head;
     internal readonly OutcomeJudge? Ambient;
@@ -173,6 +176,11 @@ public sealed class Shield<TResult>
     public Shield<TResult> Fallback(TResult fallbackValue) =>
         Append(new FallbackStrategy<TResult>((_, _) => new ValueTask<TResult>(fallbackValue), JudgeOrDefault, null, null));
 
+    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
+    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
+    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>> onFallback) =>
+        Fallback(fallbackValue, options => options.OnFallback = onFallback);
+
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
     /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
     public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure)
@@ -193,6 +201,13 @@ public sealed class Shield<TResult>
         Throw.IfNull(fallback, nameof(fallback));
         return Append(new FallbackStrategy<TResult>((_, context) => fallback(context.CancellationToken), JudgeOrDefault, null, null));
     }
+
+    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
+    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
+    public Shield<TResult> Fallback(
+        Func<CancellationToken, ValueTask<TResult>> fallback,
+        Action<FallbackEvent<TResult>> onFallback) =>
+        Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and configures notifications.</summary>
     /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
@@ -217,6 +232,13 @@ public sealed class Shield<TResult>
         Throw.IfNull(fallback, nameof(fallback));
         return Append(new FallbackStrategy<TResult>((outcome, context) => fallback(outcome, context.CancellationToken), JudgeOrDefault, null, null));
     }
+
+    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
+    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
+    public Shield<TResult> Fallback(
+        Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
+        Action<FallbackEvent<TResult>> onFallback) =>
+        Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>
     /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -170,13 +170,16 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
-    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>>? onFallback = null) =>
-        Append(new FallbackStrategy<TResult>((_, _) => new ValueTask<TResult>(fallbackValue), JudgeOrDefault, onFallback, null));
+    public Shield<TResult> Fallback(TResult fallbackValue) =>
+        Append(new FallbackStrategy<TResult>((_, _) => new ValueTask<TResult>(fallbackValue), JudgeOrDefault, null, null));
 
-    /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and uses the configured notifications.</summary>
-    public Shield<TResult> FallbackWithNotifications(TResult fallbackValue, FallbackOptions<TResult> options)
+    /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
+    /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
+    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure)
     {
-        Throw.IfNull(options, nameof(options));
+        Throw.IfNull(configure, nameof(configure));
+        var options = new FallbackOptions<TResult>();
+        configure(options);
         return Append(new FallbackStrategy<TResult>(
             (_, _) => new ValueTask<TResult>(fallbackValue),
             JudgeOrDefault,
@@ -185,19 +188,22 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
-    public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null)
+    public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback)
     {
         Throw.IfNull(fallback, nameof(fallback));
-        return Append(new FallbackStrategy<TResult>((_, context) => fallback(context.CancellationToken), JudgeOrDefault, onFallback, null));
+        return Append(new FallbackStrategy<TResult>((_, context) => fallback(context.CancellationToken), JudgeOrDefault, null, null));
     }
 
-    /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and uses the configured notifications.</summary>
-    public Shield<TResult> FallbackWithNotifications(
+    /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and configures notifications.</summary>
+    /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
+    public Shield<TResult> Fallback(
         Func<CancellationToken, ValueTask<TResult>> fallback,
-        FallbackOptions<TResult> options)
+        Action<FallbackOptions<TResult>> configure)
     {
         Throw.IfNull(fallback, nameof(fallback));
-        Throw.IfNull(options, nameof(options));
+        Throw.IfNull(configure, nameof(configure));
+        var options = new FallbackOptions<TResult>();
+        configure(options);
         return Append(new FallbackStrategy<TResult>(
             (_, context) => fallback(context.CancellationToken),
             JudgeOrDefault,
@@ -206,22 +212,25 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
-    public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback, Action<FallbackEvent<TResult>>? onFallback = null)
+    public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback)
     {
         Throw.IfNull(fallback, nameof(fallback));
-        return Append(new FallbackStrategy<TResult>((outcome, context) => fallback(outcome, context.CancellationToken), JudgeOrDefault, onFallback, null));
+        return Append(new FallbackStrategy<TResult>((outcome, context) => fallback(outcome, context.CancellationToken), JudgeOrDefault, null, null));
     }
 
     /// <summary>
     /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives
-    /// the handled outcome, and uses the configured notifications.
+    /// the handled outcome, and configures notifications.
     /// </summary>
-    public Shield<TResult> FallbackWithNotifications(
+    /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
+    public Shield<TResult> Fallback(
         Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
-        FallbackOptions<TResult> options)
+        Action<FallbackOptions<TResult>> configure)
     {
         Throw.IfNull(fallback, nameof(fallback));
-        Throw.IfNull(options, nameof(options));
+        Throw.IfNull(configure, nameof(configure));
+        var options = new FallbackOptions<TResult>();
+        configure(options);
         return Append(new FallbackStrategy<TResult>(
             (outcome, context) => fallback(outcome, context.CancellationToken),
             JudgeOrDefault,

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -90,15 +90,12 @@ public class AllocationBudgetTests
         .Fallback(7);
     private readonly Shield<int> _fallbackWithSyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(7, static _ => { });
+        .Fallback(7, static options => options.OnFallback = static _ => { });
     private readonly Shield<int> _fallbackWithAsyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .FallbackWithNotifications(
+        .Fallback(
             7,
-            new FallbackOptions<int>
-            {
-                OnFallbackAsync = static _ => ValueTask.CompletedTask,
-            });
+            static options => options.OnFallbackAsync = static _ => ValueTask.CompletedTask);
     private readonly Shield _parallelHedge = Shield.Hedge(2, TimeSpan.Zero);
     private readonly Counter _retryCounter = new();
     private readonly Counter _asyncDelayRetryCounter = new();

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -9,6 +9,48 @@ namespace Kevlar.Analyzers.Tests;
 public class PipelineHazardAnalyzerTests
 {
     [Test]
+    public async Task Legacy_Fallback_Callbacks_Cannot_Bind_As_Options_Configurators()
+    {
+        var ambiguous = CreateCompilation(CreateSource("""
+            public class TestSubject
+            {
+                public void Configure()
+                {
+                    _ = Shield.For<int>().Fallback(42, _ => { });
+                    _ = Shield.For<int>().Fallback(_ => new ValueTask<int>(42), _ => { });
+                    _ = Shield.For<int>().Fallback((_, _) => new ValueTask<int>(42), _ => { });
+                    _ = Shield.For<int>().When<Exception>().Fallback(42, _ => { });
+                    _ = Shield.For<int>().When<Exception>().Fallback(_ => new ValueTask<int>(42), _ => { });
+                    _ = Shield.For<int>().When<Exception>().Fallback((_, _) => new ValueTask<int>(42), _ => { });
+                }
+            }
+            """));
+        var ambiguousErrors = ambiguous.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        await Assert.That(ambiguousErrors).Count().IsEqualTo(6);
+        await Assert.That(ambiguousErrors).All(static diagnostic => diagnostic.Id == "CS0121");
+
+        var explicitLegacy = CreateCompilation(CreateSource("""
+            public class TestSubject
+            {
+                public void Configure()
+                {
+                    Action<FallbackEvent<int>> callback = _ => { };
+                    _ = Shield.For<int>().Fallback(42, callback);
+                }
+            }
+            """));
+        var explicitErrors = explicitLegacy.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        await Assert.That(explicitErrors).Count().IsEqualTo(1);
+        await Assert.That(explicitErrors[0].Id).IsEqualTo("CS0619");
+    }
+
+    [Test]
     public async Task KEV004_Flags_Inline_Stateful_Shields_For_All_Execution_Forms()
     {
         var cases = new[]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -284,7 +284,7 @@ public class PipelineHazardAnalyzerTests
             "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteAsync(static _ => Task.FromResult(1));",
             "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteOutcomeAsync(static _ => Task.FromResult(1));",
             "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteWithContextAsync(0, static (_, _) => { }, static (_, _) => Task.FromResult(1));",
-            "_ = Shield.Empty.FallbackWithNotifications(static _ => ValueTask.CompletedTask, new FallbackOptions()).Execute(static _ => 1);",
+            "_ = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask, static options => options.OnFallback = static _ => { }).Execute(static _ => 1);",
         };
 
         await AssertEachAsync(cases, "KEV005");
@@ -463,6 +463,8 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Fallback(0);",
             "_ = Shield.For<int>().WhenResult(0).Retry(1).Fallback(0);",
+            "_ = Shield.For<int>().Retry(1).Fallback(0, static options => options.OnFallback = static _ => { });",
+            "_ = Shield.Retry(1).Fallback(static _ => ValueTask.CompletedTask, static options => options.OnFallback = static _ => { });",
             "var shield = Shield.For<int>().Retry(1); var alias = shield; _ = alias.Fallback(0);",
             "Shield<int>? shield = Shield.For<int>().Retry(1); _ = shield?.Fallback(0);",
             "_ = ShieldExtensions.Fallback(ShieldExtensions.Retry(Shield.Empty, 1), static _ => ValueTask.CompletedTask);",

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -129,6 +129,12 @@ public class PipelineDescriptorTests
         await Assert.That(fallback.IsVoid).IsFalse();
         await Assert.That(fallback.HasNotification).IsFalse();
 
+        var configuredFallback = Shield.For<int>()
+            .Fallback(42, static options => options.OnFallback = static _ => { })
+            .GetDescriptor()
+            .AssertContainsSingle<FallbackStrategyDescriptor>();
+        await Assert.That(configuredFallback.HasNotification).IsTrue();
+
         var voidFallback = Shield
             .When<InvalidOperationException>()
             .Fallback(static (_, _) => default)

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -30,7 +30,7 @@ public class TelemetryRecorderTests
         using var recorder = new TelemetryRecorder(captureMetrics: false);
         var typed = Shield.For<int>()
             .WhenResult(static result => result < 0)
-            .Fallback(42, recorder.Record)
+            .Fallback(42, options => options.OnFallback = recorder.Record)
             .Retry(options =>
             {
                 options.MaxRetries = 1;

--- a/tests/Kevlar.Tests/AmbientContextContractTests.cs
+++ b/tests/Kevlar.Tests/AmbientContextContractTests.cs
@@ -90,7 +90,7 @@ public class AmbientContextContractTests
                     Record(observations, "fallback");
                     return new ValueTask<int>(42);
                 },
-                _ => Record(observations, "on-fallback"));
+                options => options.OnFallback = _ => Record(observations, "on-fallback"));
 
         Ambient.Value = "fallback-flow";
         var execution = StartUnderContext(synchronizationContext, () => shield.ExecuteAsync(_ =>

--- a/tests/Kevlar.Tests/AmbientContextContractTests.cs
+++ b/tests/Kevlar.Tests/AmbientContextContractTests.cs
@@ -177,7 +177,7 @@ public class AmbientContextContractTests
                     Record(observations, "fallback-action");
                     return new ValueTask<int>(2);
                 },
-                _ => Record(observations, "fallback-callback"));
+                options => options.OnFallback = _ => Record(observations, "fallback-callback"));
         await fallback.ExecuteAsync<int>(_ => throw new InvalidOperationException());
 
         var timeProvider = new ControlledTimeProvider();

--- a/tests/Kevlar.Tests/CustomStrategyContractTests.cs
+++ b/tests/Kevlar.Tests/CustomStrategyContractTests.cs
@@ -61,7 +61,7 @@ public class CustomStrategyContractTests
         var actionCalls = 0;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42, onFallback: fallback => observed = fallback.Outcome.Exception)
+            .Fallback(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
             .Use(new ThrowingStrategy(failure));
 
         var result = await shield.ExecuteAsync(_ =>
@@ -103,7 +103,7 @@ public class CustomStrategyContractTests
         Exception? observed = null;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42, onFallback: fallback => observed = fallback.Outcome.Exception)
+            .Fallback(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
             .Use(new AsynchronouslyFaultingStrategy(failure));
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(0));
@@ -119,7 +119,7 @@ public class CustomStrategyContractTests
         Exception? observed = null;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42, onFallback: fallback => observed = fallback.Outcome.Exception)
+            .Fallback(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
             .Use(new FailureStrategy(failure));
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(0));

--- a/tests/Kevlar.Tests/FallbackAsyncHookTests.cs
+++ b/tests/Kevlar.Tests/FallbackAsyncHookTests.cs
@@ -13,26 +13,26 @@ public class FallbackAsyncHookTests
         Outcome<object> factoryOutcome = default;
         var shield = Shield.For<object>()
             .WhenResult(handled)
-            .FallbackWithNotifications(
+            .Fallback(
                 (outcome, _) =>
                 {
                     order.Add("factory");
                     factoryOutcome = outcome;
                     return new ValueTask<object>(recovered);
                 },
-                new FallbackOptions<object>
+                options =>
                 {
-                    OnFallback = fallback =>
+                    options.OnFallback = fallback =>
                     {
                         order.Add("sync");
                         syncOutcome = fallback.Outcome;
-                    },
-                    OnFallbackAsync = fallback =>
+                    };
+                    options.OnFallbackAsync = fallback =>
                     {
                         order.Add("async");
                         asyncOutcome = fallback.Outcome;
                         return ValueTask.CompletedTask;
-                    },
+                    };
                 });
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<object>(handled));
@@ -50,19 +50,19 @@ public class FallbackAsyncHookTests
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var factoryCalls = 0;
-        var shield = Shield.For<int>().FallbackWithNotifications(
+        var shield = Shield.For<int>().Fallback(
             _ =>
             {
                 factoryCalls++;
                 return new ValueTask<int>(42);
             },
-            new FallbackOptions<int>
+            options =>
             {
-                OnFallbackAsync = async _ =>
+                options.OnFallbackAsync = async _ =>
                 {
                     started.SetResult();
                     await release.Task;
-                },
+                };
             });
 
         var execution = shield.ExecuteAsync(_ => throw new InvalidOperationException()).AsTask();
@@ -84,19 +84,19 @@ public class FallbackAsyncHookTests
         var hookFailure = new ApplicationException("hook failed");
         Exception? observed = null;
         var factoryCalls = 0;
-        var shield = Shield.For<int>().FallbackWithNotifications(
+        var shield = Shield.For<int>().Fallback(
             _ =>
             {
                 factoryCalls++;
                 return new ValueTask<int>(42);
             },
-            new FallbackOptions<int>
+            options =>
             {
-                OnFallbackAsync = fallback =>
+                options.OnFallbackAsync = fallback =>
                 {
                     observed = fallback.Outcome.Exception;
                     return ValueTask.FromException(hookFailure);
-                },
+                };
             });
 
         var outcome = await shield.ExecuteOutcomeAsync<int>(_ => throw original);
@@ -111,12 +111,9 @@ public class FallbackAsyncHookTests
     {
         using var cancellation = new CancellationTokenSource();
         var hookCancellation = new OperationCanceledException("hook cancelled", cancellation.Token);
-        var shield = Shield.For<int>().FallbackWithNotifications(
+        var shield = Shield.For<int>().Fallback(
             42,
-            new FallbackOptions<int>
-            {
-                OnFallbackAsync = _ => ValueTask.FromException(hookCancellation),
-            });
+            options => options.OnFallbackAsync = _ => ValueTask.FromException(hookCancellation));
 
         var outcome = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
 
@@ -131,20 +128,20 @@ public class FallbackAsyncHookTests
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         CancellationToken hookToken = default;
         CancellationToken factoryToken = default;
-        var shield = Shield.For<int>().FallbackWithNotifications(
+        var shield = Shield.For<int>().Fallback(
             (_, token) =>
             {
                 factoryToken = token;
                 return new ValueTask<int>(42);
             },
-            new FallbackOptions<int>
+            options =>
             {
-                OnFallbackAsync = async fallback =>
+                options.OnFallbackAsync = async fallback =>
                 {
                     started.SetResult();
                     await release.Task;
                     hookToken = fallback.Context.CancellationToken;
-                },
+                };
             });
 
         var execution = shield.ExecuteAsync<int>(_ => throw new InvalidOperationException(), cancellation.Token).AsTask();
@@ -169,11 +166,11 @@ public class FallbackAsyncHookTests
         Shield<int>? shield = null;
         shield = Shield<int>.Empty
             .WithName("fallback-hook")
-            .FallbackWithNotifications(
+            .Fallback(
                 42,
-                new FallbackOptions<int>
+                options =>
                 {
-                    OnFallbackAsync = async fallback =>
+                    options.OnFallbackAsync = async fallback =>
                     {
                         await Task.Yield();
                         nestedResult = await shield!.ExecuteAsync(_ => new ValueTask<int>(7));
@@ -184,7 +181,7 @@ public class FallbackAsyncHookTests
                         }
 
                         await release.Task;
-                    },
+                    };
                 });
 
         var first = shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()).AsTask();
@@ -205,25 +202,25 @@ public class FallbackAsyncHookTests
         var order = new List<string>();
         Exception? syncException = null;
         Exception? asyncException = null;
-        var shield = Shield.Empty.FallbackWithNotifications(
+        var shield = Shield.Empty.Fallback(
             (exception, _) =>
             {
                 order.Add("fallback");
                 return ValueTask.CompletedTask;
             },
-            new FallbackOptions
+            options =>
             {
-                OnFallback = fallback =>
+                options.OnFallback = fallback =>
                 {
                     order.Add("sync");
                     syncException = fallback.Exception;
-                },
-                OnFallbackAsync = fallback =>
+                };
+                options.OnFallbackAsync = fallback =>
                 {
                     order.Add("async");
                     asyncException = fallback.Exception;
                     return ValueTask.CompletedTask;
-                },
+                };
             });
 
         await shield.ExecuteAsync(_ => throw original);
@@ -240,16 +237,13 @@ public class FallbackAsyncHookTests
         var fallbackCalls = 0;
         var shield = Shield
             .When<InvalidOperationException>()
-            .FallbackWithNotifications(
+            .Fallback(
                 (_, _) =>
                 {
                     fallbackCalls++;
                     return ValueTask.CompletedTask;
                 },
-                new FallbackOptions
-                {
-                    OnFallbackAsync = _ => ValueTask.FromException(hookFailure),
-                });
+                options => options.OnFallbackAsync = _ => ValueTask.FromException(hookFailure));
 
         Exception? caught = null;
         try
@@ -266,29 +260,47 @@ public class FallbackAsyncHookTests
     }
 
     [Test]
-    public async Task Notification_Options_Are_Snapshotted_When_The_Shield_Is_Built()
+    public async Task Untyped_CancellationToken_Overload_Configures_Notifications()
     {
-        var firstCalls = 0;
-        var secondCalls = 0;
-        var options = new FallbackOptions<int>
-        {
-            OnFallbackAsync = _ =>
+        var notificationCalls = 0;
+        var fallbackCalls = 0;
+        var shield = Shield.Empty.Fallback(
+            _ =>
             {
-                firstCalls++;
+                fallbackCalls++;
                 return ValueTask.CompletedTask;
             },
-        };
-        var shield = Shield.For<int>().FallbackWithNotifications(42, options);
-        options.OnFallbackAsync = _ =>
-        {
-            secondCalls++;
-            return ValueTask.CompletedTask;
-        };
+            options => options.OnFallback = _ => notificationCalls++);
 
-        var result = await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException());
+        await shield.ExecuteAsync(_ => throw new InvalidOperationException());
 
-        await Assert.That(result).IsEqualTo(42);
-        await Assert.That(firstCalls).IsEqualTo(1);
-        await Assert.That(secondCalls).IsEqualTo(0);
+        await Assert.That(notificationCalls).IsEqualTo(1);
+        await Assert.That(fallbackCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Notification_Configuration_Runs_Once_When_The_Shield_Is_Built()
+    {
+        var configureCalls = 0;
+        var firstCalls = 0;
+        var shield = Shield.For<int>().Fallback(
+            42,
+            options =>
+            {
+                configureCalls++;
+                options.OnFallbackAsync = _ =>
+                {
+                    firstCalls++;
+                    return ValueTask.CompletedTask;
+                };
+            });
+
+        var firstResult = await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException());
+        var secondResult = await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(firstResult).IsEqualTo(42);
+        await Assert.That(secondResult).IsEqualTo(42);
+        await Assert.That(configureCalls).IsEqualTo(1);
+        await Assert.That(firstCalls).IsEqualTo(2);
     }
 }

--- a/tests/Kevlar.Tests/FallbackContractTests.cs
+++ b/tests/Kevlar.Tests/FallbackContractTests.cs
@@ -16,7 +16,7 @@ public class FallbackContractTests
                 factoryCalls++;
                 return new ValueTask<int>(42);
             },
-            onFallback: _ =>
+            options => options.OnFallback = _ =>
             {
                 callbackCalls++;
                 if (callbackCalls == 1)
@@ -119,7 +119,7 @@ public class FallbackContractTests
                     explicitFactoryCalls++;
                     return new ValueTask<int>(42);
                 },
-                onFallback: fallback => observed = fallback.Outcome.Exception);
+                options => options.OnFallback = fallback => observed = fallback.Outcome.Exception);
 
         var bypassed = await defaultShield.ExecuteOutcomeAsync<int>(_ => throw original);
         var recovered = await explicitShield.ExecuteAsync<int>(_ => throw original);
@@ -147,7 +147,7 @@ public class FallbackContractTests
                 handledOutcome = outcome;
                 fallbackToken = token;
                 return new ValueTask<int>(42);
-            }, onFallback: fallback => eventOutcome = fallback.Outcome)
+            }, options => options.OnFallback = fallback => eventOutcome = fallback.Outcome)
             .Timeout(TimeSpan.FromSeconds(1))
             .WithTimeProvider(timeProvider);
 
@@ -218,7 +218,7 @@ public class FallbackContractTests
                     observed = outcome.Exception;
                     return new ValueTask<int>(42);
                 },
-                onFallback: _ => eventCalls++)
+                options => options.OnFallback = _ => eventCalls++)
             .Hedge(3, Timeout.InfiniteTimeSpan);
 
         var result = await shield.ExecuteAsync<int>(_ =>
@@ -263,7 +263,7 @@ public class FallbackContractTests
                     factoryOutcome = outcome;
                     return new ValueTask<int>(42);
                 },
-                onFallback: fallback =>
+                options => options.OnFallback = fallback =>
                 {
                     order.Add("event");
                     eventOutcome = fallback.Outcome;
@@ -292,7 +292,7 @@ public class FallbackContractTests
                     factoryOutcome = outcome;
                     return new ValueTask<int>(42);
                 },
-                onFallback: fallback =>
+                options => options.OnFallback = fallback =>
                 {
                     order.Add("event");
                     eventOutcome = fallback.Outcome;

--- a/tests/Kevlar.Tests/FallbackEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/FallbackEdgeCaseTests.cs
@@ -92,7 +92,7 @@ public class FallbackEdgeCaseTests
         Exception? seenException = null;
         var shield = Shield.For<int>()
             .WhenResult(-1)
-            .Fallback(0, fallback =>
+            .Fallback(0, options => options.OnFallback = fallback =>
             {
                 seenResult = fallback.Outcome.Result;
                 seenException = fallback.Outcome.Exception;
@@ -110,7 +110,9 @@ public class FallbackEdgeCaseTests
     {
         var original = new InvalidOperationException("original");
         Exception? seenException = null;
-        var shield = Shield.For<int>().Fallback(0, fallback => seenException = fallback.Outcome.Exception);
+        var shield = Shield.For<int>().Fallback(
+            0,
+            options => options.OnFallback = fallback => seenException = fallback.Outcome.Exception);
 
         await shield.ExecuteAsync(_ => throw original);
 

--- a/tests/Kevlar.Tests/FallbackTests.cs
+++ b/tests/Kevlar.Tests/FallbackTests.cs
@@ -65,7 +65,7 @@ public class FallbackTests
         var fired = false;
         var shield = Shield.For<int>()
             .WhenResult(-1)
-            .Fallback(0, onFallback: _ => fired = true);
+            .Fallback(0, options => options.OnFallback = _ => fired = true);
 
         await shield.ExecuteAsync(_ => new ValueTask<int>(-1));
 

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -411,16 +411,16 @@ public class MetricsTests
         var asyncObservedMetric = false;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .FallbackWithNotifications(
+            .Fallback(
                 42,
-                new FallbackOptions<int>
+                options =>
                 {
-                    OnFallback = _ => syncObservedMetric = listener.Total("kevlar.fallbacks", name) == 1,
-                    OnFallbackAsync = _ =>
+                    options.OnFallback = _ => syncObservedMetric = listener.Total("kevlar.fallbacks", name) == 1;
+                    options.OnFallbackAsync = _ =>
                     {
                         asyncObservedMetric = listener.Total("kevlar.fallbacks", name) == 1;
                         return ValueTask.CompletedTask;
-                    },
+                    };
                 })
             .WithName(name);
 

--- a/tests/Kevlar.Tests/StrategyInspectionTests.cs
+++ b/tests/Kevlar.Tests/StrategyInspectionTests.cs
@@ -82,21 +82,21 @@ public class StrategyInspectionTests
         await Assert.That(fixedCircuit.Core.HasMonitor).IsFalse();
         await Assert.That(fixedCircuit.Core.HasNotification).IsFalse();
 
-        var notifiedFallback = GetInspection(Shield.For<int>().Fallback(42, static _ => { }));
-        var asyncNotifiedFallback = GetInspection(Shield.For<int>().FallbackWithNotifications(
+        var notifiedFallback = GetInspection(Shield.For<int>().Fallback(42, static options => options.OnFallback = static _ => { }));
+        var asyncNotifiedFallback = GetInspection(Shield.For<int>().Fallback(
             42,
-            new FallbackOptions<int> { OnFallbackAsync = static _ => default }));
+            static options => options.OnFallbackAsync = static _ => default));
         var fixedFallback = GetInspection(Shield.For<int>().Fallback(42));
         var voidFallback = GetInspection(
             Shield.When<InvalidOperationException>().Fallback(static (_, _) => default));
         var notifiedVoidFallback = GetInspection(
-            Shield.When<InvalidOperationException>().FallbackWithNotifications(
+            Shield.When<InvalidOperationException>().Fallback(
                 static (_, _) => default,
-                new FallbackOptions { OnFallback = static _ => { } }));
+                static options => options.OnFallback = static _ => { }));
         var asyncNotifiedVoidFallback = GetInspection(
-            Shield.When<InvalidOperationException>().FallbackWithNotifications(
+            Shield.When<InvalidOperationException>().Fallback(
                 static (_, _) => default,
-                new FallbackOptions { OnFallbackAsync = static _ => default }));
+                static options => options.OnFallbackAsync = static _ => default));
         await Assert.That(notifiedFallback.HasNotification).IsTrue();
         await Assert.That(asyncNotifiedFallback.HasNotification).IsTrue();
         await Assert.That(fixedFallback.HasNotification).IsFalse();


### PR DESCRIPTION
## Summary

- replace `FallbackWithNotifications` and typed optional callbacks with `Fallback(..., configure)` across untyped/typed shields and builders
- preserve `OnFallback` -> `OnFallbackAsync` -> recovery ordering and failure propagation
- update KEV003/KEV005 coverage, Kevlar.Testing descriptors, public API baselines, docs, benchmarks, and changelog

## Breaking changes

- removes all pre-release `FallbackWithNotifications` overloads
- removes typed optional `onFallback` parameters; configure `FallbackOptions` instead

## Validation

- `dotnet build Kevlar.slnx -c Release --no-restore` (0 warnings)
- Kevlar.Tests: 736 passed
- Kevlar.IntegrationTests: 118 passed
- Kevlar.Analyzers.Tests: 53 passed
- Kevlar.Testing.Tests: 31 passed
- Kevlar.Chaos.Tests: 23 passed
- Kevlar.Extensions.RateLimiting.Tests: 19 passed
- Kevlar.NetStandard.Tests: 5 passed
- Kevlar.AllocationTests: 3 passed
- documentation snippets: 97 compiled and executed
- `npm run build` in `docs/`

## Benchmark

`FallbackBenchmarks.Kevlar_Triggered`, .NET 10, BenchmarkDotNet 0.15.8:

| Revision | Mean | Allocated |
|---|---:|---:|
| main | 1.298 us | 200 B |
| branch | 1.303 us | 200 B |

Runtime delta is +0.4%, within measurement noise; allocations are unchanged.

Closes #159