### PR TITLE
feat(options): add per-strategy handling overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,14 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 - `RetryOptions<TResult>` no longer inherits `RetryOptions`. Both types retain the same scalar
   property names and defaults, but helpers that accepted `RetryOptions` must configure typed retry
   options separately. Typed callback getters now return the exact delegates assigned to them.
+- Typed circuit-breaker and hedging configuration now uses `CircuitBreakerOptions<TResult>` and
+  `HedgingOptions<TResult>` so result predicates remain strongly typed.
 
 ### Changed
 
 - **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.
+
+### Added
+
+- Reactive strategy options can replace ambient handling locally with `HandlesException` and, on
+  typed options, `HandlesResult`. Testing descriptors expose `HasHandlingOverride`.

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -82,6 +82,31 @@ var shield = Shield
 
 `WhenAnyError()` preserves existing strategies, the shield name, and its `TimeProvider`; it only changes handling for reactive strategies added afterwards. It is available on both `Shield` and `Shield<T>`.
 
+## Per-strategy overrides
+
+Use an options predicate when one reactive strategy needs different handling without changing the
+ambient clause for its neighbors:
+
+```csharp
+var shield = Shield.When<HttpRequestException>()
+    .Retry(3) // ambient clause
+    .CircuitBreaker(options =>
+    {
+        options.ConsecutiveFailures = 5;
+        options.HandlesException = exception => exception is TimeoutExceededException;
+    })
+    .Fallback(static (_, _) => default); // ambient clause again
+```
+
+`HandlesException` is available on retry, circuit-breaker, hedging, and fallback options. Their
+typed options also expose `HandlesResult`. If either property is set, that strategy ignores the
+ambient clause completely: local override > ambient clause > default. Predicates are not merged.
+
+Only what you list is handled. A result-only override does not handle exceptions, and an
+exception-only override does not handle results. Prefer the ambient clause when several neighboring
+strategies share the same rule; prefer a local override for a single exception to that rule or when
+porting one Polly `ShouldHandle` predicate directly.
+
 :::info Proactive strategies don't consult clauses
 Timeouts, rate limits and concurrency limits don't care why something failed — they act on time and concurrency, not outcomes. Clauses only drive the reactive strategies.
 :::

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -95,7 +95,7 @@ var shield = Shield.When<HttpRequestException>()
         options.ConsecutiveFailures = 5;
         options.HandlesException = exception => exception is TimeoutExceededException;
     })
-    .Fallback(static (_, _) => default); // ambient clause again
+    .Hedge(maxAttempts: 2, delay: TimeSpan.FromMilliseconds(100)); // ambient clause again
 ```
 
 `HandlesException` is available on retry, circuit-breaker, hedging, and fallback options. Their

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -11,7 +11,7 @@ Kevlar's pipeline model translates 1:1 from Polly v8 — the "first strategy add
 | Polly v8 | Kevlar |
 |---|---|
 | `new ResiliencePipelineBuilder().AddRetry(new RetryStrategyOptions { … }).Build()` | `Shield.Retry(3)` |
-| `ShouldHandle = new PredicateBuilder().Handle<T>()` | `Shield.When<T>().…` (ambient for the whole chain) |
+| `ShouldHandle = new PredicateBuilder().Handle<T>()` | `Shield.When<T>().…` for an ambient rule, or `options.HandlesException` / `HandlesResult` for a direct per-strategy equivalent |
 | `ResiliencePipeline` / `ResiliencePipeline<T>` | `Shield` / `Shield<T>` |
 | `ResilienceContextPool.Shared.Get(...)` + `Return` | automatic — contexts are pooled internally |
 | `BrokenCircuitException` | `CircuitOpenException` (with `RetryAfter`) |
@@ -68,7 +68,7 @@ Note the handling clause: written once, it covers the retry *and* the breaker. I
 ## Semantic differences worth knowing
 
 - **Retry defaults differ.** Polly's default is constant 2s delays with no jitter; Kevlar's is exponential-with-jitter from 250ms capped at 30s. If you relied on Polly's default timing, say so explicitly: `Shield.Retry(3, Backoff.Constant(TimeSpan.FromSeconds(2)))`.
-- **Handling clauses are ambient within one fluent chain.** A clause applies to every reactive strategy after it until replaced; call `WhenAnyError()` to return subsequent strategies to Kevlar's default. `Wrap` and `Compose` seal clauses at the composition boundary: strategies already inside keep their handling, while strategies appended afterwards use the default unless you declare a new local clause.
+- **Handling clauses are ambient within one fluent chain.** A clause applies to every reactive strategy after it until replaced; call `WhenAnyError()` to return subsequent strategies to Kevlar's default. `Wrap` and `Compose` seal clauses at the composition boundary: strategies already inside keep their handling, while strategies appended afterwards use the default unless you declare a new local clause. For a Polly strategy with a distinct `ShouldHandle`, set that strategy's `HandlesException` / `HandlesResult` options; a local override fully replaces the ambient clause.
 - **Default handling excludes cancellation.** With no clause at all, Kevlar handles any exception except `OperationCanceledException` — same spirit as Polly's recommended predicate, but built in.
 - **One shield, every shape.** There's no separate sync/async pipeline type: `shield.Execute(...)` and `shield.ExecuteAsync(...)` are the same instance. (Hedging is async-only, as in Polly.)
 - **Nonsense orders fail fast.** Chaining a `Fallback` *after* a retry, hedge or breaker that shares its handling clause throws at build time, because the fallback would swallow every failure before the outer strategy saw one. Polly builds such pipelines silently. Put the fallback first (outermost), or give it a narrower clause.

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -37,6 +37,8 @@ Configure either `ConsecutiveFailures` *or* `FailureRatio` — not both. When ne
 | `Monitor` | — | A `CircuitBreakerMonitor` for observing + manual control |
 | `OnStateChanged` | — | Callback on every transition: `e.From`, `e.To`, `e.LastException` |
 | `OnStateChangedAsync` | — | Awaited callback on every transition, after `OnStateChanged` |
+| `HandlesException` | — | Local exception predicate; replaces the ambient clause for this breaker |
+| `HandlesResult` (`CircuitBreakerOptions<T>`) | — | Local result predicate on `Shield<T>`; replaces the ambient clause together with `HandlesException` |
 
 ### Dynamic break duration
 
@@ -121,3 +123,7 @@ See [Composition](../composition.md#the-state-sharing-rule).
 ## What counts as a failure
 
 Whatever the current [handling clause](../handling-failures.md) says — including handled *results* on typed shields, so an HTTP breaker can trip on 5xx responses without a single exception being thrown.
+
+For one breaker with different rules, set `HandlesException` or `HandlesResult` in its options.
+This [local override](../handling-failures.md#per-strategy-overrides) replaces, rather than extends,
+the ambient clause.

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -92,6 +92,11 @@ chooses not to observe that token.
 non-generic `FallbackEvent` carrying the exact handled exception. Callback properties are
 snapshotted when the shield is built, so replacing them on the options later has no effect.
 
+Both option types expose `HandlesException`; `FallbackOptions<T>` also exposes `HandlesResult`.
+Setting either creates a [per-strategy override](../handling-failures.md#per-strategy-overrides)
+that fully replaces the ambient clause for this fallback. A result-only override does not recover
+exceptions, and an exception-only override does not recover results.
+
 Hooks may run concurrently when the same shield executes concurrently, and may re-enter the shield;
 they must therefore be thread-safe and must not depend on strategy locks. `FallbackEvent.Context`
 remains valid until that hook returns or its `ValueTask` completes. Do not retain the pooled context

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -30,6 +30,8 @@ Shield.Hedge(o =>
 | `OnHedge` | — | Callback when a hedge launches — `e.Attempt` is 1-based, so `2` = first hedge |
 | `OnHedgeAsync` | — | Awaited callback after `OnHedge` and before the attempt starts |
 | `ActionGenerator` | — | Select a different operation for each additional attempt; `null` uses the original |
+| `HandlesException` | — | Local exception predicate; replaces the ambient clause for this hedge |
+| `HandlesResult` (`HedgingOptions<T>`) | — | Local result predicate on `Shield<T>`; replaces the ambient clause together with `HandlesException` |
 
 ### Selecting another target
 
@@ -79,7 +81,9 @@ Multiple invocations of your delegate may be in flight at once — it must be sa
 - Callback contexts are pooled. Do not retain them after the synchronous callback or returned `ValueTask` completes; a generated action's isolated context remains valid until that attempt completes.
 - Callbacks and generators run without a strategy lock. They may re-enter the same shield, and concurrent shield executions may invoke them concurrently; keep captured state thread-safe.
 - Losing operations are cancelled first, then their isolated contexts are returned to the pool after those operations complete.
-- What counts as a failure is the ambient [handling clause](../handling-failures.md), like every reactive strategy.
+- What counts as a failure is the ambient [handling clause](../handling-failures.md), unless the
+  options set `HandlesException` or `HandlesResult` as a
+  [per-strategy override](../handling-failures.md#per-strategy-overrides).
 
 ## When to hedge (and when not to)
 

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -62,6 +62,8 @@ Shield.Retry(o =>
 | `OnRetryAsync` | — | Awaited before each retry sleeps |
 | `DelayGenerator` | — | Per-retry override: return a `TimeSpan` to replace the computed delay, or `null` to keep it. This is how [`Retry-After` support](../http.md) works |
 | `DelayGeneratorAsync` | — | Awaited per-retry override for asynchronous delay sources; return a `TimeSpan` to replace the current delay, or `null` to keep it |
+| `HandlesException` | — | Local exception predicate; replaces the ambient clause for this retry |
+| `HandlesResult` (`RetryOptions<T>`) | — | Local result predicate; replaces the ambient clause together with `HandlesException` |
 
 Order per retry: retry metrics are recorded → backoff computes the delay → `MaxDelay` clamps it → `DelayGenerator` may override it → the awaited `DelayGeneratorAsync` may override that result → `OnRetry`/`OnRetryAsync` see the final delay → sleep. Both generators ignore `null` and negative results, and `MaxDelay` clamps each override.
 
@@ -88,6 +90,10 @@ Shield
     .Or<TimeoutExceededException>()
     .Retry(5);
 ```
