### PR TITLE
refactor(api): immutable handling-clause builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,17 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
 - `HandlesException`/`HandlesResult` documentation on every options type now leads with the fact
   that the property makes its strategy ignore the ambient `When…` clause, and points at
   `HandlingClause`. `ShieldBuilder`/`ShieldBuilder<TResult>` document the override from the clause side.
-- `ShieldBuilder` and `ShieldBuilder<TResult>` snapshot their accumulated clause whenever a strategy
-  seals it. A builder held in a variable can be extended with further `Or…` terms afterwards without
-  changing the handling of any shield already built from it.
+- `ShieldBuilder` and `ShieldBuilder<TResult>` are immutable. Every `Or…`/`OrResult…`/
+  `OrResultIsDefault` returns a *new* builder carrying the terms so far plus the one just added, and
+  leaves the builder it was called on untouched. Branching two chains from one stored builder is now
+  safe — each branch gets only its own terms — and a shield already built from a builder still keeps
+  the clause it was built with. The corollary is that only the builder an `Or…` *returns* carries
+  the new term; `builder.Or<T>();` written as a statement adds nothing, which `KEV007` reports.
+- **Breaking:** `RetryForever` is now two overloads — `RetryForever()` and `RetryForever(Backoff)` —
+  on `Shield` (static), `ShieldExtensions`, `Shield<TResult>`, `ShieldBuilder` and
+  `ShieldBuilder<TResult>`, replacing the single `RetryForever(Backoff? backoff = null)`. This
+  matches `Retry(int, Backoff)`, whose `Backoff` was already non-nullable. The parameterless
+  overload still uses `Backoff.Default`; passing `null` explicitly is no longer legal.
 
 ### Added
 

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -175,12 +175,19 @@ A [handling clause](handling-failures.md) changes nothing on its own — it only
 reactive strategy (retry, circuit breaker, hedging, fallback, or a `Use` factory) consumes it. Two
 shapes silently do nothing.
 
-The first is a clause whose `ShieldBuilder` is dropped instead of being finished with a strategy:
+The first is a clause whose `ShieldBuilder` is dropped instead of being finished with a strategy.
+Builders are immutable — every `When…`/`Or…` returns a *new* builder and leaves its receiver
+untouched — so a dropped builder is simply lost, including a dropped `Or…` that looks like it is
+extending a clause in place:
 
 <!-- doc-test-ignore: Deliberately dead clauses that the analyzer is expected to flag. -->
 ```csharp
 Shield.When<HttpRequestException>();                          // KEV007 — nothing consumes it
 var clause = Shield.When<HttpRequestException>().Or<TimeoutExceededException>();  // KEV007 — never used
+
+var transient = Shield.When<HttpRequestException>();
+transient.Or<TimeoutExceededException>();                     // KEV007 — the new builder is dropped
+var shield = transient.Retry(3);                              // still HttpRequestException only
 ```
 
 The second is a clause that a later `When…` or `WhenAnyError()` replaces while only *proactive*
@@ -213,8 +220,9 @@ quiet when the builder escapes — returned, passed as an argument, assigned to 
 
 ## KEV008: discarded fluent chaining result
 
