### PR TITLE
refactor(api): make StrategyNode internal

### DIFF
--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 Kevlar.HandlingClause
+*REMOVED*Kevlar.StrategyNode
 Kevlar.HandlingClause.HandlingClause() -> void
 Kevlar.HandlingClause.ShouldHandle<T>(in Kevlar.Outcome<T> outcome) -> bool
 static Kevlar.HandlingClause.Default.get -> Kevlar.HandlingClause

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -141,8 +141,7 @@ public readonly struct Continuation<T, TState>
     }
 }
 
-/// <summary>A node in a shield's immutable strategy chain.</summary>
-public sealed class StrategyNode
+internal sealed class StrategyNode
 {
     internal StrategyNode(Strategy strategy, StrategyNode? next, int index)
     {

--- a/tests/Kevlar.Tests/PublicApiContractTests.cs
+++ b/tests/Kevlar.Tests/PublicApiContractTests.cs
@@ -1,0 +1,99 @@
+using System.Reflection;
+
+namespace Kevlar.Tests;
+
+public class PublicApiContractTests
+{
+    private const BindingFlags DeclaredPublicMembers =
+        BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+    private const BindingFlags AllPublicMembers =
+        BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+
+    [Test]
+    public async Task No_Public_Type_Without_Public_Members()
+    {
+        var emptyTypes = typeof(Shield).Assembly
+            .GetExportedTypes()
+            .Where(static type => !type.IsEnum && !typeof(Attribute).IsAssignableFrom(type))
+            .Where(static type => type
+                .GetMembers(AllPublicMembers)
+                .All(static member => member.MemberType == MemberTypes.Constructor
+                    || member.DeclaringType == typeof(object)))
+            .Select(static type => type.FullName!)
+            .Order()
+            .ToArray();
+
+        await Assert.That(emptyTypes).IsEmpty();
+    }
+
+    [Test]
+    public async Task Public_Signatures_Do_Not_Reference_Internal_Types()
+    {
+        var leaks = typeof(Shield).Assembly
+            .GetExportedTypes()
+            .SelectMany(GetSignatureTypes)
+            .Where(static signature => !IsPubliclyVisible(signature.Type))
+            .Select(static signature => $"{signature.Member}: {signature.Type}")
+            .Order()
+            .ToArray();
+
+        await Assert.That(leaks).IsEmpty();
+    }
+
+    private static IEnumerable<(MemberInfo Member, Type Type)> GetSignatureTypes(Type type)
+    {
+        foreach (var constructor in type.GetConstructors(DeclaredPublicMembers))
+        {
+            foreach (var parameter in constructor.GetParameters())
+            {
+                yield return (constructor, parameter.ParameterType);
+            }
+        }
+
+        foreach (var method in type.GetMethods(DeclaredPublicMembers))
+        {
+            yield return (method, method.ReturnType);
+
+            foreach (var parameter in method.GetParameters())
+            {
+                yield return (method, parameter.ParameterType);
+            }
+        }
+
+        foreach (var property in type.GetProperties(DeclaredPublicMembers))
+        {
+            yield return (property, property.PropertyType);
+
+            foreach (var parameter in property.GetIndexParameters())
+            {
+                yield return (property, parameter.ParameterType);
+            }
+        }
+
+        foreach (var field in type.GetFields(DeclaredPublicMembers))
+        {
+            yield return (field, field.FieldType);
+        }
+
+        foreach (var @event in type.GetEvents(DeclaredPublicMembers))
+        {
+            yield return (@event, @event.EventHandlerType!);
+        }
+    }
+
+    private static bool IsPubliclyVisible(Type type)
+    {
+        if (type.IsGenericParameter)
+        {
+            return true;
+        }
+
+        if (type.HasElementType)
+        {
+            return IsPubliclyVisible(type.GetElementType()!);
+        }
+
+        return type.IsVisible && (!type.IsGenericType || type.GetGenericArguments().All(IsPubliclyVisible));
+    }
+}


### PR DESCRIPTION
## Summary
- make `StrategyNode` internal because it only links private strategy chains
- record removal in public API baseline
- add reflection guards for empty exported types and internal types in public signatures

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m`
- [x] `dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m`

Closes #201