+
+The options-lambda form can instead set `HandlesException` and, on `Shield<T>`, `HandlesResult`.
+Setting either creates a [per-strategy override](../handling-failures.md#per-strategy-overrides);
+unspecified outcome kinds are not handled.
 
 ## Placement in the chain
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1472,8 +1472,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         bool? result = operation is IInvocationOperation invocation
-            ? ContainsLocalHandlingOverride(invocation.TargetMethod, context, visitedSymbols)
+            ? ContainsLocalHandlingOverride(invocation, context, visitedSymbols)
             : false;
+        if (result is true)
+        {
+            return true;
+        }
+
         foreach (var child in operation.ChildOperations)
         {
             var childResult = ContainsLocalHandlingOverride(child, context, visitedSymbols);
@@ -1489,6 +1494,47 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         return result;
+    }
+
+    private static bool? ContainsLocalHandlingOverride(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedSymbols)
+    {
+        if (!invocation.TargetMethod.DeclaringSyntaxReferences.IsEmpty)
+        {
+            return ContainsLocalHandlingOverride(invocation.TargetMethod, context, visitedSymbols);
+        }
+
+        if (IsHandlingOptionsType(Unwrap(invocation.Instance)?.Type))
+        {
+            return null;
+        }
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (IsHandlingOptionsType(Unwrap(argument.Value)?.Type))
+            {
+                return null;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsHandlingOptionsType(ITypeSymbol? type)
+    {
+        for (var current = type as INamedTypeSymbol; current is not null; current = current.BaseType)
+        {
+            if (current.ContainingNamespace.ToDisplayString() == "Kevlar"
+                && (current.GetMembers("HandlesException").Length > 0
+                    || current.GetMembers("HandlesResult").Length > 0))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool? ContainsLocalHandlingOverride(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1458,38 +1458,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         if (operation is IMethodReferenceOperation methodReference)
         {
-            visitedSymbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-            if (!visitedSymbols.Add(methodReference.Method))
-            {
-                return false;
-            }
+            return ContainsLocalHandlingOverride(methodReference.Method, context, visitedSymbols);
+        }
 
-            foreach (var syntaxReference in methodReference.Method.DeclaringSyntaxReferences)
-            {
-                var syntax = syntaxReference.GetSyntax(context.CancellationToken);
-                var semanticModel = context.Operation.SemanticModel;
-                if (semanticModel is null || semanticModel.SyntaxTree != syntax.SyntaxTree)
-                {
-                    if (ContainsLocalHandlingOverride(syntax, methodReference.Method))
-                    {
-                        visitedSymbols.Remove(methodReference.Method);
-                        return true;
-                    }
-
-                    continue;
-                }
-
-                var methodOperation = semanticModel.GetOperation(syntax, context.CancellationToken);
-                if (methodOperation is not null
-                    && ContainsLocalHandlingOverride(methodOperation, context, visitedSymbols))
-                {
-                    visitedSymbols.Remove(methodReference.Method);
-                    return true;
-                }
-            }
-
-            visitedSymbols.Remove(methodReference.Method);
-            return false;
+        if (operation is IInvocationOperation invocation
+            && !invocation.TargetMethod.DeclaringSyntaxReferences.IsEmpty
+            && ContainsLocalHandlingOverride(invocation.TargetMethod, context, visitedSymbols))
+        {
+            return true;
         }
 
         if (operation is IAssignmentOperation
@@ -1512,6 +1488,37 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        return false;
+    }
+
+    private static bool ContainsLocalHandlingOverride(
+        IMethodSymbol method,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedSymbols)
+    {
+        visitedSymbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        if (!visitedSymbols.Add(method))
+        {
+            return false;
+        }
+
+        foreach (var syntaxReference in method.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+            var semanticModel = context.Operation.SemanticModel;
+            var methodOperation = semanticModel?.SyntaxTree == syntax.SyntaxTree
+                ? semanticModel.GetOperation(syntax, context.CancellationToken)
+                : null;
+            if ((methodOperation is not null
+                    && ContainsLocalHandlingOverride(methodOperation, context, visitedSymbols))
+                || (methodOperation is null && ContainsLocalHandlingOverride(syntax, method)))
+            {
+                visitedSymbols.Remove(method);
+                return true;
+            }
+        }
+
+        visitedSymbols.Remove(method);
         return false;
     }
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1419,10 +1419,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return result;
         }
 
-        if (operation is IMethodReferenceOperation methodReference
-            && methodReference.Method.DeclaringSyntaxReferences.IsEmpty)
+        if (operation is IMethodReferenceOperation methodReference)
         {
-            return null;
+            return ContainsLocalHandlingOverride(methodReference.Method, context, visitedSymbols);
         }
 
         if (operation is IParameterReferenceOperation
@@ -1432,40 +1431,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
-        return ContainsLocalHandlingOverride(operation, context, visitedSymbols);
+        return operation is IAnonymousFunctionOperation
+            ? ContainsLocalHandlingOverride(
+                operation,
+                context,
+                visitedSymbols,
+                includeAnonymousFunctionBody: true)
+            : null;
     }
 
-    private static bool ContainsLocalHandlingOverride(
+    private static bool? ContainsLocalHandlingOverride(
         IOperation operation,
         OperationAnalysisContext context,
-        HashSet<ISymbol>? visitedSymbols)
+        HashSet<ISymbol>? visitedSymbols,
+        bool includeAnonymousFunctionBody = false)
     {
         operation = Unwrap(operation)!;
-        if (operation is ILocalReferenceOperation localReference)
+        if (operation is IDelegateCreationOperation)
         {
-            visitedSymbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-            if (!visitedSymbols.Add(localReference.Local)
-                || !TryGetStableInitializer(localReference, context, out var initializer)
-                || initializer is null)
-            {
-                return false;
-            }
-
-            var found = ContainsLocalHandlingOverride(initializer, context, visitedSymbols);
-            visitedSymbols.Remove(localReference.Local);
-            return found;
+            return false;
         }
 
-        if (operation is IMethodReferenceOperation methodReference)
+        if (operation is IAnonymousFunctionOperation anonymousFunction)
         {
-            return ContainsLocalHandlingOverride(methodReference.Method, context, visitedSymbols);
-        }
-
-        if (operation is IInvocationOperation invocation
-            && !invocation.TargetMethod.DeclaringSyntaxReferences.IsEmpty
-            && ContainsLocalHandlingOverride(invocation.TargetMethod, context, visitedSymbols))
-        {
-            return true;
+            return includeAnonymousFunctionBody
+                ? ContainsLocalHandlingOverride(anonymousFunction.Body, context, visitedSymbols)
+                : false;
         }
 
         if (operation is IAssignmentOperation
@@ -1480,18 +1471,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        bool? result = operation is IInvocationOperation invocation
+            ? ContainsLocalHandlingOverride(invocation.TargetMethod, context, visitedSymbols)
+            : false;
         foreach (var child in operation.ChildOperations)
         {
-            if (ContainsLocalHandlingOverride(child, context, visitedSymbols))
+            var childResult = ContainsLocalHandlingOverride(child, context, visitedSymbols);
+            if (childResult is true)
             {
                 return true;
             }
+
+            if (childResult is null)
+            {
+                result = null;
+            }
         }
 
-        return false;
+        return result;
     }
 
-    private static bool ContainsLocalHandlingOverride(
+    private static bool? ContainsLocalHandlingOverride(
         IMethodSymbol method,
         OperationAnalysisContext context,
         HashSet<ISymbol>? visitedSymbols)
@@ -1499,52 +1499,51 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         visitedSymbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         if (!visitedSymbols.Add(method))
         {
-            return false;
+            return null;
         }
 
-        foreach (var syntaxReference in method.DeclaringSyntaxReferences)
+        try
         {
-            var syntax = syntaxReference.GetSyntax(context.CancellationToken);
-            var semanticModel = context.Operation.SemanticModel;
-            var methodOperation = semanticModel?.SyntaxTree == syntax.SyntaxTree
-                ? semanticModel.GetOperation(syntax, context.CancellationToken)
-                : null;
-            if ((methodOperation is not null
-                    && ContainsLocalHandlingOverride(methodOperation, context, visitedSymbols))
-                || (methodOperation is null && ContainsLocalHandlingOverride(syntax, method)))
+            if (method.DeclaringSyntaxReferences.Length == 0)
             {
-                visitedSymbols.Remove(method);
-                return true;
+                return null;
             }
-        }
 
-        visitedSymbols.Remove(method);
-        return false;
-    }
-
-    private static bool ContainsLocalHandlingOverride(
-        SyntaxNode syntax,
-        IMethodSymbol method)
-    {
-        var optionParameterNames = new HashSet<string>(
-            method.Parameters.Select(static parameter => parameter.Name),
-            StringComparer.Ordinal);
-
-        foreach (var assignment in syntax.DescendantNodes().OfType<AssignmentExpressionSyntax>())
-        {
-            if (assignment.Left is MemberAccessExpressionSyntax
+            bool? result = false;
+            foreach (var syntaxReference in method.DeclaringSyntaxReferences)
+            {
+                var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+                var semanticModel = context.Operation.SemanticModel;
+                var methodOperation = semanticModel?.SyntaxTree == syntax.SyntaxTree
+                    ? semanticModel.GetOperation(syntax, context.CancellationToken)
+                    : null;
+                if (methodOperation is null)
                 {
-                    Expression: IdentifierNameSyntax receiver,
-                    Name.Identifier.ValueText: "HandlesException" or "HandlesResult",
+                    result = null;
+                    continue;
                 }
-                && optionParameterNames.Contains(receiver.Identifier.ValueText)
-                && !assignment.Right.IsKind(SyntaxKind.NullLiteralExpression))
-            {
-                return true;
-            }
-        }
 
-        return false;
+                var methodResult = ContainsLocalHandlingOverride(
+                    methodOperation,
+                    context,
+                    visitedSymbols);
+                if (methodResult is true)
+                {
+                    return true;
+                }
+
+                if (methodResult is null)
+                {
+                    result = null;
+                }
+            }
+
+            return result;
+        }
+        finally
+        {
+            visitedSymbols.Remove(method);
+        }
     }
 
     private static bool IsKnownMultiAttemptHedge(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -97,10 +97,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         if (IsKevlarFluentMethod(invocation.TargetMethod, knownTypes, "Fallback")
+            && !HasLocalHandlingOverride(invocation, context)
             && FindInPipeline(
                 GetReceiver(invocation),
                 context,
-                candidate => IsReactiveStrategyWithAmbientHandling(candidate, knownTypes),
+                candidate => IsReactiveStrategyWithAmbientHandling(candidate, context, knownTypes),
                 knownTypes,
                 stopAtHandlingClause: true,
                 stopAtCompositionBoundary: true,
@@ -586,7 +587,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             if (!FindInPipeline(
                 operands[fallbackIndex],
                 context,
-                candidate => IsKevlarFluentMethod(candidate.TargetMethod, knownTypes, "Fallback"),
+                candidate => IsKevlarFluentMethod(candidate.TargetMethod, knownTypes, "Fallback")
+                    && !HasLocalHandlingOverride(candidate, context),
                 knownTypes,
                 stopAtHandlingClause: true,
                 stopAtCompositionBoundary: true,
@@ -601,7 +603,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && FindInPipeline(
                         operands[reactiveIndex],
                         context,
-                        candidate => IsReactiveStrategyWithAmbientHandling(candidate, knownTypes),
+                        candidate => IsReactiveStrategyWithAmbientHandling(candidate, context, knownTypes),
                         knownTypes,
                         stopAtHandlingClause: true,
                         stopAtCompositionBoundary: true,
@@ -1368,16 +1370,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static bool IsReactiveStrategyWithAmbientHandling(
         IInvocationOperation invocation,
+        OperationAnalysisContext context,
         KnownTypes knownTypes) =>
         IsReactiveStrategy(Normalize(invocation.TargetMethod), knownTypes)
-        && !HasLocalHandlingOverride(invocation);
+        && !HasLocalHandlingOverride(invocation, context);
 
-    private static bool HasLocalHandlingOverride(IInvocationOperation invocation)
+    private static bool HasLocalHandlingOverride(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context)
     {
         foreach (var argument in invocation.Arguments)
         {
             if (argument.Parameter?.Name == "configure"
-                && ContainsLocalHandlingOverride(argument.Value))
+                && ContainsLocalHandlingOverride(
+                    argument.Value,
+                    context,
+                    visitedSymbols: null))
             {
                 return true;
             }
@@ -1386,9 +1394,63 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool ContainsLocalHandlingOverride(IOperation operation)
+    private static bool ContainsLocalHandlingOverride(
+        IOperation operation,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedSymbols)
     {
         operation = Unwrap(operation)!;
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedSymbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedSymbols.Add(localReference.Local)
+                || !TryGetStableInitializer(localReference, context, out var initializer)
+                || initializer is null)
+            {
+                return false;
+            }
+
+            var found = ContainsLocalHandlingOverride(initializer, context, visitedSymbols);
+            visitedSymbols.Remove(localReference.Local);
+            return found;
+        }
+
+        if (operation is IMethodReferenceOperation methodReference)
+        {
+            visitedSymbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedSymbols.Add(methodReference.Method))
+            {
+                return false;
+            }
+
+            foreach (var syntaxReference in methodReference.Method.DeclaringSyntaxReferences)
+            {
+                var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+                var semanticModel = context.Operation.SemanticModel;
+                if (semanticModel is null || semanticModel.SyntaxTree != syntax.SyntaxTree)
+                {
+                    if (ContainsLocalHandlingOverride(syntax, methodReference.Method))
+                    {
+                        visitedSymbols.Remove(methodReference.Method);
+                        return true;
+                    }
+
+                    continue;
+                }
+
+                var methodOperation = semanticModel.GetOperation(syntax, context.CancellationToken);
+                if (methodOperation is not null
+                    && ContainsLocalHandlingOverride(methodOperation, context, visitedSymbols))
+                {
+                    visitedSymbols.Remove(methodReference.Method);
+                    return true;
+                }
+            }
+
+            visitedSymbols.Remove(methodReference.Method);
+            return false;
+        }
+
         if (operation is ISimpleAssignmentOperation
             {
                 Target: IPropertyReferenceOperation propertyReference,
@@ -1403,7 +1465,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         foreach (var child in operation.ChildOperations)
         {
-            if (ContainsLocalHandlingOverride(child))
+            if (ContainsLocalHandlingOverride(child, context, visitedSymbols))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsLocalHandlingOverride(
+        SyntaxNode syntax,
+        IMethodSymbol method)
+    {
+        var optionParameterNames = new HashSet<string>(
+            method.Parameters.Select(static parameter => parameter.Name),
+            StringComparer.Ordinal);
+
+        foreach (var assignment in syntax.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.Left is MemberAccessExpressionSyntax
+                {
+                    Expression: IdentifierNameSyntax receiver,
+                    Name.Identifier.ValueText: "HandlesException" or "HandlesResult",
+                }
+                && optionParameterNames.Contains(receiver.Identifier.ValueText)
+                && !assignment.Right.IsKind(SyntaxKind.NullLiteralExpression))
             {
                 return true;
             }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -100,7 +100,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             && FindInPipeline(
                 GetReceiver(invocation),
                 context,
-                candidate => IsReactiveStrategy(Normalize(candidate.TargetMethod), knownTypes),
+                candidate => IsReactiveStrategyWithAmbientHandling(candidate, knownTypes),
                 knownTypes,
                 stopAtHandlingClause: true,
                 stopAtCompositionBoundary: true,
@@ -601,7 +601,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && FindInPipeline(
                         operands[reactiveIndex],
                         context,
-                        candidate => IsReactiveStrategy(Normalize(candidate.TargetMethod), knownTypes),
+                        candidate => IsReactiveStrategyWithAmbientHandling(candidate, knownTypes),
                         knownTypes,
                         stopAtHandlingClause: true,
                         stopAtCompositionBoundary: true,
@@ -1365,6 +1365,52 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsReactiveStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
         (method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker")
         && IsKevlarFluentMethod(method, knownTypes);
+
+    private static bool IsReactiveStrategyWithAmbientHandling(
+        IInvocationOperation invocation,
+        KnownTypes knownTypes) =>
+        IsReactiveStrategy(Normalize(invocation.TargetMethod), knownTypes)
+        && !HasLocalHandlingOverride(invocation);
+
+    private static bool HasLocalHandlingOverride(IInvocationOperation invocation)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Name == "configure"
+                && ContainsLocalHandlingOverride(argument.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsLocalHandlingOverride(IOperation operation)
+    {
+        operation = Unwrap(operation)!;
+        if (operation is ISimpleAssignmentOperation
+            {
+                Target: IPropertyReferenceOperation propertyReference,
+                Value: { } value,
+            }
+            && propertyReference.Property.Name is "HandlesException" or "HandlesResult"
+            && propertyReference.Property.ContainingNamespace.ToDisplayString() == "Kevlar"
+            && value.ConstantValue is not { HasValue: true, Value: null })
+        {
+            return true;
+        }
+
+        foreach (var child in operation.ChildOperations)
+        {
+            if (ContainsLocalHandlingOverride(child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static bool IsKnownMultiAttemptHedge(
         IInvocationOperation invocation,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1451,7 +1451,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (operation is ISimpleAssignmentOperation
+        if (operation is IAssignmentOperation
             {
                 Target: IPropertyReferenceOperation propertyReference,
                 Value: { } value,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -97,7 +97,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         if (IsKevlarFluentMethod(invocation.TargetMethod, knownTypes, "Fallback")
-            && !HasLocalHandlingOverride(invocation, context)
+            && HasLocalHandlingOverride(invocation, context) is false
             && FindInPipeline(
                 GetReceiver(invocation),
                 context,
@@ -588,7 +588,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 operands[fallbackIndex],
                 context,
                 candidate => IsKevlarFluentMethod(candidate.TargetMethod, knownTypes, "Fallback")
-                    && !HasLocalHandlingOverride(candidate, context),
+                    && HasLocalHandlingOverride(candidate, context) is false,
                 knownTypes,
                 stopAtHandlingClause: true,
                 stopAtCompositionBoundary: true,
@@ -1373,25 +1373,66 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         OperationAnalysisContext context,
         KnownTypes knownTypes) =>
         IsReactiveStrategy(Normalize(invocation.TargetMethod), knownTypes)
-        && !HasLocalHandlingOverride(invocation, context);
+        && HasLocalHandlingOverride(invocation, context) is false;
 
-    private static bool HasLocalHandlingOverride(
+    private static bool? HasLocalHandlingOverride(
         IInvocationOperation invocation,
         OperationAnalysisContext context)
     {
         foreach (var argument in invocation.Arguments)
         {
-            if (argument.Parameter?.Name == "configure"
-                && ContainsLocalHandlingOverride(
+            if (argument.Parameter?.Name == "configure")
+            {
+                return AnalyzeLocalHandlingConfigurator(
                     argument.Value,
                     context,
-                    visitedSymbols: null))
-            {
-                return true;
+                    visitedSymbols: null);
             }
         }
 
         return false;
+    }
+
+    private static bool? AnalyzeLocalHandlingConfigurator(
+        IOperation operation,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedSymbols)
+    {
+        operation = Unwrap(operation)!;
+        if (operation is IDelegateCreationOperation delegateCreation)
+        {
+            return AnalyzeLocalHandlingConfigurator(delegateCreation.Target, context, visitedSymbols);
+        }
+
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedSymbols ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedSymbols.Add(localReference.Local)
+                || !TryGetStableInitializer(localReference, context, out var initializer)
+                || initializer is null)
+            {
+                return null;
+            }
+
+            var result = AnalyzeLocalHandlingConfigurator(initializer, context, visitedSymbols);
+            visitedSymbols.Remove(localReference.Local);
+            return result;
+        }
+
+        if (operation is IMethodReferenceOperation methodReference
+            && methodReference.Method.DeclaringSyntaxReferences.IsEmpty)
+        {
+            return null;
+        }
+
+        if (operation is IParameterReferenceOperation
+            or IPropertyReferenceOperation
+            or IFieldReferenceOperation)
+        {
+            return null;
+        }
+
+        return ContainsLocalHandlingOverride(operation, context, visitedSymbols);
     }
 
     private static bool ContainsLocalHandlingOverride(

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -144,6 +144,8 @@ public static class HttpShield
         target.MaxDelay = source.MaxDelay;
         target.DelayGenerator = source.DelayGenerator;
         target.DelayGeneratorAsync = source.DelayGeneratorAsync;
+        target.HandlesException = source.HandlesException;
+        target.HandlesResult = source.HandlesResult;
         target.OnRetry = retry =>
         {
             retry.Outcome.Result?.Dispose();
@@ -160,6 +162,7 @@ public static class HttpShield
         target.SamplingWindow = source.SamplingWindow;
         target.BreakDuration = source.BreakDuration;
         target.BreakDurationGenerator = source.BreakDurationGenerator;
+        target.HandlesException = source.HandlesException;
         target.Monitor = source.Monitor;
         target.OnStateChanged = source.OnStateChanged;
         target.OnStateChangedAsync = source.OnStateChangedAsync;

--- a/src/Kevlar.Testing/CircuitBreakerStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/CircuitBreakerStrategyDescriptor.cs
@@ -11,7 +11,8 @@ public sealed class CircuitBreakerStrategyDescriptor : StrategyDescriptor
         TimeSpan samplingWindow,
         TimeSpan breakDuration,
         bool hasMonitor,
-        bool hasNotification)
+        bool hasNotification,
+        bool hasHandlingOverride)
         : base(StrategyKind.CircuitBreaker, description)
     {
         ConsecutiveFailures = consecutiveFailures;
@@ -21,6 +22,7 @@ public sealed class CircuitBreakerStrategyDescriptor : StrategyDescriptor
         BreakDuration = breakDuration;
         HasMonitor = hasMonitor;
         HasNotification = hasNotification;
+        HasHandlingOverride = hasHandlingOverride;
     }
 
     /// <summary>The consecutive-failure threshold in simple mode.</summary>
@@ -43,4 +45,7 @@ public sealed class CircuitBreakerStrategyDescriptor : StrategyDescriptor
 
     /// <summary>Whether a state-change notification is configured.</summary>
     public bool HasNotification { get; }
+
+    /// <summary>Whether local predicates replace the ambient handling clause.</summary>
+    public bool HasHandlingOverride { get; }
 }

--- a/src/Kevlar.Testing/FallbackStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/FallbackStrategyDescriptor.cs
@@ -6,11 +6,13 @@ public sealed class FallbackStrategyDescriptor : StrategyDescriptor
     internal FallbackStrategyDescriptor(
         string description,
         Type? resultType,
-        bool hasNotification)
+        bool hasNotification,
+        bool hasHandlingOverride)
         : base(StrategyKind.Fallback, description)
     {
         ResultType = resultType;
         HasNotification = hasNotification;
+        HasHandlingOverride = hasHandlingOverride;
     }
 
     /// <summary>The fallback result type, or <see langword="null"/> for a void fallback.</summary>
@@ -21,4 +23,7 @@ public sealed class FallbackStrategyDescriptor : StrategyDescriptor
 
     /// <summary>Whether a fallback notification is configured.</summary>
     public bool HasNotification { get; }
+
+    /// <summary>Whether local predicates replace the ambient handling clause.</summary>
+    public bool HasHandlingOverride { get; }
 }

--- a/src/Kevlar.Testing/HedgingStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/HedgingStrategyDescriptor.cs
@@ -7,12 +7,14 @@ public sealed class HedgingStrategyDescriptor : StrategyDescriptor
         string description,
         int maxAttempts,
         TimeSpan delay,
-        bool hasNotification)
+        bool hasNotification,
+        bool hasHandlingOverride)
         : base(StrategyKind.Hedging, description)
     {
         MaxAttempts = maxAttempts;
         Delay = delay;
         HasNotification = hasNotification;
+        HasHandlingOverride = hasHandlingOverride;
     }
 
     /// <summary>The maximum total attempts, including the primary.</summary>
@@ -23,4 +25,7 @@ public sealed class HedgingStrategyDescriptor : StrategyDescriptor
 
     /// <summary>Whether a hedge notification is configured.</summary>
     public bool HasNotification { get; }
+
+    /// <summary>Whether local predicates replace the ambient handling clause.</summary>
+    public bool HasHandlingOverride { get; }
 }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -75,6 +75,10 @@ static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyCount(th
 static Kevlar.Testing.ShieldDescriptorAssertionExtensions.AssertStrategyOrder(this Kevlar.Testing.ShieldDescriptor! descriptor, params Kevlar.Testing.StrategyKind[]! expected) -> Kevlar.Testing.ShieldDescriptor!
 static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor(this Kevlar.Shield! shield) -> Kevlar.Testing.ShieldDescriptor!
 static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor<TResult>(this Kevlar.Shield<TResult>! shield) -> Kevlar.Testing.ShieldDescriptor!
+Kevlar.Testing.CircuitBreakerStrategyDescriptor.HasHandlingOverride.get -> bool
+Kevlar.Testing.FallbackStrategyDescriptor.HasHandlingOverride.get -> bool
+Kevlar.Testing.HedgingStrategyDescriptor.HasHandlingOverride.get -> bool
+Kevlar.Testing.RetryStrategyDescriptor.HasHandlingOverride.get -> bool
 Kevlar.Testing.CircuitBreakerStateSnapshot
 Kevlar.Testing.CircuitBreakerStateSnapshot.State.get -> Kevlar.CircuitState
 Kevlar.Testing.ConcurrencyLimitStateSnapshot

--- a/src/Kevlar.Testing/RetryStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/RetryStrategyDescriptor.cs
@@ -9,7 +9,8 @@ public sealed class RetryStrategyDescriptor : StrategyDescriptor
         BackoffDescriptor backoff,
         TimeSpan? maxDelay,
         bool hasDelayGenerator,
-        bool hasNotification)
+        bool hasNotification,
+        bool hasHandlingOverride)
         : base(StrategyKind.Retry, description)
     {
         MaxRetries = maxRetries;
@@ -17,6 +18,7 @@ public sealed class RetryStrategyDescriptor : StrategyDescriptor
         MaxDelay = maxDelay;
         HasDelayGenerator = hasDelayGenerator;
         HasNotification = hasNotification;
+        HasHandlingOverride = hasHandlingOverride;
     }
 
     /// <summary>Maximum retries after the initial attempt.</summary>
@@ -33,4 +35,7 @@ public sealed class RetryStrategyDescriptor : StrategyDescriptor
 
     /// <summary>Whether a synchronous or asynchronous retry notification is configured.</summary>
     public bool HasNotification { get; }
+
+    /// <summary>Whether local predicates replace the ambient handling clause.</summary>
+    public bool HasHandlingOverride { get; }
 }

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -57,13 +57,14 @@ public static class ShieldDescriptorExtensions
                 DescribeBackoff(retry.Backoff),
                 retry.MaxDelay,
                 retry.HasDelayGenerator,
-                retry.HasNotification),
+                retry.HasNotification,
+                retry.HasHandlingOverride),
             TimeoutStrategy timeout => new TimeoutStrategyDescriptor(
                 description,
                 timeout.Timeout,
                 timeout.HasTimeoutGenerator,
                 timeout.HasNotification),
-            CircuitBreakerStrategy circuit => DescribeCircuitBreaker(description, circuit.Core),
+            CircuitBreakerStrategy circuit => DescribeCircuitBreaker(description, circuit),
             RateLimitStrategy rateLimit => new RateLimitStrategyDescriptor(
                 description,
                 rateLimit.Permits,
@@ -80,11 +81,13 @@ public static class ShieldDescriptorExtensions
                 description,
                 hedging.MaxAttempts,
                 hedging.Delay,
-                hedging.HasNotification),
+                hedging.HasNotification,
+                hedging.HasHandlingOverride),
             IFallbackStrategyInspection fallback => new FallbackStrategyDescriptor(
                 description,
                 fallback.ResultType,
-                fallback.HasNotification),
+                fallback.HasNotification,
+                strategy.HasHandlingOverride),
             _ => new CustomStrategyDescriptor(
                 description,
                 strategy.GetType(),
@@ -94,15 +97,16 @@ public static class ShieldDescriptorExtensions
 
     private static CircuitBreakerStrategyDescriptor DescribeCircuitBreaker(
         string description,
-        CircuitBreakerCore core) => new(
+        CircuitBreakerStrategy strategy) => new(
             description,
-            core.ConsecutiveFailures,
-            core.FailureRatio,
-            core.MinimumThroughput,
-            core.SamplingWindow,
-            core.BreakDuration,
-            core.HasMonitor,
-            core.HasNotification);
+            strategy.Core.ConsecutiveFailures,
+            strategy.Core.FailureRatio,
+            strategy.Core.MinimumThroughput,
+            strategy.Core.SamplingWindow,
+            strategy.Core.BreakDuration,
+            strategy.Core.HasMonitor,
+            strategy.Core.HasNotification,
+            strategy.HasHandlingOverride);
 
     private static BackoffDescriptor DescribeBackoff(Backoff backoff) => new(
         backoff.ConfigurationKind switch

--- a/src/Kevlar/Internal/HandlingOverride.cs
+++ b/src/Kevlar/Internal/HandlingOverride.cs
@@ -1,0 +1,19 @@
+namespace Kevlar.Internal;
+
+internal static class HandlingOverride
+{
+    internal static OutcomeJudge Resolve(
+        Func<Exception, bool>? handlesException,
+        OutcomeJudge ambientJudge) =>
+        handlesException is null
+            ? ambientJudge
+            : new ExceptionJudge(handlesException);
+
+    internal static OutcomeJudge Resolve<TResult>(
+        Func<Exception, bool>? handlesException,
+        Func<TResult, bool>? handlesResult,
+        OutcomeJudge ambientJudge) =>
+        handlesException is null && handlesResult is null
+            ? ambientJudge
+            : new TypedJudge<TResult>(handlesException, handlesResult);
+}

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -178,4 +178,36 @@ Kevlar.ShieldBuilder<TResult>.RateLimit(System.Action<Kevlar.RateLimitOptions!>!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.WhenResult(System.Func<TResult, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.WhenResult(TResult result) -> Kevlar.ShieldBuilder<TResult>!
 *REMOVED*static Kevlar.Shield.For<TResult>() -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.CircuitBreakerOptions.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.CircuitBreakerOptions.HandlesException.set -> void
+Kevlar.CircuitBreakerOptions<TResult>
+Kevlar.CircuitBreakerOptions<TResult>.CircuitBreakerOptions() -> void
+Kevlar.CircuitBreakerOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
+Kevlar.CircuitBreakerOptions<TResult>.HandlesResult.set -> void
+Kevlar.FallbackOptions.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.FallbackOptions.HandlesException.set -> void
+Kevlar.FallbackOptions<TResult>.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.FallbackOptions<TResult>.HandlesException.set -> void
+Kevlar.FallbackOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
+Kevlar.FallbackOptions<TResult>.HandlesResult.set -> void
+Kevlar.HedgingOptions.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.HedgingOptions.HandlesException.set -> void
+Kevlar.HedgingOptions<TResult>
+Kevlar.HedgingOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
+Kevlar.HedgingOptions<TResult>.HandlesResult.set -> void
+Kevlar.HedgingOptions<TResult>.HedgingOptions() -> void
+Kevlar.RetryOptions.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.RetryOptions.HandlesException.set -> void
+Kevlar.RetryOptions<TResult>.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.RetryOptions<TResult>.HandlesException.set -> void
+Kevlar.RetryOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
+Kevlar.RetryOptions<TResult>.HandlesResult.set -> void
+Kevlar.Shield<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Hedge(System.Action<Kevlar.HedgingOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Hedge(System.Action<Kevlar.HedgingOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.Shield<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.Shield<TResult>.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield<TResult>!
 static Kevlar.Shield.For<TResult>() -> Kevlar.Shield<TResult>!

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -86,13 +86,13 @@ public sealed class ShieldBuilder<TResult>
     public Shield<TResult> CircuitBreaker(int consecutiveFailures, TimeSpan breakDuration) => Seal().CircuitBreaker(consecutiveFailures, breakDuration);
 
     /// <summary>Adds a circuit breaker strategy configured via <paramref name="configure"/>.</summary>
-    public Shield<TResult> CircuitBreaker(Action<CircuitBreakerOptions> configure) => Seal().CircuitBreaker(configure);
+    public Shield<TResult> CircuitBreaker(Action<CircuitBreakerOptions<TResult>> configure) => Seal().CircuitBreaker(configure);
 
     /// <summary>Races concurrent attempts; a handled outcome launches the next attempt immediately.</summary>
     public Shield<TResult> Hedge(int maxAttempts, TimeSpan delay) => Seal().Hedge(maxAttempts, delay);
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
-    public Shield<TResult> Hedge(Action<HedgingOptions> configure) => Seal().Hedge(configure);
+    public Shield<TResult> Hedge(Action<HedgingOptions<TResult>> configure) => Seal().Hedge(configure);
 
     /// <summary>Creates and appends a custom strategy using the accumulated handling clause.</summary>
     public Shield<TResult> Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -26,7 +26,8 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new RetryOptions();
         configure(options);
-        return shield.Append(new RetryStrategy(options, shield.JudgeOrDefault));
+        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
+        return shield.Append(new RetryStrategy(options, judge));
     }
 
     /// <summary>Appends a retry that never gives up.</summary>
@@ -63,7 +64,8 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new CircuitBreakerOptions();
         configure(options);
-        return shield.Append(new CircuitBreakerStrategy(options, shield.JudgeOrDefault));
+        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
+        return shield.Append(new CircuitBreakerStrategy(options, judge));
     }
 
     /// <summary>Appends a token-bucket rate limit of <paramref name="permits"/> executions per <paramref name="perWindow"/>.</summary>
@@ -114,7 +116,8 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new HedgingOptions();
         configure(options);
-        return shield.Append(new HedgingStrategy(options, shield.JudgeOrDefault));
+        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
+        return shield.Append(new HedgingStrategy(options, judge));
     }
 
     /// <summary>Starts a handling clause: subsequent reactive strategies act on exceptions of type <typeparamref name="TException"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
@@ -241,11 +244,13 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions();
         configure(options);
+        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
         return shield.Append(new VoidFallbackStrategy(
             fallback,
-            shield.JudgeOrDefault,
+            judge,
             options.OnFallback,
-            options.OnFallbackAsync));
+            options.OnFallbackAsync,
+            options.HandlesException is not null));
     }
 
     /// <summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -92,7 +92,8 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new RetryOptions<TResult>();
         configure(options);
-        return Append(RetryStrategy.Create(options, JudgeOrDefault));
+        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        return Append(RetryStrategy.Create(options, judge));
     }
 
     /// <summary>Retries handled outcomes indefinitely.</summary>
@@ -122,12 +123,13 @@ public sealed class Shield<TResult>
     });
 
     /// <summary>Adds a circuit breaker strategy configured via <paramref name="configure"/>.</summary>
-    public Shield<TResult> CircuitBreaker(Action<CircuitBreakerOptions> configure)
+    public Shield<TResult> CircuitBreaker(Action<CircuitBreakerOptions<TResult>> configure)
     {
         Throw.IfNull(configure, nameof(configure));
-        var options = new CircuitBreakerOptions();
+        var options = new CircuitBreakerOptions<TResult>();
         configure(options);
-        return Append(new CircuitBreakerStrategy(options, JudgeOrDefault));
+        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        return Append(new CircuitBreakerStrategy(options, judge));
     }
 
     /// <summary>Limits throughput to <paramref name="permits"/> executions per <paramref name="perWindow"/> (token bucket).</summary>
@@ -170,12 +172,13 @@ public sealed class Shield<TResult>
     });
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
-    public Shield<TResult> Hedge(Action<HedgingOptions> configure)
+    public Shield<TResult> Hedge(Action<HedgingOptions<TResult>> configure)
     {
         Throw.IfNull(configure, nameof(configure));
-        var options = new HedgingOptions();
+        var options = new HedgingOptions<TResult>();
         configure(options);
-        return Append(new HedgingStrategy(options, JudgeOrDefault));
+        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        return Append(new HedgingStrategy(options, judge));
     }
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
@@ -194,11 +197,13 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions<TResult>();
         configure(options);
+        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (_, _) => new ValueTask<TResult>(fallbackValue),
-            JudgeOrDefault,
+            judge,
             options.OnFallback,
-            options.OnFallbackAsync));
+            options.OnFallbackAsync,
+            options.HandlesException is not null || options.HandlesResult is not null));
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
@@ -225,11 +230,13 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions<TResult>();
         configure(options);
+        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (_, context) => fallback(context.CancellationToken),
-            JudgeOrDefault,
+            judge,
             options.OnFallback,
-            options.OnFallbackAsync));
+            options.OnFallbackAsync,
+            options.HandlesException is not null || options.HandlesResult is not null));
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
@@ -259,11 +266,13 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions<TResult>();
         configure(options);
+        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (outcome, context) => fallback(outcome, context.CancellationToken),
-            JudgeOrDefault,
+            judge,
             options.OnFallback,
-            options.OnFallbackAsync));
+            options.OnFallbackAsync,
+            options.HandlesException is not null || options.HandlesResult is not null));
     }
 
     /// <summary>Appends a custom <see cref="Strategy"/> implementation to the pipeline.</summary>

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -5,8 +5,16 @@ namespace Kevlar;
 /// <see cref="ConsecutiveFailures"/> (simple mode) or <see cref="FailureRatio"/>
 /// (sampling mode). When neither is set, the breaker trips after 5 consecutive failures.
 /// </summary>
