### PR TITLE
refactor(api): third round of pre-release API cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
 
 ### Added
 
+- `KEV008`: a fluent chaining call written as a statement, such as `shield.Retry(3);`. Shields are
+  immutable, so the new shield the call returns is thrown away and nothing is configured.
+  Discarded clause builders keep reporting as `KEV007`.
 - Pipeline descriptions show handling. `ToString()`/`Describe()` now prefixes each run of strategies
   sharing a non-default clause with `[when …]` — for example
   `[when HttpRequestException | TimeoutExceededException] Retry(3, no delay) → CircuitBreaker(5 consecutive, break 30s)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
   `[when HttpRequestException | TimeoutExceededException] Retry(3, no delay) → CircuitBreaker(5 consecutive, break 30s)`
   — and marks a strategy whose options replaced the clause locally with `(local handling)`. Shields
   that use only default handling describe exactly as before.
+- Debug builds of Kevlar enforce the pooled-context contract: after a `KevlarContext` goes back to
+  the pool, its `CancellationToken`, `Properties`, `ShieldName`, `TimeProvider` and `IsSynchronous`
+  throw `InvalidOperationException` until it is rented again. Release builds are unchanged and carry
+  no extra check.
 - `KEV007`: a `When…`/`Or…` handling clause that never reaches a reactive strategy — the
   `ShieldBuilder` is discarded, or a later `When…`/`WhenAnyError()` replaces the clause while only
   proactive strategies stood between them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
 ### Changed
 
 - **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.
+- Setting both `CircuitBreakerOptions.ConsecutiveFailures` and `FailureRatio` still throws, but the
+  message now names both properties and states the fix. `ConsecutiveFailures` range errors report
+  that property as the parameter name instead of `options`.
 - `HandlesException`/`HandlesResult` documentation on every options type now leads with the fact
   that the property makes its strategy ignore the ambient `When…` clause, and points at
   `HandlingClause`. `ShieldBuilder`/`ShieldBuilder<TResult>` document the override from the clause side.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,17 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
 ### Changed
 
 - **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.
+- `HandlesException`/`HandlesResult` documentation on every options type now leads with the fact
+  that the property makes its strategy ignore the ambient `When…` clause, and points at
+  `HandlingClause`. `ShieldBuilder`/`ShieldBuilder<TResult>` document the override from the clause side.
 
 ### Added
 
+- Pipeline descriptions show handling. `ToString()`/`Describe()` now prefixes each run of strategies
+  sharing a non-default clause with `[when …]` — for example
+  `[when HttpRequestException | TimeoutExceededException] Retry(3, no delay) → CircuitBreaker(5 consecutive, break 30s)`
+  — and marks a strategy whose options replaced the clause locally with `(local handling)`. Shields
+  that use only default handling describe exactly as before.
 - `KEV007`: a `When…`/`Or…` handling clause that never reaches a reactive strategy — the
   `ShieldBuilder` is discarded, or a later `When…`/`WhenAnyError()` replaces the clause while only
   proactive strategies stood between them.

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -23,6 +23,7 @@ Generated code is ignored.
 | `KEV005` | Warning | void fallback is executed with a result-returning delegate |
 | `KEV006` | Warning | hedging is added to an untyped shield, whose action must be idempotent |
 | `KEV007` | Warning | handling clause never reaches a reactive strategy |
+| `KEV008` | Warning | fluent chaining result is discarded as a statement |
 
 ## KEV001: ignored execution cancellation
 
@@ -208,6 +209,28 @@ var shield = Shield
 The rule follows one fluent chain and a clause builder stored in a local. It deliberately stays
 quiet when the builder escapes — returned, passed as an argument, assigned to a field — and at
 `Wrap`/`Compose` boundaries, because a clause's fate is no longer visible there.
+
+## KEV008: discarded fluent chaining result
+
+Shields are immutable. Every fluent method returns a *new* shield and leaves its receiver untouched,
+so a chaining call written as a statement configures nothing:
+
+<!-- doc-test-ignore: A deliberately discarded chain that the analyzer is expected to flag. -->
+```csharp
+var shield = Shield.Timeout(TimeSpan.FromSeconds(5));
+shield.Retry(3);                                   // KEV008 — the retry is thrown away
+await shield.ExecuteAsync(ct => CallAsync(ct));    // still just a timeout
+```
+
+Keep the returned shield instead:
+
+```csharp
+var shield = Shield.Timeout(TimeSpan.FromSeconds(5)).Retry(3);
+```
+
+The rule fires only on a statement whose value is a `Shield` or `Shield<TResult>`, so assigning the
+result, returning it, or passing it as an argument is never flagged. Discarded *clause builders* are
+reported by [`KEV007`](#kev007-dead-handling-clause) instead, which names that hazard directly.
 
 ## Suppression
 

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -116,6 +116,10 @@ exception-only override does not handle results. Prefer the ambient clause when 
 strategies share the same rule; prefer a local override for a single exception to that rule or when
 porting one Polly `ShouldHandle` predicate directly.
 
+Which strategy ended up with which rule is visible at runtime: `shield.ToString()` prefixes each run
+of strategies sharing a non-default clause with `[when …]` and marks a locally overridden strategy
+`(local handling)`. See [pipeline descriptions](observability.md#pipeline-descriptions).
+
 :::info Proactive strategies don't consult clauses
 Timeouts, rate limits and concurrency limits don't care why something failed — they act on time and concurrency, not outcomes. Clauses only drive the reactive strategies.
 :::

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -24,6 +24,21 @@ Console.WriteLine(shield);
 
 Log it once at startup and every incident review starts from the actual configuration, not the configuration someone remembers. Custom strategies participate by overriding `Strategy.Describe()`.
 
+[Handling clauses](handling-failures.md) show up too, so "why didn't the breaker trip?" is answerable from the description alone. A `[when …]` prefix opens each run of strategies sharing a non-default clause, and a strategy whose options replaced that clause with `HandlesException`/`HandlesResult` is marked `(local handling)`:
+
+```csharp
+var shield = Shield
+    .When<HttpRequestException>()
+    .Or<TimeoutExceededException>()
+    .Retry(3, Backoff.None)
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+
+Console.WriteLine(shield);
+// [when HttpRequestException | TimeoutExceededException] Retry(3, no delay) → CircuitBreaker(5 consecutive, break 30s)
+```
+
+Shields that use only the default handling — any exception except `OperationCanceledException` — print exactly as before, with no prefix.
+
 ## Metrics
 
 On .NET 8+ every shield publishes metrics through a `System.Diagnostics.Metrics.Meter` named `Kevlar`, version `1.0` — zero configuration, and effectively free (an enabled check per instrument) until something listens. Subscribe with OpenTelemetry:

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,4 @@ KEV004 | Reliability | Warning | Stateful shield or partition provider is constr
 KEV005 | Configuration | Warning | Void fallback is used with a result-returning execution
 KEV006 | Reliability | Warning | Hedging on an untyped Shield requires an idempotent action
 KEV007 | Configuration | Warning | Handling clause never reaches a reactive strategy
+KEV008 | Configuration | Warning | Fluent chaining result is discarded as a statement

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -10,8 +10,8 @@ namespace Kevlar.Analyzers;
 /// <summary>
 /// Diagnoses statically provable Kevlar pipeline hazards: synchronous multi-attempt hedging, reactive
 /// strategies made unreachable by an inner fallback, per-execution construction of stateful shields,
-/// void fallbacks used for result-returning executions, hedging on an untyped shield, and handling
-/// clauses that never reach a reactive strategy.
+/// void fallbacks used for result-returning executions, hedging on an untyped shield, handling
+/// clauses that never reach a reactive strategy, and fluent chaining results discarded as statements.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
@@ -76,6 +76,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "A When/Or clause only changes behaviour once a reactive strategy consumes it. A clause whose builder is discarded, or that a later When clause replaces before any reactive strategy is added, silently does nothing.");
 
+    /// <summary>The KEV008 rule.</summary>
+    public static readonly DiagnosticDescriptor DiscardedChainResultRule = new(
+        id: "KEV008",
+        title: "Fluent chaining result is discarded",
+        messageFormat: "'{0}' returns a new shield instead of changing this one, and its result is discarded here, so this statement configures nothing. Assign the returned shield, or continue the chain from it.",
+        category: "Configuration",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Shield, Shield<TResult> and their builders are immutable: every fluent method returns a new instance and leaves its receiver untouched. A chaining call written as a statement therefore has no effect.");
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
@@ -84,7 +94,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             EphemeralStatefulShieldRule,
             VoidFallbackResultExecutionRule,
             UntypedHedgingRule,
-            DeadHandlingClauseRule);
+            DeadHandlingClauseRule,
+            DiscardedChainResultRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -191,6 +202,47 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 invocation.Syntax.GetLocation(),
                 deadClauseReason));
         }
+
+        if (IsDiscardedChainResult(invocation, knownTypes))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiscardedChainResultRule,
+                invocation.Syntax.GetLocation(),
+                Normalize(invocation.TargetMethod).Name));
+        }
+    }
+
+    /// <summary>
+    /// Reports a fluent call whose new shield is dropped where it stands. Calls that hand back a
+    /// clause builder are left to KEV007, which names that hazard precisely.
+    /// </summary>
+    private static bool IsDiscardedChainResult(IInvocationOperation invocation, KnownTypes knownTypes)
+    {
+        var method = Normalize(invocation.TargetMethod);
+        return IsKevlarFluentMethod(method, knownTypes)
+            && method.ReturnType is INamedTypeSymbol returnType
+            && knownTypes.IsShield(returnType)
+            && IsExpressionStatement(invocation);
+    }
+
+    private static bool IsExpressionStatement(IOperation operation)
+    {
+        for (var parent = operation.Parent; parent is not null; parent = parent.Parent)
+        {
+            switch (parent)
+            {
+                case IConversionOperation or IParenthesizedOperation:
+                    continue;
+
+                case IExpressionStatementOperation:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 Kevlar.Analyzers.PipelineHazardAnalyzer
 Kevlar.Analyzers.PipelineHazardAnalyzer.PipelineHazardAnalyzer() -> void
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.DeadHandlingClauseRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.DiscardedChainResultRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.EphemeralStatefulShieldRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>

--- a/src/Kevlar/Internal/DescribeHelper.cs
+++ b/src/Kevlar/Internal/DescribeHelper.cs
@@ -36,6 +36,18 @@ internal static class DescribeHelper
         return Number(value.TotalHours) + "h";
     }
 
+    /// <summary>Joins the terms of one handling clause into <c>A | B | C</c>.</summary>
+    public static string Clause(List<string> terms) => string.Join(" | ", terms);
+
+    /// <summary>Renders a result value inside a handling clause description.</summary>
+    public static string Value<TResult>(TResult value) => value switch
+    {
+        null => "null",
+        string text => "\"" + text + "\"",
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? "null",
+    };
+
     private static string Number(double value) =>
         (Math.Round(value, 1)).ToString("0.#", CultureInfo.InvariantCulture);
 }

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -9,6 +9,13 @@ internal abstract class OutcomeJudge
     /// <summary>The default: handle any exception except <see cref="OperationCanceledException"/>.</summary>
     public static readonly OutcomeJudge Default = new DefaultJudge();
 
+    /// <summary>
+    /// A human-readable rendering of the clause — the terms the caller wrote, joined with
+    /// <c>" | "</c> — for pipeline descriptions. <see langword="null"/> when the clause adds
+    /// nothing worth printing, which covers default handling and local option overrides.
+    /// </summary>
+    public virtual string? Description => null;
+
     public abstract bool ShouldHandle<T>(in Outcome<T> outcome);
 
     private sealed class DefaultJudge : OutcomeJudge
@@ -22,8 +29,15 @@ internal abstract class OutcomeJudge
 internal sealed class ExceptionJudge : OutcomeJudge
 {
     private readonly Func<Exception, bool> _predicate;
+    private readonly string? _description;
 
-    public ExceptionJudge(Func<Exception, bool> predicate) => _predicate = predicate;
+    public ExceptionJudge(Func<Exception, bool> predicate, string? description = null)
+    {
+        _predicate = predicate;
+        _description = description;
+    }
+
+    public override string? Description => _description;
 
     public override bool ShouldHandle<T>(in Outcome<T> outcome) =>
         outcome.Exception is { } exception && _predicate(exception);
@@ -37,12 +51,19 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
 {
     private readonly Func<Exception, bool>? _exceptionPredicate;
     private readonly Func<TResult, bool>? _resultPredicate;
+    private readonly string? _description;
 
-    public TypedJudge(Func<Exception, bool>? exceptionPredicate, Func<TResult, bool>? resultPredicate)
+    public TypedJudge(
+        Func<Exception, bool>? exceptionPredicate,
+        Func<TResult, bool>? resultPredicate,
+        string? description = null)
     {
         _exceptionPredicate = exceptionPredicate;
         _resultPredicate = resultPredicate;
+        _description = description;
     }
+
+    public override string? Description => _description;
 
     public override bool ShouldHandle<T>(in Outcome<T> outcome)
     {

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Reservoir;
 
 namespace Kevlar;
@@ -9,11 +10,28 @@ namespace Kevlar;
 /// or return them. A context is valid only during the current callback or delegate invocation
 /// and must never be retained.
 /// </summary>
+/// <remarks>
+/// Debug builds of Kevlar enforce that contract: a context that has gone back to the pool throws
+/// <see cref="InvalidOperationException"/> from every public member until it is handed out again.
+/// Release builds carry no such check, so a retained context there silently observes another
+/// execution's state.
+/// </remarks>
 public sealed class KevlarContext
 {
     internal const int PoolCapacity = 128;
 
     private static readonly ObjectPool<KevlarContext, PoolPolicy> Pool = new(maxCapacity: PoolCapacity);
+
+    private readonly KevlarProperties _properties = new();
+
+    private CancellationToken _cancellationToken;
+    private bool _isSynchronous;
+    private string? _shieldName;
+    private TimeProvider _timeProvider = TimeProvider.System;
+
+#if DEBUG
+    private bool _returnedToPool;
+#endif
 
     private KevlarContext()
     {
@@ -24,29 +42,73 @@ public sealed class KevlarContext
     /// token for the layers beneath them, which is why executed delegates must use the token
     /// they are handed rather than a captured one.
     /// </summary>
-    public CancellationToken CancellationToken { get; internal set; }
+    public CancellationToken CancellationToken
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _cancellationToken;
+        }
+
+        internal set => _cancellationToken = value;
+    }
 
     /// <summary><see langword="true"/> when the execution was started through a synchronous <c>Execute</c> call.</summary>
-    public bool IsSynchronous { get; internal set; }
+    public bool IsSynchronous
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _isSynchronous;
+        }
+
+        internal set => _isSynchronous = value;
+    }
 
     /// <summary>The name of the executing shield, if one was assigned via <c>WithName</c>.</summary>
-    public string? ShieldName { get; internal set; }
+    public string? ShieldName
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _shieldName;
+        }
+
+        internal set => _shieldName = value;
+    }
 
     internal int StrategyIndex { get; set; }
 
     /// <summary>The time provider used for delays, timeouts and time-window calculations.</summary>
-    public TimeProvider TimeProvider { get; internal set; } = TimeProvider.System;
+    public TimeProvider TimeProvider
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _timeProvider;
+        }
+
+        internal set => _timeProvider = value;
+    }
 
     /// <summary>
     /// Custom properties carried through the execution. The bag is pooled with this context
     /// and must not be retained beyond the current callback or delegate invocation.
     /// </summary>
-    public KevlarProperties Properties { get; } = new();
+    public KevlarProperties Properties
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _properties;
+        }
+    }
 
     internal static KevlarContext Rent(CancellationToken cancellationToken, bool isSynchronous, TimeProvider timeProvider, string? shieldName)
     {
         var context = Pool.Rent();
 
+        MarkRented(context);
         context.CancellationToken = cancellationToken;
         context.IsSynchronous = isSynchronous;
         context.TimeProvider = timeProvider;
@@ -55,7 +117,11 @@ public sealed class KevlarContext
         return context;
     }
 
-    internal static void Return(KevlarContext context) => Pool.Return(context);
+    internal static void Return(KevlarContext context)
+    {
+        MarkReturned(context);
+        Pool.Return(context);
+    }
 
     /// <summary>
     /// Creates a detached copy of this context for a concurrent attempt (used by hedging).
@@ -70,6 +136,42 @@ public sealed class KevlarContext
         return fork;
     }
 
+    /// <summary>
+    /// Clears the debug pooling guard on a context that Kevlar's own pool tests inspect after it
+    /// went back to the pool. A no-op in release builds, where the guard does not exist.
+    /// </summary>
+    internal static void AllowPooledInspection(KevlarContext context) => MarkRented(context);
+
+    [Conditional("DEBUG")]
+    private static void MarkRented(KevlarContext context)
+    {
+#if DEBUG
+        context._returnedToPool = false;
+#endif
+    }
+
+    [Conditional("DEBUG")]
+    private static void MarkReturned(KevlarContext context)
+    {
+#if DEBUG
+        context._returnedToPool = true;
+#endif
+    }
+
+    [Conditional("DEBUG")]
+    private void ThrowIfReturnedToPool()
+    {
+#if DEBUG
+        if (_returnedToPool)
+        {
+            throw new InvalidOperationException(
+                "This KevlarContext has been returned to Kevlar's context pool and is no longer valid. " +
+                "A context — and its Properties — may only be used while the callback or delegate that " +
+                "received it is running; never retain it afterwards. Copy the values you need instead.");
+        }
+#endif
+    }
+
     private readonly struct PoolPolicy : IPooledObjectPolicy<KevlarContext>
     {
         public KevlarContext Create() => new();
@@ -81,7 +183,7 @@ public sealed class KevlarContext
             context.ShieldName = null;
             context.StrategyIndex = -1;
             context.TimeProvider = TimeProvider.System;
-            context.Properties.Clear();
+            context._properties.Clear();
             return true;
         }
     }

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -488,11 +488,53 @@ public sealed class Shield
 
     internal static string Describe(string? name, Strategy[] strategies)
     {
-        var pipeline = strategies.Length == 0
-            ? "(empty)"
-            : string.Join(" → ", strategies.Select(static strategy => strategy.Describe()));
+        var pipeline = strategies.Length == 0 ? "(empty)" : DescribeStrategies(strategies);
 
         return name is null ? pipeline : $"{name}: {pipeline}";
+    }
+
+    /// <summary>
+    /// Renders the chain, prefixing each run of strategies that shares a non-default handling
+    /// clause with <c>[when …]</c> and marking strategies whose options replaced that clause
+    /// locally. Proactive strategies carry no clause and never open or close a run.
+    /// </summary>
+    private static string DescribeStrategies(Strategy[] strategies)
+    {
+        var parts = new string[strategies.Length];
+        string? activeClause = null;
+
+        for (var i = 0; i < strategies.Length; i++)
+        {
+            var strategy = strategies[i];
+            var description = strategy.Describe();
+
+            if (strategy.HasHandlingOverride)
+            {
+                parts[i] = description + " (local handling)";
+                continue;
+            }
+
+            if (strategy.ReactiveJudge is not { } judge)
+            {
+                parts[i] = description;
+                continue;
+            }
+
+            var clause = judge.Description;
+            if (clause is null)
+            {
+                activeClause = null;
+                parts[i] = description;
+                continue;
+            }
+
+            parts[i] = string.Equals(clause, activeClause, StringComparison.Ordinal)
+                ? description
+                : $"[when {clause}] {description}";
+            activeClause = clause;
+        }
+
+        return string.Join(" → ", parts);
     }
 
     internal static void ValidateChain(Strategy[] strategies)

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -9,13 +9,22 @@ namespace Kevlar;
 /// here and to reactive strategies chained afterwards, until replaced by a new clause.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Start a clause with <c>When…</c> on a shield, then continue it with <c>Or…</c> on this builder:
 /// <c>Shield.When&lt;A&gt;().Or&lt;B&gt;().Retry(3)</c>.
+/// </para>
+/// <para>
+/// One strategy can opt out of the ambient clause: setting <c>HandlesException</c> on its options
+/// (<see cref="RetryOptions"/>, <see cref="CircuitBreakerOptions"/>, <see cref="HedgeOptions"/>,
+/// <see cref="FallbackOptions"/>) makes that strategy ignore the clause and handle only what its
+/// own predicate selects. Every other strategy in the chain keeps using the ambient clause.
+/// </para>
 /// </remarks>
 public sealed class ShieldBuilder
 {
     private readonly Shield _parent;
     private readonly List<Func<Exception, bool>> _predicates = [];
+    private readonly List<string> _clauseTerms = [];
 
     internal ShieldBuilder(Shield parent) => _parent = parent;
 
@@ -24,6 +33,7 @@ public sealed class ShieldBuilder
         where TException : Exception
     {
         _predicates.Add(static exception => exception is TException);
+        _clauseTerms.Add(typeof(TException).Name);
         return this;
     }
 
@@ -33,6 +43,7 @@ public sealed class ShieldBuilder
     {
         Throw.IfNull(predicate, nameof(predicate));
         _predicates.Add(exception => exception is TException typed && predicate(typed));
+        _clauseTerms.Add(typeof(TException).Name + " matching predicate");
         return this;
     }
 
@@ -41,6 +52,7 @@ public sealed class ShieldBuilder
     {
         Throw.IfNull(predicate, nameof(predicate));
         _predicates.Add(predicate);
+        _clauseTerms.Add("exception predicate");
         return this;
     }
 
@@ -126,7 +138,11 @@ public sealed class ShieldBuilder
     public Shield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);
 
     private Shield Seal() =>
-        new(_parent.Strategies, new ExceptionJudge(Combine(_predicates)), _parent.Name, _parent.Time);
+        new(
+            _parent.Strategies,
+            new ExceptionJudge(Combine(_predicates), DescribeHelper.Clause(_clauseTerms)),
+            _parent.Name,
+            _parent.Time);
 
     internal static Func<Exception, bool> Combine(List<Func<Exception, bool>> predicates)
     {

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -9,14 +9,24 @@ namespace Kevlar;
 /// strategy added here and reactive strategies chained afterwards.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Start a clause with <c>When…</c> on a shield, then continue it with <c>Or…</c> on this builder:
 /// <c>Shield.For&lt;T&gt;().When&lt;A&gt;().OrResult(r =&gt; …).Retry(3)</c>.
+/// </para>
+/// <para>
+/// One strategy can opt out of the ambient clause: setting <c>HandlesException</c> or
+/// <c>HandlesResult</c> on its options (<see cref="RetryOptions{TResult}"/>,
+/// <see cref="CircuitBreakerOptions{TResult}"/>, <see cref="HedgeOptions{TResult}"/>,
+/// <see cref="FallbackOptions{TResult}"/>) makes that strategy ignore the clause and handle only
+/// what its own predicates select. Every other strategy in the chain keeps using the ambient clause.
+/// </para>
 /// </remarks>
 public sealed class ShieldBuilder<TResult>
 {
     private readonly Shield<TResult> _parent;
     private readonly List<Func<Exception, bool>> _exceptionPredicates = [];
     private readonly List<Func<TResult, bool>> _resultPredicates = [];
+    private readonly List<string> _clauseTerms = [];
 
     internal ShieldBuilder(Shield<TResult> parent) => _parent = parent;
 
@@ -25,6 +35,7 @@ public sealed class ShieldBuilder<TResult>
         where TException : Exception
     {
         _exceptionPredicates.Add(static exception => exception is TException);
+        _clauseTerms.Add(typeof(TException).Name);
         return this;
     }
 
@@ -34,6 +45,7 @@ public sealed class ShieldBuilder<TResult>
     {
         Throw.IfNull(predicate, nameof(predicate));
         _exceptionPredicates.Add(exception => exception is TException typed && predicate(typed));
+        _clauseTerms.Add(typeof(TException).Name + " matching predicate");
         return this;
     }
 
@@ -42,6 +54,7 @@ public sealed class ShieldBuilder<TResult>
     {
         Throw.IfNull(predicate, nameof(predicate));
         _exceptionPredicates.Add(predicate);
+        _clauseTerms.Add("exception predicate");
         return this;
     }
 
@@ -50,6 +63,7 @@ public sealed class ShieldBuilder<TResult>
     {
         Throw.IfNull(predicate, nameof(predicate));
         _resultPredicates.Add(predicate);
+        _clauseTerms.Add("result predicate");
         return this;
     }
 
@@ -57,6 +71,7 @@ public sealed class ShieldBuilder<TResult>
     public ShieldBuilder<TResult> OrResult(TResult result)
     {
         _resultPredicates.Add(candidate => EqualityComparer<TResult>.Default.Equals(candidate, result));
+        _clauseTerms.Add("result " + DescribeHelper.Value(result));
         return this;
     }
 
@@ -64,6 +79,7 @@ public sealed class ShieldBuilder<TResult>
     public ShieldBuilder<TResult> OrResultDefault()
     {
         _resultPredicates.Add(static candidate => EqualityComparer<TResult>.Default.Equals(candidate, default!));
+        _clauseTerms.Add("default result");
         return this;
     }
 
@@ -152,7 +168,10 @@ public sealed class ShieldBuilder<TResult>
     {
         var exceptionPredicate = _exceptionPredicates.Count == 0 ? null : ShieldBuilder.Combine(_exceptionPredicates);
         var resultPredicate = CombineResults(_resultPredicates);
-        var judge = new TypedJudge<TResult>(exceptionPredicate, resultPredicate);
+        var judge = new TypedJudge<TResult>(
+            exceptionPredicate,
+            resultPredicate,
+            DescribeHelper.Clause(_clauseTerms));
         return new Shield<TResult>(_parent.Strategies, judge, _parent.Name, _parent.Time);
     }
 

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -52,12 +52,18 @@ internal sealed class CircuitBreakerCore
 
     public CircuitBreakerCore(CircuitBreakerOptions options, Action<CircuitState> recordState)
     {
-        Throw.IfOutOfRange(options.ConsecutiveFailures is <= 0, nameof(options), "ConsecutiveFailures must be positive.");
+        Throw.IfOutOfRange(options.ConsecutiveFailures is <= 0, nameof(options.ConsecutiveFailures), "ConsecutiveFailures must be positive.");
         Throw.IfOutOfRange(
             options.FailureRatio is { } ratio && (double.IsNaN(ratio) || ratio <= 0 || ratio > 1),
             nameof(options.FailureRatio),
             "FailureRatio must be between 0 (exclusive) and 1 (inclusive).");
-        Throw.IfOutOfRange(options.ConsecutiveFailures is not null && options.FailureRatio is not null, nameof(options), "Configure either ConsecutiveFailures or FailureRatio, not both.");
+        Throw.IfOutOfRange(
+            options.ConsecutiveFailures is not null && options.FailureRatio is not null,
+            nameof(options),
+            "ConsecutiveFailures and FailureRatio select different trip modes and cannot both be set. " +
+            "Clear ConsecutiveFailures to trip on the failure ratio within SamplingWindow, clear " +
+            "FailureRatio to trip on consecutive failures, or leave both unset to trip after 5 " +
+            "consecutive failures.");
         Throw.IfOutOfRange(options.MinimumThroughput < 1, nameof(options), "MinimumThroughput must be at least 1.");
         Throw.IfOutOfRange(options.SamplingWindow <= TimeSpan.Zero, nameof(options), "SamplingWindow must be positive.");
         Throw.IfOutOfRange(options.BreakDuration <= TimeSpan.Zero, nameof(options), "BreakDuration must be positive.");

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -8,9 +8,16 @@ namespace Kevlar;
 public class CircuitBreakerOptions
 {
     /// <summary>
-    /// Locally selects exceptions handled by this circuit breaker. When set, this strategy ignores
-    /// the ambient handling clause and handles only outcomes selected by its local predicates.
+    /// Setting this — or, on <see cref="CircuitBreakerOptions{TResult}"/>, its <c>HandlesResult</c>
+    /// — makes this circuit breaker ignore the ambient <c>When…</c> handling clause; this predicate
+    /// then selects the exceptions it handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c> on a shield and continued with <c>Or…</c> on
+    /// the builder it returns, and applies to every reactive strategy chained after it. These
+    /// properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
     internal virtual bool HasHandlingOverride => HandlesException is not null;

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
@@ -7,10 +7,16 @@ namespace Kevlar;
 public sealed class CircuitBreakerOptions<TResult> : CircuitBreakerOptions
 {
     /// <summary>
-    /// Locally selects results handled by this circuit breaker. When either local predicate is
-    /// set, this strategy ignores the ambient handling clause and handles only outcomes selected
-    /// locally.
+    /// Setting this — or <see cref="CircuitBreakerOptions.HandlesException"/> — makes this circuit
+    /// breaker ignore the ambient <c>When…</c> handling clause; this predicate then selects the
+    /// results it handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c>/<c>WhenResult…</c> on a shield and continued
+    /// with <c>Or…</c> on the builder it returns, and applies to every reactive strategy chained
+    /// after it. These properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
     internal override bool HasHandlingOverride =>

--- a/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
@@ -9,9 +9,15 @@ namespace Kevlar;
 public sealed class FallbackOptions
 {
     /// <summary>
-    /// Locally selects exceptions handled by this fallback. When set, this strategy ignores the
-    /// ambient handling clause and handles only exceptions selected here.
+    /// Setting this makes this fallback ignore the ambient <c>When…</c> handling clause and handle
+    /// only the exceptions this predicate selects.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c> on a shield and continued with <c>Or…</c> on
+    /// the builder it returns, and applies to every reactive strategy chained after it. This
+    /// property replaces that clause for this strategy alone; it does not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
     /// <summary>Invoked synchronously before the recovery action.</summary>

--- a/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
@@ -12,15 +12,27 @@ namespace Kevlar;
 public sealed class FallbackOptions<TResult>
 {
     /// <summary>
-    /// Locally selects exceptions handled by this fallback. When either local predicate is set,
-    /// this strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// Setting this — or <see cref="HandlesResult"/> — makes this fallback ignore the ambient
+    /// <c>When…</c> handling clause; this predicate then selects the exceptions it handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c> on a shield and continued with <c>Or…</c> on
+    /// the builder it returns, and applies to every reactive strategy chained after it. These
+    /// properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
     /// <summary>
-    /// Locally selects results handled by this fallback. When either local predicate is set, this
-    /// strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// Setting this — or <see cref="HandlesException"/> — makes this fallback ignore the ambient
+    /// <c>When…</c> handling clause; this predicate then selects the results it handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c>/<c>WhenResult…</c> on a shield and continued
+    /// with <c>Or…</c> on the builder it returns, and applies to every reactive strategy chained
+    /// after it. These properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
     /// <summary>Invoked synchronously before the recovery factory, with the typed handled outcome.</summary>

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -15,9 +15,16 @@ namespace Kevlar;
 public class HedgeOptions
 {
     /// <summary>
-    /// Locally selects exceptions handled by this hedging strategy. When set, this strategy
-    /// ignores the ambient handling clause and handles only outcomes selected locally.
+    /// Setting this — or, on <see cref="HedgeOptions{TResult}"/>, its <c>HandlesResult</c> — makes
+    /// this hedging strategy ignore the ambient <c>When…</c> handling clause; this predicate then
+    /// selects the exceptions it handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c> on a shield and continued with <c>Or…</c> on
+    /// the builder it returns, and applies to every reactive strategy chained after it. These
+    /// properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
     internal virtual bool HasHandlingOverride => HandlesException is not null;

--- a/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
@@ -6,10 +6,16 @@ namespace Kevlar;
 public sealed class HedgeOptions<TResult> : HedgeOptions
 {
     /// <summary>
-    /// Locally selects results handled by this hedging strategy. When either local predicate is
-    /// set, this strategy ignores the ambient handling clause and handles only outcomes selected
-    /// locally.
+    /// Setting this — or <see cref="HedgeOptions.HandlesException"/> — makes this hedging strategy
+    /// ignore the ambient <c>When…</c> handling clause; this predicate then selects the results it
+    /// handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c>/<c>WhenResult…</c> on a shield and continued
+    /// with <c>Or…</c> on the builder it returns, and applies to every reactive strategy chained
+    /// after it. These properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
     internal override bool HasHandlingOverride =>

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -10,9 +10,15 @@ namespace Kevlar;
 public class RetryOptions
 {
     /// <summary>
-    /// Locally selects exceptions handled by this retry. When set, this strategy ignores the
-    /// ambient handling clause and handles only outcomes selected by its local predicates.
+    /// Setting this makes this retry ignore the ambient <c>When…</c> handling clause and handle
+    /// only the exceptions this predicate selects.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c> on a shield and continued with <c>Or…</c> on
+    /// the builder it returns, and applies to every reactive strategy chained after it. This
+    /// property replaces that clause for this strategy alone; it does not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
     internal bool HasHandlingOverride => HandlesException is not null;
@@ -88,15 +94,27 @@ public sealed class RetryOptions<TResult>
     public TimeSpan? MaxDelay { get; set; }
 
     /// <summary>
-    /// Locally selects exceptions handled by this retry. When either local predicate is set, this
-    /// strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// Setting this — or <see cref="HandlesResult"/> — makes this retry ignore the ambient
+    /// <c>When…</c> handling clause; this predicate then selects the exceptions it handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c> on a shield and continued with <c>Or…</c> on
+    /// the builder it returns, and applies to every reactive strategy chained after it. These
+    /// properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
     /// <summary>
-    /// Locally selects results handled by this retry. When either local predicate is set, this
-    /// strategy ignores the ambient handling clause and handles only outcomes selected locally.
+    /// Setting this — or <see cref="HandlesException"/> — makes this retry ignore the ambient
+    /// <c>When…</c> handling clause; this predicate then selects the results it handles.
     /// </summary>
+    /// <remarks>
+    /// The ambient clause is started with <c>When…</c>/<c>WhenResult…</c> on a shield and continued
+    /// with <c>Or…</c> on the builder it returns, and applies to every reactive strategy chained
+    /// after it. These properties replace that clause for this strategy alone; they do not narrow it.
+    /// </remarks>
+    /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
     internal bool HasHandlingOverride =>

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -663,6 +663,100 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV008_Flags_Static_Instance_And_Builder_Chains_Used_As_Statements()
+    {
+        var cases = new[]
+        {
+            "Shield.Retry(3);",
+            "Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "Shield.Empty.Retry(3);",
+            "Shield.Empty.WithName(\"api\");",
+            "Shield.Empty.For<int>();",
+            "Shield.For<int>().Retry(3);",
+            "Shield.When<InvalidOperationException>().Retry(3);",
+            "Shield.For<int>().WhenResult(static value => value < 0).Fallback(0);",
+            "Shield.Compose(Shield.Empty, Shield.Empty);",
+            "var shield = Shield.Empty; shield.Timeout(TimeSpan.FromSeconds(1));",
+        };
+
+        await AssertEachAsync(cases, "KEV008");
+    }
+
+    [Test]
+    public async Task KEV008_Leaves_Used_Results_And_Executions_Alone()
+    {
+        var cases = new[]
+        {
+            "var shield = Shield.Retry(3);",
+            "var shield = Shield.Empty; shield = shield.Retry(3);",
+            "_ = Shield.Retry(3);",
+            "Consume(Shield.Empty.Retry(3));",
+            "Consume(Build());",
+            "Shield.Empty.Execute(static _ => { });",
+            "await Shield.Empty.ExecuteAsync(static _ => ValueTask.CompletedTask);",
+            "_ = await Shield.For<int>().Retry(1).ExecuteAsync(static _ => new ValueTask<int>(1));",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(
+                body,
+                """
+                private static Shield Build() => Shield.Retry(3);
+
+                private static void Consume(Shield shield)
+                {
+                }
+                """);
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV008_Defers_Discarded_Clause_Builders_To_KEV007()
+    {
+        var cases = new[]
+        {
+            "Shield.When<InvalidOperationException>();",
+            "Shield.Empty.When<InvalidOperationException>().Or<TimeoutException>();",
+            "Shield.For<int>().WhenResultDefault();",
+        };
+
+        await AssertEachAsync(cases, "KEV007");
+    }
+
+    [Test]
+    public async Task KEV008_Diagnostic_Contract_And_Suppression_Are_Exact()
+    {
+        const string chain = "Shield.Empty.Retry(3)";
+        var source = $$"""
+            public class TestSubject
+            {
+                public void Build() => {{chain}};
+            }
+            """;
+        var diagnostics = await AnalyzeSourceAsync(source);
+        var suppressed = await AnalyzeBodyAsync("""
+            #pragma warning disable KEV008 // Construction is asserted on elsewhere.
+            Shield.Empty.Retry(3);
+            #pragma warning restore KEV008
+            """);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        var diagnostic = diagnostics[0];
+        await Assert.That(diagnostic.Id).IsEqualTo("KEV008");
+        await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            "'Retry' returns a new shield instead of changing this one, and its result is discarded "
+            + "here, so this statement configures nothing. Assign the returned shield, or continue "
+            + "the chain from it.");
+        await Assert.That(diagnostic.Location.SourceSpan.Start)
+            .IsEqualTo(CreateSource(source).IndexOf(chain, StringComparison.Ordinal));
+        await Assert.That(diagnostic.Location.SourceSpan.Length).IsEqualTo(chain.Length);
+        await Assert.That(suppressed).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV003_Flags_Unreachable_Reactive_Strategies()
     {
         var cases = new[]

--- a/tests/Kevlar.Tests/CallerContextTests.cs
+++ b/tests/Kevlar.Tests/CallerContextTests.cs
@@ -180,6 +180,7 @@ public class CallerContextTests
             .Throws<InvalidOperationException>();
 
         await Assert.That(captured).IsNotNull();
+        KevlarContext.AllowPooledInspection(captured!);
         await Assert.That(captured!.Properties.TryGet(RequestId, out _)).IsFalse();
         await Assert.That(captured.CancellationToken).IsEqualTo(default(CancellationToken));
         await Assert.That(captured.ShieldName).IsNull();
@@ -200,6 +201,7 @@ public class CallerContextTests
             });
 
         await Assert.That(captured).IsNotNull();
+        KevlarContext.AllowPooledInspection(captured!);
         await Assert.That(captured!.Properties.TryGet(RequestId, out _)).IsFalse();
     }
 

--- a/tests/Kevlar.Tests/ContextLifecycleTests.cs
+++ b/tests/Kevlar.Tests/ContextLifecycleTests.cs
@@ -119,6 +119,56 @@ public class ContextLifecycleTests
         }
     }
 
+    [Test]
+    public async Task A_Context_Returned_To_The_Pool_Rejects_Its_Public_Members()
+    {
+        KevlarContext? retained = null;
+        var result = await Shield.Empty.ExecuteWithContextAsync(context =>
+        {
+            retained = context;
+            return new ValueTask<int>(7);
+        });
+
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(retained).IsNotNull();
+#if DEBUG
+        await AssertPooledAccessThrows(() => retained!.CancellationToken);
+        await AssertPooledAccessThrows(() => retained!.Properties);
+        await AssertPooledAccessThrows(() => retained!.ShieldName);
+        await AssertPooledAccessThrows(() => retained!.TimeProvider);
+        await AssertPooledAccessThrows(() => retained!.IsSynchronous);
+#else
+        await Assert.That(retained!.ShieldName).IsNull();
+#endif
+    }
+
+    [Test]
+    public async Task Renting_A_Pooled_Context_Makes_It_Usable_Again()
+    {
+        KevlarContext.Return(KevlarContext.Rent(default, isSynchronous: false, TimeProvider.System, "first"));
+        var reused = KevlarContext.Rent(default, isSynchronous: true, TimeProvider.System, "second");
+
+        try
+        {
+            await Assert.That(reused.ShieldName).IsEqualTo("second");
+            await Assert.That(reused.IsSynchronous).IsTrue();
+            await Assert.That(reused.Properties.TryGet(DirtyProperty, out _)).IsFalse();
+            await Assert.That(ReferenceEquals(reused.TimeProvider, TimeProvider.System)).IsTrue();
+        }
+        finally
+        {
+            KevlarContext.Return(reused);
+        }
+    }
+
+#if DEBUG
+    private static async Task AssertPooledAccessThrows(Func<object?> access)
+    {
+        var error = await Assert.That(access).Throws<InvalidOperationException>();
+        await Assert.That(error!.Message).Contains("returned to Kevlar's context pool");
+    }
+#endif
+
     private static async Task AssertResetAfter(ExitPath exitPath)
     {
         var observer = new ContextObserverStrategy(DirtyProperty);
@@ -178,6 +228,7 @@ public class ContextLifecycleTests
         await Assert.That(snapshot.PropertiesWereInitiallyClean).IsTrue();
 
         var returned = observer.Context!;
+        KevlarContext.AllowPooledInspection(returned);
         await Assert.That(returned.CancellationToken).IsEqualTo(default(CancellationToken));
         await Assert.That(returned.IsSynchronous).IsFalse();
         await Assert.That(returned.ShieldName).IsNull();

--- a/tests/Kevlar.Tests/DescribeTests.cs
+++ b/tests/Kevlar.Tests/DescribeTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Kevlar.Tests;
 
 /// <summary>
@@ -78,7 +80,110 @@ public class DescribeTests
     {
         var shield = Shield.For<int>().WhenResult(0).Fallback(-1).Retry(1, Backoff.None);
 
-        await Assert.That(shield.ToString()).IsEqualTo("Fallback → Retry(1, no delay)");
+        await Assert.That(shield.ToString()).IsEqualTo("[when result 0] Fallback → Retry(1, no delay)");
+    }
+
+    [Test]
+    public async Task A_Non_Default_Clause_Prefixes_The_Strategies_That_Share_It()
+    {
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .Or<TimeoutExceededException>()
+            .Retry(1, Backoff.None)
+            .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+
+        await Assert.That(shield.ToString()).IsEqualTo(
+            "[when InvalidOperationException | TimeoutExceededException] Retry(1, no delay) → "
+            + "CircuitBreaker(5 consecutive, break 30s)");
+    }
+
+    [Test]
+    public async Task Each_Clause_Term_Has_Its_Own_Rendering()
+    {
+        await Assert.That(Shield.When<InvalidOperationException>(static _ => true).Retry(1, Backoff.None).ToString())
+            .IsEqualTo("[when InvalidOperationException matching predicate] Retry(1, no delay)");
+        await Assert.That(Shield.When(static _ => true).Retry(1, Backoff.None).ToString())
+            .IsEqualTo("[when exception predicate] Retry(1, no delay)");
+        await Assert.That(Shield.For<int>().WhenResult(static _ => true).Retry(1, Backoff.None).ToString())
+            .IsEqualTo("[when result predicate] Retry(1, no delay)");
+        await Assert.That(Shield.For<int>().WhenResultDefault().Retry(1, Backoff.None).ToString())
+            .IsEqualTo("[when default result] Retry(1, no delay)");
+        await Assert.That(Shield.For<string>().WhenResult("busy").Retry(1, Backoff.None).ToString())
+            .IsEqualTo("[when result \"busy\"] Retry(1, no delay)");
+    }
+
+    [Test]
+    public async Task Result_Literals_Are_Culture_Invariant()
+    {
+        var previous = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+        try
+        {
+            await Assert.That(Shield.For<double>().WhenResult(1.5).Retry(1, Backoff.None).ToString())
+                .IsEqualTo("[when result 1.5] Retry(1, no delay)");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    [Test]
+    public async Task Proactive_Strategies_Neither_Open_Nor_Close_A_Clause_Run()
+    {
+        var shield = Shield
+            .Timeout(TimeSpan.FromSeconds(30))
+            .When<InvalidOperationException>()
+            .Retry(1, Backoff.None)
+            .Timeout(TimeSpan.FromSeconds(10))
+            .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+
+        await Assert.That(shield.ToString()).IsEqualTo(
+            "Timeout(30s) → [when InvalidOperationException] Retry(1, no delay) → Timeout(10s) → "
+            + "CircuitBreaker(5 consecutive, break 30s)");
+    }
+
+    [Test]
+    public async Task A_Replaced_Or_Reset_Clause_Starts_A_New_Run()
+    {
+        var replaced = Shield
+            .When<InvalidOperationException>()
+            .Retry(1, Backoff.None)
+            .When<TimeoutExceededException>()
+            .Retry(2, Backoff.None);
+
+        var reset = Shield
+            .When<InvalidOperationException>()
+            .Retry(1, Backoff.None)
+            .WhenAnyError()
+            .Retry(2, Backoff.None)
+            .When<InvalidOperationException>()
+            .Retry(3, Backoff.None);
+
+        await Assert.That(replaced.ToString()).IsEqualTo(
+            "[when InvalidOperationException] Retry(1, no delay) → "
+            + "[when TimeoutExceededException] Retry(2, no delay)");
+        await Assert.That(reset.ToString()).IsEqualTo(
+            "[when InvalidOperationException] Retry(1, no delay) → Retry(2, no delay) → "
+            + "[when InvalidOperationException] Retry(3, no delay)");
+    }
+
+    [Test]
+    public async Task A_Local_Handling_Override_Is_Marked_On_The_Strategy()
+    {
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.HandlesException = static _ => true;
+            })
+            .CircuitBreaker(5, TimeSpan.FromSeconds(30));
+
+        await Assert.That(shield.ToString()).IsEqualTo(
+            "Retry(1, no delay) (local handling) → "
+            + "[when InvalidOperationException] CircuitBreaker(5 consecutive, break 30s)");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -89,7 +89,8 @@ public class HttpContractTests
     [Test]
     public async Task Standard_Has_The_Documented_Pipeline() =>
         await Assert.That(HttpShield.Standard().ToString()).IsEqualTo(
-            "Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
+            "Timeout(30s) → [when HttpRequestException | TimeoutExceededException | result predicate] "
+            + "Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
 
     [Test]
     public async Task Configured_Standard_Has_Custom_Stages()
@@ -117,7 +118,8 @@ public class HttpContractTests
         };
 
         await Assert.That(HttpShield.Standard(options).ToString()).IsEqualTo(
-            "Timeout(20s) → Retry(1, no delay) → CircuitBreaker(8 consecutive, break 5s) → ConcurrencyLimit(12, queue 4) → Timeout(3s)");
+            "Timeout(20s) → [when HttpRequestException | TimeoutExceededException | result predicate] "
+            + "Retry(1, no delay) → CircuitBreaker(8 consecutive, break 5s) → ConcurrencyLimit(12, queue 4) → Timeout(3s)");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/OptionsValidationTests.cs
+++ b/tests/Kevlar.Tests/OptionsValidationTests.cs
@@ -50,11 +50,35 @@ public class OptionsValidationTests
     [Test]
     public async Task CircuitBreaker_Rejects_Configuring_Both_Trip_Modes()
     {
-        await Assert.That(() => Shield.CircuitBreaker(options =>
+        var untyped = await Assert.That(() => Shield.CircuitBreaker(options =>
         {
             options.ConsecutiveFailures = 3;
             options.FailureRatio = 0.5;
         })).Throws<ArgumentOutOfRangeException>();
+
+        var typed = await Assert.That(() => Shield.For<int>().CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 3;
+            options.FailureRatio = 0.5;
+        })).Throws<ArgumentOutOfRangeException>();
+
+        foreach (var message in new[] { untyped!.Message, typed!.Message })
+        {
+            await Assert.That(message).Contains("ConsecutiveFailures");
+            await Assert.That(message).Contains("FailureRatio");
+            await Assert.That(message).Contains("cannot both be set");
+            await Assert.That(message).Contains("Clear ConsecutiveFailures");
+            await Assert.That(message).Contains("clear FailureRatio");
+        }
+    }
+
+    [Test]
+    public async Task CircuitBreaker_With_Neither_Trip_Mode_Set_Trips_After_Five_Consecutive_Failures()
+    {
+        await Assert.That(Shield.CircuitBreaker(static _ => { }).ToString())
+            .IsEqualTo("CircuitBreaker(5 consecutive, break 15s)");
+        await Assert.That(Shield.For<int>().CircuitBreaker(static _ => { }).ToString())
+            .IsEqualTo("CircuitBreaker(5 consecutive, break 15s)");
     }
 
     [Test]


### PR DESCRIPTION
Third round of pre-release API cleanups from the API review.

## Implemented

### Handling clauses are visible in `Describe()`/`ToString()`

`Describe()` printed strategy configuration but never said which handling clause a reactive strategy judged outcomes with, so "why didn't the breaker trip?" was unanswerable from the description. Clauses now record a human-readable term as they are built (lambdas cannot be introspected, so the term is captured at `When…`/`Or…` time), and the pipeline description prefixes each run of strategies sharing a non-default clause:

```
[when HttpRequestException | TimeoutExceededException] Retry(3, no delay) → CircuitBreaker(5 consecutive, break 30s)
```

Term vocabulary: `HttpRequestException`, `HttpRequestException matching predicate`, `exception predicate`, `result predicate`, `result 0` / `result "busy"` (the value-equality overload, formatted culture-invariantly), `default result`. A strategy whose options replaced the clause with `HandlesException`/`HandlesResult` is marked `(local handling)` and does not open or close a run; proactive strategies carry no clause and are transparent; `WhenAnyError()` closes a run so a later identical clause reprints its prefix.

Shields on default handling describe byte-identically to before — the only existing assertions that changed are the two that genuinely use clauses (`Shield.For<int>().WhenResult(0)…` in `DescribeTests`, and `HttpShield.Standard()` in `HttpContractTests`).

### `KEV008` — discarded fluent chaining result

`shield.Retry(3);` as an expression statement builds a new shield and throws it away. Checked the existing catalogue first: `KEV007` covers only discarded *clause builders* (`ProducesHandlingClauseBuilder` + `IsDiscardedClauseBuilder`), so nothing covered a discarded `Shield`. `KEV008` reports a Kevlar fluent call that yields a `Shield`/`Shield<TResult>` and is discarded as an expression statement. It deliberately defers `ShieldBuilder`-returning calls to `KEV007` so a single mistake produces one warning, and stays quiet for assigned, returned and argument-passed results and for executions (which never return a shield).

### Cross-linked handling vocabularies in the XML docs

Every `HandlesException`/`HandlesResult` across `RetryOptions`, `RetryOptions<TResult>`, `CircuitBreakerOptions`, `CircuitBreakerOptions<TResult>`, `HedgeOptions`, `HedgeOptions<TResult>`, `FallbackOptions` and `FallbackOptions<TResult>` now leads with the override in the first sentence, carries a consistent remarks paragraph explaining that the ambient clause is started with `When…` and continued with `Or…`, and a `<seealso cref="HandlingClause"/>`. `ShieldBuilder` and `ShieldBuilder<TResult>` gained a matching remarks paragraph pointing the other way, at the options-level override.

### Circuit breaker validation

Both-set was already validated and already named both properties, but the message did not state the fix and the `ConsecutiveFailures` range error reported `options` as its parameter name. The message now names both properties and spells out every resolution, including leaving both unset (the documented 5-consecutive-failure default, which is valid — verified, not an error case). Both untyped and `CircuitBreakerOptions<TResult>` flow through the same `CircuitBreakerCore` constructor and are covered by tests.

### `KevlarContext` debug poison guard

Debug builds now mark a context invalid as it goes back to the pool; `CancellationToken`, `Properties`, `ShieldName`, `TimeProvider` and `IsSynchronous` throw `InvalidOperationException` explaining the pooling contract until the context is rented again. The flag and the check are `#if DEBUG` / `[Conditional("DEBUG")]`, so release getters compile down to a plain field read — the release `AllocationTests` still pass. The pool's `TryReset` writes the backing fields directly, so returning and re-renting is unaffected; hedging forks are already returned only after their attempt task completes.

