### PR TITLE
refactor(api): pre-release API cleanups from review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 | `Shield.When<A>().When<B>()` | `Shield.When<A>().Or<B>()` |
 | `Shield.For<T>().Or<A>()` | `Shield.For<T>().When<A>()` |
 | `ShieldBuilder<T> builder = Shield.For<T>()` | `Shield<T> shield = Shield.For<T>()` |
+| `builder.OrWhen(predicate)` | `builder.Or(predicate)` |
+| `Shield.For<T>().WhenDefault()` | `Shield.For<T>().WhenResultDefault()` |
+| `builder.OrDefault()` | `builder.OrResultDefault()` |
+
+`OrWhen` is gone: `Or(Func<Exception, bool>)` now mirrors `When(Func<Exception, bool>)`, so the
+untyped predicate has the same spelling in both clause positions. `WhenDefault`/`OrDefault` were
+renamed to `WhenResultDefault`/`OrResultDefault` because their "default" is `default(TResult)`,
+not the default *handling* that the neighbouring `WhenAnyError()` restores.
 
 - `RetryOptions<TResult>` no longer inherits `RetryOptions`. Both types retain the same scalar
   property names and defaults, but helpers that accepted `RetryOptions` must configure typed retry
@@ -30,3 +38,11 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 
 - Reactive strategy options can replace ambient handling locally with `HandlesException` and, on
   typed options, `HandlesResult`. Testing descriptors expose `HasHandlingOverride`.
+- Context-only `ExecuteWithContext`/`ExecuteWithContextAsync` overloads that take just the
+  context-aware action, for callers that read `KevlarContext` without seeding properties. Available
+  on `Shield` and `Shield<TResult>`, synchronous and asynchronous, `ValueTask` and `Task`.
+- `KEV006` warns when `Hedge(...)` is added to an untyped `Shield`, `ShieldBuilder`, or the static
+  `Shield.Hedge` factory: hedging runs the action concurrently more than once, so it must be
+  idempotent unless a typed shield's result clause can pick the winning attempt.
+- Every `Retry` overload and `MaxRetries` documents that the value counts retries, not attempts:
+  `Retry(3)` makes up to 4 total attempts.

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -21,6 +21,7 @@ Generated code is ignored.
 | `KEV003` | Warning | inner fallback makes retry, hedging, or circuit breaker unreachable |
 | `KEV004` | Warning | stateful shield or partition provider is constructed for one execution |
 | `KEV005` | Warning | void fallback is executed with a result-returning delegate |
+| `KEV006` | Warning | hedging is added to an untyped shield, whose action must be idempotent |
 
 ## KEV001: ignored execution cancellation
 
@@ -136,6 +137,34 @@ The rule recognizes same-expression chains and stable local aliases for synchron
 outcome-returning, context-aware, and `Task<T>` execution overloads. It deliberately skips
 parameters, returned shields, reassigned locals, and fields because their construction cannot be
 proved by the current intraprocedural analysis.
+
+## KEV006: hedging on an untyped shield
+
+Hedging launches the execution delegate more than once, concurrently. An untyped `Shield` can judge
+those attempts only by their exceptions, so every attempt it starts runs to completion against the
+real dependency — and a losing hedge has still done its work. Duplicate writes, charges, or sends are
+observable unless the action is idempotent:
+
+```csharp
+var shield = Shield.Hedge(maxAttempts: 2, delay: TimeSpan.FromMilliseconds(50)); // KEV006
+```
+
+Build a result-aware shield so a [result clause](handling-failures.md#result-clauses) can decide
+which attempt is acceptable:
+
+```csharp
+var shield = Shield.For<HttpResponseMessage>()
+    .WhenResult(response => (int)response.StatusCode >= 500)
+    .Hedge(maxAttempts: 2, delay: TimeSpan.FromMilliseconds(50));
+```
+
+If the untyped shape is deliberate — the action is a genuinely idempotent read — suppress the
+warning at that site with a pragma that records why.
+
+The rule reports every `Hedge` overload that returns the untyped `Shield`: the static
+`Shield.Hedge(...)` factories, the `ShieldExtensions.Hedge(...)` chaining methods, and
+`ShieldBuilder.Hedge(...)`. `Shield<T>.Hedge(...)` and `ShieldBuilder<T>.Hedge(...)` are never
+flagged.
 
 ## Suppression
 

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -88,6 +88,20 @@ properties when each fork launches; later mutations stay isolated between attemp
 `context.CancellationToken` is the effective token for that attempt, including timeout and hedge
 cancellation.
 
+When you only need to *read* the context — the shield name, the effective token, the ambient
+`TimeProvider` — there is a shorter overload that skips the state and initializer entirely:
+
+```csharp
+var name = await shield.ExecuteWithContextAsync(
+    static context => new ValueTask<string?>(context.ShieldName),
+    cancellationToken);
+```
+
+It exists in the same shapes as the full form: result-returning and void, synchronous and
+asynchronous, `ValueTask` and `Task`, on both `Shield` and `Shield<TResult>`. It delegates to the
+state-based overload, passing your delegate as the state, so it stays closure-free when the lambda
+is `static`.
+
 `ExecuteWithContext` provides the same contract for synchronous actions. Both `Shield` and
 `Shield<TResult>` support the context-aware shape; `Task` and `ValueTask` actions are accepted.
 Use static initializer and action delegates with the state parameter to avoid closures. The pooled

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -20,16 +20,19 @@ remains available through `outcome.Exception`.
 var shield = Shield
     .When<HttpRequestException>()                     // this exception type (and subtypes)
     .Or<TimeoutExceededException>()                     // or this one
-    .OrWhen(ex => ex is IOException { Message: var m } && m.Contains("pipe"))  // or any predicate
+    .Or(ex => ex is IOException { Message: var m } && m.Contains("pipe"))  // or any predicate
     .Retry(5);
 ```
 
 - `When<TException>()` starts a clause matching `TException` and anything derived from it. `When<TException>(predicate)` narrows it further, and `When(predicate)` matches on any exception.
-- `Or<TException>()` / `Or<TException>(predicate)` / `OrWhen(predicate)` add alternatives to the clause. All alternatives OR together.
+- `Or<TException>()` / `Or<TException>(predicate)` / `Or(predicate)` add alternatives to the clause. All alternatives OR together.
+
+`Or` mirrors `When` exactly: the untyped `Or(predicate)` takes a `Func<Exception, bool>`, and a bare
+lambda binds to it because there is no type argument to infer for the generic overload.
 
 Clause position determines the vocabulary: `When…` starts a clause on a shield, while `Or…`
 continues that clause on the returned builder. The compiler therefore enforces
-`When<A>().Or<B>().OrWhen(...)`.
+`When<A>().Or<B>().Or(...)`.
 
 ## Result clauses
 
@@ -47,9 +50,13 @@ Now a 503 response triggers a retry exactly as a thrown `HttpRequestException` w
 Typed builders add result alternatives with `OrResult(predicate)` / `OrResult(value)`, and two shorthands for the most common check of all:
 
 ```csharp
-Shield.For<User?>().WhenDefault().Retry(2);   // retry when the result is null / default
-// mid-chain: .OrDefault() adds the same check to an existing clause
+Shield.For<User?>().WhenResultDefault().Retry(2);   // retry when the result is null / default
+// mid-chain: .OrResultDefault() adds the same check to an existing clause
 ```
+
+`WhenResultDefault` / `OrResultDefault` mean "the result equals `default(T)`". They are named after
+the `WhenResult` / `OrResult` family precisely so they cannot be confused with `WhenAnyError()`,
+which resets *handling* to Kevlar's default.
 
 ## Clauses are ambient
 

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -69,7 +69,7 @@ public ProfileClient(Shield<Profile?>? shield = null)
 
 ```csharp
 var client = new ProfileClient(
-    Shield.For<Profile?>().WhenDefault().Or<HttpRequestException>().Retry(3));
+    Shield.For<Profile?>().WhenResultDefault().Or<HttpRequestException>().Retry(3));
 ```
 
 ## Opinionated defaults

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -74,6 +74,15 @@ match the execution result type; a mismatch fails before the additional operatio
 Multiple invocations of your delegate may be in flight at once — it must be safe to invoke concurrently. This is also why **hedging requires async execution**: synchronous `Execute` throws `NotSupportedException`.
 :::
 
+:::warning Hedging on an untyped `Shield` needs an idempotent action
+An untyped `Shield` can judge attempts only by their *exceptions*, so every attempt it launches runs
+to completion against the real dependency. A losing hedge still did its work: duplicate writes,
+charges, or sends are observable unless the action is idempotent. Prefer `Shield.For<T>()`, where a
+[result clause](../handling-failures.md#result-clauses) decides which attempt is acceptable — or
+confirm the action is safe to repeat. The [`KEV006` analyzer](../analyzers.md#kev006-hedging-on-an-untyped-shield)
+flags untyped `Hedge(...)` for exactly this reason.
+:::
+
 - Losing attempts are cancelled through their token (use the token you're handed!).
 - Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside `OnHedge`/`OnHedgeAsync`. A cancellation already observable at the launch boundary suppresses both callbacks.
 - Launch ordering is `OnHedge`, awaited `OnHedgeAsync`, action generation, metrics, then the selected operation. Callback or generator failures preserve their exception identity, cancel in-flight attempts, and are not counted as launched hedges.

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -15,7 +15,9 @@ Shield.Retry(3, Backoff.Linear(TimeSpan.FromMilliseconds(500)));
 Shield.RetryForever(Backoff.Exponential(TimeSpan.FromSeconds(1), maxDelay: TimeSpan.FromMinutes(1)));
 ```
 