-public sealed class CircuitBreakerOptions
+public class CircuitBreakerOptions
 {
+    /// <summary>
+    /// Locally selects exceptions handled by this circuit breaker. When set, this strategy ignores
+    /// the ambient handling clause and handles only outcomes selected by its local predicates.
+    /// </summary>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
+    internal virtual bool HasHandlingOverride => HandlesException is not null;
+
     /// <summary>Trips the circuit after this many consecutive handled failures.</summary>
     public int? ConsecutiveFailures { get; set; }
 

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
@@ -1,0 +1,18 @@
+namespace Kevlar;
+
+/// <summary>
+/// Result-typed configuration for a circuit breaker strategy on a
+/// <see cref="Shield{TResult}"/>.
+/// </summary>
+public sealed class CircuitBreakerOptions<TResult> : CircuitBreakerOptions
+{
+    /// <summary>
+    /// Locally selects results handled by this circuit breaker. When either local predicate is
+    /// set, this strategy ignores the ambient handling clause and handles only outcomes selected
+    /// locally.
+    /// </summary>
+    public Func<TResult, bool>? HandlesResult { get; set; }
+
+    internal override bool HasHandlingOverride =>
+        HandlesException is not null || HandlesResult is not null;
+}

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -15,9 +15,12 @@ internal sealed class CircuitBreakerStrategy : Strategy
     {
         _core = new CircuitBreakerCore(options, RecordTransitionState);
         _judge = judge;
+        HasHandlingOverride = options.HasHandlingOverride;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
+
+    internal override bool HasHandlingOverride { get; }
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 

--- a/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
@@ -8,6 +8,12 @@ namespace Kevlar;
 /// </remarks>
 public sealed class FallbackOptions
 {
+    /// <summary>
+    /// Locally selects exceptions handled by this fallback. When set, this strategy ignores the
+    /// ambient handling clause and handles only exceptions selected here.
+    /// </summary>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
     /// <summary>Invoked synchronously before the recovery action.</summary>
     public Action<FallbackEvent>? OnFallback { get; set; }
 

--- a/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
@@ -11,6 +11,18 @@ namespace Kevlar;
 /// </remarks>
 public sealed class FallbackOptions<TResult>
 {
+    /// <summary>
+    /// Locally selects exceptions handled by this fallback. When either local predicate is set,
+    /// this strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// </summary>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
+    /// <summary>
+    /// Locally selects results handled by this fallback. When either local predicate is set, this
+    /// strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// </summary>
+    public Func<TResult, bool>? HandlesResult { get; set; }
+
     /// <summary>Invoked synchronously before the recovery factory, with the typed handled outcome.</summary>
     public Action<FallbackEvent<TResult>>? OnFallback { get; set; }
 

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -16,15 +16,19 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
         Func<Outcome<TResult>, KevlarContext, ValueTask<TResult>> fallback,
         OutcomeJudge judge,
         Action<FallbackEvent<TResult>>? onFallback,
-        Func<FallbackEvent<TResult>, ValueTask>? onFallbackAsync)
+        Func<FallbackEvent<TResult>, ValueTask>? onFallbackAsync,
+        bool hasHandlingOverride = false)
     {
         _fallback = fallback;
         _judge = judge;
         _onFallback = onFallback;
         _onFallbackAsync = onFallbackAsync;
+        HasHandlingOverride = hasHandlingOverride;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
+
+    internal override bool HasHandlingOverride { get; }
 
     internal override bool IsFallback => true;
 
@@ -137,15 +141,19 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
         Func<Exception, CancellationToken, ValueTask> fallback,
         OutcomeJudge judge,
         Action<FallbackEvent>? onFallback,
-        Func<FallbackEvent, ValueTask>? onFallbackAsync)
+        Func<FallbackEvent, ValueTask>? onFallbackAsync,
+        bool hasHandlingOverride = false)
     {
         _fallback = fallback;
         _judge = judge;
         _onFallback = onFallback;
         _onFallbackAsync = onFallbackAsync;
+        HasHandlingOverride = hasHandlingOverride;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
+
+    internal override bool HasHandlingOverride { get; }
 
     internal override bool IsFallback => true;
 

--- a/src/Kevlar/Strategies/Hedging/HedgingOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingOptions.cs
@@ -12,8 +12,16 @@ namespace Kevlar;
 /// <see cref="OnHedgeAsync"/>, then <see cref="ActionGenerator"/>. Caller cancellation is checked
 /// before callbacks and again before the generated operation starts.
 /// </remarks>
-public sealed class HedgingOptions
+public class HedgingOptions
 {
+    /// <summary>
+    /// Locally selects exceptions handled by this hedging strategy. When set, this strategy
+    /// ignores the ambient handling clause and handles only outcomes selected locally.
+    /// </summary>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
+    internal virtual bool HasHandlingOverride => HandlesException is not null;
+
     /// <summary>Total attempts including the original. Default 2.</summary>
     public int MaxAttempts { get; set; } = 2;
 

--- a/src/Kevlar/Strategies/Hedging/HedgingOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingOptionsOfT.cs
@@ -1,0 +1,17 @@
+namespace Kevlar;
+
+/// <summary>
+/// Result-typed configuration for a hedging strategy on a <see cref="Shield{TResult}"/>.
+/// </summary>
+public sealed class HedgingOptions<TResult> : HedgingOptions
+{
+    /// <summary>
+    /// Locally selects results handled by this hedging strategy. When either local predicate is
+    /// set, this strategy ignores the ambient handling clause and handles only outcomes selected
+    /// locally.
+    /// </summary>
+    public Func<TResult, bool>? HandlesResult { get; set; }
+
+    internal override bool HasHandlingOverride =>
+        HandlesException is not null || HandlesResult is not null;
+}

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -24,9 +24,12 @@ internal sealed class HedgingStrategy : Strategy
         _onHedge = options.OnHedge;
         _onHedgeAsync = options.OnHedgeAsync;
         _actionGenerator = options.ActionGenerator;
+        HasHandlingOverride = options.HasHandlingOverride;
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
+
+    internal override bool HasHandlingOverride { get; }
 
     internal int MaxAttempts => _maxAttempts;
 

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -10,6 +10,14 @@ namespace Kevlar;
 public class RetryOptions
 {
     /// <summary>
+    /// Locally selects exceptions handled by this retry. When set, this strategy ignores the
+    /// ambient handling clause and handles only outcomes selected by its local predicates.
+    /// </summary>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
+    internal bool HasHandlingOverride => HandlesException is not null;
+
+    /// <summary>
     /// Maximum number of retries after the initial attempt. The default is 3
     /// (up to 4 total executions). Use <see cref="int.MaxValue"/> to retry forever.
     /// </summary>
@@ -76,6 +84,21 @@ public sealed class RetryOptions<TResult>
     /// <see cref="DelayGenerator"/> (so a huge <c>Retry-After</c> header cannot stall the pipeline).
     /// </summary>
     public TimeSpan? MaxDelay { get; set; }
+
+    /// <summary>
+    /// Locally selects exceptions handled by this retry. When either local predicate is set, this
+    /// strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// </summary>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
+    /// <summary>
+    /// Locally selects results handled by this retry. When either local predicate is set, this
+    /// strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// </summary>
+    public Func<TResult, bool>? HandlesResult { get; set; }
+
+    internal bool HasHandlingOverride =>
+        HandlesException is not null || HandlesResult is not null;
 
     /// <summary>Invoked synchronously before each retry sleeps, with the typed handled outcome.</summary>
     public Action<RetryEvent<TResult>>? OnRetry { get; set; }

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -22,7 +22,8 @@ internal sealed class RetryStrategy : Strategy
             options.OnRetry,
             options.OnRetryAsync,
             options.DelayGenerator,
-            options.DelayGeneratorAsync)
+            options.DelayGeneratorAsync,
+            options.HasHandlingOverride)
     {
     }
 
@@ -34,7 +35,8 @@ internal sealed class RetryStrategy : Strategy
         Action<RetryEvent>? onRetry,
         Func<RetryEvent, ValueTask>? onRetryAsync,
         Func<RetryEvent, TimeSpan?>? delayGenerator,
-        Func<RetryEvent, ValueTask<TimeSpan?>>? delayGeneratorAsync)
+        Func<RetryEvent, ValueTask<TimeSpan?>>? delayGeneratorAsync,
+        bool hasHandlingOverride)
     {
         Throw.IfOutOfRange(maxRetries < 0, "options", "MaxRetries must not be negative.");
         Throw.IfNull(backoff, "options");
@@ -49,6 +51,7 @@ internal sealed class RetryStrategy : Strategy
         _onRetryAsync = onRetryAsync;
         _delayGenerator = delayGenerator;
         _delayGeneratorAsync = delayGeneratorAsync;
+        HasHandlingOverride = hasHandlingOverride;
     }
 
     internal static RetryStrategy Create<TResult>(RetryOptions<TResult> options, OutcomeJudge judge)
