### PR TITLE
+semver:minor - refactor(api): second round of pre-release API cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
   property names and defaults, but helpers that accepted `RetryOptions` must configure typed retry
   options separately. Typed callback getters now return the exact delegates assigned to them.
 - Typed circuit-breaker and hedging configuration now uses `CircuitBreakerOptions<TResult>` and
-  `HedgingOptions<TResult>` so result predicates remain strongly typed.
+  `HedgeOptions<TResult>` so result predicates remain strongly typed.
+- `HedgingOptions`/`HedgingOptions<TResult>` were renamed to `HedgeOptions`/`HedgeOptions<TResult>`
+  so the strategy method and its options type share a stem, like `Retry`/`RetryOptions` and
+  `Timeout`/`TimeoutOptions`. `Kevlar.Extensions.Http`'s `StandardHedgingShieldOptions` and
+  `AddStandardHedgingShield` are unchanged.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
 
 ### Added
 
+- `KEV007`: a `When…`/`Or…` handling clause that never reaches a reactive strategy — the
+  `ShieldBuilder` is discarded, or a later `When…`/`WhenAnyError()` replaces the clause while only
+  proactive strategies stood between them.
 - `Shield.Fallback(…)` static factories, mirroring the four untyped `ShieldExtensions.Fallback`
   overloads, so a fallback can start a chain like every other strategy. Fallback-first is the
   valid order: it recovers what the strategies chained inside it could not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
 
 ### Added
 
+- `Shield.Fallback(…)` static factories, mirroring the four untyped `ShieldExtensions.Fallback`
+  overloads, so a fallback can start a chain like every other strategy. Fallback-first is the
+  valid order: it recovers what the strategies chained inside it could not.
+- `Shield<TResult>.Compose(params Shield<TResult>[])`, the result-aware counterpart of
+  `Shield.Compose`. Same semantics: first shield outermost, first non-null name and
+  `TimeProvider` win, ambient handling clauses sealed.
 - Reactive strategy options can replace ambient handling locally with `HandlesException` and, on
   typed options, `HandlesResult`. Testing descriptors expose `HasHandlingOverride`.
 - Context-only `ExecuteWithContext`/`ExecuteWithContextAsync` overloads that take just the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Configure fallback notifications through `Fallback(..., configure)`. The pre-release `FallbackWithNotifications` methods and typed optional `onFallback` parameters were removed. Migration-only error overloads prevent old positional callback lambdas from silently binding as options configurators.
+- Configure fallback notifications through `Fallback(..., configure)`. The pre-release `FallbackWithNotifications` methods and typed `onFallback` parameters were removed, including the migration-only error overloads that briefly replaced them. Every fallback shape now has exactly two overloads — bare and `Action<FallbackOptions>`/`Action<FallbackOptions<TResult>>` — on `Shield`, `Shield<TResult>`, `ShieldBuilder` and `ShieldBuilder<TResult>`.
 
 Handling clauses now use one spelling per position. `When…` starts a clause on `Shield` or
 `Shield<TResult>`; only `Or…` continues it on a builder. `Shield.For<TResult>()` now returns

--- a/README.md
+++ b/README.md
@@ -69,8 +69,21 @@ var search = Shield.For<HttpResponseMessage>()
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 ```
 
-The clause applies to the reactive strategies that follow it. Typed shields keep result handling
-strongly typed, including callback events and `Outcome<T>` values.
+**A clause is ambient.** It applies to the strategy it is attached to *and* to every reactive
+strategy chained after it, until a new clause replaces it, `WhenAnyError()` resets it, or
+`Wrap`/`Compose` seals it. Above, the fallback, the retry *and* the circuit breaker all react to
+the same three conditions. Nothing repeats the predicate per strategy:
+
+```csharp
+var api = Shield
+    .When<HttpRequestException>()
+    .Retry(3)                        // retries HttpRequestException
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+    // the breaker inherits the clause above: only HttpRequestException counts toward tripping it
+```
+
+Typed shields keep result handling strongly typed, including callback events and `Outcome<T>`
+values.
 
 ## Compose protection in reading order
 

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -22,6 +22,7 @@ Generated code is ignored.
 | `KEV004` | Warning | stateful shield or partition provider is constructed for one execution |
 | `KEV005` | Warning | void fallback is executed with a result-returning delegate |
 | `KEV006` | Warning | hedging is added to an untyped shield, whose action must be idempotent |
+| `KEV007` | Warning | handling clause never reaches a reactive strategy |
 
 ## KEV001: ignored execution cancellation
 
@@ -165,6 +166,48 @@ The rule reports every `Hedge` overload that returns the untyped `Shield`: the s
 `Shield.Hedge(...)` factories, the `ShieldExtensions.Hedge(...)` chaining methods, and
 `ShieldBuilder.Hedge(...)`. `Shield<T>.Hedge(...)` and `ShieldBuilder<T>.Hedge(...)` are never
 flagged.
+
+## KEV007: dead handling clause
+
+A [handling clause](handling-failures.md) changes nothing on its own — it only takes effect once a
+reactive strategy (retry, circuit breaker, hedging, fallback, or a `Use` factory) consumes it. Two
+shapes silently do nothing.
+
+The first is a clause whose `ShieldBuilder` is dropped instead of being finished with a strategy:
+
+<!-- doc-test-ignore: Deliberately dead clauses that the analyzer is expected to flag. -->
+```csharp
+Shield.When<HttpRequestException>();                          // KEV007 — nothing consumes it
+var clause = Shield.When<HttpRequestException>().Or<TimeoutExceededException>();  // KEV007 — never used
+```
+
+The second is a clause that a later `When…` or `WhenAnyError()` replaces while only *proactive*
+strategies — timeout, rate limit, concurrency limit — sat in between. Proactive strategies never
+consult clauses, so the first clause never applied to anything:
+
+<!-- doc-test-ignore: Deliberately dead clauses that the analyzer is expected to flag. -->
+```csharp
+var shield = Shield
+    .When<HttpRequestException>()                 // KEV007 — only the timeout saw this clause
+    .Timeout(TimeSpan.FromSeconds(5))
+    .WhenAnyError()
+    .Retry(3);
+```
+
+Fix either by finishing the clause with the reactive strategy it was written for:
+
+```csharp
+var shield = Shield
+    .When<HttpRequestException>()
+    .Timeout(TimeSpan.FromSeconds(5))
+    .Retry(3)                                     // the clause reaches a reactive strategy
+    .WhenAnyError()
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+```
+
+The rule follows one fluent chain and a clause builder stored in a local. It deliberately stays
+quiet when the builder escapes — returned, passed as an argument, assigned to a field — and at
+`Wrap`/`Compose` boundaries, because a clause's fate is no longer visible there.
 
 ## Suppression
 

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -48,6 +48,16 @@ var writes   = Shield.Timeout(TimeSpan.FromSeconds(5)).Wrap(breaker);
 var combined = Shield.Compose(timeoutShield, retryShield, breakerShield);  // first = outermost
 ```
 