-`Retry(3)` means **3 retries** — up to 4 total attempts.
+The count is **retries, not attempts**: `Retry(3)` makes up to 4 total attempts — the initial call
+plus 3 retries. The same reading applies to `MaxRetries` in the options form, and to every `Retry`
+overload on `Shield`, `Shield<T>`, and the `When…` builders.
 
 :::tip The default is the good one
 Bare `Shield.Retry(3)` gives exponential backoff **with jitter**, 250ms base, capped at 30s. Jitter prevents retry storms where every failed caller retries in lockstep; you'd have configured this anyway.
@@ -55,7 +57,7 @@ Shield.Retry(o =>
 
 | Option | Default | What it does |
 |---|---|---|
-| `MaxRetries` | `3` | Retry attempts after the initial one; `int.MaxValue` = forever |
+| `MaxRetries` | `3` | Retries after the initial attempt — `3` means up to 4 total attempts; `int.MaxValue` = forever |
 | `Backoff` | `Backoff.Default` | The delay sequence (see above) |
 | `MaxDelay` | — | Absolute cap applied to every delay — including `DelayGenerator` output, so a hostile `Retry-After` can't stall the pipeline |
 | `OnRetry` | — | Called synchronously before each retry sleeps — attempt number, final delay, failure |

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,4 @@ KEV002 | Reliability | Warning | Statically known multi-attempt hedging requires
 KEV003 | Configuration | Warning | Fallback makes a reactive strategy unreachable
 KEV004 | Reliability | Warning | Stateful shield or partition provider is constructed per execution
 KEV005 | Configuration | Warning | Void fallback is used with a result-returning execution
+KEV006 | Reliability | Warning | Hedging on an untyped Shield requires an idempotent action

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Kevlar.Analyzers;
 /// <summary>
 /// Diagnoses statically provable Kevlar pipeline hazards: synchronous multi-attempt hedging, reactive
 /// strategies made unreachable by an inner fallback, per-execution construction of stateful shields,
-/// and void fallbacks used for result-returning executions.
+/// void fallbacks used for result-returning executions, and hedging on an untyped shield.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
@@ -55,13 +55,24 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "A void fallback cannot produce a value for a result-returning execution and fails at runtime when it handles an outcome.");
 
+    /// <summary>The KEV006 rule.</summary>
+    public static readonly DiagnosticDescriptor UntypedHedgingRule = new(
+        id: "KEV006",
+        title: "Hedging on an untyped Shield requires an idempotent action",
+        messageFormat: "Hedging on an untyped Shield runs the execution delegate more than once, concurrently. Build a result-aware shield with Shield.For<T>() so result clauses can select the winning attempt, or confirm the action is idempotent.",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "An untyped Shield can only judge hedged attempts by their exceptions, so every attempt it launches runs to completion against the real dependency. Duplicate writes, charges, or sends from a losing hedge are observable unless the action is idempotent.");
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             SynchronousHedgingRule,
             UnreachableReactiveStrategyRule,
             EphemeralStatefulShieldRule,
-            VoidFallbackResultExecutionRule);
+            VoidFallbackResultExecutionRule,
+            UntypedHedgingRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -137,6 +148,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 EphemeralStatefulShieldRule,
                 location,
                 statefulComponent));
+        }
+
+        if (IsUntypedHedge(invocation.TargetMethod, knownTypes))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                UntypedHedgingRule,
+                invocation.Syntax.GetLocation()));
         }
 
         if (IsResultReturningExecution(invocation.TargetMethod, knownTypes)
@@ -1332,6 +1350,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             && IsKevlarFluentMethod(method, knownTypes);
     }
 
+    private static bool IsUntypedHedge(IMethodSymbol method, KnownTypes knownTypes)
+    {
+        method = Normalize(method);
+        return method.Name == "Hedge"
+            && method.ReturnType is INamedTypeSymbol returnType
+            && knownTypes.IsUntypedShield(returnType)
+            && IsKevlarFluentMethod(method, knownTypes);
+    }
+
     private static bool IsStatefulStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
         method.Name is "CircuitBreaker" or "RateLimit" or "ConcurrencyLimit"
         && IsKevlarFluentMethod(method, knownTypes);
