### PR TITLE
refactor(api): API review cleanups — rename WhenResultDefault, builder aliasing fix, clause-visibility analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 | `Shield.For<T>().Or<A>()` | `Shield.For<T>().When<A>()` |
 | `ShieldBuilder<T> builder = Shield.For<T>()` | `Shield<T> shield = Shield.For<T>()` |
 | `builder.OrWhen(predicate)` | `builder.Or(predicate)` |
-| `Shield.For<T>().WhenDefault()` | `Shield.For<T>().WhenResultDefault()` |
-| `builder.OrDefault()` | `builder.OrResultDefault()` |
+| `Shield.For<T>().WhenDefault()` | `Shield.For<T>().WhenResultIsDefault()` |
+| `builder.OrDefault()` | `builder.OrResultIsDefault()` |
 
 `OrWhen` is gone: `Or(Func<Exception, bool>)` now mirrors `When(Func<Exception, bool>)`, so the
 untyped predicate has the same spelling in both clause positions. `WhenDefault`/`OrDefault` were
-renamed to `WhenResultDefault`/`OrResultDefault` because their "default" is `default(TResult)`,
-not the default *handling* that the neighbouring `WhenAnyError()` restores.
+renamed to `WhenResultIsDefault`/`OrResultIsDefault` because their "default" is `default(TResult)`,
+not the default *handling* that the neighbouring `WhenAnyError()` restores. (An earlier pre-release
+build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the reading unambiguous.)
 
 - `RetryOptions<TResult>` no longer inherits `RetryOptions`. Both types retain the same scalar
   property names and defaults, but helpers that accepted `RetryOptions` must configure typed retry
@@ -43,9 +44,16 @@ not the default *handling* that the neighbouring `WhenAnyError()` restores.
 - `HandlesException`/`HandlesResult` documentation on every options type now leads with the fact
   that the property makes its strategy ignore the ambient `When…` clause, and points at
   `HandlingClause`. `ShieldBuilder`/`ShieldBuilder<TResult>` document the override from the clause side.
+- `ShieldBuilder` and `ShieldBuilder<TResult>` snapshot their accumulated clause whenever a strategy
+  seals it. A builder held in a variable can be extended with further `Or…` terms afterwards without
+  changing the handling of any shield already built from it.
 
 ### Added
 
+- `KEV009`: an informational hint marking each reactive strategy that inherits a handling clause
+  declared earlier in its chain, so the clause's span is visible in the editor. It is `Info`
+  severity — the inheritance is by design, and the hint never fails a build. Proactive strategies
+  and strategies with a local `HandlesException`/`HandlesResult` override are never flagged.
 - `KEV008`: a fluent chaining call written as a statement, such as `shield.Retry(3);`. Shields are
   immutable, so the new shield the call returns is thrown away and nothing is configured.
   Discarded clause builders keep reporting as `KEV007`.

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -24,6 +24,7 @@ Generated code is ignored.
 | `KEV006` | Warning | hedging is added to an untyped shield, whose action must be idempotent |
 | `KEV007` | Warning | handling clause never reaches a reactive strategy |
 | `KEV008` | Warning | fluent chaining result is discarded as a statement |
+| `KEV009` | Info | strategy inherits a handling clause declared earlier in the chain |
 
 ## KEV001: ignored execution cancellation
 