+Result-aware shields compose the same way through `Shield<T>.Compose`, with the same metadata and
+clause-sealing rules:
+
+```csharp
+var typedTimeout = Shield.For<HttpResponseMessage>().Timeout(TimeSpan.FromSeconds(5));
+var typedRetry = Shield.For<HttpResponseMessage>().Retry(3);
+
+var typed = Shield<HttpResponseMessage>.Compose(typedTimeout, typedRetry);  // first = outermost
+```
+
 :::note What survives a merge
 `Wrap` and `Compose` carry the *strategies* (with their state) forward. Both keep the first non-null name and `TimeProvider` from outer to inner. Ambient [handling clauses](handling-failures.md) stop at the composition boundary, so reactive strategies appended to the merged shield use default handling unless you declare a new clause.
 

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -87,7 +87,23 @@ var background  = Shield.Timeout(TimeSpan.FromSeconds(30)).Retry(5).Wrap(downstr
 
 ## Handling clauses flow down a fluent chain
 
-A [handling clause](handling-failures.md) applies to the strategy it precedes *and* to every reactive strategy chained after it, until you write a new clause or compose the shield:
+:::tip The ambient clause rule
+A [handling clause](handling-failures.md) applies to **the strategy it is attached to and to every reactive strategy chained after it**, until a new clause replaces it, `WhenAnyError()` resets it, or `Wrap`/`Compose` seals it at a composition boundary.
+:::
+
+The circuit breaker below never declares a clause of its own. It inherits the one written at the top of the chain, so only `HttpRequestException` counts toward tripping it:
+
+```csharp
+var shield = Shield
+    .When<HttpRequestException>()
+    .Retry(3)                                                                     // retries HttpRequestException
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+    // ↑ the breaker counts HttpRequestException failures only
+```
+
+Proactive strategies — timeout, rate limit, concurrency limit — never consult a clause, but they do not end it either: the clause stays ambient for the next reactive strategy. A clause that reaches no reactive strategy at all is dead, and the optional analyzer reports it as [`KEV007`](analyzers.md#kev007-dead-handling-clause).
+
+Writing a new clause mid-chain replaces the previous one from that point on:
 
 <!-- doc-test-ignore: Uses an ellipsis to illustrate a fallback body defined by the application. -->
 ```csharp

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -74,7 +74,15 @@ Registry semantics worth knowing:
 services.AddShield("github", builder.Configuration.GetSection("Resilience:GitHub"));
 ```
 
-The schema is `ShieldDefinition`: optional `Timeout`, `Retry`, `CircuitBreaker`, `RateLimit`, `ConcurrencyLimit` and `AttemptTimeout` sections, chained in that fixed order (outermost first). Only the sections you declare are added, and the defaults inside each section match the fluent API's.
+The schema is `ShieldDefinition`. `ShieldDefinition.Build()` always chains the sections it finds in one fixed order, outermost first:
+
+```text
+Timeout → Retry → CircuitBreaker → RateLimit → ConcurrencyLimit → AttemptTimeout
+```
+
+Read that the same way as any [fluent chain](composition.md): `Timeout` is the total budget wrapping everything, retries happen inside it, each attempt passes through the breaker and the two limiters, and `AttemptTimeout` is the innermost per-attempt budget. Only the sections you declare are added; the remaining ones keep their relative order. The defaults inside each section match the fluent API's.
+
+Configuration cannot reorder that chain — the order is what makes a definition readable across environments. Build the shield with the fluent API and register the instance when you need a different shape.
 
 ### Reloading configuration atomically
 

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -60,8 +60,8 @@ which resets *handling* to Kevlar's default.
 
 ## Clauses are ambient
 
-A clause applies to the strategy it creates *and* to every reactive strategy chained after it,
-until you write a new clause, call `WhenAnyError()`, or compose with `Wrap`/`Compose`:
+A clause applies to the strategy it is attached to *and* to every reactive strategy chained after
+it, until you write a new clause, call `WhenAnyError()`, or compose with `Wrap`/`Compose`:
 
 <!-- doc-test-ignore: Uses an ellipsis for the application-specific fallback implementation. -->
 ```csharp
@@ -74,6 +74,8 @@ Shield
 ```
 
 This is why most chains only need one clause, written once at the top — and why you never repeat a `ShouldHandle` predicate per strategy like in Polly v8.
+
+A clause that never reaches a reactive strategy does nothing at all. The optional analyzer reports that as [`KEV007`](analyzers.md#kev007-dead-handling-clause).
 
 ### Reset to default handling
 

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -55,8 +55,8 @@ Every overload also has an options configurator for fallback notifications:
     options => options.OnFallback = e => metrics.Increment("config.fallback"))
 ```
 
-Legacy positional notification callbacks intentionally fail compilation instead of being
-reinterpreted as configurators. Assign the callback to `options.OnFallback` as shown above.
+Each shape has exactly two overloads — bare and `configure`. There is no positional `onFallback`
+parameter: assign the callback to `options.OnFallback` as shown above.
 
 The `FallbackEvent<T>` carries the failure that triggered it as a typed `Outcome<T>` — `Outcome.Exception` when an exception was handled, `Outcome.Result` when a result value was. No casting, no boxing.
 

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -24,6 +24,15 @@ var shield = Shield
 await shield.ExecuteAsync(ct => bus.PublishAsync(message, ct));
 ```
 
+`Shield.Fallback(…)` is the static factory form, for when the fallback is the outermost strategy —
+which is the valid position for one, since it recovers what everything inside it could not:
+
+```csharp
+var shield = Shield
+    .Fallback((exception, ct) => deadLetter.PublishAsync(exception, ct))
+    .Retry(3);
+```
+
 A void fallback guards void executions only; executing a result-returning delegate through it fails
 with a descriptive error rather than inventing a default value. The optional analyzer reports this
 mistake as [`KEV005`](../analyzers.md#kev005-void-fallback-with-a-result) when the pipeline is visible

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -31,7 +31,7 @@ Shield.Hedge(o =>
 | `OnHedgeAsync` | — | Awaited callback after `OnHedge` and before the attempt starts |
 | `ActionGenerator` | — | Select a different operation for each additional attempt; `null` uses the original |
 | `HandlesException` | — | Local exception predicate; replaces the ambient clause for this hedge |
-| `HandlesResult` (`HedgingOptions<T>`) | — | Local result predicate on `Shield<T>`; replaces the ambient clause together with `HandlesException` |
+| `HandlesResult` (`HedgeOptions<T>`) | — | Local result predicate on `Shield<T>`; replaces the ambient clause together with `HandlesException` |
 
 ### Selecting another target
 

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@ KEV003 | Configuration | Warning | Fallback makes a reactive strategy unreachabl
 KEV004 | Reliability | Warning | Stateful shield or partition provider is constructed per execution
 KEV005 | Configuration | Warning | Void fallback is used with a result-returning execution
 KEV006 | Reliability | Warning | Hedging on an untyped Shield requires an idempotent action
+KEV007 | Configuration | Warning | Handling clause never reaches a reactive strategy

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -10,7 +10,8 @@ namespace Kevlar.Analyzers;
 /// <summary>
 /// Diagnoses statically provable Kevlar pipeline hazards: synchronous multi-attempt hedging, reactive
 /// strategies made unreachable by an inner fallback, per-execution construction of stateful shields,
-/// void fallbacks used for result-returning executions, and hedging on an untyped shield.
+/// void fallbacks used for result-returning executions, hedging on an untyped shield, and handling
+/// clauses that never reach a reactive strategy.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
@@ -65,6 +66,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "An untyped Shield can only judge hedged attempts by their exceptions, so every attempt it launches runs to completion against the real dependency. Duplicate writes, charges, or sends from a losing hedge are observable unless the action is idempotent.");
 
+    /// <summary>The KEV007 rule.</summary>
+    public static readonly DiagnosticDescriptor DeadHandlingClauseRule = new(
+        id: "KEV007",
+        title: "Handling clause never reaches a reactive strategy",
+        messageFormat: "This handling clause never reaches a reactive strategy, so it has no effect: {0}. Finish the clause with Retry, CircuitBreaker, Hedge, Fallback, or Use, or remove it.",
+        category: "Configuration",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A When/Or clause only changes behaviour once a reactive strategy consumes it. A clause whose builder is discarded, or that a later When clause replaces before any reactive strategy is added, silently does nothing.");
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
@@ -72,7 +83,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             UnreachableReactiveStrategyRule,
             EphemeralStatefulShieldRule,
             VoidFallbackResultExecutionRule,
-            UntypedHedgingRule);
+            UntypedHedgingRule,
+            DeadHandlingClauseRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -171,6 +183,196 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 VoidFallbackResultExecutionRule,
                 invocation.Syntax.GetLocation()));
         }