@@ -1614,7 +1641,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool StartsHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
-        (method.Name is "When" or "WhenResult" or "WhenDefault" or "WhenAnyError")
+        (method.Name is "When" or "WhenResult" or "WhenResultDefault" or "WhenAnyError")
         && (knownTypes.IsShield(method.ContainingType)
             || knownTypes.IsShieldExtensions(method.ContainingType));
 

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -5,4 +5,5 @@ override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalys
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.UnreachableReactiveStrategyRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.UntypedHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.VoidFallbackResultExecutionRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -211,3 +211,20 @@ Kevlar.ShieldBuilder<TResult>.Hedge(System.Action<Kevlar.HedgingOptions<TResult>
 *REMOVED*Kevlar.ShieldBuilder<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield<TResult>!
 static Kevlar.Shield.For<TResult>() -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.Shield<TResult>.WhenDefault() -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.OrDefault() -> Kevlar.ShieldBuilder<TResult>!
+*REMOVED*Kevlar.ShieldBuilder.OrWhen(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.OrWhen(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.Shield<TResult>.WhenResultDefault() -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.ShieldBuilder<TResult>.OrResultDefault() -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.ShieldBuilder.Or(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder!
+Kevlar.ShieldBuilder<TResult>.Or(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.Shield.ExecuteWithContext<T>(System.Func<Kevlar.KevlarContext!, T>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T
+Kevlar.Shield.ExecuteWithContext(System.Action<Kevlar.KevlarContext!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Kevlar.Shield.ExecuteWithContextAsync<T>(System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.ValueTask<T>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+Kevlar.Shield.ExecuteWithContextAsync(System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.ValueTask>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Kevlar.Shield<TResult>.ExecuteWithContext(System.Func<Kevlar.KevlarContext!, TResult>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
+Kevlar.Shield<TResult>.ExecuteWithContextAsync(System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.ValueTask<TResult>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
+static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<T>(this Kevlar.Shield! shield, System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.Task<T>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
+static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync(this Kevlar.Shield! shield, System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.Task!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<TResult>(this Kevlar.Shield<TResult>! shield, System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.Task<TResult>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -51,12 +51,25 @@ public sealed class Shield
     // ── Static factories ────────────────────────────────────────────────────────────────
 
     /// <summary>Retries failed executions up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
     public static Shield Retry(int maxRetries = 3) => ShieldExtensions.Retry(Empty, maxRetries);
 
     /// <summary>Retries failed executions up to <paramref name="maxRetries"/> times with the given backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
     public static Shield Retry(int maxRetries, Backoff backoff) => ShieldExtensions.Retry(Empty, maxRetries, backoff);
 
     /// <summary>Adds a retry strategy configured via <paramref name="configure"/>.</summary>
+    /// <remarks>
+    /// <see cref="RetryOptions.MaxRetries"/> counts <em>retries</em>, not attempts:
+    /// <c>MaxRetries = 3</c> makes up to 4 total attempts — the initial call plus 3 retries.
+    /// </remarks>
     public static Shield Retry(Action<RetryOptions> configure) => ShieldExtensions.Retry(Empty, configure);
 
     /// <summary>Retries failed executions indefinitely.</summary>
@@ -88,9 +101,21 @@ public sealed class Shield
     public static Shield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => ShieldExtensions.ConcurrencyLimit(Empty, configure);
 
     /// <summary>Races up to <paramref name="maxAttempts"/> concurrent attempts staggered by <paramref name="delay"/>; first acceptable outcome wins.</summary>
+    /// <remarks>
+    /// Hedging on an untyped <see cref="Shield"/> runs the execution delegate more than once,
+    /// concurrently, and only its exceptions can select a winner. The delegate must therefore be
+    /// idempotent: duplicate writes, charges, or sends are otherwise observable side effects of a
+    /// hedge that later loses. Prefer <see cref="For{TResult}"/>, where result clauses decide which
+    /// attempt is acceptable, or confirm the action is safe to repeat.
+    /// </remarks>
     public static Shield Hedge(int maxAttempts, TimeSpan delay) => ShieldExtensions.Hedge(Empty, maxAttempts, delay);
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
+    /// <remarks>
+    /// Hedging on an untyped <see cref="Shield"/> runs the execution delegate more than once,
+    /// concurrently, so the delegate must be idempotent. Prefer <see cref="For{TResult}"/>, or
+    /// confirm the action is safe to repeat.
+    /// </remarks>
     public static Shield Hedge(Action<HedgingOptions> configure) => ShieldExtensions.Hedge(Empty, configure);
 
     /// <summary>Starts a pipeline with a custom <see cref="Strategy"/> implementation.</summary>
@@ -190,6 +215,22 @@ public sealed class Shield
             cancellationToken);
     }
 
+    /// <summary>
+    /// Executes a context-aware delegate through the pipeline without seeding execution properties.
+    /// The context is pooled and is valid only for the duration of the delegate invocation; never retain it.
+    /// </summary>
+    public ValueTask<T> ExecuteWithContextAsync<T>(
+        Func<KevlarContext, ValueTask<T>> action,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(action, nameof(action));
+        return ExecuteWithContextAsync(
+            action,
+            static (_, _) => { },
+            static (a, context) => a(context),
+            cancellationToken);
+    }
+
     /// <summary>Executes the void delegate through the pipeline.</summary>
     public ValueTask ExecuteAsync(Func<CancellationToken, ValueTask> action, CancellationToken cancellationToken = default)
     {
@@ -251,6 +292,22 @@ public sealed class Shield
     }
 
     /// <summary>
+    /// Executes a context-aware void delegate through the pipeline without seeding execution properties.
+    /// The context is pooled and is valid only for the duration of the delegate invocation; never retain it.
+    /// </summary>
+    public ValueTask ExecuteWithContextAsync(
+        Func<KevlarContext, ValueTask> action,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(action, nameof(action));
+        return ExecuteWithContextAsync(
+            action,
+            static (_, _) => { },
+            static (a, context) => a(context),
+            cancellationToken);
+    }
+
+    /// <summary>
     /// Executes the delegate through the pipeline and returns the outcome instead of throwing.
     /// </summary>
     public ValueTask<Outcome<T>> ExecuteOutcomeAsync<T>(Func<CancellationToken, ValueTask<T>> action, CancellationToken cancellationToken = default)
@@ -308,6 +365,21 @@ public sealed class Shield
             cancellationToken);
     }
 
+    /// <summary>
+    /// Executes a context-aware delegate synchronously through the pipeline without seeding execution
+    /// properties. The context is pooled and is valid only for the duration of the delegate invocation;
+    /// never retain it.
+    /// </summary>
+    public T ExecuteWithContext<T>(Func<KevlarContext, T> action, CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(action, nameof(action));
+        return ExecuteWithContext(
+            action,
+            static (_, _) => { },
+            static (a, context) => a(context),
+            cancellationToken);
+    }
+
     /// <summary>Executes the void delegate synchronously through the pipeline.</summary>
     public void Execute(Action<CancellationToken> action, CancellationToken cancellationToken = default)
     {
@@ -353,6 +425,21 @@ public sealed class Shield
                 s.action(s.state, context);
                 return Nothing.Value;
             },
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes a context-aware void delegate synchronously through the pipeline without seeding
+    /// execution properties. The context is pooled and is valid only for the duration of the delegate
+    /// invocation; never retain it.
+    /// </summary>
+    public void ExecuteWithContext(Action<KevlarContext> action, CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(action, nameof(action));
+        ExecuteWithContext(
+            action,
+            static (_, _) => { },
+            static (a, context) => a(context),
             cancellationToken);
     }
 

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -36,26 +36,34 @@ public sealed class ShieldBuilder
         return this;
     }
 
-    /// <summary>Also handle exceptions matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder OrWhen(Func<Exception, bool> predicate)
+    /// <summary>Also handle exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
+    public ShieldBuilder Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
-        return Or(predicate);
-    }
-
-    private ShieldBuilder Or(Func<Exception, bool> predicate)
-    {
         _predicates.Add(predicate);
         return this;
     }
 
     /// <summary>Retries handled exceptions up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
     public Shield Retry(int maxRetries = 3) => Seal().Retry(maxRetries);
 
     /// <summary>Retries handled exceptions up to <paramref name="maxRetries"/> times with the given backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
     public Shield Retry(int maxRetries, Backoff backoff) => Seal().Retry(maxRetries, backoff);
 
     /// <summary>Adds a retry strategy configured via <paramref name="configure"/>.</summary>
+    /// <remarks>
+    /// <see cref="RetryOptions.MaxRetries"/> counts <em>retries</em>, not attempts:
+    /// <c>MaxRetries = 3</c> makes up to 4 total attempts — the initial call plus 3 retries.
+    /// </remarks>
     public Shield Retry(Action<RetryOptions> configure) => Seal().Retry(configure);
 
     /// <summary>Retries handled exceptions indefinitely.</summary>
@@ -68,9 +76,21 @@ public sealed class ShieldBuilder
     public Shield CircuitBreaker(Action<CircuitBreakerOptions> configure) => Seal().CircuitBreaker(configure);
 
     /// <summary>Races concurrent attempts; a handled exception launches the next attempt immediately.</summary>
+    /// <remarks>
+    /// Hedging on an untyped <see cref="Shield"/> runs the execution delegate more than once,
+    /// concurrently, and only its exceptions can select a winner. The delegate must therefore be
+    /// idempotent: duplicate writes, charges, or sends are otherwise observable side effects of a
+    /// hedge that later loses. Prefer <c>Shield.For&lt;T&gt;()</c>, where result clauses decide which
+    /// attempt is acceptable, or confirm the action is safe to repeat.
+    /// </remarks>
     public Shield Hedge(int maxAttempts, TimeSpan delay) => Seal().Hedge(maxAttempts, delay);
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
+    /// <remarks>
+    /// Hedging on an untyped <see cref="Shield"/> runs the execution delegate more than once,
+    /// concurrently, so the delegate must be idempotent. Prefer <c>Shield.For&lt;T&gt;()</c>, or
+    /// confirm the action is safe to repeat.
+    /// </remarks>
     public Shield Hedge(Action<HedgingOptions> configure) => Seal().Hedge(configure);
 
     /// <summary>Creates and appends a custom strategy using the accumulated handling clause.</summary>

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -40,8 +40,8 @@ public sealed class ShieldBuilder<TResult>
         return this;
     }
 
-    /// <summary>Also handle exceptions matching <paramref name="predicate"/>.</summary>
-    public ShieldBuilder<TResult> OrWhen(Func<Exception, bool> predicate)
+    /// <summary>Also handle exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
+    public ShieldBuilder<TResult> Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         _exceptionPredicates.Add(predicate);
@@ -63,20 +63,33 @@ public sealed class ShieldBuilder<TResult>
         return this;
     }
 
-    /// <summary>Also handle results equal to <c>default</c> — <see langword="null"/> for reference types.</summary>
-    public ShieldBuilder<TResult> OrDefault()
+    /// <summary>Also handle results equal to <c>default(TResult)</c> — <see langword="null"/> for reference types.</summary>
+    public ShieldBuilder<TResult> OrResultDefault()
     {
         _resultPredicates.Add(static candidate => EqualityComparer<TResult>.Default.Equals(candidate, default!));
         return this;
     }
 
     /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
     public Shield<TResult> Retry(int maxRetries = 3) => Seal().Retry(maxRetries);
 
     /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the given backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
     public Shield<TResult> Retry(int maxRetries, Backoff backoff) => Seal().Retry(maxRetries, backoff);
 
     /// <summary>Adds a retry strategy configured via <paramref name="configure"/>.</summary>
+    /// <remarks>
+    /// <see cref="RetryOptions{TResult}.MaxRetries"/> counts <em>retries</em>, not attempts:
+    /// <c>MaxRetries = 3</c> makes up to 4 total attempts — the initial call plus 3 retries.
+    /// </remarks>
     public Shield<TResult> Retry(Action<RetryOptions<TResult>> configure) => Seal().Retry(configure);
 
     /// <summary>Retries handled outcomes indefinitely.</summary>

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -10,9 +10,20 @@ namespace Kevlar;
 public static class ShieldExtensions
 {
     /// <summary>Appends a retry of handled exceptions, up to <paramref name="maxRetries"/> times, with the default exponential jittered backoff.</summary>
+    /// <param name="shield">The shield to append the retry to.</param>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
     public static Shield Retry(this Shield shield, int maxRetries = 3) => shield.Retry(options => options.MaxRetries = maxRetries);
 
     /// <summary>Appends a retry of handled exceptions, up to <paramref name="maxRetries"/> times, with the given backoff.</summary>
+    /// <param name="shield">The shield to append the retry to.</param>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
     public static Shield Retry(this Shield shield, int maxRetries, Backoff backoff) => shield.Retry(options =>
     {
         options.MaxRetries = maxRetries;
@@ -20,6 +31,10 @@ public static class ShieldExtensions
     });
 
     /// <summary>Appends a retry strategy configured via <paramref name="configure"/>.</summary>
+    /// <remarks>
+    /// <see cref="RetryOptions.MaxRetries"/> counts <em>retries</em>, not attempts:
+    /// <c>MaxRetries = 3</c> makes up to 4 total attempts — the initial call plus 3 retries.
+    /// </remarks>
     public static Shield Retry(this Shield shield, Action<RetryOptions> configure)
     {
         Throw.IfNull(shield, nameof(shield));
@@ -103,6 +118,13 @@ public static class ShieldExtensions
     }
 
     /// <summary>Appends hedging: up to <paramref name="maxAttempts"/> concurrent attempts staggered by <paramref name="delay"/>.</summary>
+    /// <remarks>
+    /// Hedging on an untyped <see cref="Shield"/> runs the execution delegate more than once,
+    /// concurrently, and only its exceptions can select a winner. The delegate must therefore be
+    /// idempotent: duplicate writes, charges, or sends are otherwise observable side effects of a
+    /// hedge that later loses. Prefer <c>Shield.For&lt;T&gt;()</c>, where result clauses decide which
+    /// attempt is acceptable, or confirm the action is safe to repeat.
+    /// </remarks>
     public static Shield Hedge(this Shield shield, int maxAttempts, TimeSpan delay) => shield.Hedge(options =>
     {
         options.MaxAttempts = maxAttempts;
@@ -110,6 +132,11 @@ public static class ShieldExtensions
     });
 
     /// <summary>Appends a hedging strategy configured via <paramref name="configure"/>.</summary>
+    /// <remarks>
+    /// Hedging on an untyped <see cref="Shield"/> runs the execution delegate more than once,
+    /// concurrently, so the delegate must be idempotent. Prefer <c>Shield.For&lt;T&gt;()</c>, or
+    /// confirm the action is safe to repeat.
+    /// </remarks>
     public static Shield Hedge(this Shield shield, Action<HedgingOptions> configure)
     {
         Throw.IfNull(shield, nameof(shield));
@@ -140,7 +167,7 @@ public static class ShieldExtensions
     public static ShieldBuilder When(this Shield shield, Func<Exception, bool> predicate)
     {
         Throw.IfNull(shield, nameof(shield));
-        return new ShieldBuilder(shield).OrWhen(predicate);
+        return new ShieldBuilder(shield).Or(predicate);
     }
 
     /// <summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -52,7 +52,7 @@ public sealed class Shield<TResult>
         => new ShieldBuilder<TResult>(this).Or(predicate);
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
-    public ShieldBuilder<TResult> When(Func<Exception, bool> predicate) => new ShieldBuilder<TResult>(this).OrWhen(predicate);
+    public ShieldBuilder<TResult> When(Func<Exception, bool> predicate) => new ShieldBuilder<TResult>(this).Or(predicate);
 
     /// <summary>Starts a handling clause for results matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
     public ShieldBuilder<TResult> WhenResult(Func<TResult, bool> predicate) => new ShieldBuilder<TResult>(this).OrResult(predicate);
@@ -60,8 +60,15 @@ public sealed class Shield<TResult>
     /// <summary>Starts a handling clause for results equal to <paramref name="result"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
     public ShieldBuilder<TResult> WhenResult(TResult result) => new ShieldBuilder<TResult>(this).OrResult(result);
 
-    /// <summary>Starts a handling clause for results equal to <c>default</c> — <see langword="null"/> for reference types. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
-    public ShieldBuilder<TResult> WhenDefault() => new ShieldBuilder<TResult>(this).OrDefault();
+    /// <summary>
+    /// Starts a handling clause for results equal to <c>default(TResult)</c> — <see langword="null"/>
+    /// for reference types. Use <see cref="WhenAnyError"/> to return to default handling.
+    /// </summary>
+    /// <remarks>
+    /// The <c>Default</c> here means "the default value of <typeparamref name="TResult"/>", not
+    /// "Kevlar's default handling"; <see cref="WhenAnyError"/> is the one that resets handling.
+    /// </remarks>
+    public ShieldBuilder<TResult> WhenResultDefault() => new ShieldBuilder<TResult>(this).OrResultDefault();
 
     /// <summary>
     /// Resets the ambient handling clause. Subsequent reactive strategies use the default
@@ -72,9 +79,18 @@ public sealed class Shield<TResult>
     // ── Strategy chaining ───────────────────────────────────────────────────────────────
 
     /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
     public Shield<TResult> Retry(int maxRetries = 3) => Retry(options => options.MaxRetries = maxRetries);
 
     /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the given backoff.</summary>
+    /// <param name="maxRetries">
+    /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
+    /// total attempts — the initial call plus 3 retries.
+    /// </param>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
     public Shield<TResult> Retry(int maxRetries, Backoff backoff) => Retry(options =>
     {
         options.MaxRetries = maxRetries;
@@ -87,6 +103,10 @@ public sealed class Shield<TResult>
     /// <c>DelayGeneratorAsync</c> receive a <see cref="RetryEvent{TResult}"/> carrying the handled
     /// <see cref="Outcome{TResult}"/>.
     /// </summary>
+    /// <remarks>
+    /// <see cref="RetryOptions{TResult}.MaxRetries"/> counts <em>retries</em>, not attempts:
+    /// <c>MaxRetries = 3</c> makes up to 4 total attempts — the initial call plus 3 retries.
+    /// </remarks>
     public Shield<TResult> Retry(Action<RetryOptions<TResult>> configure)
     {
         Throw.IfNull(configure, nameof(configure));
@@ -378,6 +398,22 @@ public sealed class Shield<TResult>
             cancellationToken);
     }
 
+    /// <summary>
+    /// Executes a context-aware delegate through the pipeline without seeding execution properties.
+    /// The context is pooled and is valid only for the duration of the delegate invocation; never retain it.
+    /// </summary>
+    public ValueTask<TResult> ExecuteWithContextAsync(
+        Func<KevlarContext, ValueTask<TResult>> action,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(action, nameof(action));
+        return ExecuteWithContextAsync(
+            action,
+            static (_, _) => { },
+            static (a, context) => a(context),
+            cancellationToken);
+    }
+
     /// <summary>Executes the delegate through the pipeline and returns the outcome instead of throwing.</summary>
     public ValueTask<Outcome<TResult>> ExecuteOutcomeAsync(Func<CancellationToken, ValueTask<TResult>> action, CancellationToken cancellationToken = default)
     {
@@ -431,6 +467,23 @@ public sealed class Shield<TResult>
             state,
             initializeProperties,
             action,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes a context-aware delegate synchronously through the pipeline without seeding execution
+    /// properties. The context is pooled and is valid only for the duration of the delegate invocation;
+    /// never retain it.
+    /// </summary>
+    public TResult ExecuteWithContext(
+        Func<KevlarContext, TResult> action,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(action, nameof(action));
+        return ExecuteWithContext(
+            action,
+            static (_, _) => { },
+            static (a, context) => a(context),
             cancellationToken);
     }
 

--- a/src/Kevlar/ShieldTaskExtensions.cs
+++ b/src/Kevlar/ShieldTaskExtensions.cs
@@ -50,6 +50,24 @@ public static class ShieldTaskExtensions
             cancellationToken);
     }
 
+    /// <summary>
+    /// Executes a context-aware <see cref="Task{TResult}"/>-returning delegate without seeding
+    /// execution properties. The context is pooled; never retain it beyond the delegate.
+    /// </summary>
+    public static ValueTask<T> ExecuteWithContextAsync<T>(
+        this Shield shield,
+        Func<KevlarContext, Task<T>> action,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfNull(action, nameof(action));
+        return shield.ExecuteWithContextAsync(
+            action,
+            static (_, _) => { },
+            static (a, context) => new ValueTask<T>(a(context)),
+            cancellationToken);
+    }
+
     /// <summary>Executes the <see cref="Task"/>-returning void delegate through the pipeline.</summary>
     public static ValueTask ExecuteAsync(this Shield shield, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
     {
@@ -81,6 +99,24 @@ public static class ShieldTaskExtensions
             (state, initializeProperties, action),
             static (s, properties) => s.initializeProperties(s.state, properties),
             static (s, context) => new ValueTask(s.action(s.state, context)),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes a context-aware <see cref="Task"/>-returning void delegate without seeding execution
+    /// properties. The context is pooled; never retain it beyond the delegate.
+    /// </summary>
+    public static ValueTask ExecuteWithContextAsync(
+        this Shield shield,
+        Func<KevlarContext, Task> action,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfNull(action, nameof(action));
+        return shield.ExecuteWithContextAsync(
+            action,
+            static (_, _) => { },
+            static (a, context) => new ValueTask(a(context)),
             cancellationToken);
     }
 
@@ -133,6 +169,24 @@ public static class ShieldTaskExtensions
             (state, initializeProperties, action),
             static (s, properties) => s.initializeProperties(s.state, properties),
             static (s, context) => new ValueTask<TResult>(s.action(s.state, context)),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes a context-aware <see cref="Task{TResult}"/>-returning delegate without seeding
+    /// execution properties. The context is pooled; never retain it beyond the delegate.
+    /// </summary>
+    public static ValueTask<TResult> ExecuteWithContextAsync<TResult>(
+        this Shield<TResult> shield,
+        Func<KevlarContext, Task<TResult>> action,
+        CancellationToken cancellationToken = default)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfNull(action, nameof(action));
+        return shield.ExecuteWithContextAsync(
+            action,
+            static (_, _) => { },
+            static (a, context) => new ValueTask<TResult>(a(context)),
             cancellationToken);
     }
 

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -18,8 +18,9 @@ public class RetryOptions
     internal bool HasHandlingOverride => HandlesException is not null;
 
     /// <summary>
-    /// Maximum number of retries after the initial attempt. The default is 3
-    /// (up to 4 total executions). Use <see cref="int.MaxValue"/> to retry forever.
+    /// The number of <em>retries</em> made after the initial attempt — not the number of attempts.
+    /// <c>MaxRetries = 3</c> (the default) makes up to 4 total attempts: the initial call plus
+    /// 3 retries. Use <see cref="int.MaxValue"/> to retry forever.
     /// </summary>
     public int MaxRetries { get; set; } = 3;
 
@@ -71,8 +72,9 @@ public class RetryOptions
 public sealed class RetryOptions<TResult>
 {
     /// <summary>
-    /// Maximum number of retries after the initial attempt. The default is 3
-    /// (up to 4 total executions). Use <see cref="int.MaxValue"/> to retry forever.
+    /// The number of <em>retries</em> made after the initial attempt — not the number of attempts.
+    /// <c>MaxRetries = 3</c> (the default) makes up to 4 total attempts: the initial call plus
+    /// 3 retries. Use <see cref="int.MaxValue"/> to retry forever.
     /// </summary>
     public int MaxRetries { get; set; } = 3;
 

--- a/tests/Kevlar.Analyzers.Tests/IgnoredCancellationTokenTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/IgnoredCancellationTokenTests.cs
@@ -50,6 +50,15 @@ public class IgnoredCancellationTokenTests
         ("await Shield<int>.Empty.ExecuteWithContextAsync(1, (_, _) => { }, (state, context) => Task.FromResult(state));", "Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync(Kevlar.Shield<M0>,M1,System.Action<M1,Kevlar.KevlarProperties>,System.Func<M1,Kevlar.KevlarContext,System.Threading.Tasks.Task<M0>>,System.Threading.CancellationToken)"),
         ("await Shield<int>.Empty.ExecuteOutcomeAsync(ct => Task.FromResult(1));", "Kevlar.ShieldTaskExtensions.ExecuteOutcomeAsync(Kevlar.Shield<M0>,System.Func<System.Threading.CancellationToken,System.Threading.Tasks.Task<M0>>,System.Threading.CancellationToken)"),
         ("await Shield<int>.Empty.ExecuteOutcomeAsync(1, (state, ct) => Task.FromResult(state));", "Kevlar.ShieldTaskExtensions.ExecuteOutcomeAsync(Kevlar.Shield<M0>,M1,System.Func<M1,System.Threading.CancellationToken,System.Threading.Tasks.Task<M0>>,System.Threading.CancellationToken)"),
+        ("var result = Shield.Empty.ExecuteWithContext(context => 1);", "Kevlar.Shield.ExecuteWithContext(System.Func<Kevlar.KevlarContext,M0>,System.Threading.CancellationToken)"),
+        ("Shield.Empty.ExecuteWithContext(context => { });", "Kevlar.Shield.ExecuteWithContext(System.Action<Kevlar.KevlarContext>,System.Threading.CancellationToken)"),
+        ("await Shield.Empty.ExecuteWithContextAsync(context => new ValueTask<int>(1));", "Kevlar.Shield.ExecuteWithContextAsync(System.Func<Kevlar.KevlarContext,System.Threading.Tasks.ValueTask<M0>>,System.Threading.CancellationToken)"),
+        ("await Shield.Empty.ExecuteWithContextAsync(context => ValueTask.CompletedTask);", "Kevlar.Shield.ExecuteWithContextAsync(System.Func<Kevlar.KevlarContext,System.Threading.Tasks.ValueTask>,System.Threading.CancellationToken)"),
+        ("var result = Shield<int>.Empty.ExecuteWithContext(context => 1);", "Kevlar.Shield<T0>.ExecuteWithContext(System.Func<Kevlar.KevlarContext,T0>,System.Threading.CancellationToken)"),
+        ("await Shield<int>.Empty.ExecuteWithContextAsync(context => new ValueTask<int>(1));", "Kevlar.Shield<T0>.ExecuteWithContextAsync(System.Func<Kevlar.KevlarContext,System.Threading.Tasks.ValueTask<T0>>,System.Threading.CancellationToken)"),
+        ("await Shield.Empty.ExecuteWithContextAsync(context => Task.FromResult(1));", "Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync(Kevlar.Shield,System.Func<Kevlar.KevlarContext,System.Threading.Tasks.Task<M0>>,System.Threading.CancellationToken)"),
+        ("await Shield.Empty.ExecuteWithContextAsync(context => Task.CompletedTask);", "Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync(Kevlar.Shield,System.Func<Kevlar.KevlarContext,System.Threading.Tasks.Task>,System.Threading.CancellationToken)"),
+        ("await Shield<int>.Empty.ExecuteWithContextAsync(context => Task.FromResult(1));", "Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync(Kevlar.Shield<M0>,System.Func<Kevlar.KevlarContext,System.Threading.Tasks.Task<M0>>,System.Threading.CancellationToken)"),
     ];
 
     private static readonly string[] CleanContextExecutionCases =
@@ -63,6 +72,15 @@ public class IgnoredCancellationTokenTests
         "var result = Shield<int>.Empty.ExecuteWithContext(1, static (_, _) => { }, static (_, context) => context.CancellationToken.GetHashCode());",
         "await Shield<int>.Empty.ExecuteWithContextAsync(1, static (_, _) => { }, static (_, context) => new ValueTask<int>(context.CancellationToken.GetHashCode()));",
         "await Shield<int>.Empty.ExecuteWithContextAsync(1, static (_, _) => { }, static (_, context) => Task.FromResult(context.CancellationToken.GetHashCode()));",
+        "var result = Shield.Empty.ExecuteWithContext(static context => context.CancellationToken.GetHashCode());",
+        "Shield.Empty.ExecuteWithContext(static context => context.CancellationToken.ThrowIfCancellationRequested());",
+        "await Shield.Empty.ExecuteWithContextAsync(static context => new ValueTask<int>(context.CancellationToken.GetHashCode()));",
+        "await Shield.Empty.ExecuteWithContextAsync(static context => { context.CancellationToken.ThrowIfCancellationRequested(); return ValueTask.CompletedTask; });",
+        "await Shield.Empty.ExecuteWithContextAsync(static context => Task.FromResult(context.CancellationToken.GetHashCode()));",
+        "await Shield.Empty.ExecuteWithContextAsync(static context => { context.CancellationToken.ThrowIfCancellationRequested(); return Task.CompletedTask; });",
+        "var result = Shield<int>.Empty.ExecuteWithContext(static context => context.CancellationToken.GetHashCode());",
+        "await Shield<int>.Empty.ExecuteWithContextAsync(static context => new ValueTask<int>(context.CancellationToken.GetHashCode()));",
+        "await Shield<int>.Empty.ExecuteWithContextAsync(static context => Task.FromResult(context.CancellationToken.GetHashCode()));",
     ];
 
     private static Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string body) =>

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -434,7 +434,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield<int>.Empty.Wrap(Shield.Hedge(2, TimeSpan.Zero)).Execute(_ => 1);",
         };
 
-        await AssertEachAsync(cases, "KEV002");
+        await AssertEachAsync(cases, "KEV002", "KEV006");
     }
 
     [Test]
@@ -455,7 +455,7 @@ public class PipelineHazardAnalyzerTests
             }
             """);
 
-        await AssertRuleAsync(aliasDiagnostics, "KEV002");
+        await AssertRuleAsync(Without(aliasDiagnostics, "KEV006"), "KEV002");
         await AssertRuleAsync(genericDiagnostics, "KEV002");
     }
 
@@ -476,7 +476,7 @@ public class PipelineHazardAnalyzerTests
         foreach (var body in cases)
         {
             var diagnostics = await AnalyzeBodyAsync(body, "private static Shield CreateShield() => Shield.Hedge(2, TimeSpan.Zero);");
-            await Assert.That(diagnostics).IsEmpty();
+            await Assert.That(Without(diagnostics, "KEV006")).IsEmpty();
         }
     }
 
@@ -492,8 +492,77 @@ public class PipelineHazardAnalyzerTests
         foreach (var body in cases)
         {
             var diagnostics = await AnalyzeBodyAsync(body);
+            await Assert.That(Without(diagnostics, "KEV006")).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV006_Flags_Hedging_On_Untyped_Shields_And_Builders()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.Hedge(2, TimeSpan.Zero);",
+            "_ = Shield.Hedge(options => options.MaxAttempts = 2);",
+            "_ = Shield.Empty.Hedge(2, TimeSpan.Zero);",
+            "_ = Shield.Empty.Hedge(options => options.MaxAttempts = 2);",
+            "_ = ShieldExtensions.Hedge(Shield.Empty, 2, TimeSpan.Zero);",
+            "_ = Shield.When<InvalidOperationException>().Hedge(2, TimeSpan.Zero);",
+            "_ = Shield.When<InvalidOperationException>().Hedge(options => options.MaxAttempts = 2);",
+            "_ = Shield.Timeout(TimeSpan.FromSeconds(1)).Hedge(2, TimeSpan.Zero).Retry(1);",
+        };
+
+        await AssertEachAsync(cases, "KEV006");
+    }
+
+    [Test]
+    public async Task KEV006_Skips_Typed_Shields_And_Typed_Builders()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero);",
+            "_ = Shield.For<int>().Hedge(options => options.MaxAttempts = 2);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Hedge(2, TimeSpan.Zero);",
+            "_ = Shield.For<int>().WhenResult(0).Hedge(options => options.MaxAttempts = 2);",
+            "_ = Shield.Empty.For<int>().Hedge(2, TimeSpan.Zero);",
+            "_ = Shield.For<int>().Retry(1);",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body);
             await Assert.That(diagnostics).IsEmpty();
         }
+    }
+
+    [Test]
+    public async Task KEV006_Diagnostic_Contract_And_Suppression_Are_Exact()
+    {
+        const string construction = "Shield.Hedge(2, TimeSpan.Zero)";
+        var source = $$"""
+            public class TestSubject
+            {
+                public Shield Build() => {{construction}};
+            }
+            """;
+        var diagnostics = await AnalyzeSourceAsync(source);
+        var suppressed = await AnalyzeBodyAsync("""
+            #pragma warning disable KEV006 // The documented action is idempotent.
+            _ = Shield.Hedge(2, TimeSpan.Zero);
+            #pragma warning restore KEV006
+            """);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        var diagnostic = diagnostics[0];
+        await Assert.That(diagnostic.Id).IsEqualTo("KEV006");
+        await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            "Hedging on an untyped Shield runs the execution delegate more than once, concurrently. "
+            + "Build a result-aware shield with Shield.For<T>() so result clauses can select the "
+            + "winning attempt, or confirm the action is idempotent.");
+        await Assert.That(diagnostic.Location.SourceSpan.Start)
+            .IsEqualTo(CreateSource(source).IndexOf(construction, StringComparison.Ordinal));
+        await Assert.That(diagnostic.Location.SourceSpan.Length).IsEqualTo(construction.Length);
+        await Assert.That(suppressed).IsEmpty();
     }
 
     [Test]
@@ -716,14 +785,30 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(generated).IsEmpty();
     }
 
-    private static async Task AssertEachAsync(IEnumerable<string> cases, string expectedRule)
+    private static async Task AssertEachAsync(
+        IEnumerable<string> cases,
+        string expectedRule,
+        params string[] expectedCompanionRules)
     {
         foreach (var body in cases)
         {
             var diagnostics = await AnalyzeBodyAsync(body);
-            await AssertRuleAsync(diagnostics, expectedRule);
+            await AssertRuleAsync(Without(diagnostics, expectedCompanionRules), expectedRule);
         }
     }
+
+    /// <summary>
+    /// Drops rules a case is expected to trigger in addition to the rule under test — untyped
+    /// hedging cases, for instance, always also report KEV006.
+    /// </summary>
+    private static ImmutableArray<Diagnostic> Without(
+        ImmutableArray<Diagnostic> diagnostics,
+        params string[] ruleIds) =>
+        ruleIds.Length == 0
+            ? diagnostics
+            : diagnostics
+                .Where(diagnostic => !ruleIds.Contains(diagnostic.Id, StringComparer.Ordinal))
+                .ToImmutableArray();
 
     private static async Task AssertRuleAsync(ImmutableArray<Diagnostic> diagnostics, string expectedRule)
     {

--- a/tests/Kevlar.Tests/CompositionContractTests.cs
+++ b/tests/Kevlar.Tests/CompositionContractTests.cs
@@ -198,12 +198,12 @@ public class CompositionContractTests
                 calls.Add("first");
                 return exception is ArgumentNullException;
             })
-            .OrWhen(exception =>
+            .Or(exception =>
             {
                 calls.Add("second");
                 return exception is ArgumentException;
             })
-            .OrWhen(_ =>
+            .Or(_ =>
             {
                 calls.Add("third");
                 throw new InvalidOperationException("must be short-circuited");

--- a/tests/Kevlar.Tests/ExecutionOverloadContractTests.cs
+++ b/tests/Kevlar.Tests/ExecutionOverloadContractTests.cs
@@ -13,6 +13,8 @@ public class ExecutionOverloadContractTests
         new("Shield.ExecuteAsync:ValueTaskVoid:state", true, true, InvokeShieldValueTaskVoidState),
         new("Shield.ExecuteWithContextAsync:ValueTaskResult:state", true, true, InvokeShieldContextValueTaskResultState),
         new("Shield.ExecuteWithContextAsync:ValueTaskVoid:state", true, true, InvokeShieldContextValueTaskVoidState),
+        new("Shield.ExecuteWithContextAsync:ValueTaskResult", true, false, InvokeShieldContextValueTaskResult),
+        new("Shield.ExecuteWithContextAsync:ValueTaskVoid", true, false, InvokeShieldContextValueTaskVoid),
         new("Shield.ExecuteOutcomeAsync:ValueTaskResult", true, false, InvokeShieldValueTaskOutcome, CapturesOutcome: true),
         new("Shield.ExecuteOutcomeAsync:ValueTaskResult:state", true, true, InvokeShieldValueTaskOutcomeState, CapturesOutcome: true),
         new("Shield.Execute:SyncResult", false, false, InvokeShieldSyncResult),
@@ -21,15 +23,19 @@ public class ExecutionOverloadContractTests
         new("Shield.Execute:SyncVoid:state", false, true, InvokeShieldSyncVoidState),
         new("Shield.ExecuteWithContext:SyncResult:state", false, true, InvokeShieldContextSyncResultState),
         new("Shield.ExecuteWithContext:SyncVoid:state", false, true, InvokeShieldContextSyncVoidState),
+        new("Shield.ExecuteWithContext:SyncResult", false, false, InvokeShieldContextSyncResult),
+        new("Shield.ExecuteWithContext:SyncVoid", false, false, InvokeShieldContextSyncVoid),
 
         new("Shield<TResult>.ExecuteAsync:ValueTaskResult", true, false, InvokeTypedValueTaskResult),
         new("Shield<TResult>.ExecuteAsync:ValueTaskResult:state", true, true, InvokeTypedValueTaskResultState),
         new("Shield<TResult>.ExecuteWithContextAsync:ValueTaskResult:state", true, true, InvokeTypedContextValueTaskResultState),
+        new("Shield<TResult>.ExecuteWithContextAsync:ValueTaskResult", true, false, InvokeTypedContextValueTaskResult),
         new("Shield<TResult>.ExecuteOutcomeAsync:ValueTaskResult", true, false, InvokeTypedValueTaskOutcome, CapturesOutcome: true),
         new("Shield<TResult>.ExecuteOutcomeAsync:ValueTaskResult:state", true, true, InvokeTypedValueTaskOutcomeState, CapturesOutcome: true),
         new("Shield<TResult>.Execute:SyncResult", false, false, InvokeTypedSyncResult),
         new("Shield<TResult>.Execute:SyncResult:state", false, true, InvokeTypedSyncResultState),
         new("Shield<TResult>.ExecuteWithContext:SyncResult:state", false, true, InvokeTypedContextSyncResultState),
+        new("Shield<TResult>.ExecuteWithContext:SyncResult", false, false, InvokeTypedContextSyncResult),
 
         new("ShieldTaskExtensions[Shield].ExecuteAsync:TaskResult", true, false, InvokeShieldTaskResult),
         new("ShieldTaskExtensions[Shield].ExecuteAsync:TaskResult:state", true, true, InvokeShieldTaskResultState),
@@ -37,12 +43,15 @@ public class ExecutionOverloadContractTests
         new("ShieldTaskExtensions[Shield].ExecuteAsync:TaskVoid:state", true, true, InvokeShieldTaskVoidState),
         new("ShieldTaskExtensions[Shield].ExecuteWithContextAsync:TaskResult:state", true, true, InvokeShieldContextTaskResultState),
         new("ShieldTaskExtensions[Shield].ExecuteWithContextAsync:TaskVoid:state", true, true, InvokeShieldContextTaskVoidState),
+        new("ShieldTaskExtensions[Shield].ExecuteWithContextAsync:TaskResult", true, false, InvokeShieldContextTaskResult),
+        new("ShieldTaskExtensions[Shield].ExecuteWithContextAsync:TaskVoid", true, false, InvokeShieldContextTaskVoid),
         new("ShieldTaskExtensions[Shield].ExecuteOutcomeAsync:TaskResult", true, false, InvokeShieldTaskOutcome, CapturesOutcome: true),
         new("ShieldTaskExtensions[Shield].ExecuteOutcomeAsync:TaskResult:state", true, true, InvokeShieldTaskOutcomeState, CapturesOutcome: true),
 
         new("ShieldTaskExtensions[Shield<TResult>].ExecuteAsync:TaskResult", true, false, InvokeTypedTaskResult),
         new("ShieldTaskExtensions[Shield<TResult>].ExecuteAsync:TaskResult:state", true, true, InvokeTypedTaskResultState),
         new("ShieldTaskExtensions[Shield<TResult>].ExecuteWithContextAsync:TaskResult:state", true, true, InvokeTypedContextTaskResultState),
+        new("ShieldTaskExtensions[Shield<TResult>].ExecuteWithContextAsync:TaskResult", true, false, InvokeTypedContextTaskResult),
         new("ShieldTaskExtensions[Shield<TResult>].ExecuteOutcomeAsync:TaskResult", true, false, InvokeTypedTaskOutcome, CapturesOutcome: true),
         new("ShieldTaskExtensions[Shield<TResult>].ExecuteOutcomeAsync:TaskResult:state", true, true, InvokeTypedTaskOutcomeState, CapturesOutcome: true),
     ];
@@ -446,6 +455,60 @@ public class ExecutionOverloadContractTests
             token);
         return InvocationResult.Success(ExecutionProbe.ExpectedResult);
     }
+
+    private static async ValueTask<InvocationResult> InvokeShieldContextValueTaskResult(bool pipelined, ExecutionProbe probe, CancellationToken token) =>
+        InvocationResult.Success(await GetShield(pipelined).ExecuteWithContextAsync(
+            context => probe.ValueTaskResult(context.CancellationToken),
+            token));
+
+    private static async ValueTask<InvocationResult> InvokeShieldContextValueTaskVoid(bool pipelined, ExecutionProbe probe, CancellationToken token)
+    {
+        await GetShield(pipelined).ExecuteWithContextAsync(
+            context => probe.ValueTaskVoid(context.CancellationToken),
+            token);
+        return InvocationResult.Success(ExecutionProbe.ExpectedResult);
+    }
+
+    private static ValueTask<InvocationResult> InvokeShieldContextSyncResult(bool pipelined, ExecutionProbe probe, CancellationToken token) =>
+        new(InvocationResult.Success(GetShield(pipelined).ExecuteWithContext(
+            context => probe.SyncResult(context.CancellationToken),
+            token)));
+
+    private static ValueTask<InvocationResult> InvokeShieldContextSyncVoid(bool pipelined, ExecutionProbe probe, CancellationToken token)
+    {
+        GetShield(pipelined).ExecuteWithContext(
+            context => probe.SyncVoid(context.CancellationToken),
+            token);
+        return new ValueTask<InvocationResult>(InvocationResult.Success(ExecutionProbe.ExpectedResult));
+    }
+
+    private static async ValueTask<InvocationResult> InvokeTypedContextValueTaskResult(bool pipelined, ExecutionProbe probe, CancellationToken token) =>
+        InvocationResult.Success(await GetTypedShield(pipelined).ExecuteWithContextAsync(
+            context => probe.ValueTaskResult(context.CancellationToken),
+            token));
+
+    private static ValueTask<InvocationResult> InvokeTypedContextSyncResult(bool pipelined, ExecutionProbe probe, CancellationToken token) =>
+        new(InvocationResult.Success(GetTypedShield(pipelined).ExecuteWithContext(
+            context => probe.SyncResult(context.CancellationToken),
+            token)));
+
+    private static async ValueTask<InvocationResult> InvokeShieldContextTaskResult(bool pipelined, ExecutionProbe probe, CancellationToken token) =>
+        InvocationResult.Success(await GetShield(pipelined).ExecuteWithContextAsync(
+            context => probe.TaskResult(context.CancellationToken),
+            token));
+
+    private static async ValueTask<InvocationResult> InvokeShieldContextTaskVoid(bool pipelined, ExecutionProbe probe, CancellationToken token)
+    {
+        await GetShield(pipelined).ExecuteWithContextAsync(
+            context => probe.TaskVoid(context.CancellationToken),
+            token);
+        return InvocationResult.Success(ExecutionProbe.ExpectedResult);
+    }
+
+    private static async ValueTask<InvocationResult> InvokeTypedContextTaskResult(bool pipelined, ExecutionProbe probe, CancellationToken token) =>
+        InvocationResult.Success(await GetTypedShield(pipelined).ExecuteWithContextAsync(
+            context => probe.TaskResult(context.CancellationToken),
+            token));
 
     private static ValueTask<InvocationResult> InvokeShieldSyncResult(bool pipelined, ExecutionProbe probe, CancellationToken token) =>
         new(InvocationResult.Success(GetShield(pipelined).Execute(probe.SyncResult, token)));

--- a/tests/Kevlar.Tests/NewApiTests.cs
+++ b/tests/Kevlar.Tests/NewApiTests.cs
@@ -3,8 +3,9 @@ using Microsoft.Extensions.Time.Testing;
 namespace Kevlar.Tests;
 
 /// <summary>
-/// Guards the API refinements: the unified When/Or clause grammar, WhenDefault, typed retry
-/// events, the MaxDelay absolute cap, and Compose preserving metadata while sealing clauses.
+/// Guards the API refinements: the unified When/Or clause grammar, WhenResultDefault, typed retry
+/// events, the MaxDelay absolute cap, the context-only ExecuteWithContext overloads, and Compose
+/// preserving metadata while sealing clauses.
 /// </summary>
 public class NewApiTests
 {
@@ -63,7 +64,7 @@ public class NewApiTests
         var shield = Shield
             .When<ArgumentException>()
             .Or<InvalidOperationException>()
-            .OrWhen(exception => exception is TimeoutException)
+            .Or(exception => exception is TimeoutException)
             .Retry(3, Backoff.None);
 
         await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
@@ -109,10 +110,10 @@ public class NewApiTests
     }
 
     [Test]
-    public async Task WhenDefault_Retries_Null_Results()
+    public async Task WhenResultDefault_Retries_Null_Results()
     {
         var attempts = 0;
-        var shield = Shield.For<string?>().WhenDefault().Retry(2, Backoff.None);
+        var shield = Shield.For<string?>().WhenResultDefault().Retry(2, Backoff.None);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<string?>(attempts++ < 2 ? null : "loaded"));
 
@@ -121,10 +122,10 @@ public class NewApiTests
     }
 
     [Test]
-    public async Task WhenDefault_Matches_Default_Value_Types()
+    public async Task WhenResultDefault_Matches_Default_Value_Types()
     {
         var attempts = 0;
-        var shield = Shield.For<int>().WhenDefault().Retry(1, Backoff.None);
+        var shield = Shield.For<int>().WhenResultDefault().Retry(1, Backoff.None);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(attempts++ == 0 ? 0 : 7));
 
@@ -442,6 +443,134 @@ public class NewApiTests
         await Assert.That(composed.Ambient).IsNull();
         await Assert.That(result).IsEqualTo(42);
         await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Or_Accepts_A_Bare_Exception_Predicate_On_Both_Builders()
+    {
+        // A bare lambda cannot infer TException for Or<TException>(Func<TException, bool>),
+        // so this binds to the non-generic Or(Func<Exception, bool>) continuation.
+        var untypedAttempts = 0;
+        var untyped = Shield
+            .When<ArgumentException>()
+            .Or(exception => exception is TimeoutException)
+            .Retry(2, Backoff.None);
+
+        await Assert.That(async () => await untyped.ExecuteAsync<int>(_ =>
+        {
+            untypedAttempts++;
+            throw untypedAttempts switch
+            {
+                1 => new ArgumentException(),
+                2 => (Exception)new TimeoutException(),
+                _ => new ShortCircuitException(),
+            };
+        })).Throws<ShortCircuitException>();
+        await Assert.That(untypedAttempts).IsEqualTo(3);
+
+        var typedAttempts = 0;
+        var typed = Shield.For<int>()
+            .WhenResult(0)
+            .Or(exception => exception is TimeoutException)
+            .Retry(2, Backoff.None);
+
+        var result = await typed.ExecuteAsync(_ =>
+        {
+            typedAttempts++;
+            return typedAttempts switch
+            {
+                1 => new ValueTask<int>(0),
+                2 => throw new TimeoutException(),
+                _ => new ValueTask<int>(42),
+            };
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(typedAttempts).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Or_Is_The_Only_Predicate_Continuation_On_The_Builders()
+    {
+        foreach (var builderType in new[] { typeof(ShieldBuilder), typeof(ShieldBuilder<int>) })
+        {
+            var declared = builderType.GetMethods(System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.DeclaredOnly);
+
+            await Assert.That(declared.Any(static method => method.Name == "OrWhen")).IsFalse();
+
+            var predicateContinuation = declared
+                .Single(static method => method.Name == "Or" && !method.IsGenericMethodDefinition);
+            await Assert.That(predicateContinuation.GetParameters().Single().ParameterType)
+                .IsEqualTo(typeof(Func<Exception, bool>));
+        }
+    }
+
+    [Test]
+    public async Task ExecuteWithContext_Reads_The_Context_Without_Property_Ceremony()
+    {
+        var shield = Shield.Retry(1, Backoff.None).WithName("context-only");
+        var typed = Shield.For<int>().Retry(1, Backoff.None).WithName("typed-context-only");
+
+        await Assert.That(await shield.ExecuteWithContextAsync(
+            context => new ValueTask<string?>(context.ShieldName))).IsEqualTo("context-only");
+        await Assert.That(await shield.ExecuteWithContextAsync(
+            context => Task.FromResult(context.ShieldName))).IsEqualTo("context-only");
+        await Assert.That(shield.ExecuteWithContext(context => context.ShieldName)).IsEqualTo("context-only");
+
+        await Assert.That(await typed.ExecuteWithContextAsync(
+            context => new ValueTask<int>(context.ShieldName!.Length))).IsEqualTo("typed-context-only".Length);
+        await Assert.That(await typed.ExecuteWithContextAsync(
+            context => Task.FromResult(context.ShieldName!.Length))).IsEqualTo("typed-context-only".Length);
+        await Assert.That(typed.ExecuteWithContext(context => context.ShieldName!.Length))
+            .IsEqualTo("typed-context-only".Length);
+
+        string? fromValueTaskVoid = null;
+        await shield.ExecuteWithContextAsync(context =>
+        {
+            fromValueTaskVoid = context.ShieldName;
+            return ValueTask.CompletedTask;
+        });
+
+        string? fromTaskVoid = null;
+        await shield.ExecuteWithContextAsync(context =>
+        {
+            fromTaskVoid = context.ShieldName;
+            return Task.CompletedTask;
+        });
+
+        string? fromSyncVoid = null;
+        shield.ExecuteWithContext(context => { fromSyncVoid = context.ShieldName; });
+
+        await Assert.That(fromValueTaskVoid).IsEqualTo("context-only");
+        await Assert.That(fromTaskVoid).IsEqualTo("context-only");
+        await Assert.That(fromSyncVoid).IsEqualTo("context-only");
+    }
+
+    [Test]
+    public async Task ExecuteWithContext_Without_Properties_Still_Retries_And_Threads_Cancellation()
+    {
+        var shield = Shield.Retry(1, Backoff.None);
+        var attempts = 0;
+
+        var result = await shield.ExecuteWithContextAsync(context =>
+        {
+            attempts++;
+            context.CancellationToken.ThrowIfCancellationRequested();
+            return attempts == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException())
+                : new ValueTask<int>(7);
+        });
+
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(attempts).IsEqualTo(2);
+
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        await Assert.That(async () => await shield.ExecuteWithContextAsync(
+            context => new ValueTask<int>(1),
+            cancellation.Token)).Throws<OperationCanceledException>();
     }
 
     private sealed class ShortCircuitException : Exception;


### PR DESCRIPTION
Five cleanups from the API review. Kevlar is **pre-release**, so the renames are breaking with no `[Obsolete]` shims — every call site in the repo, tests, and docs moved with them, and `PublicAPI.Unshipped.txt` records the `*REMOVED*` lines.

## 1. `WhenDefault()` → `WhenResultDefault()`, `OrDefault()` → `OrResultDefault()`

`WhenDefault` meant "the result equals `default(TResult)`", but it sat right next to `WhenAnyError()`, which means "reset to default *handling*" — two meanings of "default" inside one clause family. The new names join the existing `WhenResult`/`OrResult` pairing, so the noun in the name is the thing being matched.

| Before | After |
|---|---|
| `Shield.For<T>().WhenDefault()` | `Shield.For<T>().WhenResultDefault()` |
| `builder.OrDefault()` | `builder.OrResultDefault()` |

The `KEV003` analyzer's clause detection was updated to match the new name.

## 2. `Or(Func<Exception, bool>)` replaces `OrWhen`

`When(predicate)` already coexisted with `When<TException>(predicate)` on the shield, but the builder spelled the same thing `OrWhen` — an asymmetry with no reason to survive into 1.0. `Or(Func<Exception, bool>)` is now public on both `ShieldBuilder` and `ShieldBuilder<TResult>`, and `OrWhen` is gone.

Overload resolution works because a bare lambda like `Or(e => e is TimeoutException)` gives the compiler nothing to infer `TException` from, so the generic overload is not applicable and the non-generic one binds. `NewApiTests.Or_Accepts_A_Bare_Exception_Predicate_On_Both_Builders` proves it compiles and behaves on both builders; `Or_Is_The_Only_Predicate_Continuation_On_The_Builders` pins the shape.

## 3. Retries-vs-attempts documented on every `Retry` overload

Every `Retry(int maxRetries …)` overload — `Shield.Retry`, `ShieldExtensions.Retry`, `Shield<TResult>.Retry`, `ShieldBuilder.Retry`, `ShieldBuilder<TResult>.Retry` — plus `RetryOptions.MaxRetries` and `RetryOptions<TResult>.MaxRetries` now say explicitly that the value counts **retries**, not attempts: `Retry(3)` makes up to 4 total attempts, the initial call plus 3 retries. The docs-site retry page already said it for the shorthand; it now says it for `MaxRetries` and the options form too.

## 4. Context-only `ExecuteWithContext*` overloads

Every `ExecuteWithContext`/`ExecuteWithContextAsync` overload previously required a `TState` **and** an `Action<TState, KevlarProperties>` initializer, even when the caller only wanted to read `ShieldName` or the effective token. Added overloads that take just the context-aware action:

```csharp
var name = await shield.ExecuteWithContextAsync(
    static context => new ValueTask<string?>(context.ShieldName),
    cancellationToken);
```

- `Shield`: `ValueTask<T>`, `ValueTask`, sync `T`, sync `void`
- `Shield<TResult>`: async + sync
- `ShieldTaskExtensions`: the `Task`-returning equivalents, kept as extension methods on purpose so the instance `ValueTask` overloads still win for async lambdas

Each delegates to the existing state-based overload, passing the delegate itself as the state, so a `static` lambda stays closure-free. The reflection-driven `ExecutionOverloadContractTests` and `IgnoredCancellationTokenTests` catalogs were extended, so the new overloads are covered by the full success / deferred-completion / exception-identity / pre-cancellation / mid-flight-cancellation / null-guard matrix as well as by KEV001.

## 5. `KEV006`: hedging on an untyped shield

New analyzer diagnostic (Warning) for `Hedge(...)` invoked on the untyped `Shield`, `ShieldBuilder`, or the static `Shield.Hedge` factory. An untyped shield can judge hedged attempts only by their exceptions, so every attempt it launches runs to completion against the real dependency — a losing hedge has still done its work, and duplicate writes, charges, or sends are observable unless the action is idempotent. The message points at `Shield.For<T>()`, where a result clause can pick the winning attempt, or at confirming idempotency. `Shield<TResult>.Hedge` and `ShieldBuilder<TResult>.Hedge` are never flagged.

The same warning was added to the XML docs of the untyped `Hedge` overloads and to the docs-site hedging page, and `KEV006` is documented on the analyzers page.

Because untyped hedging cases now report `KEV002` *and* `KEV006`, the analyzer test helpers gained a `Without(diagnostics, ruleIds)` filter so each rule's tests still assert exactly one diagnostic of the rule under test.

## Validation

- `dotnet build Kevlar.slnx -c Release` — clean, 0 warnings (warnings are errors)
- `Kevlar.Tests` — 760/760 pass
- `Kevlar.IntegrationTests` — 118/118 pass
- `Kevlar.Analyzers.Tests` — 64/64 pass
- Also green: `Kevlar.Chaos.Tests` 23, `Kevlar.Testing.Tests` 33, `Kevlar.NetStandard.Tests` 5, `Kevlar.Extensions.RateLimiting.Tests` 19, `Kevlar.AllocationTests` 3 (Release)
- `scripts/Verify-DocSnippets.ps1` — 104 documentation snippets compile and execute

Nothing from the review was left out.

https://claude.ai/code/session_01DarFLgjrFgAsDiGr3cwWkZ