@@ -231,6 +232,43 @@ var shield = Shield.Timeout(TimeSpan.FromSeconds(5)).Retry(3);
 The rule fires only on a statement whose value is a `Shield` or `Shield<TResult>`, so assigning the
 result, returning it, or passing it as an argument is never flagged. Discarded *clause builders* are
 reported by [`KEV007`](#kev007-dead-handling-clause) instead, which names that hazard directly.
+
+## KEV009: inherited handling clause
+
+A [handling clause](handling-failures.md) stays ambient: it applies to the strategy it is attached to
+*and* to every reactive strategy chained after it, until a new `When…` replaces it, `WhenAnyError()`
+resets it, or `Wrap`/`Compose` seals it. That is by design — writing the clause once is the point —
+but only the *first* strategy states it at its own call site. `KEV009` is an informational hint, not
+a warning: it marks the second and later strategies so the clause's span is visible in the editor.
+
+```csharp
+var shield = Shield
+    .When<HttpRequestException>()
+    .Retry(3)                                      // states the clause here
+    .Timeout(TimeSpan.FromSeconds(5))
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+//   ^^^^^^^^^^^^^^ KEV009 — only HttpRequestException opens this circuit
+```
+
+Nothing needs fixing if that is what you meant. If it is not, give the later strategy its own
+handling — a new clause, a reset, or a local override:
+
+```csharp
+var shield = Shield
+    .When<HttpRequestException>()
+    .Retry(3)
+    .WhenAnyError()
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+```
+
+Proactive strategies — timeout, rate limit, concurrency limit — never consult a clause, so they are
+never flagged and never end the inherited span. A strategy that sets `HandlesException` or
+`HandlesResult` in its own options has opted out of the ambient clause and is not flagged either.
+The rule follows one fluent chain and a stable local, and stops at `Wrap`/`Compose` boundaries.
+
+Because it is `Info`, `KEV009` never fails a build, including under `TreatWarningsAsErrors`. Turn it
+off entirely with `dotnet_diagnostic.KEV009.severity = none` in `.editorconfig` if the ambient model
+is already second nature to your team.
 
 ## Suppression
 

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -50,11 +50,11 @@ Now a 503 response triggers a retry exactly as a thrown `HttpRequestException` w
 Typed builders add result alternatives with `OrResult(predicate)` / `OrResult(value)`, and two shorthands for the most common check of all:
 
 ```csharp
-Shield.For<User?>().WhenResultDefault().Retry(2);   // retry when the result is null / default
-// mid-chain: .OrResultDefault() adds the same check to an existing clause
+Shield.For<User?>().WhenResultIsDefault().Retry(2);   // retry when the result is null / default
+// mid-chain: .OrResultIsDefault() adds the same check to an existing clause
 ```
 
-`WhenResultDefault` / `OrResultDefault` mean "the result equals `default(T)`". They are named after
+`WhenResultIsDefault` / `OrResultIsDefault` mean "the result equals `default(T)`". They are named after
 the `WhenResult` / `OrResult` family precisely so they cannot be confused with `WhenAnyError()`,
 which resets *handling* to Kevlar's default.
 
@@ -75,7 +75,7 @@ Shield
 
 This is why most chains only need one clause, written once at the top — and why you never repeat a `ShouldHandle` predicate per strategy like in Polly v8.
 
-A clause that never reaches a reactive strategy does nothing at all. The optional analyzer reports that as [`KEV007`](analyzers.md#kev007-dead-handling-clause).
+A clause that never reaches a reactive strategy does nothing at all. The optional analyzer reports that as [`KEV007`](analyzers.md#kev007-dead-handling-clause). It also marks the strategies that *inherit* a clause, rather than declaring one, as the informational hint [`KEV009`](analyzers.md#kev009-inherited-handling-clause), so the span above is visible in the editor.
 
 ### Reset to default handling
 

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -69,7 +69,7 @@ public ProfileClient(Shield<Profile?>? shield = null)
 
 ```csharp
 var client = new ProfileClient(
-    Shield.For<Profile?>().WhenResultDefault().Or<HttpRequestException>().Retry(3));
+    Shield.For<Profile?>().WhenResultIsDefault().Or<HttpRequestException>().Retry(3));
 ```
 
 ## Opinionated defaults

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -22,6 +22,38 @@ Kevlar's pipeline model translates 1:1 from Polly v8 — the "first strategy add
 | Retry default: constant 2s, no jitter | exponential + jitter, 30s cap |
 | First strategy added is outermost | same rule — pipelines translate 1:1 |
 
+:::warning `TimeoutExceededException` is **not** a `System.TimeoutException`
+
+`Kevlar.TimeoutExceededException` derives from `KevlarException`, not from `System.TimeoutException`.
+Polly set the same trap — `TimeoutRejectedException` derived from `ExecutionRejectedException`, never
+from `System.TimeoutException` — and the reflex is the same in both libraries: a `catch (TimeoutException)`
+carried over from application code still compiles, never matches, and lets the timeout escape as an
+unhandled exception.
+
+Catch the exception the strategy actually throws, or `KevlarException` for any Kevlar rejection:
+
+```csharp
+var saveShield = Shield.Timeout(TimeSpan.FromSeconds(30));
+
+try
+{
+    await saveShield.ExecuteAsync(ct => SaveAsync(ct), cancellationToken);
+}
+catch (TimeoutExceededException exception)      // not System.TimeoutException
+{
+    logger.LogWarning("Timed out after {Timeout}", exception.Timeout);
+}
+catch (KevlarException exception)               // CircuitOpenException, RateLimitExceededException, …
+{
+    logger.LogWarning(exception, "Shielded call was rejected");
+}
+```
+
+The same applies to `CircuitOpenException`, `RateLimitExceededException` and
+`ConcurrencyLimitExceededException`: every rejection Kevlar raises derives from `KevlarException`.
+
+:::
+
 ## Worked example
 
 Polly v8:

--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -17,7 +17,10 @@ Shield.Timeout(o =>
 });
 ```
 
-Exceeding the budget surfaces `TimeoutExceededException` (with a `Timeout` property).
+Exceeding the budget surfaces `TimeoutExceededException` (with a `Timeout` property). It derives from
+`KevlarException`, **not** from `System.TimeoutException`, so a reflexive `catch (TimeoutException)`
+compiles but never matches — catch `TimeoutExceededException` (or `KevlarException` for any Kevlar
+rejection) instead.
 
 ## Timeouts are cooperative
 

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -13,3 +13,4 @@ KEV005 | Configuration | Warning | Void fallback is used with a result-returning
 KEV006 | Reliability | Warning | Hedging on an untyped Shield requires an idempotent action
 KEV007 | Configuration | Warning | Handling clause never reaches a reactive strategy
 KEV008 | Configuration | Warning | Fluent chaining result is discarded as a statement
+KEV009 | Configuration | Info | Strategy inherits a handling clause declared earlier in the chain

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -12,6 +12,8 @@ namespace Kevlar.Analyzers;
 /// strategies made unreachable by an inner fallback, per-execution construction of stateful shields,
 /// void fallbacks used for result-returning executions, hedging on an untyped shield, handling
 /// clauses that never reach a reactive strategy, and fluent chaining results discarded as statements.
+/// It also reports, at hint severity, the strategies that inherit a handling clause declared
+/// earlier in their chain, so the clause's span is visible where it applies.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
@@ -86,6 +88,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "Shield, Shield<TResult> and their builders are immutable: every fluent method returns a new instance and leaves its receiver untouched. A chaining call written as a statement therefore has no effect.");
 
+    /// <summary>The KEV009 rule.</summary>
+    public static readonly DiagnosticDescriptor InheritedHandlingClauseRule = new(
+        id: "KEV009",
+        title: "Strategy inherits a handling clause declared earlier in the chain",
+        messageFormat: "This strategy inherits the handling clause declared earlier in the chain ('{0}'); only those exceptions or results count toward it. Declare a new clause, or call 'WhenAnyError()' first, to give it different handling.",
+        category: "Configuration",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "A handling clause stays ambient for every reactive strategy chained after it until a new clause replaces it, WhenAnyError resets it, or Wrap/Compose seals it. That is by design; this diagnostic makes the inherited span visible at the strategies that silently pick the clause up.");
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
@@ -95,7 +107,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             VoidFallbackResultExecutionRule,
             UntypedHedgingRule,
             DeadHandlingClauseRule,
-            DiscardedChainResultRule);
+            DiscardedChainResultRule,
+            InheritedHandlingClauseRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -210,7 +223,124 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 invocation.Syntax.GetLocation(),
                 Normalize(invocation.TargetMethod).Name));
         }
+
+        if (InheritsAmbientHandlingClause(invocation, context, knownTypes, out var inheritedClause))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                InheritedHandlingClauseRule,
+                GetMethodNameLocation(invocation),
+                inheritedClause));
+        }
     }
+
+    /// <summary>
+    /// Reports the second and later reactive strategies that read one ambient handling clause.
+    /// The first strategy after a <c>When…</c> states its own handling at the call site; the ones
+    /// after it inherit it silently, which is what this walk surfaces.
+    /// </summary>
+    private static bool InheritsAmbientHandlingClause(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        out string? clause)
+    {
+        clause = null;
+        if (!IsClauseConsumingStrategy(Normalize(invocation.TargetMethod), knownTypes)
+            || HasLocalHandlingOverride(invocation, context) is not false)
+        {
+            return false;
+        }
+
+        HashSet<ISymbol>? visitedLocals = null;
+        var sawEarlierStrategy = false;
+        for (var current = Unwrap(GetReceiver(invocation)); current is not null;)
+        {
+            if (current is ILocalReferenceOperation localReference)
+            {
+                visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                if (!visitedLocals.Add(localReference.Local)
+                    || !TryGetStableInitializer(localReference, context, out var initializer))
+                {
+                    return false;
+                }
+
+                current = Unwrap(initializer);
+                continue;
+            }
+
+            if (current is IConditionalAccessOperation conditionalAccess)
+            {
+                current = Unwrap(conditionalAccess.Operation);
+                continue;
+            }
+
+            if (current is not IInvocationOperation link)
+            {
+                return false;
+            }
+
+            var method = Normalize(link.TargetMethod);
+
+            // WhenAnyError resets the clause and Wrap/Compose seals it, so nothing is inherited
+            // across either. Checked before StartsHandlingClause, which also matches WhenAnyError.
+            if (method.Name == "WhenAnyError" || IsCompositionBoundary(method, knownTypes))
+            {
+                return false;
+            }
+
+            if (StartsHandlingClause(method, knownTypes))
+            {
+                if (!sawEarlierStrategy)
+                {
+                    return false;
+                }
+
+                clause = DescribeClause(link);
+                return true;
+            }
+
+            if (!IsKevlarFluentMethod(method, knownTypes))
+            {
+                return false;
+            }
+
+            // Proactive strategies carry no clause and Or… only extends the one being walked to,
+            // so neither counts as an earlier consumer.
+            if (IsClauseConsumingStrategy(method, knownTypes)
+                && HasLocalHandlingOverride(link, context) is false)
+            {
+                sawEarlierStrategy = true;
+            }
+
+            current = Unwrap(GetReceiver(link));
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The built-in reactive strategies that read the ambient clause rather than declaring handling.
+    /// <c>Use</c> is excluded: its factory takes the <c>HandlingClause</c> as a parameter, so what it
+    /// inherits is already spelled out at the call site.
+    /// </summary>
+    private static bool IsClauseConsumingStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
+        (method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker" or "Fallback")
+        && IsKevlarFluentMethod(method, knownTypes);
+
+    /// <summary>Renders a clause declaration the way it was written, e.g. <c>When&lt;HttpRequestException&gt;…</c>.</summary>
+    private static string DescribeClause(IInvocationOperation invocation) =>
+        (invocation.Syntax is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax memberAccess }
+            ? memberAccess.Name.ToString()
+            : Normalize(invocation.TargetMethod).Name) + "…";
+
+    /// <summary>
+    /// The invoked method's name alone, so a hint marks the one strategy it is about rather than
+    /// underlining the whole fluent chain leading up to it.
+    /// </summary>
+    private static Location GetMethodNameLocation(IInvocationOperation invocation) =>
+        invocation.Syntax is InvocationExpressionSyntax { Expression: MemberAccessExpressionSyntax memberAccess }
+            ? memberAccess.Name.GetLocation()
+            : invocation.Syntax.GetLocation();
 
     /// <summary>
     /// Reports a fluent call whose new shield is dropped where it stands. Calls that hand back a
@@ -288,8 +418,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     /// <summary>Whether a reactive strategy reads the ambient clause this method seals.</summary>
     private static bool ConsumesHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
-        (method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker" or "Fallback" or "Use")
-        && IsKevlarFluentMethod(method, knownTypes);
+        IsClauseConsumingStrategy(method, knownTypes)
+        || (method.Name == "Use" && IsKevlarFluentMethod(method, knownTypes));
 
     private static bool IsDiscardedClauseBuilder(
         IInvocationOperation invocation,
@@ -1895,7 +2025,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool StartsHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
-        (method.Name is "When" or "WhenResult" or "WhenResultDefault" or "WhenAnyError")
+        (method.Name is "When" or "WhenResult" or "WhenResultIsDefault" or "WhenAnyError")
         && (knownTypes.IsShield(method.ContainingType)
             || knownTypes.IsShieldExtensions(method.ContainingType));
 

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ Kevlar.Analyzers.PipelineHazardAnalyzer.PipelineHazardAnalyzer() -> void
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.DeadHandlingClauseRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.DiscardedChainResultRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.EphemeralStatefulShieldRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.InheritedHandlingClauseRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -209,8 +209,8 @@ static Kevlar.Shield.For<TResult>() -> Kevlar.Shield<TResult>!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.OrDefault() -> Kevlar.ShieldBuilder<TResult>!
 *REMOVED*Kevlar.ShieldBuilder.OrWhen(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder!
 *REMOVED*Kevlar.ShieldBuilder<TResult>.OrWhen(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
-Kevlar.Shield<TResult>.WhenResultDefault() -> Kevlar.ShieldBuilder<TResult>!
-Kevlar.ShieldBuilder<TResult>.OrResultDefault() -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.Shield<TResult>.WhenResultIsDefault() -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.ShieldBuilder<TResult>.OrResultIsDefault() -> Kevlar.ShieldBuilder<TResult>!
 Kevlar.ShieldBuilder.Or(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder!
 Kevlar.ShieldBuilder<TResult>.Or(System.Func<System.Exception!, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
 Kevlar.Shield.ExecuteWithContext<T>(System.Func<Kevlar.KevlarContext!, T>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> T

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -14,6 +14,13 @@ namespace Kevlar;
 /// <c>Shield.When&lt;A&gt;().Or&lt;B&gt;().Retry(3)</c>.
 /// </para>
 /// <para>
+/// <c>Or…</c> accumulates into the builder and returns that same builder, so a builder held in a
+/// variable keeps every term added to it. The clause is snapshotted when a strategy is added:
+/// adding further <c>Or…</c> terms afterwards never changes a shield already built. Branching two
+/// chains from one stored builder, however, gives both chains every term either branch added, so
+/// start a fresh <c>When…</c> for each chain.
+/// </para>
+/// <para>
 /// One strategy can opt out of the ambient clause: setting <c>HandlesException</c> on its options
 /// (<see cref="RetryOptions"/>, <see cref="CircuitBreakerOptions"/>, <see cref="HedgeOptions"/>,
 /// <see cref="FallbackOptions"/>) makes that strategy ignore the clause and handle only what its
@@ -137,29 +144,33 @@ public sealed class ShieldBuilder
     /// <summary>Adds a configured concurrency limit. The handling clauses remain ambient for later strategies.</summary>
     public Shield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);
 
+    /// <summary>
+    /// Freezes the clause accumulated so far into a shield. The predicates are copied and the
+    /// description is rendered here, so a builder kept in a variable and extended with further
+    /// <c>Or…</c> calls can never change the handling of a shield already built from it.
+    /// </summary>
     private Shield Seal() =>
         new(
             _parent.Strategies,
-            new ExceptionJudge(Combine(_predicates), DescribeHelper.Clause(_clauseTerms)),
+            new ExceptionJudge(Combine(_predicates.ToArray()), DescribeHelper.Clause(_clauseTerms)),
             _parent.Name,
             _parent.Time);
 
-    internal static Func<Exception, bool> Combine(List<Func<Exception, bool>> predicates)
+    internal static Func<Exception, bool> Combine(Func<Exception, bool>[] predicates)
     {
-        if (predicates.Count == 0)
+        if (predicates.Length == 0)
         {
             throw new InvalidOperationException("No handling clauses were added.");
         }
 
-        if (predicates.Count == 1)
+        if (predicates.Length == 1)
         {
             return predicates[0];
         }
 
-        var snapshot = predicates.ToArray();
         return exception =>
         {
-            foreach (var predicate in snapshot)
+            foreach (var predicate in predicates)
             {
                 if (predicate(exception))
                 {

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -14,6 +14,13 @@ namespace Kevlar;
 /// <c>Shield.For&lt;T&gt;().When&lt;A&gt;().OrResult(r =&gt; …).Retry(3)</c>.
 /// </para>
 /// <para>
+/// <c>Or…</c> accumulates into the builder and returns that same builder, so a builder held in a
+/// variable keeps every term added to it. The clause is snapshotted when a strategy is added:
+/// adding further <c>Or…</c> terms afterwards never changes a shield already built. Branching two
+/// chains from one stored builder, however, gives both chains every term either branch added, so
+/// start a fresh <c>When…</c> for each chain.
+/// </para>
+/// <para>
 /// One strategy can opt out of the ambient clause: setting <c>HandlesException</c> or
 /// <c>HandlesResult</c> on its options (<see cref="RetryOptions{TResult}"/>,
 /// <see cref="CircuitBreakerOptions{TResult}"/>, <see cref="HedgeOptions{TResult}"/>,
@@ -76,7 +83,7 @@ public sealed class ShieldBuilder<TResult>
     }
 
     /// <summary>Also handle results equal to <c>default(TResult)</c> — <see langword="null"/> for reference types.</summary>
-    public ShieldBuilder<TResult> OrResultDefault()
+    public ShieldBuilder<TResult> OrResultIsDefault()
     {
         _resultPredicates.Add(static candidate => EqualityComparer<TResult>.Default.Equals(candidate, default!));
         _clauseTerms.Add("default result");
@@ -164,10 +171,18 @@ public sealed class ShieldBuilder<TResult>
     /// <summary>Adds a configured concurrency limit. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);
 
+    /// <summary>
+    /// Freezes the clause accumulated so far into a shield. Both predicate lists are copied and the
+    /// description is rendered here, so a builder kept in a variable and extended with further
+    /// <c>Or…</c> calls can never change the handling of a shield already built from it.
+    /// </summary>
     private Shield<TResult> Seal()
     {
-        var exceptionPredicate = _exceptionPredicates.Count == 0 ? null : ShieldBuilder.Combine(_exceptionPredicates);
-        var resultPredicate = CombineResults(_resultPredicates);
+        var exceptionPredicates = _exceptionPredicates.ToArray();
+        var exceptionPredicate = exceptionPredicates.Length == 0
+            ? null
+            : ShieldBuilder.Combine(exceptionPredicates);
+        var resultPredicate = CombineResults(_resultPredicates.ToArray());
         var judge = new TypedJudge<TResult>(
             exceptionPredicate,
             resultPredicate,
@@ -175,22 +190,21 @@ public sealed class ShieldBuilder<TResult>
         return new Shield<TResult>(_parent.Strategies, judge, _parent.Name, _parent.Time);
     }
 
-    private static Func<TResult, bool>? CombineResults(List<Func<TResult, bool>> predicates)
+    private static Func<TResult, bool>? CombineResults(Func<TResult, bool>[] predicates)
     {
-        if (predicates.Count == 0)
+        if (predicates.Length == 0)
         {
             return null;
         }
 
-        if (predicates.Count == 1)
+        if (predicates.Length == 1)
         {
             return predicates[0];
         }
 
-        var snapshot = predicates.ToArray();
         return result =>
         {
-            foreach (var predicate in snapshot)
+            foreach (var predicate in predicates)
             {
                 if (predicate(result))
                 {

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -61,11 +61,7 @@ public sealed class Shield<TResult>
     /// Starts a handling clause for results equal to <c>default(TResult)</c> — <see langword="null"/>
     /// for reference types. Use <see cref="WhenAnyError"/> to return to default handling.
     /// </summary>
-    /// <remarks>
-    /// The <c>Default</c> here means "the default value of <typeparamref name="TResult"/>", not
-    /// "Kevlar's default handling"; <see cref="WhenAnyError"/> is the one that resets handling.
-    /// </remarks>
-    public ShieldBuilder<TResult> WhenResultDefault() => new ShieldBuilder<TResult>(this).OrResultDefault();
+    public ShieldBuilder<TResult> WhenResultIsDefault() => new ShieldBuilder<TResult>(this).OrResultIsDefault();
 
     /// <summary>
     /// Resets the ambient handling clause. Subsequent reactive strategies use the default

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -582,7 +582,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.When<InvalidOperationException>();",
             "_ = Shield.Empty.When<InvalidOperationException>();",
             "_ = Shield.For<int>().WhenResult(static value => value < 0);",
-            "_ = Shield.For<int>().WhenResultDefault().Or<TimeoutException>();",
+            "_ = Shield.For<int>().WhenResultIsDefault().Or<TimeoutException>();",
             "var clause = Shield.When<InvalidOperationException>().Or<TimeoutException>();",
             "var clause = Shield.For<int>().When<InvalidOperationException>();",
         };
@@ -719,7 +719,7 @@ public class PipelineHazardAnalyzerTests
         {
             "Shield.When<InvalidOperationException>();",
             "Shield.Empty.When<InvalidOperationException>().Or<TimeoutException>();",
-            "Shield.For<int>().WhenResultDefault();",
+            "Shield.For<int>().WhenResultIsDefault();",
         };
 
         await AssertEachAsync(cases, "KEV007");
@@ -794,8 +794,9 @@ public class PipelineHazardAnalyzerTests
         };
 
         // Some cases replace a clause that only a timeout ever saw, which is exactly what KEV007
-        // reports; the fallback reachability under test is unaffected.
-        await AssertEachAsync(cases, "KEV003", "KEV007");
+        // reports, and some chain a fallback behind a reactive strategy under one clause, which is
+        // what KEV009 makes visible; the fallback reachability under test is unaffected by either.
+        await AssertEachAsync(cases, "KEV003", "KEV007", "KEV009");
     }
 
     [Test]
@@ -954,6 +955,104 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV009_Flags_Reactive_Strategies_That_Inherit_An_Earlier_Clause()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.When<InvalidOperationException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.When<InvalidOperationException>().Retry(1).RetryForever(Backoff.None);",
+            "_ = Shield.For<int>().WhenResult(0).Retry(1).Hedge(2, TimeSpan.Zero);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Fallback(0).Retry(1);",
+            "_ = Shield.For<int>().WhenResultIsDefault().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "var outer = Shield.When<InvalidOperationException>().Retry(1); _ = outer.CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+        };
+
+        await AssertEachAsync(cases, "KEV009", DiagnosticSeverity.Info);
+    }
+
+    [Test]
+    public async Task KEV009_Flags_Every_Strategy_After_The_First_Across_Proactive_Links()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            """
+            _ = Shield.When<InvalidOperationException>()
+                .Retry(1)
+                .Timeout(TimeSpan.FromSeconds(1))
+                .CircuitBreaker(2, TimeSpan.FromSeconds(1))
+                .RateLimit(10, TimeSpan.FromSeconds(1))
+                .RetryForever(Backoff.None);
+            """);
+
+        // The retry states the clause at its own call site; the breaker and the forever-retry
+        // inherit it across the timeout and rate limit, which carry no clause of their own.
+        await Assert.That(diagnostics.Length).IsEqualTo(2);
+        await Assert.That(diagnostics).All(static diagnostic => diagnostic.Id == "KEV009");
+        await Assert.That(MarkedText(diagnostics)).IsEquivalentTo(new[] { "CircuitBreaker", "RetryForever" });
+    }
+
+    private static string[] MarkedText(ImmutableArray<Diagnostic> diagnostics) =>
+        diagnostics
+            .OrderBy(static diagnostic => diagnostic.Location.SourceSpan.Start)
+            .Select(static diagnostic => diagnostic.Location.SourceTree!.ToString()
+                .Substring(diagnostic.Location.SourceSpan.Start, diagnostic.Location.SourceSpan.Length))
+            .ToArray();
+
+    [Test]
+    public async Task KEV009_Skips_Reset_Replaced_Absent_Overridden_And_Sealed_Clauses()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.When<InvalidOperationException>().Retry(1);",
+            "_ = Shield.Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.When<InvalidOperationException>().Retry(1).WhenAnyError().CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.When<InvalidOperationException>().Retry(1).When<TimeoutException>().CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).RateLimit(10, TimeSpan.FromSeconds(1)).ConcurrencyLimit(2).Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Retry(1).Wrap(Shield.Empty).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.Compose(Shield.When<InvalidOperationException>().Retry(1), Shield.Empty).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Retry(1).CircuitBreaker(options => options.HandlesException = exception => exception is TimeoutException);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException = exception => exception is TimeoutException).Retry(1);",
+            "_ = CreateShield().CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(
+                body,
+                "private static Shield CreateShield() => Shield.When<InvalidOperationException>().Retry(1);");
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV009_Diagnostic_Contract_And_Suppression_Are_Exact()
+    {
+        const string body = "_ = Shield.When<InvalidOperationException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));";
+        var diagnostics = await AnalyzeBodyAsync(body);
+        var suppressed = await AnalyzeBodyAsync($"""
+            #pragma warning disable KEV009 // The inherited clause is deliberate here.
+            {body}
+            #pragma warning restore KEV009
+            """);
+
+        await Assert.That(diagnostics.Length).IsEqualTo(1);
+        var diagnostic = diagnostics[0];
+        await Assert.That(diagnostic.Id).IsEqualTo("KEV009");
+        await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Info);
+        await Assert.That(diagnostic.GetMessage()).IsEqualTo(
+            "This strategy inherits the handling clause declared earlier in the chain "
+            + "('When<InvalidOperationException>…'); only those exceptions or results count toward "
+            + "it. Declare a new clause, or call 'WhenAnyError()' first, to give it different "
+            + "handling.");
+
+        // The hint marks only the inheriting strategy's name, not the whole chain.
+        var span = diagnostic.Location.SourceSpan;
+        await Assert.That(diagnostic.Location.SourceTree!.ToString().Substring(span.Start, span.Length))
+            .IsEqualTo("CircuitBreaker");
+        await Assert.That(suppressed).IsEmpty();
+    }
+
+    [Test]
     public async Task Non_Kevlar_Methods_And_Generated_Code_Are_Ignored()
     {
         var unrelated = await AnalyzeSourceAsync("""
@@ -990,6 +1089,19 @@ public class PipelineHazardAnalyzerTests
         }
     }
 
+    private static async Task AssertEachAsync(
+        IEnumerable<string> cases,
+        string expectedRule,
+        DiagnosticSeverity expectedSeverity,
+        params string[] expectedCompanionRules)
+    {
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body);
+            await AssertRuleAsync(Without(diagnostics, expectedCompanionRules), expectedRule, expectedSeverity);
+        }
+    }
+
     /// <summary>
     /// Drops rules a case is expected to trigger in addition to the rule under test — untyped
     /// hedging cases, for instance, always also report KEV006.
@@ -1003,11 +1115,14 @@ public class PipelineHazardAnalyzerTests
                 .Where(diagnostic => !ruleIds.Contains(diagnostic.Id, StringComparer.Ordinal))
                 .ToImmutableArray();
 
-    private static async Task AssertRuleAsync(ImmutableArray<Diagnostic> diagnostics, string expectedRule)
+    private static async Task AssertRuleAsync(
+        ImmutableArray<Diagnostic> diagnostics,
+        string expectedRule,
+        DiagnosticSeverity expectedSeverity = DiagnosticSeverity.Warning)
     {
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         await Assert.That(diagnostics[0].Id).IsEqualTo(expectedRule);
-        await Assert.That(diagnostics[0].Severity).IsEqualTo(DiagnosticSeverity.Warning);
+        await Assert.That(diagnostics[0].Severity).IsEqualTo(expectedSeverity);
     }
 
     private static Task<ImmutableArray<Diagnostic>> AnalyzeBodyAsync(

--- a/tests/Kevlar.Tests/DescribeTests.cs
+++ b/tests/Kevlar.Tests/DescribeTests.cs
@@ -106,7 +106,7 @@ public class DescribeTests
             .IsEqualTo("[when exception predicate] Retry(1, no delay)");
         await Assert.That(Shield.For<int>().WhenResult(static _ => true).Retry(1, Backoff.None).ToString())
             .IsEqualTo("[when result predicate] Retry(1, no delay)");
-        await Assert.That(Shield.For<int>().WhenResultDefault().Retry(1, Backoff.None).ToString())
+        await Assert.That(Shield.For<int>().WhenResultIsDefault().Retry(1, Backoff.None).ToString())
             .IsEqualTo("[when default result] Retry(1, no delay)");
         await Assert.That(Shield.For<string>().WhenResult("busy").Retry(1, Backoff.None).ToString())
             .IsEqualTo("[when result \"busy\"] Retry(1, no delay)");

--- a/tests/Kevlar.Tests/NewApiTests.cs
+++ b/tests/Kevlar.Tests/NewApiTests.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Time.Testing;
 namespace Kevlar.Tests;
 
 /// <summary>
-/// Guards the API refinements: the unified When/Or clause grammar, WhenResultDefault, typed retry
+/// Guards the API refinements: the unified When/Or clause grammar, WhenResultIsDefault, typed retry
 /// events, the MaxDelay absolute cap, the context-only ExecuteWithContext overloads, and Compose
 /// preserving metadata while sealing clauses.
 /// </summary>
@@ -110,10 +110,10 @@ public class NewApiTests
     }
 
     [Test]
-    public async Task WhenResultDefault_Retries_Null_Results()
+    public async Task WhenResultIsDefault_Retries_Null_Results()
     {
         var attempts = 0;
-        var shield = Shield.For<string?>().WhenResultDefault().Retry(2, Backoff.None);
+        var shield = Shield.For<string?>().WhenResultIsDefault().Retry(2, Backoff.None);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<string?>(attempts++ < 2 ? null : "loaded"));
 
@@ -122,10 +122,10 @@ public class NewApiTests
     }
 
     [Test]
-    public async Task WhenResultDefault_Matches_Default_Value_Types()
+    public async Task WhenResultIsDefault_Matches_Default_Value_Types()
     {
         var attempts = 0;
-        var shield = Shield.For<int>().WhenResultDefault().Retry(1, Backoff.None);
+        var shield = Shield.For<int>().WhenResultIsDefault().Retry(1, Backoff.None);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(attempts++ == 0 ? 0 : 7));
 

--- a/tests/Kevlar.Tests/ShieldBuilderAliasingTests.cs
+++ b/tests/Kevlar.Tests/ShieldBuilderAliasingTests.cs
@@ -1,0 +1,123 @@
+namespace Kevlar.Tests;
+
+/// <summary>
+/// Guards the snapshot taken when a <see cref="ShieldBuilder"/> or <see cref="ShieldBuilder{TResult}"/>
+/// seals a clause. <c>Or…</c> accumulates into the builder and returns that same instance, so a
+/// builder held in a variable stays live; a shield already built from it must keep the clause it
+/// was built with, whatever is added to the builder afterwards.
+/// </summary>
+public class ShieldBuilderAliasingTests
+{
+    [Test]
+    public async Task Untyped_Shield_Keeps_The_Clause_It_Was_Built_With()
+    {
+        var builder = Shield.When<ArgumentException>();
+        var first = builder.Retry(1, Backoff.None);
+
+        builder.Or<InvalidOperationException>();
+        var second = builder.Retry(1, Backoff.None);
+
+        var firstAttempts = 0;
+        await Assert.That(async () => await first.ExecuteAsync<int>(_ =>
+        {
+            firstAttempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+
+        var secondAttempts = 0;
+        await Assert.That(async () => await second.ExecuteAsync<int>(_ =>
+        {
+            secondAttempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+
+        // The first shield never learned about InvalidOperationException, so it did not retry.
+        await Assert.That(firstAttempts).IsEqualTo(1);
+        await Assert.That(secondAttempts).IsEqualTo(2);
+        await Assert.That(first.ToString()).IsEqualTo("[when ArgumentException] Retry(1, no delay)");
+        await Assert.That(second.ToString())
+            .IsEqualTo("[when ArgumentException | InvalidOperationException] Retry(1, no delay)");
+    }
+
+    [Test]
+    public async Task Untyped_Single_Term_Clause_Is_Not_Extended_After_Sealing()
+    {
+        var builder = Shield.When<ArgumentException>();
+        var first = builder.Retry(1, Backoff.None);
+
+        builder.Or(static exception => exception is TimeoutException);
+
+        var attempts = 0;
+        await Assert.That(async () => await first.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new TimeoutException();
+        })).Throws<TimeoutException>();
+
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Typed_Shield_Keeps_The_Result_Clause_It_Was_Built_With()
+    {
+        var builder = Shield.For<int>().When<ArgumentException>();
+        var first = builder.Retry(1, Backoff.None);
+
+        builder.OrResult(0);
+        var second = builder.Retry(1, Backoff.None);
+
+        var firstAttempts = 0;
+        var firstResult = await first.ExecuteAsync(_ =>
+        {
+            firstAttempts++;
+            return new ValueTask<int>(0);
+        });
+
+        var secondAttempts = 0;
+        var secondResult = await second.ExecuteAsync(_ =>
+        {
+            secondAttempts++;
+            return new ValueTask<int>(secondAttempts == 1 ? 0 : 7);
+        });
+
+        // The first shield's clause never gained the result term, so 0 was an acceptable result.
+        await Assert.That(firstResult).IsEqualTo(0);
+        await Assert.That(firstAttempts).IsEqualTo(1);
+        await Assert.That(secondResult).IsEqualTo(7);
+        await Assert.That(secondAttempts).IsEqualTo(2);
+        await Assert.That(first.ToString()).IsEqualTo("[when ArgumentException] Retry(1, no delay)");
+        await Assert.That(second.ToString())
+            .IsEqualTo("[when ArgumentException | result 0] Retry(1, no delay)");
+    }
+
+    [Test]
+    public async Task Typed_Shield_Keeps_The_Exception_Clause_It_Was_Built_With()
+    {
+        var builder = Shield.For<int>().When<ArgumentException>();
+        var first = builder.Retry(1, Backoff.None);
+
+        builder.Or<InvalidOperationException>();
+
+        var attempts = 0;
+        await Assert.That(async () => await first.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return ValueTask.FromException<int>(new InvalidOperationException());
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Sealing_Twice_Without_Changes_Produces_Independent_Shields()
+    {
+        var builder = Shield.When<ArgumentException>().Or<InvalidOperationException>();
+        var first = builder.Retry(1, Backoff.None);
+        var second = builder.CircuitBreaker(2, TimeSpan.FromSeconds(1));
+
+        await Assert.That(first.ToString())
+            .IsEqualTo("[when ArgumentException | InvalidOperationException] Retry(1, no delay)");
+        await Assert.That(second.ToString())
+            .IsEqualTo("[when ArgumentException | InvalidOperationException] CircuitBreaker(2 consecutive, break 1s)");
+    }
+}


### PR DESCRIPTION
Four findings from an API review of the public surface, plus one that turned out to be already covered.

## 1. `WhenResultDefault()` → `WhenResultIsDefault()` (breaking)

`Shield<TResult>.WhenResultDefault()` and `ShieldBuilder<TResult>.OrResultDefault()` are renamed to `WhenResultIsDefault()` / `OrResultIsDefault()`. Both spellings are pre-release only (the names live in `PublicAPI.Unshipped.txt`, never shipped), so this is a straight rename with no `[Obsolete]` shim, matching how 848f0d0 handled the previous round. The `Is` is what removes the ambiguity: `WhenResultDefault` could be read as "when handling is default", while `WhenResultIsDefault` can only be read as "when the result is `default(T)`". The XML remark that existed solely to spell that distinction out is therefore deleted; the summary keeps its pointer to `WhenAnyError()` as the thing that actually resets handling. Call sites updated in src, tests, docs and CHANGELOG (README never referenced it).

## 2. `ShieldBuilder` mutable-builder aliasing

`Or…` accumulates into `List<>` fields and returns `this`, so a builder stored in a variable stays live after a strategy has been added to it. `Seal()` now copies both predicate lists into arrays and renders the clause description before constructing the shield, unconditionally — previously `Combine`/`CombineResults` snapshotted only when the list held more than one predicate, so the guarantee depended on an internal branch rather than being stated once at the seal point. A shield built from a builder can no longer be affected by `Or…` calls made afterwards.

What a snapshot cannot fix is two chains branched off one *shared* builder — they are the same object and both see every term either branch added. That is inherent to the mutable-builder shape, so the class-level XML docs on both builders now state the rule: `Or…` returns the same builder; start a fresh `When…` per chain.

Coverage: new `tests/Kevlar.Tests/ShieldBuilderAliasingTests.cs`, five tests — build shield A, add another `Or`, build shield B, assert A's handling and description are unchanged, for untyped exception clauses, typed exception clauses, typed result clauses, the single-term case, and two shields sealed from one unchanged builder.

## 3. KEV009: ambient-clause span visibility

New Info-severity diagnostic on `PipelineHazardAnalyzer`. When a chain declares a handling clause and then chains two or more reactive strategies without a new clause or `WhenAnyError()` between them, the second and later ones are marked: *"This strategy inherits the handling clause declared earlier in the chain ('When&lt;X&gt;…'); only those exceptions or results count toward it."* The behaviour is by design — writing the clause once is the point — so this is a hint, not a warning: it never fails a build, including under this repo's `TreatWarningsAsErrors`.

Scope: `Retry`, `RetryForever`, `CircuitBreaker`, `Hedge`, `Fallback`. Not flagged — the first strategy after a clause (it states the clause at its own call site), proactive strategies (`Timeout`, `RateLimit`, `ConcurrencyLimit`, which carry no clause and also do not end the inherited span), strategies whose options set `HandlesException`/`HandlesResult`, and anything past `WhenAnyError()`, a replacing `When…`, or a `Wrap`/`Compose` boundary. `Use` is excluded too: its factory takes the `HandlingClause` as a parameter, so the inheritance is already visible in the signature. The walk follows one fluent chain plus stable locals, reusing the analyzer's existing helpers. The hint marks the strategy's method name rather than the whole chain, so the squiggle is readable in an editor.

Coverage: four new tests — flagging cases (untyped, `Or…` continuations, typed result clauses, `RetryForever`, `Hedge`, fallback-first, local alias), a multi-report case across intervening proactive strategies, ten non-flagging cases, and an exact contract test for id, `Info` severity, message text, marked span, and pragma suppression. `AssertRuleAsync`/`AssertEachAsync` gained an optional expected-severity parameter; `KEV003_Flags_Unreachable_Reactive_Strategies` gained `KEV009` as an expected companion rule for its one clause-plus-two-strategies case. Registered in `AnalyzerReleases.Unshipped.md` and `PublicAPI.Unshipped.txt`, documented in `docs/docs/analyzers.md` with a cross-link from `handling-failures.md`.

## 4. Untyped `Fallback` + result-returning execution — already covered, skipped

`KEV005` (`VoidFallbackResultExecutionRule`) already does exactly this: it fires on `IsResultReturningExecution` when the receiver's pipeline contains an untyped `Fallback`, at Warning severity, with six existing tests covering `Execute`/`ExecuteAsync`/`ExecuteOutcomeAsync`/`ExecuteWithContext(Async)`, the `Task<T>` extension overloads, stable locals, aliases, `.For<T>()` lifts, and `Wrap`/`Compose` operands. No change made. One deliberate gap is left as-is: `KEV005` skips fields, parameters and reassigned locals, which `docs/docs/analyzers.md` already documents as a conservatism of the current intraprocedural analysis — extending it to fields would need whole-program flow analysis to stay false-positive-free, which the brief asked me not to build.

## 5. `TimeoutExceededException` vs `System.TimeoutException`

`Kevlar.TimeoutExceededException` derives from `KevlarException`, so the reflexive `catch (TimeoutException)` compiles and silently never fires. `docs/docs/polly-migration.md` gains a `:::warning` callout directly under the translation table (which is where `TimeoutRejectedException` → `TimeoutExceededException` is introduced), noting that Polly set the same trap and showing a correct two-arm catch — `TimeoutExceededException` for the timeout, `KevlarException` for any Kevlar rejection. `docs/docs/strategies/timeout.md` gains one sentence next to the existing mention of the exception.

## Test and build results

- `dotnet build Kevlar.slnx -c Release` — clean, 0 warnings (`TreatWarningsAsErrors` is on).
- 1053 tests across all seven CI test projects pass: Kevlar.Tests 779, IntegrationTests 118, Analyzers.Tests 76, Chaos.Tests 23, Extensions.RateLimiting.Tests 19, Testing.Tests 33, NetStandard.Tests 5. AllocationTests 3 pass.
- `scripts/Verify-DocSnippets.ps1` run against locally packed packages: 114 documentation snippets compile and the executable ones behave as documented, so the new Polly-migration and analyzer snippets are verified, not just written.

https://claude.ai/code/session_01DarFLgjrFgAsDiGr3cwWkZ
