### PR TITLE
test: expand resilience coverage

### DIFF
--- a/.github/workflows/model-tests.yml
+++ b/.github/workflows/model-tests.yml
@@ -1,6 +1,13 @@
 name: Model tests
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/Kevlar/**'
+      - 'tests/Kevlar.Tests/StrategyModelTests.cs'
+      - 'tests/Kevlar.Tests/Infrastructure/ModelRunner.cs'
+      - '.github/workflows/model-tests.yml'
   schedule:
     - cron: '17 3 * * 1-5'
   workflow_dispatch:
@@ -16,6 +23,7 @@ permissions:
 
 jobs:
   model-sweep:
+    name: Deterministic model sweep
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,6 +1,12 @@
 name: Stress tests
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/Kevlar/**'
+      - 'benchmarks/Kevlar.StressTests/**'
+      - '.github/workflows/stress.yml'
   push:
     branches: [main]
     paths:
@@ -21,7 +27,7 @@ concurrency:
 
 jobs:
   run-stress-test:
-    name: Run 15-minute stress test
+    name: ${{ github.event_name == 'pull_request' && 'Run 30-second stress smoke test' || 'Run 15-minute stress test' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -39,7 +45,8 @@ jobs:
       - name: Run stress test
         run: >-
           dotnet run --project benchmarks/Kevlar.StressTests -c Release --no-build --
-          --duration 00:15:00
+          --duration ${{ github.event_name == 'pull_request' && '00:00:30' || '00:15:00' }}
+          --warmup ${{ github.event_name == 'pull_request' && '00:00:01' || '00:00:02' }}
           --output artifacts/stress/stress-results.json
 
       - name: Generate run summary

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -7,6 +7,7 @@ on:
       - 'src/Kevlar/**'
       - 'benchmarks/Kevlar.StressTests/**'
       - '.github/workflows/stress.yml'
+      - '.github/scripts/stress_docs.py'
   push:
     branches: [main]
     paths:

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -108,7 +108,7 @@ capturing replenished availability.
 
 ## Repository quality gates
 
-Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, analyzer, testing-package, and rate-limiting-adapter suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run.
+Pull requests build on Windows and Linux, then run the unit, chaos, netstandard2.0 asset, integration, analyzer, testing-package, and rate-limiting-adapter suites independently with a five-minute timeout. Every suite requires at least one discovered test, so a runner or discovery regression cannot pass as an empty run. Changes to core sources also run the expanded deterministic model sweep and a 30-second concurrency stress smoke test before merge; scheduled stress runs retain the full 15-minute duration.
 
 The Linux coverage job merges all seven suites into Cobertura XML and an HTML report. It excludes test assemblies, benchmarks, generated code, and code marked with `ExcludeFromCodeCoverageAttribute`, then enforces the measured baselines of 92% line coverage and 86% branch coverage. Download the `coverage-report` workflow artifact to inspect either format.
 

--- a/tests/Kevlar.Chaos.Tests/ChaosBoundaryTests.cs
+++ b/tests/Kevlar.Chaos.Tests/ChaosBoundaryTests.cs
@@ -1,0 +1,219 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Chaos.Tests;
+
+public class ChaosBoundaryTests
+{
+    [Test]
+    public async Task Decision_Filters_Short_Circuit_In_Declared_Order()
+    {
+        var calls = new List<string>();
+        var enabled = false;
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.EnabledGenerator = _ =>
+            {
+                calls.Add("enabled");
+                return enabled;
+            };
+            options.Predicate = _ =>
+            {
+                calls.Add("predicate");
+                return false;
+            };
+            options.InjectionRateGenerator = _ =>
+            {
+                calls.Add("rate");
+                return 1;
+            };
+            options.ExceptionGenerator = _ =>
+            {
+                calls.Add("exception");
+                return new ChaosInjectedException();
+            };
+            options.OnInjected = _ => calls.Add("injected");
+        });
+
+        var disabled = await shield.ExecuteAsync(static _ => new ValueTask<int>(1));
+        enabled = true;
+        var rejected = await shield.ExecuteAsync(static _ => new ValueTask<int>(2));
+
+        await Assert.That(disabled).IsEqualTo(1);
+        await Assert.That(rejected).IsEqualTo(2);
+        await Assert.That(string.Join(",", calls)).IsEqualTo("enabled,enabled,predicate");
+    }
+
+    [Test]
+    public async Task Zero_Rate_Skips_Payload_Callback_And_Continues()
+    {
+        var resultGeneratorCalls = 0;
+        var injectionCallbacks = 0;
+        var actionCalls = 0;
+        var shield = ChaosShield.Outcome<int>(options =>
+        {
+            options.Enabled = true;
+            options.InjectionRate = 0;
+            options.ResultGenerator = _ =>
+            {
+                resultGeneratorCalls++;
+                return -1;
+            };
+            options.OnInjected = _ => injectionCallbacks++;
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(resultGeneratorCalls).IsEqualTo(0);
+        await Assert.That(injectionCallbacks).IsEqualTo(0);
+        await Assert.That(actionCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Outcome_Can_Inject_Null_And_Skip_The_Action()
+    {
+        var actionCalls = 0;
+        var shield = ChaosShield.Outcome<string>(options =>
+        {
+            options.Enabled = true;
+            options.Result = null;
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<string>("real");
+        });
+
+        await Assert.That(outcome.Exception).IsNull();
+        await Assert.That(outcome.Result).IsNull();
+        await Assert.That(actionCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Invalid_Generated_Delay_Fails_Before_Notification_Or_Action()
+    {
+        var injections = 0;
+        var actionCalls = 0;
+        var shield = ChaosShield.Latency(options =>
+        {
+            options.Enabled = true;
+            options.DelayGenerator = static _ => TimeSpan.FromDays(100);
+            options.OnInjected = _ => injections++;
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(outcome.Exception).IsTypeOf<ArgumentOutOfRangeException>();
+        await Assert.That(injections).IsEqualTo(0);
+        await Assert.That(actionCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Generated_Zero_Delay_Notifies_Then_Continues()
+    {
+        var order = new List<string>();
+        var shield = ChaosShield.Latency(options =>
+        {
+            options.Enabled = true;
+            options.DelayGenerator = _ =>
+            {
+                order.Add("delay");
+                return TimeSpan.Zero;
+            };
+            options.OnInjected = _ => order.Add("injected");
+        }).WithTimeProvider(new FakeTimeProvider());
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            order.Add("action");
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(string.Join(",", order)).IsEqualTo("delay,injected,action");
+    }
+
+    [Test]
+    public async Task Scope_Labels_Are_Ordinal_Case_Sensitive()
+    {
+        var shield = ChaosShield.Fault(options =>
+        {
+            options.Enabled = true;
+            options.Operation = "Checkout";
+            options.Environment = "Test";
+        });
+
+        Outcome<int> wrongCase;
+        using (ChaosScope.Begin("checkout", "test"))
+        {
+            wrongCase = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(1));
+        }
+
+        Outcome<int> exact;
+        using (ChaosScope.Begin("Checkout", "Test"))
+        {
+            exact = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(2));
+        }
+
+        await Assert.That(wrongCase.Result).IsEqualTo(1);
+        await Assert.That(exact.Exception).IsTypeOf<ChaosInjectedException>();
+    }
+
+    [Test]
+    public async Task Scope_State_Is_Isolated_Between_Concurrent_Async_Flows()
+    {
+        var firstEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var first = Task.Run(async () =>
+        {
+            using (ChaosScope.Begin("first", "one"))
+            {
+                firstEntered.SetResult();
+                await secondEntered.Task;
+                return (ChaosScope.Operation, ChaosScope.Environment);
+            }
+        });
+        var second = Task.Run(async () =>
+        {
+            await firstEntered.Task;
+            using (ChaosScope.Begin("second", "two"))
+            {
+                secondEntered.SetResult();
+                await Task.Yield();
+                return (ChaosScope.Operation, ChaosScope.Environment);
+            }
+        });
+
+        var results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(results[0]).IsEqualTo(("first", "one"));
+        await Assert.That(results[1]).IsEqualTo(("second", "two"));
+        await Assert.That(ChaosScope.Operation).IsNull();
+        await Assert.That(ChaosScope.Environment).IsNull();
+    }
+
+    [Test]
+    public async Task Default_Injected_Exception_Has_Stable_Contract()
+    {
+        var cause = new InvalidOperationException("cause");
+        var defaultException = new ChaosInjectedException();
+        var custom = new ChaosInjectedException("custom");
+        var wrapped = new ChaosInjectedException("wrapped", cause);
+
+        await Assert.That(defaultException.Message).IsEqualTo("A fault was injected by Kevlar.Chaos.");
+        await Assert.That(custom.Message).IsEqualTo("custom");
+        await Assert.That(wrapped.Message).IsEqualTo("wrapped");
+        await Assert.That(ReferenceEquals(wrapped.InnerException, cause)).IsTrue();
+    }
+}

--- a/tests/Kevlar.Extensions.RateLimiting.Tests/RateLimiterAdapterTests.cs
+++ b/tests/Kevlar.Extensions.RateLimiting.Tests/RateLimiterAdapterTests.cs
@@ -276,6 +276,42 @@ public class RateLimiterAdapterTests
     }
 
     [Test]
+    public async Task Async_Execution_Failure_Preserves_Identity_And_Releases_Lease()
+    {
+        var failure = new InvalidOperationException("operation failed");
+        var lease = new TrackingLease(isAcquired: true);
+        var shield = Shield.Empty.RateLimit(
+            (_, _) => new ValueTask<RateLimitLease>(lease));
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(async _ =>
+        {
+            await Task.Yield();
+            throw failure;
+        });
+
+        await Assert.That(ReferenceEquals(outcome.Exception, failure)).IsTrue();
+        await Assert.That(lease.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Async_Execution_Surfaces_Lease_Disposal_Failure()
+    {
+        var disposalFailure = new InvalidOperationException("lease disposal");
+        var lease = new TrackingLease(isAcquired: true) { DisposalFailure = disposalFailure };
+        var shield = Shield.Empty.RateLimit(
+            (_, _) => new ValueTask<RateLimitLease>(lease));
+
+        var outcome = await shield.ExecuteOutcomeAsync(async _ =>
+        {
+            await Task.Yield();
+            return 42;
+        });
+
+        await Assert.That(ReferenceEquals(outcome.Exception, disposalFailure)).IsTrue();
+        await Assert.That(lease.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Rejected_Custom_Lease_Snapshots_Metadata_Before_Disposal()
     {
         var retryAfter = TimeSpan.FromSeconds(7);
@@ -298,6 +334,27 @@ public class RateLimiterAdapterTests
         await Assert.That(observed.Metadata["tenant"]).IsEqualTo("alpha");
         await Assert.That(lease.DisposeCount).IsEqualTo(1);
         await Assert.That(lease.MetadataReadAfterDispose).IsFalse();
+    }
+
+    [Test]
+    public async Task Rejection_Metadata_Is_An_Immutable_Point_In_Time_Snapshot()
+    {
+        var source = new Dictionary<string, object?> { ["tenant"] = "alpha" };
+        var lease = new TrackingLease(isAcquired: false, source);
+        RateLimiterRejectedEvent observed = default;
+        var shield = Shield.Empty.RateLimit(
+            (_, _) => new ValueTask<RateLimitLease>(lease),
+            options => options.OnRejected = rejection => observed = rejection);
+
+        _ = await shield.ExecuteOutcomeAsync(static _ => new ValueTask<int>(42));
+        source["tenant"] = "beta";
+        source["added-later"] = true;
+
+        await Assert.That(observed.Metadata["tenant"]).IsEqualTo("alpha");
+        await Assert.That(observed.Metadata.ContainsKey("added-later")).IsFalse();
+        await Assert.That(() => ((IDictionary<string, object?>)observed.Metadata)
+                .Add("mutation", 1))
+            .Throws<NotSupportedException>();
     }
 
     [Test]

--- a/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
@@ -325,10 +325,17 @@ public class GrpcResilienceTests
     [Test]
     public async Task Transient_Status_Set_Is_Explicit()
     {
-        await Assert.That(GrpcShield.IsTransient(StatusCode.Unavailable)).IsTrue();
-        await Assert.That(GrpcShield.IsTransient(StatusCode.DeadlineExceeded)).IsTrue();
-        await Assert.That(GrpcShield.IsTransient(StatusCode.ResourceExhausted)).IsTrue();
-        await Assert.That(GrpcShield.IsTransient(StatusCode.InvalidArgument)).IsFalse();
+        foreach (var statusCode in Enum.GetValues<StatusCode>())
+        {
+            var expected = statusCode is StatusCode.Unavailable
+                or StatusCode.DeadlineExceeded
+                or StatusCode.ResourceExhausted;
+
+            await Assert.That(GrpcShield.IsTransient(statusCode)).IsEqualTo(expected);
+            await Assert.That(GrpcShield.IsTransient(
+                new RpcException(new Status(statusCode, "status")))).IsEqualTo(expected);
+        }
+
         await Assert.That(GrpcShield.IsTransient((RpcException?)null)).IsFalse();
     }
 
@@ -337,6 +344,125 @@ public class GrpcResilienceTests
     {
         _ = await Assert.That(() => new ShieldUnaryClientInterceptor(null!))
             .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Unary_Entry_Point_Rejects_Null_Request_And_Continuation()
+    {
+        var interceptor = new ShieldUnaryClientInterceptor(Shield.Empty);
+        var method = new Method<TestRequest, TestReply>(
+            MethodType.Unary,
+            "kevlar.tests.Guards",
+            "Unary",
+            Marshallers.Create(static _ => [], static _ => new TestRequest()),
+            Marshallers.Create(static _ => [], static _ => new TestReply()));
+        var context = new ClientInterceptorContext<TestRequest, TestReply>(
+            method,
+            host: null,
+            default);
+        Interceptor.AsyncUnaryCallContinuation<TestRequest, TestReply> continuation =
+            static (_, _) => throw new InvalidOperationException("must not run");
+
+        var requestError = await Assert.That(() => interceptor.AsyncUnaryCall(
+                null!,
+                context,
+                continuation))
+            .Throws<ArgumentNullException>();
+        var continuationError = await Assert.That(() => interceptor.AsyncUnaryCall(
+                new TestRequest(),
+                context,
+                null!))
+            .Throws<ArgumentNullException>();
+
+        await Assert.That(requestError!.ParamName).IsEqualTo("request");
+        await Assert.That(continuationError!.ParamName).IsEqualTo("continuation");
+    }
+
+    [Test]
+    public async Task Blocking_Unary_Calls_Pass_Through_Without_Applying_Shield()
+    {
+        var interceptor = new ShieldUnaryClientInterceptor(
+            GrpcShield.WhenTransient().Retry(3, Backoff.None));
+        var request = new TestRequest();
+        var expected = new TestReply { Attempt = 17 };
+        var method = new Method<TestRequest, TestReply>(
+            MethodType.Unary,
+            "kevlar.tests.PassThrough",
+            "Blocking",
+            Marshallers.Create(static _ => [], static _ => new TestRequest()),
+            Marshallers.Create(static _ => [], static _ => new TestReply()));
+        var context = new ClientInterceptorContext<TestRequest, TestReply>(
+            method,
+            host: "authority.test",
+            default);
+        var calls = 0;
+        TestRequest? observedRequest = null;
+        string? observedHost = null;
+
+        var actual = interceptor.BlockingUnaryCall(
+            request,
+            context,
+            (actualRequest, actualContext) =>
+            {
+                calls++;
+                observedRequest = actualRequest;
+                observedHost = actualContext.Host;
+                return expected;
+            });
+
+        await Assert.That(ReferenceEquals(actual, expected)).IsTrue();
+        await Assert.That(ReferenceEquals(observedRequest, request)).IsTrue();
+        await Assert.That(observedHost).IsEqualTo(context.Host);
+        await Assert.That(calls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Grpc_Client_Builder_Overloads_Report_Exact_Null_Parameters()
+    {
+        var builder = new ServiceCollection().AddHttpClient("grpc-guards");
+        Func<IServiceProvider, Shield> factory = static _ => Shield.Empty;
+
+        await AssertNullParameterAsync(
+            () => ShieldGrpcClientBuilderExtensions.AddShieldUnaryInterceptor(
+                null!,
+                Shield.Empty),
+            "builder");
+        await AssertNullParameterAsync(
+            () => ShieldGrpcClientBuilderExtensions.AddShieldUnaryInterceptor(null!, factory),
+            "builder");
+        await AssertNullParameterAsync(
+            () => ShieldGrpcClientBuilderExtensions.AddShieldUnaryInterceptor(null!, "name"),
+            "builder");
+        await AssertNullParameterAsync(
+            () => builder.AddShieldUnaryInterceptor((Shield)null!),
+            "shield");
+        await AssertNullParameterAsync(
+            () => builder.AddShieldUnaryInterceptor((Func<IServiceProvider, Shield>)null!),
+            "shieldFactory");
+        await AssertNullParameterAsync(
+            () => builder.AddShieldUnaryInterceptor((string)null!),
+            "shieldName");
+        await AssertNullParameterAsync(
+            () => ShieldGrpcClientBuilderExtensions.AddShieldStreamingInterceptor(
+                null!,
+                Shield.Empty),
+            "builder");
+        await AssertNullParameterAsync(
+            () => ShieldGrpcClientBuilderExtensions.AddShieldStreamingInterceptor(null!, factory),
+            "builder");
+        await AssertNullParameterAsync(
+            () => ShieldGrpcClientBuilderExtensions.AddShieldStreamingInterceptor(null!, "name"),
+            "builder");
+        await AssertNullParameterAsync(
+            () => builder.AddShieldStreamingInterceptor((Shield)null!),
+            "shield");
+        await AssertNullParameterAsync(
+            () => builder.AddShieldStreamingInterceptor(
+                (Func<IServiceProvider, Shield>)null!),
+            "shieldFactory");
+        await AssertNullParameterAsync(
+            () => builder.AddShieldStreamingInterceptor((string)null!),
+            "shieldName");
     }
 
     [Test]
@@ -884,6 +1010,12 @@ public class GrpcResilienceTests
 
     private static void NoOp()
     {
+    }
+
+    private static async Task AssertNullParameterAsync(Action action, string parameterName)
+    {
+        var error = await Assert.That(action).Throws<ArgumentNullException>();
+        await Assert.That(error!.ParamName).IsEqualTo(parameterName);
     }
 
     private sealed class DelegateCallInvoker(

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -194,6 +194,57 @@ public class HttpReplayTests
     }
 
     [Test]
+    public async Task Declared_Content_Length_Over_Limit_Fails_Before_Serialization_Or_Transport()
+    {
+        var content = new SerializationTrackingContent(contentLength: 5);
+        var transport = new RecordingHandler((_, _, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var invoker = CreateInvoker(
+            Shield<HttpResponseMessage>.Empty,
+            new ShieldHttpHandlerOptions
+            {
+                ContentReplayPolicy = HttpContentReplayPolicy.Buffer,
+                MaximumBufferSize = 4,
+            },
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = content,
+        };
+
+        var exception = await Assert.That(async () =>
+                await invoker.SendAsync(request, CancellationToken.None))
+            .Throws<HttpRequestReplayException>();
+
+        await Assert.That(exception!.Message).Contains("4-byte replay buffer limit");
+        await Assert.That(content.SerializationAttempts).IsEqualTo(0);
+        await Assert.That(transport.Attempts).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Null_RequestFactory_Result_Fails_Actionably_Before_Transport()
+    {
+        var transport = new RecordingHandler((_, _, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var invoker = CreateInvoker(
+            Shield<HttpResponseMessage>.Empty,
+            new ShieldHttpHandlerOptions
+            {
+                RequestFactory = static (_, _, _) =>
+                    new ValueTask<HttpRequestMessage>((HttpRequestMessage)null!),
+            },
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://origin.example/api");
+
+        var exception = await Assert.That(async () =>
+                await invoker.SendAsync(request, CancellationToken.None))
+            .Throws<HttpRequestReplayException>();
+
+        await Assert.That(exception!.Message).Contains("RequestFactory returned null");
+        await Assert.That(transport.Attempts).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Caller_Cancellation_Interrupts_Request_Buffering()
     {
         using var cancellation = new CancellationTokenSource();
@@ -899,6 +950,25 @@ public class HttpReplayTests
             }
 
             base.Dispose(disposing);
+        }
+    }
+
+    private sealed class SerializationTrackingContent(long contentLength) : HttpContent
+    {
+        private int _serializationAttempts;
+
+        public int SerializationAttempts => Volatile.Read(ref _serializationAttempts);
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            Interlocked.Increment(ref _serializationAttempts);
+            return Task.CompletedTask;
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = contentLength;
+            return true;
         }
     }
 

--- a/tests/Kevlar.NetStandard.Tests/ChaosCancellationTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/ChaosCancellationTests.cs
@@ -1,0 +1,36 @@
+using Kevlar.Chaos;
+
+namespace Kevlar.NetStandard.Tests;
+
+public class ChaosCancellationTests
+{
+    [Test]
+    public async Task Latency_Caller_Cancellation_Preserves_Caller_Token_And_Skips_Action()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var injectionStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionCalls = 0;
+        var shield = ChaosShield.Latency(options =>
+        {
+            options.Enabled = true;
+            options.Delay = TimeSpan.FromDays(1);
+            options.OnInjected = _ => injectionStarted.TrySetResult();
+        });
+
+        var execution = shield.ExecuteOutcomeAsync<int>(_ =>
+        {
+            actionCalls++;
+            return new ValueTask<int>(42);
+        }, cancellation.Token).AsTask();
+        await injectionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken)
+            .IsEqualTo(cancellation.Token);
+        await Assert.That(actionCalls).IsEqualTo(0);
+    }
+}

--- a/tests/Kevlar.NetStandard.Tests/CompatibilityTargetTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/CompatibilityTargetTests.cs
@@ -1,0 +1,28 @@
+using Kevlar.Chaos;
+using Kevlar.Extensions.Grpc;
+using Kevlar.Extensions.Http;
+
+namespace Kevlar.NetStandard.Tests;
+
+public class CompatibilityTargetTests
+{
+    [Test]
+    public async Task Compatibility_Suite_Loads_NetStandard20_Assemblies()
+    {
+        var assemblies = new[]
+        {
+            typeof(Shield).Assembly,
+            typeof(ShieldDelegatingHandler).Assembly,
+            typeof(ShieldStreamingClientInterceptor).Assembly,
+            typeof(ChaosShield).Assembly,
+        };
+
+        foreach (var assembly in assemblies)
+        {
+            var target = (System.Runtime.Versioning.TargetFrameworkAttribute)assembly
+                .GetCustomAttributes(typeof(System.Runtime.Versioning.TargetFrameworkAttribute), false)
+                .Single();
+            await Assert.That(target.FrameworkName).IsEqualTo(".NETStandard,Version=v2.0");
+        }
+    }
+}

--- a/tests/Kevlar.NetStandard.Tests/GrpcStreamingCancellationTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/GrpcStreamingCancellationTests.cs
@@ -9,28 +9,64 @@ public class GrpcStreamingCancellationTests
     [Test]
     public async Task Client_Write_Timeout_Cancels_The_NetStandard_Call_Lifetime()
     {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var interceptor = new ShieldStreamingClientInterceptor(
             Shield.Timeout(TimeSpan.FromMilliseconds(50)));
         using var call = interceptor.AsyncClientStreamingCall(
             Context(),
             context => new AsyncClientStreamingCall<Request, Reply>(
-                new BlockingWriter(context.Options.CancellationToken, cancelled),
+                new BlockingWriter(context.Options.CancellationToken, started, cancelled),
                 Task.FromResult(new Reply()),
                 Task.FromResult(new Metadata()),
                 static () => Status.DefaultSuccess,
                 static () => new Metadata(),
                 static () => { }));
 
-        _ = await Assert.That(async () =>
-                await call.RequestStream.WriteAsync(new Request())
-                    .WaitAsync(TimeSpan.FromSeconds(5)))
+        var write = call.RequestStream.WriteAsync(new Request());
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        _ = await Assert.That(async () => await write.WaitAsync(TimeSpan.FromSeconds(5)))
             .Throws<OperationCanceledException>();
 
         await cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
-    private static ClientInterceptorContext<Request, Reply> Context()
+    [Test]
+    public async Task Caller_Cancellation_Preserves_The_Call_Token_For_Writes()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetimeCancelled = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var interceptor = new ShieldStreamingClientInterceptor(Shield.Empty);
+        using var call = interceptor.AsyncClientStreamingCall(
+            Context(cancellation.Token),
+            context => new AsyncClientStreamingCall<Request, Reply>(
+                new BlockingWriter(
+                    context.Options.CancellationToken,
+                    started,
+                    lifetimeCancelled),
+                Task.FromResult(new Reply()),
+                Task.FromResult(new Metadata()),
+                static () => Status.DefaultSuccess,
+                static () => new Metadata(),
+                static () => { }));
+
+        var write = call.RequestStream.WriteAsync(new Request());
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        var exception = await Assert.That(async () =>
+                await write.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+        await lifetimeCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static ClientInterceptorContext<Request, Reply> Context(
+        CancellationToken cancellationToken = default)
     {
         var method = new Method<Request, Reply>(
             MethodType.ClientStreaming,
@@ -38,28 +74,33 @@ public class GrpcStreamingCancellationTests
             "ClientStreaming",
             Marshallers.Create(static _ => [], static _ => new Request()),
             Marshallers.Create(static _ => [], static _ => new Reply()));
-        return new ClientInterceptorContext<Request, Reply>(method, host: null, default);
+        return new ClientInterceptorContext<Request, Reply>(
+            method,
+            host: null,
+            new CallOptions(cancellationToken: cancellationToken));
     }
 
     private sealed class BlockingWriter(
         CancellationToken lifetimeToken,
+        TaskCompletionSource started,
         TaskCompletionSource cancelled) : IClientStreamWriter<Request>
     {
         public WriteOptions? WriteOptions { get; set; }
 
         public Task CompleteAsync() => Task.CompletedTask;
 
-        public Task WriteAsync(Request message)
+        public async Task WriteAsync(Request message)
         {
             var completion = new TaskCompletionSource(
                 TaskCreationOptions.RunContinuationsAsynchronously);
-            lifetimeToken.Register(() =>
+            using var registration = lifetimeToken.Register(() =>
             {
                 cancelled.TrySetResult();
                 completion.TrySetException(
                     new RpcException(new Status(StatusCode.Cancelled, "cancelled")));
             });
-            return completion.Task;
+            started.TrySetResult();
+            await completion.Task.ConfigureAwait(false);
         }
     }
 

--- a/tests/Kevlar.NetStandard.Tests/HttpPropertiesReplayTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/HttpPropertiesReplayTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using Kevlar.Extensions.Http;
+
+namespace Kevlar.NetStandard.Tests;
+
+public class HttpPropertiesReplayTests
+{
+    [Test]
+    public async Task Buffered_Retry_Preserves_NetStandard_Request_Properties()
+    {
+        var marker = new object();
+        var observed = new List<object?>();
+        using var invoker = new HttpMessageInvoker(new ShieldDelegatingHandler(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions
+            {
+                AllowUnsafeMethodReplay = true,
+                ContentReplayPolicy = HttpContentReplayPolicy.Buffer,
+            })
+        {
+            InnerHandler = new PropertyRecordingHandler(observed),
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+#pragma warning disable CS0618 // netstandard2.0 compatibility contract uses HttpRequestMessage.Properties.
+        request.Properties["request-marker"] = marker;
+#pragma warning restore CS0618
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(observed.Count).IsEqualTo(2);
+        await Assert.That(observed.All(value => ReferenceEquals(value, marker))).IsTrue();
+    }
+
+    private sealed class PropertyRecordingHandler(List<object?> observed) : HttpMessageHandler
+    {
+        private int _attempt;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0618 // netstandard2.0 compatibility contract uses HttpRequestMessage.Properties.
+            request.Properties.TryGetValue("request-marker", out var marker);
+#pragma warning restore CS0618
+            observed.Add(marker);
+            var status = Interlocked.Increment(ref _attempt) == 1
+                ? HttpStatusCode.ServiceUnavailable
+                : HttpStatusCode.OK;
+            return Task.FromResult(new HttpResponseMessage(status));
+        }
+    }
+}

--- a/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
+++ b/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
@@ -18,6 +18,8 @@
                       SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.Grpc\Kevlar.Extensions.Grpc.csproj"
                       SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="..\..\src\Kevlar.Chaos\Kevlar.Chaos.csproj"
+                      SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Kevlar.NetStandard.Tests/RetryCancellationTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/RetryCancellationTests.cs
@@ -25,4 +25,34 @@ public class RetryCancellationTests
             .IsEqualTo(cancellation.Token);
         await Assert.That(attempts).IsEqualTo(1);
     }
+
+    [Test]
+    public async Task Nonzero_Delay_Caller_Cancellation_Preserves_Caller_Token()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var retryStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 3;
+            options.Backoff = Backoff.Constant(TimeSpan.FromDays(1));
+            options.OnRetry = _ => retryStarted.TrySetResult();
+        });
+
+        var execution = shield.ExecuteOutcomeAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException("retry me");
+        }, cancellation.Token).AsTask();
+        await retryStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<OperationCanceledException>();
+        await Assert.That(((OperationCanceledException)outcome.Exception!).CancellationToken)
+            .IsEqualTo(cancellation.Token);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
 }

--- a/tests/Kevlar.Testing.Tests/HelperContractTests.cs
+++ b/tests/Kevlar.Testing.Tests/HelperContractTests.cs
@@ -1,0 +1,113 @@
+using Kevlar.Testing;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Testing.Tests;
+
+public class HelperContractTests
+{
+    [Test]
+    public async Task ExecutionProbe_Rejects_Invalid_Inputs_Without_Changing_Counts()
+    {
+        var probe = new ExecutionProbe();
+
+        await Assert.That(() => probe.Wrap((Func<CancellationToken, ValueTask>)null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => probe.Wrap<int>((Func<CancellationToken, ValueTask<int>>)null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => probe.WaitForAttemptCountAsync(-1))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => probe.WaitForCancellationCountAsync(-1))
+            .Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(probe.AttemptCount).IsEqualTo(0);
+        await Assert.That(probe.CancellationCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ExecutionProbe_Only_Counts_Cancellation_While_An_Attempt_Is_Active()
+    {
+        var probe = new ExecutionProbe();
+        using var cancellation = new CancellationTokenSource();
+
+        await Shield.Empty.ExecuteAsync(
+            probe.Wrap(static _ => ValueTask.CompletedTask),
+            cancellation.Token);
+        cancellation.Cancel();
+
+        await Assert.That(probe.AttemptCount).IsEqualTo(1);
+        await Assert.That(probe.CancellationCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ExecutionProbe_Releases_All_Concurrent_Waiters()
+    {
+        var probe = new ExecutionProbe();
+        var waiters = Enumerable.Range(0, 16)
+            .Select(_ => probe.WaitForAttemptCountAsync(1))
+            .ToArray();
+
+        await Shield.Empty.ExecuteAsync(probe.Wrap(static _ => ValueTask.CompletedTask));
+        await Task.WhenAll(waiters).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(waiters).All(static waiter => waiter.IsCompletedSuccessfully);
+    }
+
+    [Test]
+    public async Task StateSnapshot_Supports_VoidShield_And_Preserves_Pipeline_Indexes()
+    {
+        var shield = Shield
+            .Fallback(static _ => ValueTask.CompletedTask)
+            .Timeout(TimeSpan.FromSeconds(1))
+            .ConcurrencyLimit(3)
+            .Retry(1, Backoff.None);
+
+        var snapshot = shield.GetStateSnapshot();
+        var concurrency = snapshot.Strategies.Single();
+
+        await Assert.That(concurrency).IsTypeOf<ConcurrencyLimitStateSnapshot>();
+        await Assert.That(concurrency.Kind).IsEqualTo(StrategyKind.ConcurrencyLimit);
+        await Assert.That(concurrency.StrategyIndex).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task StateSnapshot_Rejects_Null_VoidShield()
+    {
+        VoidShield? shield = null;
+
+        await Assert.That(() => shield!.GetStateSnapshot())
+            .Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task FakeTime_Does_Not_Advance_When_Condition_Is_Already_Satisfied()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var initial = timeProvider.GetUtcNow();
+        var evaluations = 0;
+
+        await timeProvider.AdvanceUntilAsync(
+            TimeSpan.FromHours(1),
+            () => Interlocked.Increment(ref evaluations) == 1,
+            "an already-satisfied condition");
+
+        await Assert.That(timeProvider.GetUtcNow()).IsEqualTo(initial);
+        await Assert.That(evaluations).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task FakeTime_Advancement_Preserves_Cancellation_Token()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var exception = await Assert.That(async () => await timeProvider.AdvanceUntilAsync(
+                TimeSpan.FromSeconds(1),
+                static () => false,
+                "cancelled advancement",
+                cancellationToken: cancellation.Token))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+    }
+}

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -151,6 +151,54 @@ public class TelemetryRecorderTests
     }
 
     [Test]
+    public async Task Disposal_Releases_Pending_Waiters_With_ObjectDisposedException()
+    {
+        var recorder = new TelemetryRecorder(captureMetrics: false);
+        var callbackWait = recorder.WaitForCallbackCountAsync(1);
+        var metricWait = recorder.WaitForMetricCountAsync(1);
+
+        recorder.Dispose();
+
+        await Assert.That(async () => await callbackWait)
+            .Throws<ObjectDisposedException>();
+        await Assert.That(async () => await metricWait)
+            .Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task Disposed_Recorder_Rejects_Callbacks_And_New_Waiters()
+    {
+        var recorder = new TelemetryRecorder(captureMetrics: false);
+        recorder.Dispose();
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.OnRetry = recorder.Record;
+        });
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(
+            static _ => throw new InvalidOperationException());
+
+        await Assert.That(outcome.Exception).IsTypeOf<ObjectDisposedException>();
+        await Assert.That(() => recorder.WaitForCallbackCountAsync(0))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(() => recorder.WaitForMetricCountAsync(0))
+            .Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task Waiters_Reject_Negative_Counts()
+    {
+        using var recorder = new TelemetryRecorder(captureMetrics: false);
+
+        await Assert.That(() => recorder.WaitForCallbackCountAsync(-1))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => recorder.WaitForMetricCountAsync(-1))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task Records_Every_Documented_Metric_Family()
     {
         using var recorder = new TelemetryRecorder();

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -73,19 +73,55 @@ public class DependencyInjectionContractTests
     }
 
     [Test]
-    public async Task Last_Duplicate_Registration_Wins_On_Every_Path()
+    public async Task Void_Registry_TryGet_And_Keyed_Paths_Return_The_Same_Singleton()
+    {
+        var expected = Shield.Fallback(static _ => ValueTask.CompletedTask);
+        using var services = new ServiceCollection()
+            .AddShield("void", expected)
+            .BuildServiceProvider();
+        var registry = services.GetRequiredService<IKevlarRegistry>();
+
+        var direct = registry.GetVoidShield("void");
+        var found = registry.TryGetVoidShield("void", out var tried);
+        var keyed = services.GetRequiredKeyedService<VoidShield>("void");
+
+        await Assert.That(found).IsTrue();
+        await Assert.That(ReferenceEquals(direct, expected)).IsTrue();
+        await Assert.That(ReferenceEquals(tried, expected)).IsTrue();
+        await Assert.That(ReferenceEquals(keyed, expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Last_Duplicate_Registration_Wins_For_Every_Shield_Kind()
     {
         var first = Shield.Retry(1, Backoff.None);
         var last = Shield.Timeout(TimeSpan.FromSeconds(1));
+        var firstTyped = Shield<int>.Empty;
+        var lastTyped = Shield.For<int>().Fallback(42);
+        var firstVoid = Shield.Fallback(static _ => ValueTask.CompletedTask);
+        var lastVoid = Shield.Fallback(static _ => ValueTask.FromException(
+            new InvalidOperationException("last")));
         using var provider = new ServiceCollection()
             .AddShield("duplicate", first)
             .AddShield("duplicate", last)
+            .AddShield("duplicate", firstTyped)
+            .AddShield("duplicate", lastTyped)
+            .AddShield("duplicate", firstVoid)
+            .AddShield("duplicate", lastVoid)
             .BuildServiceProvider();
 
         var registry = provider.GetRequiredService<IKevlarRegistry>();
 
         await Assert.That(ReferenceEquals(registry.GetShield("duplicate"), last)).IsTrue();
         await Assert.That(ReferenceEquals(provider.GetRequiredKeyedService<Shield>("duplicate"), last)).IsTrue();
+        await Assert.That(ReferenceEquals(registry.GetShield<int>("duplicate"), lastTyped)).IsTrue();
+        await Assert.That(ReferenceEquals(
+            provider.GetRequiredKeyedService<Shield<int>>("duplicate"),
+            lastTyped)).IsTrue();
+        await Assert.That(ReferenceEquals(registry.GetVoidShield("duplicate"), lastVoid)).IsTrue();
+        await Assert.That(ReferenceEquals(
+            provider.GetRequiredKeyedService<VoidShield>("duplicate"),
+            lastVoid)).IsTrue();
     }
 
     [Test]
@@ -122,6 +158,100 @@ public class DependencyInjectionContractTests
         await AssertNullNameAsync(() => registry.GetShield<int>(null!));
         await AssertNullNameAsync(() => registry.TryGetShield(null!, out _));
         await AssertNullNameAsync(() => registry.TryGetShield<int>(null!, out _));
+        await AssertNullNameAsync(() => registry.GetVoidShield(null!));
+        await AssertNullNameAsync(() => registry.TryGetVoidShield(null!, out _));
+    }
+
+    [Test]
+    public async Task Registration_Overloads_Reject_Null_Inputs_With_Exact_Parameter_Names()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        Func<IServiceProvider, Shield> shieldFactory = static _ => Shield.Empty;
+        Func<IServiceProvider, Shield<int>> typedFactory = static _ => Shield<int>.Empty;
+        Func<IServiceProvider, VoidShield> voidFactory = static _ =>
+            Shield.Fallback(static _ => ValueTask.CompletedTask);
+        Func<IServiceProvider, string, Shield> partitionedFactory = static (_, _) => Shield.Empty;
+        Func<IServiceProvider, string, Shield<int>> typedPartitionedFactory =
+            static (_, _) => Shield<int>.Empty;
+        Func<IServiceProvider, string, VoidShield> voidPartitionedFactory = static (_, _) =>
+            Shield.Fallback(static _ => ValueTask.CompletedTask);
+
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddKevlar(null!),
+            "services");
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddShield(null!, "name", shieldFactory),
+            "services");
+        await AssertNullParameterAsync(() => services.AddShield(null!, shieldFactory), "name");
+        await AssertNullParameterAsync(
+            () => services.AddShield("name", (Func<IServiceProvider, Shield>)null!),
+            "factory");
+        await AssertNullParameterAsync(
+            () => services.AddShield("name", (Shield)null!),
+            "shield");
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddShield(null!, "name", configuration),
+            "services");
+        await AssertNullParameterAsync(
+            () => services.AddShield("name", (IConfiguration)null!),
+            "configuration");
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddVoidShield(null!, "name", voidFactory),
+            "services");
+        await AssertNullParameterAsync(() => services.AddVoidShield(null!, voidFactory), "name");
+        await AssertNullParameterAsync(
+            () => services.AddVoidShield("name", (Func<IServiceProvider, VoidShield>)null!),
+            "factory");
+        await AssertNullParameterAsync(
+            () => services.AddShield("name", (VoidShield)null!),
+            "shield");
+        await AssertNullParameterAsync(
+            () => services.AddShield<int>("name", (Func<IServiceProvider, Shield<int>>)null!),
+            "factory");
+        await AssertNullParameterAsync(
+            () => services.AddShield<int>("name", (Shield<int>)null!),
+            "shield");
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddShield<int>(null!, "name", typedFactory),
+            "services");
+        await AssertNullParameterAsync(() => services.AddShield<int>(null!, typedFactory), "name");
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddPartitionedShield(
+                null!,
+                "name",
+                partitionedFactory),
+            "services");
+        await AssertNullParameterAsync(
+            () => services.AddPartitionedShield<string>(null!, partitionedFactory),
+            "name");
+        await AssertNullParameterAsync(
+            () => services.AddPartitionedShield<string>("name", null!),
+            "factory");
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddPartitionedVoidShield(
+                null!,
+                "name",
+                voidPartitionedFactory),
+            "services");
+        await AssertNullParameterAsync(
+            () => services.AddPartitionedVoidShield<string>(null!, voidPartitionedFactory),
+            "name");
+        await AssertNullParameterAsync(
+            () => services.AddPartitionedVoidShield<string>("name", null!),
+            "factory");
+        await AssertNullParameterAsync(
+            () => KevlarServiceCollectionExtensions.AddPartitionedShield(
+                null!,
+                "name",
+                typedPartitionedFactory),
+            "services");
+        await AssertNullParameterAsync(
+            () => services.AddPartitionedShield<string, int>(null!, typedPartitionedFactory),
+            "name");
+        await AssertNullParameterAsync(
+            () => services.AddPartitionedShield<string, int>("name", null!),
+            "factory");
     }
 
     [Test]
@@ -261,7 +391,12 @@ public class DependencyInjectionContractTests
 
     private static async Task AssertNullNameAsync(Action action)
     {
+        await AssertNullParameterAsync(action, "name");
+    }
+
+    private static async Task AssertNullParameterAsync(Action action, string parameterName)
+    {
         var error = await Assert.That(action).Throws<ArgumentNullException>();
-        await Assert.That(error!.ParamName).IsEqualTo("name");
+        await Assert.That(error!.ParamName).IsEqualTo(parameterName);
     }
 }

--- a/tests/Kevlar.Tests/ExecutionContextPlumbingTests.cs
+++ b/tests/Kevlar.Tests/ExecutionContextPlumbingTests.cs
@@ -1,0 +1,221 @@
+using System.Reflection;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+[NotInParallel]
+public class ExecutionContextPlumbingTests
+{
+    private const string ExceptionProxyDataKey =
+        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
+
+    [Test]
+    public async Task Every_Context_Initializer_Has_An_Exact_Null_Guard()
+    {
+        var methods = GetContextInitializerMethods().ToArray();
+
+        await Assert.That(methods.Length > 0).IsTrue();
+        foreach (var method in methods)
+        {
+            var closedMethod = CloseGenericMethod(method);
+            var target = closedMethod.IsStatic ? null : CreateShield(closedMethod.DeclaringType!);
+            var arguments = closedMethod.GetParameters()
+                .Select(parameter => CreateArgument(parameter, nullInitializer: true))
+                .ToArray();
+
+            var exception = CaptureReflectionFailure(() => closedMethod.Invoke(target, arguments));
+
+            await Assert.That(exception).IsTypeOf<ArgumentNullException>();
+            await Assert.That(((ArgumentNullException)exception).ParamName)
+                .IsEqualTo("initializeProperties");
+        }
+    }
+
+    [Test]
+    public async Task Synchronous_Context_Action_Failure_Returns_The_Exact_Context_Clean()
+    {
+        var key = new KevlarKey<string>("dirty");
+        var expected = new InvalidOperationException("context action failed");
+        var timeProvider = new FakeTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        KevlarContext? captured = null;
+        var shield = Shield.Empty
+            .WithName("sync-context-failure")
+            .WithTimeProvider(timeProvider);
+
+        var failure = await Assert.That(() => shield.ExecuteWithContext<int, int>(
+                42,
+                (_, properties) => properties.Set(key, "value"),
+                (_, context) =>
+                {
+                    captured = context;
+                    throw expected;
+                },
+                cancellation.Token))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(failure).IsSameReferenceAs(expected);
+        await Assert.That(captured).IsNotNull();
+        KevlarContext.AllowPooledInspection(captured!);
+        await Assert.That(captured!.Properties.TryGet(key, out _)).IsFalse();
+        await Assert.That(captured.CancellationToken).IsEqualTo(default(CancellationToken));
+        await Assert.That(captured.IsSynchronous).IsFalse();
+        await Assert.That(captured.ShieldName).IsNull();
+        await Assert.That(captured.TimeProvider).IsSameReferenceAs(TimeProvider.System);
+    }
+
+    [Test]
+    public async Task Returning_Context_Clears_A_Large_Property_Bag()
+    {
+        var keys = Enumerable.Range(0, 40)
+            .Select(index => new KevlarKey<object>($"property-{index}"))
+            .ToArray();
+        var values = keys.Select(_ => new object()).ToArray();
+        KevlarContext? captured = null;
+
+        var result = await Shield.Empty.ExecuteWithContextAsync(
+            (keys, values),
+            static (state, properties) =>
+            {
+                for (var index = 0; index < state.keys.Length; index++)
+                {
+                    properties.Set(state.keys[index], state.values[index]);
+                }
+            },
+            (_, context) =>
+            {
+                captured = context;
+                return new ValueTask<int>(42);
+            });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(captured).IsNotNull();
+        KevlarContext.AllowPooledInspection(captured!);
+        foreach (var key in keys)
+        {
+            await Assert.That(captured!.Properties.TryGet(key, out _)).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Fork_Copies_Metadata_And_All_Properties_But_Isolates_Later_Writes()
+    {
+        var textKey = new KevlarKey<string>("text");
+        var numberKey = new KevlarKey<int>("number");
+        var nullKey = new KevlarKey<string?>("nullable");
+        var timeProvider = new FakeTimeProvider();
+        using var parentCancellation = new CancellationTokenSource();
+        using var forkCancellation = new CancellationTokenSource();
+        var parent = KevlarContext.Rent(
+            parentCancellation.Token,
+            isSynchronous: true,
+            timeProvider,
+            "parent");
+        parent.StrategyIndex = 7;
+        parent.Properties.Set(textKey, "original");
+        parent.Properties.Set(numberKey, 42);
+        parent.Properties.Set(nullKey, null);
+        var fork = parent.Fork(forkCancellation.Token);
+
+        try
+        {
+            parent.Properties.Set(textKey, "changed-parent");
+            fork.Properties.Set(numberKey, 84);
+
+            await Assert.That(fork.CancellationToken).IsEqualTo(forkCancellation.Token);
+            await Assert.That(fork.IsSynchronous).IsTrue();
+            await Assert.That(fork.TimeProvider).IsSameReferenceAs(timeProvider);
+            await Assert.That(fork.ShieldName).IsEqualTo("parent");
+            await Assert.That(fork.StrategyIndex).IsEqualTo(7);
+            await Assert.That(fork.Properties.GetOrDefault<string>(textKey)).IsEqualTo("original");
+            await Assert.That(fork.Properties.GetOrDefault(numberKey)).IsEqualTo(84);
+            await Assert.That(fork.Properties.TryGet(nullKey, out var nullValue)).IsTrue();
+            await Assert.That(nullValue).IsNull();
+            await Assert.That(parent.Properties.GetOrDefault(numberKey)).IsEqualTo(42);
+            await Assert.That(parent.Properties.GetOrDefault<string>(textKey)).IsEqualTo("changed-parent");
+        }
+        finally
+        {
+            KevlarContext.Return(fork);
+            KevlarContext.Return(parent);
+        }
+    }
+
+    [Test]
+    public async Task Exception_Proxy_Never_Leaks_From_Public_Outcome_Members()
+    {
+        var original = new InvalidOperationException("original");
+        var proxy = new Exception("transport proxy");
+        proxy.Data[ExceptionProxyDataKey] = original;
+        var outcome = Outcome<int>.FromException(proxy);
+
+        var failure = await Assert.That(() => outcome.GetResultOrRethrow())
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(outcome.Exception).IsSameReferenceAs(original);
+        await Assert.That(failure).IsSameReferenceAs(original);
+        await Assert.That(outcome.ToString()).IsEqualTo(original.ToString());
+    }
+
+    private static IEnumerable<MethodInfo> GetContextInitializerMethods() =>
+        typeof(Shield).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Concat(typeof(Shield<int>).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Concat(typeof(VoidShield).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Concat(typeof(ShieldTaskExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            .Where(static method => method.Name is "ExecuteWithContext" or "ExecuteWithContextAsync")
+            .Where(static method => method.GetParameters()
+                .Any(parameter => parameter.Name == "initializeProperties"));
+
+    private static MethodInfo CloseGenericMethod(MethodInfo method) =>
+        method.IsGenericMethodDefinition
+            ? method.MakeGenericMethod(Enumerable.Repeat(typeof(int), method.GetGenericArguments().Length).ToArray())
+            : method;
+
+    private static object CreateShield(Type type) => type == typeof(Shield)
+        ? Shield.Empty
+        : type == typeof(Shield<int>)
+            ? Shield<int>.Empty
+            : CreateVoidShield();
+
+    private static object? CreateArgument(ParameterInfo parameter, bool nullInitializer)
+    {
+        if (parameter.Name == "initializeProperties" && nullInitializer)
+        {
+            return null;
+        }
+
+        if (parameter.Name == "shield")
+        {
+            return CreateShield(parameter.ParameterType);
+        }
+
+        if (parameter.Name == "cancellationToken")
+        {
+            return default(CancellationToken);
+        }
+
+        return parameter.ParameterType.IsValueType
+            ? Activator.CreateInstance(parameter.ParameterType)
+            : null;
+    }
+
+    private static VoidShield CreateVoidShield() =>
+        Shield.Fallback(static _ => ValueTask.CompletedTask);
+
+    private static Exception CaptureReflectionFailure(Action action)
+    {
+        try
+        {
+            action();
+            throw new InvalidOperationException("Expected a null guard failure.");
+        }
+        catch (TargetInvocationException exception)
+        {
+            return exception.InnerException!;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+}

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -10,6 +10,40 @@ namespace Kevlar.Tests;
 public class HttpContractTests
 {
     [Test]
+    public async Task Endpoint_Value_Object_Validates_And_Preserves_Inputs()
+    {
+        var uri = new Uri("https://api.example:8443/base");
+        var endpoint = new HttpEndpoint(uri, weight: 7);
+
+        await Assert.That(ReferenceEquals(endpoint.Uri, uri)).IsTrue();
+        await Assert.That(endpoint.Weight).IsEqualTo(7);
+
+        var nullUri = await Assert.That(() => new HttpEndpoint(null!))
+            .Throws<ArgumentNullException>();
+        var relativeUri = await Assert.That(() => new HttpEndpoint(new Uri("relative", UriKind.Relative)))
+            .Throws<ArgumentException>();
+        var zeroWeight = await Assert.That(() => new HttpEndpoint(uri, weight: 0))
+            .Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(nullUri!.ParamName).IsEqualTo("uri");
+        await Assert.That(relativeUri!.ParamName).IsEqualTo("uri");
+        await Assert.That(zeroWeight!.ParamName).IsEqualTo("weight");
+    }
+
+    [Test]
+    public async Task Replay_Exception_Constructors_Preserve_Message_And_Inner_Exception()
+    {
+        var inner = new IOException("serialization failed");
+        var simple = new HttpRequestReplayException("replay failed");
+        var wrapped = new HttpRequestReplayException("buffer failed", inner);
+
+        await Assert.That(simple.Message).IsEqualTo("replay failed");
+        await Assert.That(simple.InnerException).IsNull();
+        await Assert.That(wrapped.Message).IsEqualTo("buffer failed");
+        await Assert.That(ReferenceEquals(wrapped.InnerException, inner)).IsTrue();
+    }
+
+    [Test]
     [Arguments(200, false)]
     [Arguments(301, false)]
     [Arguments(400, false)]
@@ -641,7 +675,19 @@ public class HttpContractTests
             .Throws<ArgumentNullException>();
         await Assert.That(() => builder.AddShield((Shield<HttpResponseMessage>)null!))
             .Throws<ArgumentNullException>();
+        await Assert.That(() => builder.AddShield(
+                Shield<HttpResponseMessage>.Empty,
+                null!))
+            .Throws<ArgumentNullException>();
         await Assert.That(() => builder.AddShield((Func<IServiceProvider, Shield<HttpResponseMessage>>)null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => builder.AddShield(
+                static _ => Shield<HttpResponseMessage>.Empty,
+                null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => new ShieldDelegatingHandler(
+                Shield<HttpResponseMessage>.Empty,
+                null!))
             .Throws<ArgumentNullException>();
         await Assert.That(() => ShieldHttpClientBuilderExtensions.AddStandardShield(nullBuilder!))
             .Throws<ArgumentNullException>();

--- a/tests/Kevlar.Tests/PartitionedShieldContractTests.cs
+++ b/tests/Kevlar.Tests/PartitionedShieldContractTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class PartitionedShieldContractTests
+{
+    [Test]
+    public async Task TryGetShield_Refreshes_Lru_Order()
+    {
+        var provider = new PartitionedShield<string>(
+            _ => Shield.Empty,
+            new PartitionedShieldOptions { MaximumPartitions = 2 });
+        var first = provider.GetShield("first");
+        _ = provider.GetShield("second");
+
+        var found = provider.TryGetShield("first", out var retained);
+        _ = provider.GetShield("third");
+
+        await Assert.That(found).IsTrue();
+        await Assert.That(retained).IsSameReferenceAs(first);
+        await Assert.That(provider.TryGetShield("first", out _)).IsTrue();
+        await Assert.That(provider.TryGetShield("second", out _)).IsFalse();
+        await Assert.That(provider.TryGetShield("third", out _)).IsTrue();
+        await Assert.That(provider.CapacityEvictionCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TryGetShield_Refreshes_Idle_Expiration()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var provider = new PartitionedShield<string>(
+            _ => Shield.Empty,
+            new PartitionedShieldOptions
+            {
+                IdleExpiration = TimeSpan.FromMinutes(1),
+                TimeProvider = timeProvider,
+            });
+        var original = provider.GetShield("tenant");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(45));
+        await Assert.That(provider.TryGetShield("tenant", out var touched)).IsTrue();
+        timeProvider.Advance(TimeSpan.FromSeconds(45));
+
+        await Assert.That(provider.PruneExpired()).IsEqualTo(0);
+        await Assert.That(provider.TryGetShield("tenant", out var retained)).IsTrue();
+        await Assert.That(touched).IsSameReferenceAs(original);
+        await Assert.That(retained).IsSameReferenceAs(original);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        await Assert.That(provider.PruneExpired()).IsEqualTo(1);
+        await Assert.That(provider.TryGetShield("tenant", out _)).IsFalse();
+        await Assert.That(provider.ExpirationEvictionCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Custom_Comparer_Coalesces_Equivalent_Keys()
+    {
+        var factoryKeys = new List<string>();
+        var provider = new PartitionedShield<string>(
+            key =>
+            {
+                factoryKeys.Add(key);
+                return Shield.Retry(0, Backoff.None);
+            },
+            comparer: StringComparer.OrdinalIgnoreCase);
+
+        var first = provider.GetShield("Tenant");
+        var equivalent = provider.GetShield("TENANT");
+
+        await Assert.That(equivalent).IsSameReferenceAs(first);
+        await Assert.That(provider.Count).IsEqualTo(1);
+        await Assert.That(provider.CreatedCount).IsEqualTo(1);
+        await Assert.That(factoryKeys).IsEquivalentTo(["Tenant"]);
+        await Assert.That(provider.Remove("tenant")).IsTrue();
+        await Assert.That(provider.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Null_Factory_Result_Does_Not_Poison_Later_Creation()
+    {
+        var attempts = 0;
+        var provider = new PartitionedShield<string>(_ =>
+            Interlocked.Increment(ref attempts) == 1 ? null! : Shield.Empty);
+
+        var failure = await Assert.That(() => provider.GetShield("tenant"))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(failure!.Message).IsEqualTo("The partition factory returned null.");
+        await Assert.That(provider.Count).IsEqualTo(0);
+        await Assert.That(provider.CreatedCount).IsEqualTo(0);
+
+        var created = provider.GetShield("tenant");
+
+        await Assert.That(created).IsSameReferenceAs(Shield.Empty);
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(provider.Count).IsEqualTo(1);
+        await Assert.That(provider.CreatedCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Factory_Exception_Does_Not_Poison_Later_Creation()
+    {
+        var expected = new InvalidOperationException("first creation failed");
+        var attempts = 0;
+        var provider = new PartitionedShield<string>(_ =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                throw expected;
+            }
+
+            return Shield.Empty;
+        });
+
+        var failure = await Assert.That(() => provider.GetShield("tenant"))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(failure).IsSameReferenceAs(expected);
+        await Assert.That(provider.Count).IsEqualTo(0);
+        await Assert.That(provider.CreatedCount).IsEqualTo(0);
+
+        var created = provider.GetShield("tenant");
+
+        await Assert.That(created).IsSameReferenceAs(Shield.Empty);
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(provider.CreatedCount).IsEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary

- add 45 focused tests across core execution plumbing, partitioning, HTTP, gRPC, dependency injection, rate limiting, Chaos, testing helpers, and netstandard2.0 compatibility
- strengthen exhaustive status, overload-guard, cancellation-token, replay, cleanup, metadata, and concurrent-flow contracts
- run deterministic model sweeps and a 30-second concurrency stress smoke test on relevant pull requests
- document the expanded pull-request quality gates

## Coverage

- line coverage: 93.76% (gate: 92%)
- branch coverage: 89.79% (gate: 86%)
- merged report includes every production assembly

## Validation

- `dotnet build Kevlar.slnx -c Release`
- all 8 executable suites: 1,113 passed, 0 failed, 0 skipped
- expanded 250-seed strategy model sweep
- 30-second stress smoke test
- `npm run build` in `docs/`
- merged Cobertura coverage gate
- workflow YAML parse validation