-Shields are immutable. Every fluent method returns a *new* shield and leaves its receiver untouched,
-so a chaining call written as a statement configures nothing:
+Shields — and the clause builders they hand back — are immutable. Every fluent method returns a
+*new* value and leaves its receiver untouched, so a chaining call written as a statement configures
+nothing:
 
 <!-- doc-test-ignore: A deliberately discarded chain that the analyzer is expected to flag. -->
 ```csharp

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -34,6 +34,25 @@ Clause position determines the vocabulary: `When…` starts a clause on a shield
 continues that clause on the returned builder. The compiler therefore enforces
 `When<A>().Or<B>().Or(...)`.
 
+### Builders are immutable
+
+Clause builders are immutable, exactly like shields. Every `Or…` returns a *new* builder holding the
+terms so far plus the one just added, and leaves the builder it was called on untouched — so a
+builder held in a variable can be branched into independent chains:
+
+```csharp
+var transient = Shield.When<HttpRequestException>();
+
+var reads = transient.Or<TimeoutExceededException>().Retry(3);
+var writes = transient.Or<IOException>().Retry(1);   // no TimeoutExceededException here
+```
+
+`reads` handles `HttpRequestException | TimeoutExceededException`, `writes` handles
+`HttpRequestException | IOException`, and neither branch sees the other's term. The corollary is
+that only the builder an `Or…` *returns* carries the new term: writing `builder.Or<TException>();`
+as a statement adds nothing to anything, which the analyzer reports as
+[`KEV007`](analyzers.md#kev007-dead-handling-clause).
+
 ## Result clauses
 
 Sometimes failure isn't an exception — it's a well-formed response you don't like (an HTTP 500, an empty payload, a `Status = "Retry"` field). Lift into a typed shield with `For<T>` and add `WhenResult`:

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -281,5 +281,5 @@ shield so every additional send goes through safe replay and routing.
 - **Compose with other handlers normally.** The Kevlar handler is a regular `DelegatingHandler`; ordering relative to your own handlers follows the usual `AddHttpMessageHandler` rules.
 
 :::tip Handling clause already done
-`WhenTransient()` is a normal [handling clause](handling-failures.md) — everything you chain after it (retry, breaker, fallback) reacts to that transient-fault definition. Add your own `WhenResult` calls to extend it.
+`WhenTransient()` is a normal [handling clause](handling-failures.md) — everything you chain after it (retry, breaker, fallback) reacts to that transient-fault definition. Add your own `Or…`/`OrResult…` calls to extend it. The builder it returns is immutable, so one stored `WhenTransient()` can be branched into several pipelines without the branches leaking terms into each other.
 :::

--- a/src/Kevlar/Internal/DescribeHelper.cs
+++ b/src/Kevlar/Internal/DescribeHelper.cs
@@ -37,7 +37,7 @@ internal static class DescribeHelper
     }
 
     /// <summary>Joins the terms of one handling clause into <c>A | B | C</c>.</summary>
-    public static string Clause(List<string> terms) => string.Join(" | ", terms);
+    public static string Clause(string[] terms) => string.Join(" | ", terms);
 
     /// <summary>Renders a result value inside a handling clause description.</summary>
     public static string Value<TResult>(TResult value) => value switch

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -249,3 +249,18 @@ static Kevlar.Shield.Fallback(System.Func<System.Exception!, System.Threading.Ca
 static Kevlar.Shield.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
 static Kevlar.Shield.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.Shield<TResult>.Compose(params Kevlar.Shield<TResult>![]! shields) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.Shield<TResult>.RetryForever(Kevlar.Backoff? backoff = null) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder.RetryForever(Kevlar.Backoff? backoff = null) -> Kevlar.Shield!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.RetryForever(Kevlar.Backoff? backoff = null) -> Kevlar.Shield<TResult>!
+*REMOVED*static Kevlar.Shield.RetryForever(Kevlar.Backoff? backoff = null) -> Kevlar.Shield!
+*REMOVED*static Kevlar.ShieldExtensions.RetryForever(this Kevlar.Shield! shield, Kevlar.Backoff? backoff = null) -> Kevlar.Shield!
+Kevlar.Shield<TResult>.RetryForever() -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.RetryForever(Kevlar.Backoff! backoff) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder.RetryForever() -> Kevlar.Shield!
+Kevlar.ShieldBuilder.RetryForever(Kevlar.Backoff! backoff) -> Kevlar.Shield!
+Kevlar.ShieldBuilder<TResult>.RetryForever() -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.RetryForever(Kevlar.Backoff! backoff) -> Kevlar.Shield<TResult>!
+static Kevlar.Shield.RetryForever() -> Kevlar.Shield!
+static Kevlar.Shield.RetryForever(Kevlar.Backoff! backoff) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.RetryForever(this Kevlar.Shield! shield) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.RetryForever(this Kevlar.Shield! shield, Kevlar.Backoff! backoff) -> Kevlar.Shield!

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -72,8 +72,12 @@ public sealed class Shield
     /// </remarks>
     public static Shield Retry(Action<RetryOptions> configure) => ShieldExtensions.Retry(Empty, configure);
 
-    /// <summary>Retries failed executions indefinitely.</summary>
-    public static Shield RetryForever(Backoff? backoff = null) => ShieldExtensions.RetryForever(Empty, backoff);
+    /// <summary>Retries failed executions indefinitely with the default exponential jittered backoff.</summary>
+    public static Shield RetryForever() => ShieldExtensions.RetryForever(Empty);
+
+    /// <summary>Retries failed executions indefinitely with the given backoff.</summary>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
+    public static Shield RetryForever(Backoff backoff) => ShieldExtensions.RetryForever(Empty, backoff);
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>, surfacing <see cref="TimeoutExceededException"/>.</summary>
     public static Shield Timeout(TimeSpan timeout) => ShieldExtensions.Timeout(Empty, timeout);

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -3,9 +3,9 @@ using Kevlar.Internal;
 namespace Kevlar;
 
 /// <summary>
-/// Accumulates exception-handling clauses for a <see cref="Shield"/> chain. Obtained via
-/// <c>Shield.When&lt;T&gt;()</c> or <c>shield.When&lt;T&gt;()</c>; finished by adding a
-/// strategy. The clauses become the shield's ambient handling: they apply to the strategy added
+/// An immutable exception-handling clause under construction for a <see cref="Shield"/> chain.
+/// Obtained via <c>Shield.When&lt;T&gt;()</c> or <c>shield.When&lt;T&gt;()</c>; finished by adding a
+/// strategy. The clause becomes the shield's ambient handling: it applies to the strategy added
 /// here and to reactive strategies chained afterwards, until replaced by a new clause.
 /// </summary>
 /// <remarks>
@@ -14,11 +14,13 @@ namespace Kevlar;
 /// <c>Shield.When&lt;A&gt;().Or&lt;B&gt;().Retry(3)</c>.
 /// </para>
 /// <para>
-/// <c>Or…</c> accumulates into the builder and returns that same builder, so a builder held in a
-/// variable keeps every term added to it. The clause is snapshotted when a strategy is added:
-/// adding further <c>Or…</c> terms afterwards never changes a shield already built. Branching two
-/// chains from one stored builder, however, gives both chains every term either branch added, so
-/// start a fresh <c>When…</c> for each chain.
+/// The builder is immutable. Each <c>Or…</c> returns a <em>new</em> builder holding the terms
+/// accumulated so far plus the one just added, and leaves the builder it was called on untouched.
+/// A builder held in a variable can therefore be branched into two chains safely: each branch gets
+/// only its own terms. The corollary is that code must use the builder each <c>Or…</c>
+/// <em>returns</em> — calling <c>Or…</c> and discarding the result adds nothing to anything.
+/// Adding a strategy freezes the clause of that builder, so a shield already built is never
+/// changed by further chaining either.
 /// </para>
 /// <para>
 /// One strategy can opt out of the ambient clause: setting <c>HandlesException</c> on its options
@@ -30,37 +32,41 @@ namespace Kevlar;
 public sealed class ShieldBuilder
 {
     private readonly Shield _parent;
-    private readonly List<Func<Exception, bool>> _predicates = [];
-    private readonly List<string> _clauseTerms = [];
+    private readonly Func<Exception, bool>[] _predicates;
+    private readonly string[] _clauseTerms;
 
-    internal ShieldBuilder(Shield parent) => _parent = parent;
-
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/>.</summary>
-    public ShieldBuilder Or<TException>()
-        where TException : Exception
+    internal ShieldBuilder(Shield parent)
+        : this(parent, [], [])
     {
-        _predicates.Add(static exception => exception is TException);
-        _clauseTerms.Add(typeof(TException).Name);
-        return this;
     }
 
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
+    private ShieldBuilder(Shield parent, Func<Exception, bool>[] predicates, string[] clauseTerms)
+    {
+        _parent = parent;
+        _predicates = predicates;
+        _clauseTerms = clauseTerms;
+    }
+
+    /// <summary>Returns a new builder that also handles exceptions of type <typeparamref name="TException"/>.</summary>
+    public ShieldBuilder Or<TException>()
+        where TException : Exception
+        => With(static exception => exception is TException, typeof(TException).Name);
+
+    /// <summary>Returns a new builder that also handles exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
     public ShieldBuilder Or<TException>(Func<TException, bool> predicate)
         where TException : Exception
     {
         Throw.IfNull(predicate, nameof(predicate));
-        _predicates.Add(exception => exception is TException typed && predicate(typed));
-        _clauseTerms.Add(typeof(TException).Name + " matching predicate");
-        return this;
+        return With(
+            exception => exception is TException typed && predicate(typed),
+            typeof(TException).Name + " matching predicate");
     }
 
-    /// <summary>Also handle exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
+    /// <summary>Returns a new builder that also handles exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
     public ShieldBuilder Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
-        _predicates.Add(predicate);
-        _clauseTerms.Add("exception predicate");
-        return this;
+        return With(predicate, "exception predicate");
     }
 
     /// <summary>Retries handled exceptions up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
@@ -85,8 +91,12 @@ public sealed class ShieldBuilder
     /// </remarks>
     public Shield Retry(Action<RetryOptions> configure) => Seal().Retry(configure);
 
-    /// <summary>Retries handled exceptions indefinitely.</summary>
-    public Shield RetryForever(Backoff? backoff = null) => Seal().RetryForever(backoff);
+    /// <summary>Retries handled exceptions indefinitely with the default exponential jittered backoff.</summary>
+    public Shield RetryForever() => Seal().RetryForever();
+
+    /// <summary>Retries handled exceptions indefinitely with the given backoff.</summary>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
+    public Shield RetryForever(Backoff backoff) => Seal().RetryForever(backoff);
 
     /// <summary>Breaks the circuit for <paramref name="breakDuration"/> after <paramref name="consecutiveFailures"/> consecutive handled exceptions.</summary>
     public Shield CircuitBreaker(int consecutiveFailures, TimeSpan breakDuration) => Seal().CircuitBreaker(consecutiveFailures, breakDuration);
@@ -145,16 +155,29 @@ public sealed class ShieldBuilder
     public Shield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);
 
     /// <summary>
-    /// Freezes the clause accumulated so far into a shield. The predicates are copied and the
-    /// description is rendered here, so a builder kept in a variable and extended with further
-    /// <c>Or…</c> calls can never change the handling of a shield already built from it.
+    /// Freezes this builder's clause into a shield. The predicate array is already private and
+    /// never mutated, and the description is rendered here, so no later chaining — on this builder
+    /// or on any builder derived from it — can change the handling of a shield already built.
     /// </summary>
     private Shield Seal() =>
         new(
             _parent.Strategies,
-            new ExceptionJudge(Combine(_predicates.ToArray()), DescribeHelper.Clause(_clauseTerms)),
+            new ExceptionJudge(Combine(_predicates), DescribeHelper.Clause(_clauseTerms)),
             _parent.Name,
             _parent.Time);
+
+    /// <summary>Builds the successor holding this builder's terms plus one more.</summary>
+    private ShieldBuilder With(Func<Exception, bool> predicate, string clauseTerm) =>
+        new(_parent, Append(_predicates, predicate), Append(_clauseTerms, clauseTerm));
+
+    /// <summary>Copies <paramref name="source"/> with <paramref name="item"/> appended.</summary>
+    internal static T[] Append<T>(T[] source, T item)
+    {
+        var appended = new T[source.Length + 1];
+        Array.Copy(source, appended, source.Length);
+        appended[source.Length] = item;
+        return appended;
+    }
 
     internal static Func<Exception, bool> Combine(Func<Exception, bool>[] predicates)
     {

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -3,10 +3,10 @@ using Kevlar.Internal;
 namespace Kevlar;
 
 /// <summary>
-/// Accumulates exception and result handling clauses for a <see cref="Shield{TResult}"/> chain.
-/// Obtained via the <c>When</c>/<c>WhenResult</c> methods on <see cref="Shield{TResult}"/> and
-/// finished by adding a strategy. The clauses become the shield's ambient handling for the
-/// strategy added here and reactive strategies chained afterwards.
+/// An immutable exception and result handling clause under construction for a
+/// <see cref="Shield{TResult}"/> chain. Obtained via the <c>When</c>/<c>WhenResult</c> methods on
+/// <see cref="Shield{TResult}"/> and finished by adding a strategy. The clause becomes the shield's
+/// ambient handling for the strategy added here and reactive strategies chained afterwards.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -14,11 +14,13 @@ namespace Kevlar;
 /// <c>Shield.For&lt;T&gt;().When&lt;A&gt;().OrResult(r =&gt; …).Retry(3)</c>.
 /// </para>
 /// <para>
-/// <c>Or…</c> accumulates into the builder and returns that same builder, so a builder held in a
-/// variable keeps every term added to it. The clause is snapshotted when a strategy is added:
-/// adding further <c>Or…</c> terms afterwards never changes a shield already built. Branching two
-/// chains from one stored builder, however, gives both chains every term either branch added, so
-/// start a fresh <c>When…</c> for each chain.
+/// The builder is immutable. Each <c>Or…</c> returns a <em>new</em> builder holding the terms
+/// accumulated so far plus the one just added, and leaves the builder it was called on untouched.
+/// A builder held in a variable can therefore be branched into two chains safely: each branch gets
+/// only its own terms. The corollary is that code must use the builder each <c>Or…</c>
+/// <em>returns</em> — calling <c>Or…</c> and discarding the result adds nothing to anything.
+/// Adding a strategy freezes the clause of that builder, so a shield already built is never
+/// changed by further chaining either.
 /// </para>
 /// <para>
 /// One strategy can opt out of the ambient clause: setting <c>HandlesException</c> or
@@ -31,64 +33,67 @@ namespace Kevlar;
 public sealed class ShieldBuilder<TResult>
 {
     private readonly Shield<TResult> _parent;
-    private readonly List<Func<Exception, bool>> _exceptionPredicates = [];
-    private readonly List<Func<TResult, bool>> _resultPredicates = [];
-    private readonly List<string> _clauseTerms = [];
+    private readonly Func<Exception, bool>[] _exceptionPredicates;
+    private readonly Func<TResult, bool>[] _resultPredicates;
+    private readonly string[] _clauseTerms;
 
-    internal ShieldBuilder(Shield<TResult> parent) => _parent = parent;
-
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/>.</summary>
-    public ShieldBuilder<TResult> Or<TException>()
-        where TException : Exception
+    internal ShieldBuilder(Shield<TResult> parent)
+        : this(parent, [], [], [])
     {
-        _exceptionPredicates.Add(static exception => exception is TException);
-        _clauseTerms.Add(typeof(TException).Name);
-        return this;
     }
 
-    /// <summary>Also handle exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
+    private ShieldBuilder(
+        Shield<TResult> parent,
+        Func<Exception, bool>[] exceptionPredicates,
+        Func<TResult, bool>[] resultPredicates,
+        string[] clauseTerms)
+    {
+        _parent = parent;
+        _exceptionPredicates = exceptionPredicates;
+        _resultPredicates = resultPredicates;
+        _clauseTerms = clauseTerms;
+    }
+
+    /// <summary>Returns a new builder that also handles exceptions of type <typeparamref name="TException"/>.</summary>
+    public ShieldBuilder<TResult> Or<TException>()
+        where TException : Exception
+        => WithException(static exception => exception is TException, typeof(TException).Name);
+
+    /// <summary>Returns a new builder that also handles exceptions of type <typeparamref name="TException"/> matching <paramref name="predicate"/>.</summary>
     public ShieldBuilder<TResult> Or<TException>(Func<TException, bool> predicate)
         where TException : Exception
     {
         Throw.IfNull(predicate, nameof(predicate));
-        _exceptionPredicates.Add(exception => exception is TException typed && predicate(typed));
-        _clauseTerms.Add(typeof(TException).Name + " matching predicate");
-        return this;
+        return WithException(
+            exception => exception is TException typed && predicate(typed),
+            typeof(TException).Name + " matching predicate");
     }
 
-    /// <summary>Also handle exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
+    /// <summary>Returns a new builder that also handles exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
     public ShieldBuilder<TResult> Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
-        _exceptionPredicates.Add(predicate);
-        _clauseTerms.Add("exception predicate");
-        return this;
+        return WithException(predicate, "exception predicate");
     }
 
-    /// <summary>Also handle results matching <paramref name="predicate"/>.</summary>
+    /// <summary>Returns a new builder that also handles results matching <paramref name="predicate"/>.</summary>
     public ShieldBuilder<TResult> OrResult(Func<TResult, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
-        _resultPredicates.Add(predicate);
-        _clauseTerms.Add("result predicate");
-        return this;
+        return WithResult(predicate, "result predicate");
     }
 
-    /// <summary>Also handle results equal to <paramref name="result"/>.</summary>
-    public ShieldBuilder<TResult> OrResult(TResult result)
-    {
-        _resultPredicates.Add(candidate => EqualityComparer<TResult>.Default.Equals(candidate, result));
-        _clauseTerms.Add("result " + DescribeHelper.Value(result));
-        return this;
-    }
+    /// <summary>Returns a new builder that also handles results equal to <paramref name="result"/>.</summary>
+    public ShieldBuilder<TResult> OrResult(TResult result) =>
+        WithResult(
+            candidate => EqualityComparer<TResult>.Default.Equals(candidate, result),
+            "result " + DescribeHelper.Value(result));
 
-    /// <summary>Also handle results equal to <c>default(TResult)</c> — <see langword="null"/> for reference types.</summary>
-    public ShieldBuilder<TResult> OrResultIsDefault()
-    {
-        _resultPredicates.Add(static candidate => EqualityComparer<TResult>.Default.Equals(candidate, default!));
-        _clauseTerms.Add("default result");
-        return this;
-    }
+    /// <summary>Returns a new builder that also handles results equal to <c>default(TResult)</c> — <see langword="null"/> for reference types.</summary>
+    public ShieldBuilder<TResult> OrResultIsDefault() =>
+        WithResult(
+            static candidate => EqualityComparer<TResult>.Default.Equals(candidate, default!),
+            "default result");
 
     /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
     /// <param name="maxRetries">
@@ -112,8 +117,12 @@ public sealed class ShieldBuilder<TResult>
     /// </remarks>
     public Shield<TResult> Retry(Action<RetryOptions<TResult>> configure) => Seal().Retry(configure);
 
-    /// <summary>Retries handled outcomes indefinitely.</summary>
-    public Shield<TResult> RetryForever(Backoff? backoff = null) => Seal().RetryForever(backoff);
+    /// <summary>Retries handled outcomes indefinitely with the default exponential jittered backoff.</summary>
+    public Shield<TResult> RetryForever() => Seal().RetryForever();
+
+    /// <summary>Retries handled outcomes indefinitely with the given backoff.</summary>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
+    public Shield<TResult> RetryForever(Backoff backoff) => Seal().RetryForever(backoff);
 
     /// <summary>Breaks the circuit for <paramref name="breakDuration"/> after <paramref name="consecutiveFailures"/> consecutive handled outcomes.</summary>
     public Shield<TResult> CircuitBreaker(int consecutiveFailures, TimeSpan breakDuration) => Seal().CircuitBreaker(consecutiveFailures, breakDuration);
@@ -172,23 +181,38 @@ public sealed class ShieldBuilder<TResult>
     public Shield<TResult> ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);
 
     /// <summary>
-    /// Freezes the clause accumulated so far into a shield. Both predicate lists are copied and the
-    /// description is rendered here, so a builder kept in a variable and extended with further
-    /// <c>Or…</c> calls can never change the handling of a shield already built from it.
+    /// Freezes this builder's clause into a shield. Both predicate arrays are already private and
+    /// never mutated, and the description is rendered here, so no later chaining — on this builder
+    /// or on any builder derived from it — can change the handling of a shield already built.
     /// </summary>
     private Shield<TResult> Seal()
     {
-        var exceptionPredicates = _exceptionPredicates.ToArray();
-        var exceptionPredicate = exceptionPredicates.Length == 0
+        var exceptionPredicate = _exceptionPredicates.Length == 0
             ? null
-            : ShieldBuilder.Combine(exceptionPredicates);
-        var resultPredicate = CombineResults(_resultPredicates.ToArray());
+            : ShieldBuilder.Combine(_exceptionPredicates);
+        var resultPredicate = CombineResults(_resultPredicates);
         var judge = new TypedJudge<TResult>(
             exceptionPredicate,
             resultPredicate,
             DescribeHelper.Clause(_clauseTerms));
         return new Shield<TResult>(_parent.Strategies, judge, _parent.Name, _parent.Time);
     }
+
+    /// <summary>Builds the successor holding this builder's terms plus one more exception term.</summary>
+    private ShieldBuilder<TResult> WithException(Func<Exception, bool> predicate, string clauseTerm) =>
+        new(
+            _parent,
+            ShieldBuilder.Append(_exceptionPredicates, predicate),
+            _resultPredicates,
+            ShieldBuilder.Append(_clauseTerms, clauseTerm));
+
+    /// <summary>Builds the successor holding this builder's terms plus one more result term.</summary>
+    private ShieldBuilder<TResult> WithResult(Func<TResult, bool> predicate, string clauseTerm) =>
+        new(
+            _parent,
+            _exceptionPredicates,
+            ShieldBuilder.Append(_resultPredicates, predicate),
+            ShieldBuilder.Append(_clauseTerms, clauseTerm));
 
     private static Func<TResult, bool>? CombineResults(Func<TResult, bool>[] predicates)
     {

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -45,12 +45,22 @@ public static class ShieldExtensions
         return shield.Append(new RetryStrategy(options, judge));
     }
 
-    /// <summary>Appends a retry that never gives up.</summary>
-    public static Shield RetryForever(this Shield shield, Backoff? backoff = null) => shield.Retry(options =>
+    /// <summary>Appends a retry that never gives up, with the default exponential jittered backoff.</summary>
+    /// <param name="shield">The shield to append the retry to.</param>
+    public static Shield RetryForever(this Shield shield) => shield.RetryForever(Backoff.Default);
+
+    /// <summary>Appends a retry that never gives up, with the given backoff.</summary>
+    /// <param name="shield">The shield to append the retry to.</param>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
+    public static Shield RetryForever(this Shield shield, Backoff backoff)
     {
-        options.MaxRetries = int.MaxValue;
-        options.Backoff = backoff ?? Backoff.Default;
-    });
+        Throw.IfNull(backoff, nameof(backoff));
+        return shield.Retry(options =>
+        {
+            options.MaxRetries = int.MaxValue;
+            options.Backoff = backoff;
+        });
+    }
 
     /// <summary>Appends a timeout, surfacing <see cref="TimeoutExceededException"/> when exceeded.</summary>
     public static Shield Timeout(this Shield shield, TimeSpan timeout) => shield.Timeout(options => options.Timeout = timeout);

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -109,12 +109,20 @@ public sealed class Shield<TResult>
         return Append(RetryStrategy.Create(options, judge));
     }
 
-    /// <summary>Retries handled outcomes indefinitely.</summary>
-    public Shield<TResult> RetryForever(Backoff? backoff = null) => Retry(options =>
+    /// <summary>Retries handled outcomes indefinitely with the default exponential jittered backoff.</summary>
+    public Shield<TResult> RetryForever() => RetryForever(Backoff.Default);
+
+    /// <summary>Retries handled outcomes indefinitely with the given backoff.</summary>
+    /// <param name="backoff">The delay computation applied between attempts.</param>
+    public Shield<TResult> RetryForever(Backoff backoff)
     {
-        options.MaxRetries = int.MaxValue;
-        options.Backoff = backoff ?? Backoff.Default;
-    });
+        Throw.IfNull(backoff, nameof(backoff));
+        return Retry(options =>
+        {
+            options.MaxRetries = int.MaxValue;
+            options.Backoff = backoff;
+        });
+    }
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>, surfacing <see cref="TimeoutExceededException"/>.</summary>
     public Shield<TResult> Timeout(TimeSpan timeout) => Timeout(options => options.Timeout = timeout);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -585,6 +585,11 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.For<int>().WhenResultIsDefault().Or<TimeoutException>();",
             "var clause = Shield.When<InvalidOperationException>().Or<TimeoutException>();",
             "var clause = Shield.For<int>().When<InvalidOperationException>();",
+
+            // Builders are immutable, so an Or… whose new builder is dropped extends nothing —
+            // the stored builder still carries InvalidOperationException alone.
+            "var clause = Shield.When<InvalidOperationException>(); clause.Or<TimeoutException>(); _ = clause.Retry(1);",
+            "var clause = Shield.For<int>().When<InvalidOperationException>(); clause.OrResultIsDefault(); _ = clause.Retry(1);",
         };
 
         await AssertEachAsync(cases, "KEV007");

--- a/tests/Kevlar.Tests/ShieldBuilderAliasingTests.cs
+++ b/tests/Kevlar.Tests/ShieldBuilderAliasingTests.cs
@@ -1,71 +1,134 @@
 namespace Kevlar.Tests;
 
 /// <summary>
-/// Guards the snapshot taken when a <see cref="ShieldBuilder"/> or <see cref="ShieldBuilder{TResult}"/>
-/// seals a clause. <c>Or…</c> accumulates into the builder and returns that same instance, so a
-/// builder held in a variable stays live; a shield already built from it must keep the clause it
-/// was built with, whatever is added to the builder afterwards.
+/// Guards the immutability of <see cref="ShieldBuilder"/> and <see cref="ShieldBuilder{TResult}"/>.
+/// Every <c>Or…</c> returns a new builder and leaves its receiver untouched, so a builder held in a
+/// variable can be branched into independent chains, a shield already built from it keeps the clause
+/// it was built with, and an <c>Or…</c> whose result is discarded changes nothing at all.
 /// </summary>
 public class ShieldBuilderAliasingTests
 {
+    [Test]
+    public async Task Untyped_Branching_One_Builder_Gives_Independent_Clauses()
+    {
+        var shared = Shield.When<ArgumentException>();
+        var left = shared.Or<InvalidOperationException>().Retry(1, Backoff.None);
+        var right = shared.Or<TimeoutException>().Retry(1, Backoff.None);
+
+        await Assert.That(left.ToString())
+            .IsEqualTo("[when ArgumentException | InvalidOperationException] Retry(1, no delay)");
+        await Assert.That(right.ToString())
+            .IsEqualTo("[when ArgumentException | TimeoutException] Retry(1, no delay)");
+
+        // Each branch retries only the exception it added: neither inherited the other's term.
+        await Assert.That(await AttemptsUntilThrow<InvalidOperationException>(left)).IsEqualTo(2);
+        await Assert.That(await AttemptsUntilThrow<TimeoutException>(left)).IsEqualTo(1);
+        await Assert.That(await AttemptsUntilThrow<InvalidOperationException>(right)).IsEqualTo(1);
+        await Assert.That(await AttemptsUntilThrow<TimeoutException>(right)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Untyped_Discarded_Or_Leaves_The_Builder_Unchanged()
+    {
+        var builder = Shield.When<ArgumentException>();
+
+        // The returned builder is dropped, so nothing is added anywhere (the shape KEV007 flags).
+        builder.Or<InvalidOperationException>();
+
+        var shield = builder.Retry(1, Backoff.None);
+
+        await Assert.That(shield.ToString()).IsEqualTo("[when ArgumentException] Retry(1, no delay)");
+        await Assert.That(await AttemptsUntilThrow<InvalidOperationException>(shield)).IsEqualTo(1);
+    }
+
     [Test]
     public async Task Untyped_Shield_Keeps_The_Clause_It_Was_Built_With()
     {
         var builder = Shield.When<ArgumentException>();
         var first = builder.Retry(1, Backoff.None);
+        var second = builder.Or<InvalidOperationException>().Retry(1, Backoff.None);
 
-        builder.Or<InvalidOperationException>();
-        var second = builder.Retry(1, Backoff.None);
-
-        var firstAttempts = 0;
-        await Assert.That(async () => await first.ExecuteAsync<int>(_ =>
-        {
-            firstAttempts++;
-            throw new InvalidOperationException();
-        })).Throws<InvalidOperationException>();
-
-        var secondAttempts = 0;
-        await Assert.That(async () => await second.ExecuteAsync<int>(_ =>
-        {
-            secondAttempts++;
-            throw new InvalidOperationException();
-        })).Throws<InvalidOperationException>();
-
-        // The first shield never learned about InvalidOperationException, so it did not retry.
-        await Assert.That(firstAttempts).IsEqualTo(1);
-        await Assert.That(secondAttempts).IsEqualTo(2);
         await Assert.That(first.ToString()).IsEqualTo("[when ArgumentException] Retry(1, no delay)");
         await Assert.That(second.ToString())
             .IsEqualTo("[when ArgumentException | InvalidOperationException] Retry(1, no delay)");
+
+        // The first shield never learned about InvalidOperationException, so it did not retry.
+        await Assert.That(await AttemptsUntilThrow<InvalidOperationException>(first)).IsEqualTo(1);
+        await Assert.That(await AttemptsUntilThrow<InvalidOperationException>(second)).IsEqualTo(2);
     }
 
     [Test]
-    public async Task Untyped_Single_Term_Clause_Is_Not_Extended_After_Sealing()
+    public async Task Typed_Branching_One_Builder_Gives_Independent_Clauses()
     {
-        var builder = Shield.When<ArgumentException>();
-        var first = builder.Retry(1, Backoff.None);
+        var shared = Shield.For<int>().When<ArgumentException>();
+        var left = shared.OrResult(0).Retry(1, Backoff.None);
+        var right = shared.Or<InvalidOperationException>().Retry(1, Backoff.None);
 
-        builder.Or(static exception => exception is TimeoutException);
+        await Assert.That(left.ToString())
+            .IsEqualTo("[when ArgumentException | result 0] Retry(1, no delay)");
+        await Assert.That(right.ToString())
+            .IsEqualTo("[when ArgumentException | InvalidOperationException] Retry(1, no delay)");
+
+        // The result term went only to the left branch; the exception term only to the right.
+        var leftAttempts = 0;
+        var leftResult = await left.ExecuteAsync(_ =>
+        {
+            leftAttempts++;
+            return new ValueTask<int>(leftAttempts == 1 ? 0 : 7);
+        });
+        await Assert.That(leftResult).IsEqualTo(7);
+        await Assert.That(leftAttempts).IsEqualTo(2);
+
+        var rightAttempts = 0;
+        var rightResult = await right.ExecuteAsync(_ =>
+        {
+            rightAttempts++;
+            return new ValueTask<int>(0);
+        });
+        await Assert.That(rightResult).IsEqualTo(0);
+        await Assert.That(rightAttempts).IsEqualTo(1);
+
+        await Assert.That(await TypedAttemptsUntilThrow<InvalidOperationException>(left)).IsEqualTo(1);
+        await Assert.That(await TypedAttemptsUntilThrow<InvalidOperationException>(right)).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Typed_Discarded_Or_Leaves_The_Builder_Unchanged()
+    {
+        var builder = Shield.For<int>().When<ArgumentException>();
+
+        // Both returned builders are dropped, so the clause stays a single term.
+        builder.OrResult(0);
+        builder.Or<InvalidOperationException>();
+
+        var shield = builder.Retry(1, Backoff.None);
+
+        await Assert.That(shield.ToString()).IsEqualTo("[when ArgumentException] Retry(1, no delay)");
 
         var attempts = 0;
-        await Assert.That(async () => await first.ExecuteAsync<int>(_ =>
+        var result = await shield.ExecuteAsync(_ =>
         {
             attempts++;
-            throw new TimeoutException();
-        })).Throws<TimeoutException>();
+            return new ValueTask<int>(0);
+        });
 
+        await Assert.That(result).IsEqualTo(0);
         await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(await TypedAttemptsUntilThrow<InvalidOperationException>(shield)).IsEqualTo(1);
     }
 
     [Test]
-    public async Task Typed_Shield_Keeps_The_Result_Clause_It_Was_Built_With()
+    public async Task Typed_Shield_Keeps_The_Clause_It_Was_Built_With()
     {
         var builder = Shield.For<int>().When<ArgumentException>();
         var first = builder.Retry(1, Backoff.None);
+        var second = builder.OrResult(0).Retry(1, Backoff.None);
 
-        builder.OrResult(0);
-        var second = builder.Retry(1, Backoff.None);
+        await Assert.That(first.ToString()).IsEqualTo("[when ArgumentException] Retry(1, no delay)");
+        await Assert.That(second.ToString())
+            .IsEqualTo("[when ArgumentException | result 0] Retry(1, no delay)");
 
+        // The first shield's clause never gained the result term, so 0 was an acceptable result.
         var firstAttempts = 0;
         var firstResult = await first.ExecuteAsync(_ =>
         {
@@ -73,39 +136,8 @@ public class ShieldBuilderAliasingTests
             return new ValueTask<int>(0);
         });
 
-        var secondAttempts = 0;
-        var secondResult = await second.ExecuteAsync(_ =>
-        {
-            secondAttempts++;
-            return new ValueTask<int>(secondAttempts == 1 ? 0 : 7);
-        });
-
-        // The first shield's clause never gained the result term, so 0 was an acceptable result.
         await Assert.That(firstResult).IsEqualTo(0);
         await Assert.That(firstAttempts).IsEqualTo(1);
-        await Assert.That(secondResult).IsEqualTo(7);
-        await Assert.That(secondAttempts).IsEqualTo(2);
-        await Assert.That(first.ToString()).IsEqualTo("[when ArgumentException] Retry(1, no delay)");
-        await Assert.That(second.ToString())
-            .IsEqualTo("[when ArgumentException | result 0] Retry(1, no delay)");
-    }
-
-    [Test]
-    public async Task Typed_Shield_Keeps_The_Exception_Clause_It_Was_Built_With()
-    {
-        var builder = Shield.For<int>().When<ArgumentException>();
-        var first = builder.Retry(1, Backoff.None);
-
-        builder.Or<InvalidOperationException>();
-
-        var attempts = 0;
-        await Assert.That(async () => await first.ExecuteAsync(_ =>
-        {
-            attempts++;
-            return ValueTask.FromException<int>(new InvalidOperationException());
-        })).Throws<InvalidOperationException>();
-
-        await Assert.That(attempts).IsEqualTo(1);
     }
 
     [Test]
@@ -119,5 +151,33 @@ public class ShieldBuilderAliasingTests
             .IsEqualTo("[when ArgumentException | InvalidOperationException] Retry(1, no delay)");
         await Assert.That(second.ToString())
             .IsEqualTo("[when ArgumentException | InvalidOperationException] CircuitBreaker(2 consecutive, break 1s)");
+    }
+
+    /// <summary>Counts the attempts a shield makes before <typeparamref name="TException"/> escapes.</summary>
+    private static async Task<int> AttemptsUntilThrow<TException>(Shield shield)
+        where TException : Exception, new()
+    {
+        var attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new TException();
+        })).Throws<TException>();
+
+        return attempts;
+    }
+
+    /// <summary>Counts the attempts a result-aware shield makes before <typeparamref name="TException"/> escapes.</summary>
+    private static async Task<int> TypedAttemptsUntilThrow<TException>(Shield<int> shield)
+        where TException : Exception, new()
+    {
+        var attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return ValueTask.FromException<int>(new TException());
+        })).Throws<TException>();
+
+        return attempts;
     }
 }


### PR DESCRIPTION
API review follow-up. Two changes, both config-time only.

## 1. `ShieldBuilder` / `ShieldBuilder<TResult>` are immutable

Every `Or…`, `OrResult…` and `OrResultIsDefault` now returns a **new** builder carrying copies of the predicate and clause-term collections plus the parent shield reference, instead of mutating shared `List<T>` fields and returning `this`. The internal representation is plain arrays with an append-returns-new-array helper — the collections are tiny and this is configuration code, so clarity wins over cleverness. Both classes stay `sealed` with `internal` constructors, and the public surface is unchanged apart from the doc comments.

**Why:** this removes the last documented footgun in the clause API. The old xmldoc had to warn:

> Branching two chains from one stored builder, however, gives both chains every term either branch added, so start a fresh `When…` for each chain.

That trap is gone. `HttpShield.WhenTransient()` — which hands a builder back to callers — and any builder held in a local or field can now be branched per-pipeline safely, each branch seeing only its own terms.

The corollary is the new rule, documented in both files, in `docs/docs/handling-failures.md` and on the KEV007 analyzer page: code must use the builder each `Or…` **returns**; `builder.Or<T>();` written as a statement adds nothing to anything.

`Seal()` keeps identical observable behaviour — it simply drops the `ToArray()` defensive copies that the immutable fields make redundant. Describe output is unchanged (clause terms are still appended in call order, interleaving exception and result terms exactly as before), so `DescribeTests` needed no edits.

### Analyzer interplay

KEV007 already flags a discarded clause builder, including a discarded `Or…` (`ProducesHandlingClauseBuilder` matches any Kevlar fluent method returning a `ShieldBuilder`, and `IsDiscardedClauseBuilder` matches an expression statement). Under mutable semantics that diagnostic was arguably over-eager; under immutable semantics it is strictly accurate. No analyzer logic changed — only the wording of the KEV007/KEV008 doc pages, plus two new cases in `KEV007_Flags_Clause_Builders_That_Never_Reach_A_Strategy` pinning the discarded-`Or…` shape for both builders.

## 2. `RetryForever` overload symmetry

`RetryForever(Backoff? backoff = null)` becomes the overload pair `RetryForever()` and `RetryForever(Backoff)` at all five sites: `Shield` (static), `ShieldExtensions`, `Shield<TResult>`, `ShieldBuilder`, `ShieldBuilder<TResult>`.

**Why:** the nullable optional parameter was the odd one out next to `Retry(int, Backoff)`, whose `Backoff` was already non-nullable. The new shape null-checks `backoff` through the internal `Throw.IfNull` helper like every other reference argument. The parameterless overload still uses `Backoff.Default`, so behaviour is identical. No caller, test or doc snippet passed `null` explicitly, so nothing needed migrating; `PublicAPI.Unshipped.txt` records the five removals and ten additions.

## Test coverage

`tests/Kevlar.Tests/ShieldBuilderAliasingTests.cs` was rewritten. It previously asserted the **old mutable** behaviour — two of its tests explicitly verified that a discarded `builder.Or<T>();` / `builder.OrResult(0);` still took effect on a later seal. Those assertions are now inverted, and the file covers, for both the untyped and typed builder:

- branching one stored builder into two chains yields independent clauses (asserted both on `ToString()` and behaviourally, by counting attempts per exception/result term);
- calling `Or…`/`OrResult…` without using the return value does not affect the original builder;
- a shield already built from a builder keeps the clause it was built with when the builder is legitimately extended afterwards;
- sealing one builder twice still produces independent shields.

All other tests that hold a builder in a local already used the returned value and passed unchanged — notably `CompositionContractTests.Reusing_A_Builder_Does_Not_Mutate_An_Existing_Shield`, whose name is now exactly right.

### Results (Debug, `--timeout 120s`)

| Suite | Passed | Failed |
|---|---|---|
| Kevlar.Tests | 781 | 0 |
| Kevlar.IntegrationTests | 118 | 0 |
| Kevlar.Analyzers.Tests | 76 | 0 |
| Kevlar.Testing.Tests | 33 | 0 |
| Kevlar.Chaos.Tests | 23 | 0 |
| Kevlar.Extensions.RateLimiting.Tests | 19 | 0 |
| Kevlar.NetStandard.Tests | 5 | 0 |

`dotnet build Kevlar.slnx` is clean — 0 warnings, 0 errors, with warnings-as-errors and the public API analyzers on. AllocationTests (Release-only) and the doc-snippet verification are left to CI; the doc snippets added here use only existing API and were written to avoid tripping KEV007/KEV008.

## Hot path

No runtime impact. Builders exist only while a pipeline is being configured — they are consumed by `Seal()` before any strategy runs — so the extra array copies happen once per `Or…` at construction time and never during execution.

https://claude.ai/code/session_01KAPqkMyQnM44sRnoYQ6hmg