+
+        if (TryFindDeadHandlingClause(invocation, context, knownTypes, out var deadClauseReason))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DeadHandlingClauseRule,
+                invocation.Syntax.GetLocation(),
+                deadClauseReason));
+        }
+    }
+
+    /// <summary>
+    /// Reports a handling clause that cannot change any strategy's behaviour: either the
+    /// <c>ShieldBuilder</c> it produces is dropped without a strategy, or a later <c>When…</c> in
+    /// the same fluent chain replaces it before a reactive strategy consumes it.
+    /// </summary>
+    private static bool TryFindDeadHandlingClause(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        out string? reason)
+    {
+        var method = Normalize(invocation.TargetMethod);
+
+        if (ProducesHandlingClauseBuilder(method, knownTypes)
+            && IsDiscardedClauseBuilder(invocation, context))
+        {
+            reason = "the ShieldBuilder it returns is discarded";
+            return true;
+        }
+
+        if (DeclaresHandlingClause(method, knownTypes)
+            && IsReplacedBeforeUse(invocation, knownTypes))
+        {
+            reason = "a later When clause replaces it first";
+            return true;
+        }
+
+        reason = null;
+        return false;
+    }
+
+    /// <summary>Whether the fluent method hands back a clause builder that still needs a strategy.</summary>
+    private static bool ProducesHandlingClauseBuilder(IMethodSymbol method, KnownTypes knownTypes) =>
+        method.ReturnType is INamedTypeSymbol returnType
+        && knownTypes.IsShieldBuilder(returnType)
+        && IsKevlarFluentMethod(method, knownTypes);
+
+    /// <summary>Whether the method opens a clause carrying predicates, as opposed to resetting one.</summary>
+    private static bool DeclaresHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
+        method.Name != "WhenAnyError" && StartsHandlingClause(method, knownTypes);
+
+    /// <summary>Whether a reactive strategy reads the ambient clause this method seals.</summary>
+    private static bool ConsumesHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
+        (method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker" or "Fallback" or "Use")
+        && IsKevlarFluentMethod(method, knownTypes);
+
+    private static bool IsDiscardedClauseBuilder(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context)
+    {
+        for (var parent = invocation.Parent; parent is not null; parent = parent.Parent)
+        {
+            switch (parent)
+            {
+                case IConversionOperation or IParenthesizedOperation:
+                    continue;
+
+                // `shield.When<T>();` — the builder is dropped where it stands.
+                case IExpressionStatementOperation:
+                    return true;
+
+                // `_ = shield.When<T>();` — dropped just as deliberately.
+                case IAssignmentOperation { Target: IDiscardOperation }:
+                    return true;
+
+                // `var clause = shield.When<T>();` with no later mention of `clause`.
+                case IVariableInitializerOperation { Parent: IVariableDeclaratorOperation declarator }:
+                    return IsNeverRead(declarator.Symbol, context);
+
+                // A chained call consumes it: either another Or… (analysed in its own right, so
+                // only the outermost link of a dead chain is reported) or a strategy that seals it.
+                // Anything else — an argument, a return, a field — escapes this analysis.
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsNeverRead(ILocalSymbol local, OperationAnalysisContext context)
+    {
+        var declarations = local.DeclaringSyntaxReferences;
+        var semanticModel = context.Operation.SemanticModel;
+        if (declarations.Length != 1 || semanticModel is null)
+        {
+            return false;
+        }
+
+        var declarator = declarations[0].GetSyntax(context.CancellationToken);
+        if (semanticModel.SyntaxTree != declarator.SyntaxTree)
+        {
+            return false;
+        }
+
+        var scope = GetExecutableScope(declarator, context.CancellationToken);
+        foreach (var identifier in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText == local.Name
+                && SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol,
+                    local))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Walks outward from a <c>When…</c> through the calls that consume its value. Only a chain
+    /// that reaches another clause declaration — with nothing reactive in between — is dead;
+    /// anything the walk cannot follow leaves the clause alone.
+    /// </summary>
+    private static bool IsReplacedBeforeUse(IInvocationOperation invocation, KnownTypes knownTypes)
+    {
+        for (var consumer = FindChainedConsumer(invocation); consumer is not null; consumer = FindChainedConsumer(consumer))
+        {
+            var method = Normalize(consumer.TargetMethod);
+
+            if (ConsumesHandlingClause(method, knownTypes))
+            {
+                return false;
+            }
+
+            // A new clause replaced the old one, and nothing reactive read it on the way here.
+            // Checked before the builder test because When… also returns a builder; only the
+            // Or… continuations declared on ShieldBuilder itself extend the existing clause.
+            if (StartsHandlingClause(method, knownTypes))
+            {
+                return true;
+            }
+
+            // Or… continues the same clause.
+            if (ProducesHandlingClauseBuilder(method, knownTypes))
+            {
+                continue;
+            }
+
+            // Proactive strategies and metadata keep the clause ambient; anything else — including
+            // Wrap and Compose, which seal clauses — is beyond what this walk should judge.
+            if (IsCompositionBoundary(method, knownTypes) || !IsKevlarFluentMethod(method, knownTypes))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>The invocation that takes <paramref name="invocation"/> as its fluent receiver, if any.</summary>
+    private static IInvocationOperation? FindChainedConsumer(IInvocationOperation invocation)
+    {
+        for (IOperation? current = invocation, parent = invocation.Parent;
+            parent is not null;
+            current = parent, parent = parent.Parent)
+        {
+            switch (parent)
+            {
+                case IConversionOperation or IParenthesizedOperation:
+                    continue;
+
+                // An instance call: `clause.Retry(3)`.
+                case IInvocationOperation consumer
+                    when ReferenceEquals(GetReceiver(consumer), current):
+                    return consumer;
+
+                // A reduced extension call: `shield.When<T>()` parents the receiver under the
+                // argument that carries it, not under the invocation itself.
+                case IArgumentOperation { Parent: IInvocationOperation extensionConsumer }
+                    when ReferenceEquals(GetReceiver(extensionConsumer), current):
+                    return extensionConsumer;
+
+                default:
+                    return null;
+            }
+        }
+
+        return null;
     }
 
     private static bool TryFindEphemeralStatefulConstruction(

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 Kevlar.Analyzers.PipelineHazardAnalyzer
 Kevlar.Analyzers.PipelineHazardAnalyzer.PipelineHazardAnalyzer() -> void
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.DeadHandlingClauseRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.EphemeralStatefulShieldRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>

--- a/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
@@ -3,11 +3,22 @@ namespace Kevlar.Extensions.DependencyInjection;
 /// <summary>
 /// A declarative shield that can be bound from configuration (appsettings, environment,
 /// key vault…), so retry counts, timeouts and breaker thresholds are tunable without a redeploy.
-/// Strategies are chained in a fixed, sensible order, outermost first:
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Build"/> chains the sections in one fixed order, outermost first:
 /// <see cref="Timeout"/> → <see cref="Retry"/> → <see cref="CircuitBreaker"/> →
 /// <see cref="RateLimit"/> → <see cref="ConcurrencyLimit"/> → <see cref="AttemptTimeout"/>.
-/// Only the sections present in configuration are added.
-/// </summary>
+/// Only the sections present in configuration are added; the rest keep their relative order.
+/// </para>
+/// <para>
+/// The order reads like any fluent chain: <see cref="Timeout"/> is the total budget around
+/// everything, retries happen inside it, every attempt passes through the breaker and the two
+/// limiters, and <see cref="AttemptTimeout"/> is the innermost per-attempt budget. Configuration
+/// cannot reorder the chain — build the shield with the fluent API when a different shape is
+/// needed.
+/// </para>
+/// </remarks>
 public sealed class ShieldDefinition
 {
     /// <summary>Total budget for the whole operation (outermost). Omit for none.</summary>
@@ -28,7 +39,12 @@ public sealed class ShieldDefinition
     /// <summary>Budget for each individual attempt (innermost). Omit for none.</summary>
     public TimeSpan? AttemptTimeout { get; set; }
 
-    /// <summary>Builds the configured <see cref="Shield"/>.</summary>
+    /// <summary>
+    /// Builds the configured <see cref="Shield"/>, chaining the declared sections outermost first:
+    /// <see cref="Timeout"/> → <see cref="Retry"/> → <see cref="CircuitBreaker"/> →
+    /// <see cref="RateLimit"/> → <see cref="ConcurrencyLimit"/> → <see cref="AttemptTimeout"/>.
+    /// Sections left null are skipped without changing the order of the rest.
+    /// </summary>
     public Shield Build()
     {
         var shield = Shield.Empty;

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -129,10 +129,10 @@ Kevlar.HedgeActionGeneratorEvent<TResult>.HedgeActionGeneratorEvent() -> void
 Kevlar.HedgeActionGeneratorEvent<TResult>.Attempt.get -> int
 Kevlar.HedgeActionGeneratorEvent<TResult>.Context.get -> Kevlar.KevlarContext!
 Kevlar.HedgeActionGeneratorEvent<TResult>.OriginalAction.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>!
-Kevlar.HedgingOptions.ActionGenerator.get -> Kevlar.HedgeActionGenerator?
-Kevlar.HedgingOptions.ActionGenerator.set -> void
-Kevlar.HedgingOptions.OnHedgeAsync.get -> System.Func<Kevlar.HedgeEvent, System.Threading.Tasks.ValueTask>?
-Kevlar.HedgingOptions.OnHedgeAsync.set -> void
+Kevlar.HedgeOptions.ActionGenerator.get -> Kevlar.HedgeActionGenerator?
+Kevlar.HedgeOptions.ActionGenerator.set -> void
+Kevlar.HedgeOptions.OnHedgeAsync.get -> System.Func<Kevlar.HedgeEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.HedgeOptions.OnHedgeAsync.set -> void
 static Kevlar.HedgeActionGenerator.Create(System.Func<Kevlar.HedgeActionGeneratorEvent, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>?>! generator) -> Kevlar.HedgeActionGenerator!
 static Kevlar.HedgeActionGenerator.Create<TResult>(System.Func<Kevlar.HedgeActionGeneratorEvent<TResult>, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>?>! generator) -> Kevlar.HedgeActionGenerator!
 Kevlar.ConcurrencyLimitOptions.OnRejected.get -> System.Action<Kevlar.ConcurrencyLimitRejectedEvent>?
@@ -184,12 +184,12 @@ Kevlar.FallbackOptions<TResult>.HandlesException.get -> System.Func<System.Excep
 Kevlar.FallbackOptions<TResult>.HandlesException.set -> void
 Kevlar.FallbackOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
 Kevlar.FallbackOptions<TResult>.HandlesResult.set -> void
-Kevlar.HedgingOptions.HandlesException.get -> System.Func<System.Exception!, bool>?
-Kevlar.HedgingOptions.HandlesException.set -> void
-Kevlar.HedgingOptions<TResult>
-Kevlar.HedgingOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
-Kevlar.HedgingOptions<TResult>.HandlesResult.set -> void
-Kevlar.HedgingOptions<TResult>.HedgingOptions() -> void
+Kevlar.HedgeOptions.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.HedgeOptions.HandlesException.set -> void
+Kevlar.HedgeOptions<TResult>
+Kevlar.HedgeOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
+Kevlar.HedgeOptions<TResult>.HandlesResult.set -> void
+Kevlar.HedgeOptions<TResult>.HedgeOptions() -> void
 Kevlar.RetryOptions.HandlesException.get -> System.Func<System.Exception!, bool>?
 Kevlar.RetryOptions.HandlesException.set -> void
 Kevlar.RetryOptions<TResult>.HandlesException.get -> System.Func<System.Exception!, bool>?
@@ -197,9 +197,9 @@ Kevlar.RetryOptions<TResult>.HandlesException.set -> void
 Kevlar.RetryOptions<TResult>.HandlesResult.get -> System.Func<TResult, bool>?
 Kevlar.RetryOptions<TResult>.HandlesResult.set -> void
 Kevlar.Shield<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.Hedge(System.Action<Kevlar.HedgingOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.Hedge(System.Action<Kevlar.HedgeOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.Hedge(System.Action<Kevlar.HedgingOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Hedge(System.Action<Kevlar.HedgeOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 *REMOVED*Kevlar.Shield<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
 *REMOVED*Kevlar.Shield<TResult>.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield<TResult>!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
@@ -222,3 +222,25 @@ Kevlar.Shield<TResult>.ExecuteWithContextAsync(System.Func<Kevlar.KevlarContext!
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<T>(this Kevlar.Shield! shield, System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.Task<T>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T>
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync(this Kevlar.Shield! shield, System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.Task!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<TResult>(this Kevlar.Shield<TResult>! shield, System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.Task<TResult>!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult>
+*REMOVED*Kevlar.HedgingOptions
+*REMOVED*Kevlar.HedgingOptions.Delay.get -> System.TimeSpan
+*REMOVED*Kevlar.HedgingOptions.Delay.set -> void
+*REMOVED*Kevlar.HedgingOptions.HedgingOptions() -> void
+*REMOVED*Kevlar.HedgingOptions.MaxAttempts.get -> int
+*REMOVED*Kevlar.HedgingOptions.MaxAttempts.set -> void
+*REMOVED*Kevlar.HedgingOptions.OnHedge.get -> System.Action<Kevlar.HedgeEvent>?
+*REMOVED*Kevlar.HedgingOptions.OnHedge.set -> void
+*REMOVED*Kevlar.ShieldBuilder.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield!
+*REMOVED*static Kevlar.Shield.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield!
+*REMOVED*static Kevlar.ShieldExtensions.Hedge(this Kevlar.Shield! shield, System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield!
+Kevlar.HedgeOptions
+Kevlar.HedgeOptions.Delay.get -> System.TimeSpan
+Kevlar.HedgeOptions.Delay.set -> void
+Kevlar.HedgeOptions.HedgeOptions() -> void
+Kevlar.HedgeOptions.MaxAttempts.get -> int
+Kevlar.HedgeOptions.MaxAttempts.set -> void
+Kevlar.HedgeOptions.OnHedge.get -> System.Action<Kevlar.HedgeEvent>?
+Kevlar.HedgeOptions.OnHedge.set -> void
+Kevlar.ShieldBuilder.Hedge(System.Action<Kevlar.HedgeOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.Shield.Hedge(System.Action<Kevlar.HedgeOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.Hedge(this Kevlar.Shield! shield, System.Action<Kevlar.HedgeOptions!>! configure) -> Kevlar.Shield!

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -104,23 +104,17 @@ Kevlar.FallbackOptions<TResult>.OnFallbackAsync.set -> void
 *REMOVED*Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>! onFallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -244,3 +244,8 @@ Kevlar.HedgeOptions.OnHedge.set -> void
 Kevlar.ShieldBuilder.Hedge(System.Action<Kevlar.HedgeOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.Shield.Hedge(System.Action<Kevlar.HedgeOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.Hedge(this Kevlar.Shield! shield, System.Action<Kevlar.HedgeOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.Shield.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
+static Kevlar.Shield.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.Shield.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
+static Kevlar.Shield.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
+static Kevlar.Shield<TResult>.Compose(params Kevlar.Shield<TResult>![]! shields) -> Kevlar.Shield<TResult>!

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -118,6 +118,48 @@ public sealed class Shield
     /// </remarks>
     public static Shield Hedge(Action<HedgeOptions> configure) => ShieldExtensions.Hedge(Empty, configure);
 
+    /// <summary>
+    /// Starts a pipeline with a fallback that runs <paramref name="fallback"/> in place of handled
+    /// failures, receiving the handled exception. Applies to void executions only; result-returning
+    /// executions fail with a descriptive <see cref="InvalidOperationException"/> — use
+    /// <c>Shield.For&lt;T&gt;().Fallback(…)</c> for those.
+    /// </summary>
+    /// <remarks>
+    /// A fallback is legitimately the outermost strategy: it recovers what everything chained
+    /// inside it could not.
+    /// </remarks>
+    public static Shield Fallback(Func<Exception, CancellationToken, ValueTask> fallback) =>
+        ShieldExtensions.Fallback(Empty, fallback);
+
+    /// <summary>
+    /// Starts a pipeline with a fallback that runs <paramref name="fallback"/> in place of handled
+    /// failures and configures notifications. Applies to void executions only.
+    /// </summary>
+    /// <remarks>Runs <see cref="FallbackOptions.OnFallback"/>, then <see cref="FallbackOptions.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
+    public static Shield Fallback(
+        Func<Exception, CancellationToken, ValueTask> fallback,
+        Action<FallbackOptions> configure) =>
+        ShieldExtensions.Fallback(Empty, fallback, configure);
+
+    /// <summary>
+    /// Starts a pipeline with a fallback that runs <paramref name="fallback"/> in place of handled
+    /// failures. Applies to void executions only; result-returning executions fail with a
+    /// descriptive <see cref="InvalidOperationException"/> — use <c>Shield.For&lt;T&gt;().Fallback(…)</c>
+    /// for those.
+    /// </summary>
+    public static Shield Fallback(Func<CancellationToken, ValueTask> fallback) =>
+        ShieldExtensions.Fallback(Empty, fallback);
+
+    /// <summary>
+    /// Starts a pipeline with a fallback that runs <paramref name="fallback"/> in place of handled
+    /// failures and configures notifications. Applies to void executions only.
+    /// </summary>
+    /// <remarks>Runs <see cref="FallbackOptions.OnFallback"/>, then <see cref="FallbackOptions.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
+    public static Shield Fallback(
+        Func<CancellationToken, ValueTask> fallback,
+        Action<FallbackOptions> configure) =>
+        ShieldExtensions.Fallback(Empty, fallback, configure);
+
     /// <summary>Starts a pipeline with a custom <see cref="Strategy"/> implementation.</summary>
     public static Shield Use(Strategy strategy) => ShieldExtensions.Use(Empty, strategy);
 
@@ -154,27 +196,20 @@ public sealed class Shield
     {
         Throw.IfNull(shields, nameof(shields));
 
-        var total = 0;
+        var parts = new Strategy[shields.Length][];
         string? name = null;
         TimeProvider? time = null;
 
-        foreach (var shield in shields)
+        for (var i = 0; i < shields.Length; i++)
         {
+            var shield = shields[i];
             Throw.IfNull(shield, nameof(shields));
-            total += shield.Strategies.Length;
+            parts[i] = shield.Strategies;
             name ??= shield.Name;
             time ??= shield.Time;
         }
 
-        var strategies = new Strategy[total];
-        var offset = 0;
-        foreach (var shield in shields)
-        {
-            Array.Copy(shield.Strategies, 0, strategies, offset, shield.Strategies.Length);
-            offset += shield.Strategies.Length;
-        }
-
-        return new Shield(strategies, null, name, time);
+        return new Shield(Concat(parts), null, name, time);
     }
 
     // ── Execution ───────────────────────────────────────────────────────────────────────
@@ -535,6 +570,26 @@ public sealed class Shield
         var strategies = new Strategy[first.Length + second.Length];
         Array.Copy(first, strategies, first.Length);
         Array.Copy(second, 0, strategies, first.Length, second.Length);
+        return strategies;
+    }
+
+    /// <summary>Flattens the strategy arrays of composed shields, first shield outermost.</summary>
+    internal static Strategy[] Concat(Strategy[][] parts)
+    {
+        var total = 0;
+        foreach (var part in parts)
+        {
+            total += part.Length;
+        }
+
+        var strategies = new Strategy[total];
+        var offset = 0;
+        foreach (var part in parts)
+        {
+            Array.Copy(part, 0, strategies, offset, part.Length);
+            offset += part.Length;
+        }
+
         return strategies;
     }
 

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -116,7 +116,7 @@ public sealed class Shield
     /// concurrently, so the delegate must be idempotent. Prefer <see cref="For{TResult}"/>, or
     /// confirm the action is safe to repeat.
     /// </remarks>
-    public static Shield Hedge(Action<HedgingOptions> configure) => ShieldExtensions.Hedge(Empty, configure);
+    public static Shield Hedge(Action<HedgeOptions> configure) => ShieldExtensions.Hedge(Empty, configure);
 
     /// <summary>Starts a pipeline with a custom <see cref="Strategy"/> implementation.</summary>
     public static Shield Use(Strategy strategy) => ShieldExtensions.Use(Empty, strategy);

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -91,7 +91,7 @@ public sealed class ShieldBuilder
     /// concurrently, so the delegate must be idempotent. Prefer <c>Shield.For&lt;T&gt;()</c>, or
     /// confirm the action is safe to repeat.
     /// </remarks>
-    public Shield Hedge(Action<HedgingOptions> configure) => Seal().Hedge(configure);
+    public Shield Hedge(Action<HedgeOptions> configure) => Seal().Hedge(configure);
 
     /// <summary>Creates and appends a custom strategy using the accumulated handling clause.</summary>
     public Shield Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -102,7 +102,7 @@ public sealed class ShieldBuilder<TResult>
     public Shield<TResult> Hedge(int maxAttempts, TimeSpan delay) => Seal().Hedge(maxAttempts, delay);
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
-    public Shield<TResult> Hedge(Action<HedgingOptions<TResult>> configure) => Seal().Hedge(configure);
+    public Shield<TResult> Hedge(Action<HedgeOptions<TResult>> configure) => Seal().Hedge(configure);
 
     /// <summary>Creates and appends a custom strategy using the accumulated handling clause.</summary>
     public Shield<TResult> Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -14,9 +14,6 @@ namespace Kevlar;
 /// </remarks>
 public sealed class ShieldBuilder<TResult>
 {
-    private const string LegacyFallbackCallbackMessage =
-        "Configure fallback notifications with Fallback(..., options => options.OnFallback = callback).";
-
     private readonly Shield<TResult> _parent;
     private readonly List<Func<Exception, bool>> _exceptionPredicates = [];
     private readonly List<Func<TResult, bool>> _resultPredicates = [];
@@ -113,24 +110,12 @@ public sealed class ShieldBuilder<TResult>
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
     public Shield<TResult> Fallback(TResult fallbackValue) => Seal().Fallback(fallbackValue);
 
-    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
-    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
-    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>> onFallback) =>
-        Seal().Fallback(fallbackValue, options => options.OnFallback = onFallback);
-
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
     public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure) =>
         Seal().Fallback(fallbackValue, configure);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
     public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback) => Seal().Fallback(fallback);
-
-    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
-    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
-    public Shield<TResult> Fallback(
-        Func<CancellationToken, ValueTask<TResult>> fallback,
-        Action<FallbackEvent<TResult>> onFallback) =>
-        Seal().Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and configures notifications.</summary>
     public Shield<TResult> Fallback(
@@ -139,13 +124,6 @@ public sealed class ShieldBuilder<TResult>
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
     public Shield<TResult> Fallback(Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback) => Seal().Fallback(fallback);
-
-    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
-    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
-    public Shield<TResult> Fallback(
-        Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
-        Action<FallbackEvent<TResult>> onFallback) =>
-        Seal().Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>
     /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -137,11 +137,11 @@ public static class ShieldExtensions
     /// concurrently, so the delegate must be idempotent. Prefer <c>Shield.For&lt;T&gt;()</c>, or
     /// confirm the action is safe to repeat.
     /// </remarks>
-    public static Shield Hedge(this Shield shield, Action<HedgingOptions> configure)
+    public static Shield Hedge(this Shield shield, Action<HedgeOptions> configure)
     {
         Throw.IfNull(shield, nameof(shield));
         Throw.IfNull(configure, nameof(configure));
-        var options = new HedgingOptions();
+        var options = new HedgeOptions();
         configure(options);
         var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
         return shield.Append(new HedgingStrategy(options, judge));

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -324,6 +324,33 @@ public sealed class Shield<TResult>
             Time ?? inner.Time);
     }
 
+    /// <summary>
+    /// Merges result-aware shields into one pipeline. The first shield is the outermost. Stateful
+    /// strategies keep their identity, so a shared circuit breaker shield shares its circuit here.
+    /// The result keeps the first non-null <see cref="Name"/> and <see cref="TimeProvider"/>
+    /// among the inputs. Composition seals handling clauses, so reactive strategies appended
+    /// afterwards use default handling unless a new clause is declared.
+    /// </summary>
+    public static Shield<TResult> Compose(params Shield<TResult>[] shields)
+    {
+        Throw.IfNull(shields, nameof(shields));
+
+        var parts = new Strategy[shields.Length][];
+        string? name = null;
+        TimeProvider? time = null;
+
+        for (var i = 0; i < shields.Length; i++)
+        {
+            var shield = shields[i];
+            Throw.IfNull(shield, nameof(shields));
+            parts[i] = shield.Strategies;
+            name ??= shield.Name;
+            time ??= shield.Time;
+        }
+
+        return new Shield<TResult>(Shield.Concat(parts), null, name, time);
+    }
+
     /// <summary>Returns a copy of this shield with a diagnostic name (surfaced as <see cref="KevlarContext.ShieldName"/>).</summary>
     public Shield<TResult> WithName(string name)
     {

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -11,9 +11,6 @@ namespace Kevlar;
 /// </summary>
 public sealed class Shield<TResult>
 {
-    private const string LegacyFallbackCallbackMessage =
-        "Configure fallback notifications with Fallback(..., options => options.OnFallback = callback).";
-
     internal readonly Strategy[] Strategies;
     internal readonly StrategyNode? Head;
     internal readonly OutcomeJudge? Ambient;
@@ -205,11 +202,6 @@ public sealed class Shield<TResult>
     public Shield<TResult> Fallback(TResult fallbackValue) =>
         Append(new FallbackStrategy<TResult>((_, _) => new ValueTask<TResult>(fallbackValue), JudgeOrDefault, null, null));
 
-    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
-    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
-    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackEvent<TResult>> onFallback) =>
-        Fallback(fallbackValue, options => options.OnFallback = onFallback);
-
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
     /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
     public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure)
@@ -232,13 +224,6 @@ public sealed class Shield<TResult>
         Throw.IfNull(fallback, nameof(fallback));
         return Append(new FallbackStrategy<TResult>((_, context) => fallback(context.CancellationToken), JudgeOrDefault, null, null));
     }
-
-    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
-    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
-    public Shield<TResult> Fallback(
-        Func<CancellationToken, ValueTask<TResult>> fallback,
-        Action<FallbackEvent<TResult>> onFallback) =>
-        Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and configures notifications.</summary>
     /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
@@ -265,13 +250,6 @@ public sealed class Shield<TResult>
         Throw.IfNull(fallback, nameof(fallback));
         return Append(new FallbackStrategy<TResult>((outcome, context) => fallback(outcome, context.CancellationToken), JudgeOrDefault, null, null));
     }
-
-    /// <summary>Prevents legacy notification callbacks from binding as options configurators.</summary>
-    [Obsolete(LegacyFallbackCallbackMessage, error: true)]
-    public Shield<TResult> Fallback(
-        Func<Outcome<TResult>, CancellationToken, ValueTask<TResult>> fallback,
-        Action<FallbackEvent<TResult>> onFallback) =>
-        Fallback(fallback, options => options.OnFallback = onFallback);
 
     /// <summary>
     /// Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -189,10 +189,10 @@ public sealed class Shield<TResult>
     });
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
-    public Shield<TResult> Hedge(Action<HedgingOptions<TResult>> configure)
+    public Shield<TResult> Hedge(Action<HedgeOptions<TResult>> configure)
     {
         Throw.IfNull(configure, nameof(configure));
-        var options = new HedgingOptions<TResult>();
+        var options = new HedgeOptions<TResult>();
         configure(options);
         var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
         return Append(new HedgingStrategy(options, judge));

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -12,7 +12,7 @@ namespace Kevlar;
 /// <see cref="OnHedgeAsync"/>, then <see cref="ActionGenerator"/>. Caller cancellation is checked
 /// before callbacks and again before the generated operation starts.
 /// </remarks>
-public class HedgingOptions
+public class HedgeOptions
 {
     /// <summary>
     /// Locally selects exceptions handled by this hedging strategy. When set, this strategy

--- a/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
@@ -3,7 +3,7 @@ namespace Kevlar;
 /// <summary>
 /// Result-typed configuration for a hedging strategy on a <see cref="Shield{TResult}"/>.
 /// </summary>
-public sealed class HedgingOptions<TResult> : HedgingOptions
+public sealed class HedgeOptions<TResult> : HedgeOptions
 {
     /// <summary>
     /// Locally selects results handled by this hedging strategy. When either local predicate is

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -12,7 +12,7 @@ internal sealed class HedgingStrategy : Strategy
     private readonly Func<HedgeEvent, ValueTask>? _onHedgeAsync;
     private readonly HedgeActionGenerator? _actionGenerator;
 
-    public HedgingStrategy(HedgingOptions options, OutcomeJudge judge)
+    public HedgingStrategy(HedgeOptions options, OutcomeJudge judge)
     {
         Throw.IfOutOfRange(options.MaxAttempts < 1, nameof(options), "MaxAttempts must be at least 1.");
         Throw.IfOutOfRange(options.Delay < TimeSpan.Zero && options.Delay != System.Threading.Timeout.InfiniteTimeSpan, nameof(options), "Delay must be non-negative or Timeout.InfiniteTimeSpan.");

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -144,7 +144,18 @@ public readonly struct RetryEvent
     /// <summary>The exception from the failed attempt, or <see langword="null"/> when a result was handled.</summary>
     public Exception? Exception { get; }
 
-    /// <summary>The handled result from the failed attempt (boxed), or <see langword="null"/> when an exception occurred.</summary>
+    /// <summary>
+    /// The handled result from the failed attempt, or <see langword="null"/> when an exception
+    /// occurred.
+    /// </summary>
+    /// <remarks>
+    /// The untyped event carries the result as <see cref="object"/>, so a value-type result is
+    /// boxed on every retry and has to be unboxed — and its type re-asserted — by the callback.
+    /// Configure the retry through <see cref="RetryOptions{TResult}"/> on a
+    /// <see cref="Shield{TResult}"/> to receive <see cref="RetryEvent{TResult}"/> instead: its
+    /// <see cref="RetryEvent{TResult}.Outcome"/> is a typed <see cref="Outcome{TResult}"/>, with
+    /// no boxing and no cast.
+    /// </remarks>
     public object? Result { get; }
 
     /// <summary>

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -9,45 +9,51 @@ namespace Kevlar.Analyzers.Tests;
 public class PipelineHazardAnalyzerTests
 {
     [Test]
-    public async Task Legacy_Fallback_Callbacks_Cannot_Bind_As_Options_Configurators()
+    public async Task Typed_Fallback_Keeps_Only_The_Bare_And_Configure_Tiers()
     {
-        var ambiguous = CreateCompilation(CreateSource("""
+        var supported = CreateCompilation(CreateSource("""
             public class TestSubject
             {
                 public void Configure()
                 {
-                    _ = Shield.For<int>().Fallback(42, _ => { });
-                    _ = Shield.For<int>().Fallback(_ => new ValueTask<int>(42), _ => { });
-                    _ = Shield.For<int>().Fallback((_, _) => new ValueTask<int>(42), _ => { });
-                    _ = Shield.For<int>().When<Exception>().Fallback(42, _ => { });
-                    _ = Shield.For<int>().When<Exception>().Fallback(_ => new ValueTask<int>(42), _ => { });
-                    _ = Shield.For<int>().When<Exception>().Fallback((_, _) => new ValueTask<int>(42), _ => { });
+                    _ = Shield.For<int>().Fallback(42);
+                    _ = Shield.For<int>().Fallback(_ => new ValueTask<int>(42));
+                    _ = Shield.For<int>().Fallback((_, _) => new ValueTask<int>(42));
+                    _ = Shield.For<int>().Fallback(42, options => options.OnFallback = _ => { });
+                    _ = Shield.For<int>().Fallback(_ => new ValueTask<int>(42), options => options.OnFallback = _ => { });
+                    _ = Shield.For<int>().Fallback((_, _) => new ValueTask<int>(42), options => options.OnFallback = _ => { });
+                    _ = Shield.For<int>().When<Exception>().Fallback(42);
+                    _ = Shield.For<int>().When<Exception>().Fallback(_ => new ValueTask<int>(42));
+                    _ = Shield.For<int>().When<Exception>().Fallback((_, _) => new ValueTask<int>(42));
+                    _ = Shield.For<int>().When<Exception>().Fallback(42, options => options.OnFallback = _ => { });
+                    _ = Shield.For<int>().When<Exception>().Fallback(_ => new ValueTask<int>(42), options => options.OnFallback = _ => { });
+                    _ = Shield.For<int>().When<Exception>().Fallback((_, _) => new ValueTask<int>(42), options => options.OnFallback = _ => { });
                 }
             }
             """));
-        var ambiguousErrors = ambiguous.GetDiagnostics()
+        var supportedErrors = supported.GetDiagnostics()
             .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
             .ToArray();
 
-        await Assert.That(ambiguousErrors).Count().IsEqualTo(6);
-        await Assert.That(ambiguousErrors).All(static diagnostic => diagnostic.Id == "CS0121");
+        await Assert.That(supportedErrors).IsEmpty();
 
-        var explicitLegacy = CreateCompilation(CreateSource("""
+        var legacyCallback = CreateCompilation(CreateSource("""
             public class TestSubject
             {
                 public void Configure()
                 {
                     Action<FallbackEvent<int>> callback = _ => { };
                     _ = Shield.For<int>().Fallback(42, callback);
+                    _ = Shield.For<int>().When<Exception>().Fallback(42, callback);
                 }
             }
             """));
-        var explicitErrors = explicitLegacy.GetDiagnostics()
+        var legacyErrors = legacyCallback.GetDiagnostics()
             .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
             .ToArray();
 
-        await Assert.That(explicitErrors).Count().IsEqualTo(1);
-        await Assert.That(explicitErrors[0].Id).IsEqualTo("CS0619");
+        await Assert.That(legacyErrors).Count().IsEqualTo(2);
+        await Assert.That(legacyErrors).All(static diagnostic => diagnostic.Id == "CS1503");
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -572,6 +572,97 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV007_Flags_Clause_Builders_That_Never_Reach_A_Strategy()
+    {
+        var cases = new[]
+        {
+            "Shield.When<InvalidOperationException>();",
+            "Shield.When<InvalidOperationException>().Or<TimeoutException>();",
+            "Shield.When<InvalidOperationException>().Or<TimeoutException>().Or(static exception => exception is null);",
+            "_ = Shield.When<InvalidOperationException>();",
+            "_ = Shield.Empty.When<InvalidOperationException>();",
+            "_ = Shield.For<int>().WhenResult(static value => value < 0);",
+            "_ = Shield.For<int>().WhenResultDefault().Or<TimeoutException>();",
+            "var clause = Shield.When<InvalidOperationException>().Or<TimeoutException>();",
+            "var clause = Shield.For<int>().When<InvalidOperationException>();",
+        };
+
+        await AssertEachAsync(cases, "KEV007");
+    }
+
+    [Test]
+    public async Task KEV007_Flags_A_Clause_Replaced_Before_Any_Reactive_Strategy()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).WhenAnyError().Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).When<TimeoutException>().Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().RateLimit(1, TimeSpan.FromSeconds(1)).When<TimeoutException>().Retry(1);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).WhenResult(static value => value < 0).Retry(1);",
+        };
+
+        await AssertEachAsync(cases, "KEV007", "KEV004");
+    }
+
+    [Test]
+    public async Task KEV007_Leaves_Consumed_And_Escaping_Clauses_Alone()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.When<InvalidOperationException>().Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Fallback(static (_, _) => default);",
+            "_ = Shield.For<int>().WhenResult(static value => value < 0).Fallback(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
+            "var clause = Shield.When<InvalidOperationException>(); _ = clause.Retry(1);",
+            "var clause = Shield.When<InvalidOperationException>(); _ = clause.Or<TimeoutException>().Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Wrap(Shield.Empty).When<TimeoutException>().Retry(1);",
+            "_ = Clause().Retry(1);",
+            "_ = Shield.Empty.WhenAnyError().Retry(1);",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(
+                body,
+                "private static ShieldBuilder Clause() => Shield.When<InvalidOperationException>();");
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV007_Diagnostic_Contract_And_Suppression_Are_Exact()
+    {
+        const string clause = "Shield.When<InvalidOperationException>().Or<TimeoutException>()";
+        var source = $$"""
+            public class TestSubject
+            {
+                public void Build() => {{clause}};
+            }
+            """;
+        var diagnostics = await AnalyzeSourceAsync(source);
+        var suppressed = await AnalyzeBodyAsync("""
+            #pragma warning disable KEV007 // The clause is asserted on elsewhere.
+            Shield.When<InvalidOperationException>();
+            #pragma warning restore KEV007
+            """);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        var diagnostic = diagnostics[0];
+        await Assert.That(diagnostic.Id).IsEqualTo("KEV007");
+        await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            "This handling clause never reaches a reactive strategy, so it has no effect: "
+            + "the ShieldBuilder it returns is discarded. Finish the clause with Retry, "
+            + "CircuitBreaker, Hedge, Fallback, or Use, or remove it.");
+        await Assert.That(diagnostic.Location.SourceSpan.Start)
+            .IsEqualTo(CreateSource(source).IndexOf(clause, StringComparison.Ordinal));
+        await Assert.That(diagnostic.Location.SourceSpan.Length).IsEqualTo(clause.Length);
+        await Assert.That(suppressed).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV003_Flags_Unreachable_Reactive_Strategies()
     {
         var cases = new[]
@@ -608,7 +699,9 @@ public class PipelineHazardAnalyzerTests
             "var retry = Shield.Retry(1); var fallback = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); _ = Shield.Compose(retry, fallback);",
         };
 
-        await AssertEachAsync(cases, "KEV003");
+        // Some cases replace a clause that only a timeout ever saw, which is exactly what KEV007
+        // reports; the fallback reachability under test is unaffected.
+        await AssertEachAsync(cases, "KEV003", "KEV007");
     }
 
     [Test]
@@ -744,7 +837,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.For<int>().Fallback(0).Retry(1);",
             "_ = Shield.For<int>().Retry(1).When<InvalidOperationException>().Fallback(0);",
             "_ = Shield.For<int>().When<InvalidOperationException>().Retry(1).WhenAnyError().Fallback(0);",
-            "_ = Shield.For<int>().When<ArgumentException>().Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero).WhenAnyError().Fallback(0);",
+            "_ = Shield.For<int>().When<ArgumentException>().Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero).CircuitBreaker(2, TimeSpan.FromSeconds(1)).WhenAnyError().Fallback(0);",
             "_ = Shield.For<int>().Timeout(TimeSpan.FromSeconds(1)).Fallback(0);",
             "var shield = CreateShield(); _ = shield.Fallback(0);",
             "var shield = Shield.For<int>().Retry(1); shield = Shield<int>.Empty; _ = shield.Fallback(0);",

--- a/tests/Kevlar.Tests/CompositionTests.cs
+++ b/tests/Kevlar.Tests/CompositionTests.cs
@@ -54,6 +54,56 @@ public class CompositionTests
     }
 
     [Test]
+    public async Task Typed_Compose_Merges_Policies_In_Order()
+    {
+        var log = new List<string>();
+        var first = Shield<int>.Empty.Use(new MarkerStrategy(log, "first"));
+        var second = Shield<int>.Empty.Use(new MarkerStrategy(log, "second"));
+
+        var composed = Shield<int>.Compose(first, second);
+
+        await composed.ExecuteAsync(_ => new ValueTask<int>(1));
+
+        await Assert.That(log).IsEquivalentTo(["first:enter", "second:enter", "second:exit", "first:exit"]);
+    }
+
+    [Test]
+    public async Task Typed_Compose_Keeps_The_First_Non_Null_Metadata_And_Seals_Clauses()
+    {
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var unnamed = Shield<int>.Empty;
+        var named = Shield<int>.Empty.WithName("first").WithTimeProvider(time);
+        var later = Shield<int>.Empty.WithName("second");
+
+        var composed = Shield<int>.Compose(unnamed, named, later);
+
+        await Assert.That(composed.Name).IsEqualTo("first");
+
+        // The composed shield's ambient clause is sealed, so the retry below handles any
+        // exception rather than only the ArgumentException clause declared before composing.
+        var clauseCarrier = Shield.For<int>().When<ArgumentException>();
+        var attempts = 0;
+        var sealedShield = Shield<int>.Compose(clauseCarrier.Timeout(TimeSpan.FromMinutes(1)))
+            .Retry(1, Backoff.None);
+
+        await Assert.That(async () => await sealedShield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Typed_Compose_Rejects_Null_Inputs()
+    {
+        await Assert.That(() => Shield<int>.Compose(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => Shield<int>.Compose(Shield<int>.Empty, null!)).Throws<ArgumentNullException>();
+        await Assert.That(Shield<int>.Compose().Strategies).IsEmpty();
+    }
+
+    [Test]
     public async Task Wrap_Places_The_Outer_Policy_First()
     {
         var log = new List<string>();

--- a/tests/Kevlar.Tests/VoidFallbackTests.cs
+++ b/tests/Kevlar.Tests/VoidFallbackTests.cs
@@ -127,4 +127,65 @@ public class VoidFallbackTests
 
         await Assert.That(fallbackRan).IsTrue();
     }
+
+    [Test]
+    public async Task The_Static_Factory_Starts_A_Pipeline_With_A_Fallback()
+    {
+        Exception? seenException = null;
+        var exceptionFree = false;
+        var notified = 0;
+
+        var withException = Shield.Fallback((exception, _) =>
+        {
+            seenException = exception;
+            return default;
+        });
+        var withoutException = Shield.Fallback(_ =>
+        {
+            exceptionFree = true;
+            return default;
+        });
+        var withExceptionAndOptions = Shield.Fallback(
+            static (_, _) => default,
+            options => options.OnFallback = _ => notified++);
+        var withoutExceptionAndOptions = Shield.Fallback(
+            static _ => default,
+            options => options.OnFallback = _ => notified++);
+
+        var original = new InvalidOperationException("boom");
+        await withException.ExecuteAsync(_ => throw original);
+        await withoutException.ExecuteAsync(_ => throw new InvalidOperationException());
+        await withExceptionAndOptions.ExecuteAsync(_ => throw new InvalidOperationException());
+        await withoutExceptionAndOptions.ExecuteAsync(_ => throw new InvalidOperationException());
+
+        await Assert.That(ReferenceEquals(seenException, original)).IsTrue();
+        await Assert.That(exceptionFree).IsTrue();
+        await Assert.That(notified).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task The_Static_Factory_Keeps_The_Fallback_Outermost()
+    {
+        var attempts = 0;
+        var recovered = false;
+
+        // Fallback first is the valid order: the retry runs inside it.
+        var shield = Shield
+            .Fallback((_, _) =>
+            {
+                recovered = true;
+                return default;
+            })
+            .Retry(2, Backoff.None);
+
+        await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        });
+
+        await Assert.That(shield.ToString()).StartsWith("Fallback");
+        await Assert.That(attempts).IsEqualTo(3);
+        await Assert.That(recovered).IsTrue();
+    }
 }


### PR DESCRIPTION
Six changes from the second API review pass. The library is pre-release, so the removals and the rename are breaking with no `[Obsolete]` shims.

## 1. Trim the typed `Fallback` overload matrix (breaking)

`Shield<TResult>` and `ShieldBuilder<TResult>` carried three fallback shapes across three tiers: bare, a positional `Action<FallbackEvent<T>> onFallback`, and an `Action<FallbackOptions<T>> configure`. **The six middle-tier overloads are removed.** They only ever existed as `[Obsolete(error: true)]` migration shims — poison overloads that stopped an old positional callback from silently binding as a configurator — so no live call site could reference them.

Notifications stay reachable through `configure(o => o.OnFallback = ...)`, which is the only spelling the untyped `Shield`/`ShieldExtensions` fallbacks ever had. Both matrices are now bare + configure. A leftover positional `Action<FallbackEvent<T>>` callback now fails with `CS1503` instead of `CS0619`; the analyzer test that pinned the old poison-overload behaviour was rewritten to pin the new two-tier matrix instead.

## 2. `HedgingOptions` → `HedgeOptions` (breaking)

Every other strategy shares a stem with its options type — `Retry`/`RetryOptions`, `Timeout`/`TimeoutOptions`, `CircuitBreaker`/`CircuitBreakerOptions` — but `Hedge` took `HedgingOptions`. Renamed `HedgingOptions` → `HedgeOptions` and `HedgingOptions<TResult>` → `HedgeOptions<TResult>` across the core package, its docs, and `PublicAPI`.

`Kevlar.Extensions.Http` keeps `StandardHedgingShieldOptions` and `AddStandardHedgingShield` — those read as "the standard hedging shield", not as a strategy/options pair, and were out of scope. The internal `HedgingStrategy` type is unchanged.

## 3. `Shield.Fallback(…)` static factories

`Shield` had static factories for every strategy except fallback, so a fallback-first chain had to start from `Shield.Empty`. Added the four static factories mirroring the untyped `ShieldExtensions.Fallback` overloads (delegate with and without the `Exception` parameter, each with and without an `Action<FallbackOptions> configure`), each delegating to `ShieldExtensions.Fallback(Empty, ...)` like the other factories.

Fallback-first is the valid order — `Shield.ValidateChain` only rejects a fallback nested *inside* a retry/hedge/breaker sharing its judge, and that behaviour is untouched.

## 4. Typed `Shield<TResult>.Compose`

`Shield<TResult>` had `Wrap` but no `Compose`, while the untyped `Shield.Compose(params Shield[])` existed. Added `static Shield<TResult>.Compose(params Shield<TResult>[] shields)` with the untyped semantics: first shield outermost, first non-null `Name` and `TimeProvider` win, ambient handling clause sealed. Both implementations now share a new internal `Shield.Concat(Strategy[][])` overload.

> **Note on the ambient clause.** The task described `Compose` as keeping "the LAST ambient clause". The existing untyped implementation passes `null` for ambient — it *seals* the clause, matching the documented "composition seals handling clauses" behaviour and `CompositionContractTests`. The instruction to match the untyped implementation exactly won, so typed `Compose` seals too.

## 5. New analyzer rule: KEV007 — dead handling clause

`KEV006` was the last ID in use, so the new rule is **`KEV007` (Configuration, Warning)**: *"Handling clause never reaches a reactive strategy."* A `When…`/`Or…` clause only changes behaviour once a reactive strategy consumes it, so a clause that never reaches one is a silent no-op. Two shapes are reported:

- **The `ShieldBuilder` is discarded** — dropped as a statement (`shield.When<T>();`), assigned to a discard (`_ = ...`), or stored in a local nothing ever reads. Only the outermost link of a dead `Or` chain is reported, so one dangling clause produces one diagnostic.
- **The clause is replaced before use** — a later `When…`/`WhenAnyError()` supersedes it while only *proactive* strategies (timeout, rate limit, concurrency limit) sat in between, so nothing ever consulted it. This is the "replaced before any reactive strategy consumed it" case from the review, and it **is** tractable syntactically: within a single fluent chain a clause cannot be replaced without first being sealed by a strategy, because `ShieldBuilder`/`ShieldBuilder<T>` expose no `When…`. **It is implemented, not skipped.**

The walk deliberately stays quiet wherever it loses sight of the clause: builders that are returned, passed as arguments, or assigned to fields, and `Wrap`/`Compose` boundaries. Registered in `SupportedDiagnostics`, `AnalyzerReleases.Unshipped.md`, `Kevlar.Analyzers/PublicAPI.Unshipped.txt`, and the analyzers docs page (rule table + a `## KEV007` section).

### Guard-test catalogs touched

Two existing `KEV003` cases build exactly the "replaced before use" shape to exercise clause-replacement tracking, so `KEV007` now fires on them — correctly, since those clauses really are dead:

- `KEV003_Flags_Unreachable_Reactive_Strategies` declares `KEV007` as an expected companion rule, using the file's existing `Without(...)` mechanism.
- `KEV003_Skips_Valid_Or_Unknown_Compositions` keeps its strict `IsEmpty()` assertion; one case gained a `CircuitBreaker` so the replaced clause actually reaches a reactive strategy.

`ExecutionOverloadContractTests` enumerates `Execute*` overloads only and needed no change — no execution overloads were added or removed. The `KEV001` catalog in `IgnoredCancellationTokenAnalyzer` is likewise untouched.

## 6. Documentation

- **Ambient clause scoping made prominent.** README's "Choose what counts as failure" and the composition page now state the rule up front — a clause applies to the strategy it is attached to **and** to every reactive strategy chained after it, until replaced, reset by `WhenAnyError()`, or sealed by `Wrap`/`Compose` — each with a short example of a circuit breaker inheriting an earlier clause. `handling-failures.md` got the same wording fix and a pointer to KEV007.
- **DI build order documented.** `ShieldDefinition`, `ShieldDefinition.Build()` xmldoc, and the DI docs page now spell out the fixed order `Build()` produces, outermost first: `Timeout → Retry → CircuitBreaker → RateLimit → ConcurrencyLimit → AttemptTimeout`, that skipped sections do not disturb it, and that configuration cannot reorder the chain.
- **`RetryEvent.Result` boxing note.** The untyped event's xmldoc now says the result is `object?`, that a value-type result is boxed on every retry and has to be unboxed by the callback, and points at `RetryOptions<TResult>`/`RetryEvent<TResult>` whose typed `Outcome<TResult>` avoids both.

## Public API tracking

`PublicAPI.Unshipped.txt` updated in `src/Kevlar` and `src/Kevlar.Analyzers`. Entries that only existed in `Unshipped` were edited or deleted in place; the `HedgingOptions` members that appear in `PublicAPI.Shipped.txt` got `*REMOVED*` lines alongside their `HedgeOptions` replacements.

## Test results (local)

`dotnet build Kevlar.slnx` — succeeded, 0 warnings, 0 errors. Test executables run directly from `artifacts/bin/<project>/debug/` with `--timeout 120s`:

| Suite | Result |
|---|---|
| Kevlar.Tests | 765 passed, 0 failed |
| Kevlar.IntegrationTests | 118 passed, 0 failed |
| Kevlar.Analyzers.Tests | 68 passed, 0 failed |
| Kevlar.Chaos.Tests | 23 passed, 0 failed |
| Kevlar.Testing.Tests | 33 passed, 0 failed |
| Kevlar.Extensions.RateLimiting.Tests | 19 passed, 0 failed |
| Kevlar.NetStandard.Tests | 5 passed, 0 failed |
| Kevlar.AllocationTests (Release) | 3 passed, 0 failed |

Also run:

- `scripts/Verify-DocSnippets.ps1` against a local `99.0.0-doctest` pack — **109 snippets compiled and executed successfully**. (The two new deliberately-dead-clause snippets in the KEV007 docs section are marked `doc-test-ignore`, since they exist to be flagged.)
- `npm run build` in `docs/` — succeeded.
- `scripts/Verify-Packages.ps1` was **not** run locally (it needs a NativeAOT toolchain); its analyzer-consumer program is a single `Shield.Empty.ExecuteAsync` that only trips KEV001, so KEV007 does not affect it.

## Nothing skipped

Both halves of the analyzer request are implemented, including the clause-replacement detection. The only deviation is the typed `Compose` ambient-clause behaviour noted in section 4, where matching the existing untyped implementation took precedence.

https://claude.ai/code/session_01DarFLgjrFgAsDiGr3cwWkZ