Three of Kevlar's own tests deliberately inspect a context *after* it went back to the pool to prove `TryReset` cleared it. They now call a new internal `KevlarContext.AllowPooledInspection(context)`, itself a no-op in release.

## Skipped — already covered

**Analyzer for untyped `Fallback` with a result-returning `Execute`** is `KEV005` (`VoidFallbackResultExecutionRule`, "Fallback on a non-generic Shield applies only to void executions"). It already fires via `IsResultReturningExecution` + `FindInPipeline(IsVoidFallback)` and is covered by five existing tests: direct fluent chains across every result-returning overload, `Task` extensions and the notification overload, stable locals/aliases/builders/`For<T>()` lifts/`Wrap`/`Compose`, negative cases for typed `Shield<T>.Fallback` and void executions, and an exact message/severity/suppression contract test. Fields are *deliberately* not followed — `KEV005_Defers_Fields_And_Skips_Escaped_Or_Unstable_Locals` asserts that, matching the documented analyzer policy that only stable local initializers are followed — so I left that decision alone rather than reversing it.

## Tests

Built and run per suite (TUnit executables, `--timeout 120s`):

| Suite | Total | Failed |
|---|---|---|
| Kevlar.Tests (debug) | 774 | 0 |
| Kevlar.Tests (release) | 774 | 0 |
| Kevlar.Analyzers.Tests | 72 | 0 |
| Kevlar.IntegrationTests | 118 | 0 |
| Kevlar.Testing.Tests | 33 | 0 |
| Kevlar.Chaos.Tests | 23 | 0 |
| Kevlar.NetStandard.Tests | 5 | 0 |
| Kevlar.Extensions.RateLimiting.Tests | 19 | 0 |
| Kevlar.AllocationTests (release) | 3 | 0 |

`dotnet build Kevlar.slnx` and `dotnet build Kevlar.slnx -c Release` both succeed with 0 warnings, confirming the `#if DEBUG` guard compiles both ways. New doc snippets were compiled and executed against the local build to confirm the documented description output is exact.

https://claude.ai/code/session_01DarFLgjrFgAsDiGr3cwWkZ