@@ -68,10 +71,13 @@ internal sealed class RetryStrategy : Strategy
             delayGenerator is null ? null : retry => delayGenerator(new RetryEvent<TResult>(retry)),
             delayGeneratorAsync is null
                 ? null
-                : retry => delayGeneratorAsync(new RetryEvent<TResult>(retry)));
+                : retry => delayGeneratorAsync(new RetryEvent<TResult>(retry)),
+            options.HasHandlingOverride);
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
+
+    internal override bool HasHandlingOverride { get; }
 
     internal int MaxRetries => _maxRetries;
 

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -48,6 +48,9 @@ public abstract class Strategy
     /// <summary>The handling clause this reactive strategy acts on; null for proactive strategies.</summary>
     internal virtual OutcomeJudge? ReactiveJudge => Handling?.Judge;
 
+    /// <summary>Whether this reactive strategy replaces ambient handling with local predicates.</summary>
+    internal virtual bool HasHandlingOverride => false;
+
     /// <summary>Marks fallback strategies for chain-order validation.</summary>
     internal virtual bool IsFallback => false;
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -566,6 +566,36 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV003_Skips_Fallback_With_Local_Handling_Override()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            "_ = Shield.For<int>().Retry(1).Fallback(0, options => options.HandlesException = exception => exception is TimeoutException);");
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV003_Resolves_Reusable_Local_Handling_Configurators()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            """
+            Action<CircuitBreakerOptions<int>> configure = ConfigureBreaker;
+            _ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).Fallback(0);
+            _ = Shield.For<int>().CircuitBreaker(configure).Fallback(0);
+            _ = Shield.For<int>().Retry(1).Fallback(0, ConfigureFallback);
+            """,
+            """
+            private static void ConfigureBreaker(CircuitBreakerOptions<int> options) =>
+                options.HandlesException = exception => exception is TimeoutException;
+
+            private static void ConfigureFallback(FallbackOptions<int> options) =>
+                options.HandlesException = exception => exception is TimeoutException;
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV003_Skips_Valid_Or_Unknown_Compositions()
     {
         var cases = new[]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -612,6 +612,22 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV003_Follows_Source_Configurator_Helper_Calls()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            "_ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).Fallback(0);",
+            """
+            private static void ConfigureBreaker(CircuitBreakerOptions<int> options) =>
+                ApplyHandling(options);
+
+            private static void ApplyHandling(CircuitBreakerOptions<int> options) =>
+                options.HandlesException = exception => exception is TimeoutException;
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV003_Skips_Opaque_Local_Handling_Configurator()
     {
         var diagnostics = await AnalyzeBodyAsync(

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -566,6 +566,22 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV003_Recognizes_Compound_Local_Handling_Assignments()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException ??= exception => exception is TimeoutException).Fallback(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException += exception => exception is TimeoutException).Fallback(0);",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body);
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
     public async Task KEV003_Skips_Fallback_With_Local_Handling_Override()
     {
         var diagnostics = await AnalyzeBodyAsync(

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -612,6 +612,22 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV003_Skips_Opaque_Local_Handling_Configurator()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            "_ = Build(options => options.HandlesException = exception => exception is TimeoutException);",
+            """
+            private static Shield<int> Build(Action<CircuitBreakerOptions<int>> configure) =>
+                Shield.For<int>()
+                    .When<InvalidOperationException>()
+                    .CircuitBreaker(configure)
+                    .Fallback(0);
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV003_Skips_Valid_Or_Unknown_Compositions()
     {
         var cases = new[]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -505,6 +505,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(options => options.ConsecutiveFailures = 2).Fallback(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.BreakDuration = TimeSpan.FromSeconds(1)).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(options => options.HandlesException = null).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(options => options.OnStateChanged = _ => options.HandlesException = exception => exception is TimeoutException).Fallback(0);",
             "_ = Shield.For<int>().WhenResult(0).Retry(1).Fallback(0);",

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -506,6 +506,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(options => options.ConsecutiveFailures = 2).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(options => options.HandlesException = null).Fallback(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.OnStateChanged = _ => options.HandlesException = exception => exception is TimeoutException).Fallback(0);",
             "_ = Shield.For<int>().WhenResult(0).Retry(1).Fallback(0);",
             "_ = Shield.For<int>().Retry(1).Fallback(0, static options => options.OnFallback = static _ => { });",
             "_ = Shield.Retry(1).Fallback(static _ => ValueTask.CompletedTask, static options => options.OnFallback = static _ => { });",
@@ -622,6 +623,22 @@ public class PipelineHazardAnalyzerTests
 
             private static void ApplyHandling(CircuitBreakerOptions<int> options) =>
                 options.HandlesException = exception => exception is TimeoutException;
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV003_Propagates_Unknown_From_Nested_Configurator_Call()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            "_ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).Fallback(0);",
+            """
+            private static Action<CircuitBreakerOptions<int>> SharedConfigure { get; } =
+                options => options.HandlesException = exception => exception is TimeoutException;
+
+            private static void ConfigureBreaker(CircuitBreakerOptions<int> options) =>
+                SharedConfigure(options);
             """);
 
         await Assert.That(diagnostics).IsEmpty();

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -504,6 +504,8 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.For<int>().Retry(1).Fallback(0);",
             "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero).Fallback(0);",
             "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Fallback(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.ConsecutiveFailures = 2).Fallback(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.HandlesException = null).Fallback(0);",
             "_ = Shield.For<int>().WhenResult(0).Retry(1).Fallback(0);",
             "_ = Shield.For<int>().Retry(1).Fallback(0, static options => options.OnFallback = static _ => { });",
             "_ = Shield.Retry(1).Fallback(static _ => ValueTask.CompletedTask, static options => options.OnFallback = static _ => { });",
@@ -552,6 +554,15 @@ public class PipelineHazardAnalyzerTests
 
         await AssertRuleAsync(aliasDiagnostics, "KEV003");
         await AssertRuleAsync(genericDiagnostics, "KEV003");
+    }
+
+    [Test]
+    public async Task KEV003_Skips_Reactive_Strategy_With_Local_Handling_Override()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException = exception => exception is TimeoutException).Fallback(0);");
+
+        await Assert.That(diagnostics).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -146,6 +146,27 @@ public class PipelineDescriptorTests
     }
 
     [Test]
+    public async Task Reactive_Descriptors_Report_Local_Handling_Overrides()
+    {
+        var descriptor = Shield.Empty
+            .Retry(options => options.HandlesException = _ => true)
+            .CircuitBreaker(options => options.HandlesException = _ => true)
+            .Hedge(options => options.HandlesException = _ => true)
+            .Fallback(
+                static (_, _) => default,
+                options => options.HandlesException = _ => true)
+            .GetDescriptor();
+
+        await Assert.That(descriptor.AssertContainsSingle<RetryStrategyDescriptor>().HasHandlingOverride).IsTrue();
+        await Assert.That(descriptor.AssertContainsSingle<CircuitBreakerStrategyDescriptor>().HasHandlingOverride).IsTrue();
+        await Assert.That(descriptor.AssertContainsSingle<HedgingStrategyDescriptor>().HasHandlingOverride).IsTrue();
+        await Assert.That(descriptor.AssertContainsSingle<FallbackStrategyDescriptor>().HasHandlingOverride).IsTrue();
+
+        var ambient = Shield.Retry(1).GetDescriptor().AssertContainsSingle<RetryStrategyDescriptor>();
+        await Assert.That(ambient.HasHandlingOverride).IsFalse();
+    }
+
+    [Test]
     public async Task Custom_Strategy_Uses_A_Diagnostic_Descriptor()
     {
         var shield = Shield.Empty.Use(new PassThroughStrategy());

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -121,6 +121,47 @@ public class HttpContractTests
     }
 
     [Test]
+    public async Task Configured_Standard_Copies_Local_Handling_Overrides()
+    {
+        var retryOptions = new StandardHttpShieldOptions();
+        retryOptions.Retry.HandlesException = static _ => false;
+        retryOptions.Retry.HandlesResult = static _ => false;
+        var retryCalls = 0;
+        var retryShield = HttpShield.Standard(retryOptions);
+
+        using var response = await retryShield.ExecuteAsync(_ =>
+        {
+            retryCalls++;
+            return new ValueTask<HttpResponseMessage>(
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        });
+
+        await Assert.That(retryCalls).IsEqualTo(1);
+
+        var exceptionCalls = 0;
+        await Assert.That(async () => await retryShield.ExecuteAsync<HttpResponseMessage>(_ =>
+        {
+            exceptionCalls++;
+            throw new HttpRequestException("not handled");
+        })).Throws<HttpRequestException>();
+        await Assert.That(exceptionCalls).IsEqualTo(1);
+
+        var breakerOptions = new StandardHttpShieldOptions();
+        breakerOptions.Retry.MaxRetries = 0;
+        breakerOptions.CircuitBreaker.ConsecutiveFailures = 1;
+        breakerOptions.CircuitBreaker.FailureRatio = null;
+        breakerOptions.CircuitBreaker.HandlesException = static _ => false;
+        var breakerShield = HttpShield.Standard(breakerOptions);
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            await Assert.That(async () => await breakerShield.ExecuteAsync<HttpResponseMessage>(
+                _ => throw new HttpRequestException("not handled")))
+                .Throws<HttpRequestException>();
+        }
+    }
+
+    [Test]
     public async Task Configured_Standard_Replays_Buffered_Unsafe_Requests()
     {
         var calls = 0;

--- a/tests/Kevlar.Tests/StrategyHandlingOverrideTests.cs
+++ b/tests/Kevlar.Tests/StrategyHandlingOverrideTests.cs
@@ -1,0 +1,189 @@
+namespace Kevlar.Tests;
+
+public class StrategyHandlingOverrideTests
+{
+    [Test]
+    public async Task Retry_Exception_Override_Replaces_Ambient_Handling()
+    {
+        var attempts = 0;
+        var shield = Shield.When<InvalidOperationException>().Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.HandlesException = exception => exception is ArgumentException;
+        });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new ArgumentException();
+        })).Throws<ArgumentException>();
+        await Assert.That(attempts).IsEqualTo(2);
+
+        attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Result_Only_Retry_Override_Does_Not_Handle_Exceptions()
+    {
+        var attempts = 0;
+        var shield = Shield.For<int>().When<InvalidOperationException>().Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.HandlesResult = result => result < 0;
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+            new ValueTask<int>(++attempts == 1 ? -1 : 7));
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(attempts).IsEqualTo(2);
+
+        attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Typed_Retry_Exception_Override_Uses_Typed_Options()
+    {
+        var attempts = 0;
+        var shield = Shield.For<int>().WhenResult(-1).Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.HandlesException = exception => exception is ArgumentException;
+        });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new ArgumentException();
+        })).Throws<ArgumentException>();
+        await Assert.That(attempts).IsEqualTo(2);
+
+        attempts = 0;
+        await Assert.That(await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return new ValueTask<int>(-1);
+        })).IsEqualTo(-1);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Typed_Circuit_Breaker_Override_Handles_Results_Only()
+    {
+        var shield = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.HandlesResult = result => result < 0;
+        });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(1))).IsEqualTo(1);
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(-1))).IsEqualTo(-1);
+        await Assert.That(async () => await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+    }
+
+    [Test]
+    public async Task Typed_Hedging_Override_Handles_Results_Only()
+    {
+        var attempts = 0;
+        var shield = Shield.For<int>().When<InvalidOperationException>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = System.Threading.Timeout.InfiniteTimeSpan;
+            options.HandlesResult = result => result < 0;
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+            new ValueTask<int>(Interlocked.Increment(ref attempts) == 1 ? -1 : 7));
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(attempts).IsEqualTo(2);
+
+        attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            Interlocked.Increment(ref attempts);
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Retry_Override_Leaves_Ambient_Fallback_For_Neighbor()
+    {
+        var attempts = 0;
+        var shield = Shield.For<int>()
+            .When<InvalidOperationException>()
+            .Fallback(42)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.HandlesException = exception => exception is ArgumentException;
+            });
+
+        var recovered = await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        });
+        await Assert.That(recovered).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(1);
+
+        attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new ArgumentException();
+        })).Throws<ArgumentException>();
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Typed_Fallback_Result_Override_Replaces_Ambient_Handling()
+    {
+        var shield = Shield.For<int>()
+            .When<InvalidOperationException>()
+            .Fallback(0, options =>
+            {
+                options.HandlesResult = result => result < 0;
+            });
+
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(-1))).IsEqualTo(0);
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Fallback_Validation_Distinguishes_Local_Overrides()
+    {
+        var shield = Shield.For<int>()
+            .Retry(options => options.HandlesException = exception => exception is InvalidOperationException)
+            .Fallback(0, options =>
+            {
+                options.HandlesException = exception => exception is InvalidOperationException;
+            });
+
+        await Assert.That(shield).IsNotNull();
+        await Assert.That(() => Shield.For<int>()
+            .Retry(1)
+            .Fallback(0))
+            .Throws<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
## Summary

- add local `HandlesException` / `HandlesResult` overrides to every reactive strategy options type
- add typed circuit-breaker and hedging options for strongly typed result predicates
- expose `HasHandlingOverride` through Kevlar.Testing descriptors
- teach KEV003 to distinguish inline and reusable local handling configurators
- document precedence, only-what-you-list semantics, and Polly migration

Local predicates fully replace the ambient clause for one strategy, preserving ambient handling for neighboring strategies. Typed circuit-breaker and hedging configure overloads now accept their typed options variants.

Closes #157

## Validation

- `dotnet build Kevlar.slnx -c Release --no-restore` (0 warnings)
- unit 755, integration 118, analyzer 58, testing 33
- pre-rebase auxiliary suites: chaos 23, rate limiting 19, netstandard 5, allocation 3
- `npm run build` (docs)
- exact combined package after #167: 101 documentation snippets compiled and documented behavior executed