### PR TITLE
docs: expose partitioning guide

### DIFF
--- a/.github/scripts/benchmark_docs.py
+++ b/.github/scripts/benchmark_docs.py
@@ -210,7 +210,7 @@ def build_page(classes, host_info, history, window, commit):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     lines = [
         "---",
-        "sidebar_position: 12",
+        "sidebar_position: 17",
         "sidebar_label: Benchmarks",
         "---",
         "",

--- a/.github/scripts/stress_docs.py
+++ b/.github/scripts/stress_docs.py
@@ -55,7 +55,7 @@ def build_page(data, commit):
 
     lines = [
         "---",
-        "sidebar_position: 13",
+        "sidebar_position: 18",
         "sidebar_label: Stress Tests",
         "---",
         "",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
           PACKAGE_VERSION: ${{ steps.gitversion.outputs.semVer }}
         run: ./scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version $env:PACKAGE_VERSION
 
+      - name: Verify documentation structure
+        if: matrix.os == 'ubuntu-latest'
+        shell: pwsh
+        run: ./scripts/Verify-Docs.ps1
+
       - name: Compile and execute documentation snippets
         if: matrix.os == 'ubuntu-latest'
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ stateful strategies: calls made through the same shield share its circuit breake
   or both, without changing the shape of the pipeline.
 - **Composition is explicit.** Chain strategies, or combine existing shields with `Wrap` and
   `Compose`. The first strategy is always the outermost.
+- **State can be isolated by key.** [Partitioned shields](https://thomhurst.github.io/Kevlar/docs/partitioning)
+  retain independent breaker, limiter, and queue state per tenant, endpoint, or other bounded key.
 - **It is designed for hot paths.** Struct outcomes, pooled contexts, state-passing overloads and
   `ValueTask` keep overhead and allocations low. Browse the
   [benchmark suite](benchmarks/Kevlar.Benchmarks) or the published comparative

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 # Analyzers
@@ -103,9 +103,10 @@ await _dependencyShield.ExecuteAsync(static _ => ValueTask.CompletedTask);
 ```
 
 Store stateful shields in a field, singleton or keyed dependency-injection registration, or registry.
-Store `PartitionedShield<TKey>`, `PartitionedVoidShield<TKey>`, and
-`PartitionedShield<TKey, TResult>` providers for the same reason: their retained per-key shields
-disappear when the provider is constructed per call.
+Store [`PartitionedShield<TKey>`](partitioning.md),
+[`PartitionedVoidShield<TKey>`](partitioning.md), and
+[`PartitionedShield<TKey, TResult>`](partitioning.md) providers for the same reason: their retained
+per-key shields disappear when the provider is constructed per call.
 
 The rule is deliberately conservative. It reports inline construction and a stable local or local
 alias that has exactly one use in the same method or lambda. Fields, parameters, opaque factory

--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 17
 sidebar_label: Benchmarks
 ---
 

--- a/docs/docs/chaos.md
+++ b/docs/docs/chaos.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 9
 ---
 
 # Chaos engineering

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 4
 ---
 
 # Composition
@@ -81,6 +81,9 @@ That's the whole rule. Consequences:
 - Stateless custom strategy instances may appear more than once in one chain. Kevlar rejects duplicate references to built-in stateful breakers and limiters because nesting the same instance can deadlock or double-count. A stateful custom `Strategy` can opt into the same protection by overriding `IsDuplicateReferenceUnsafe` and returning `true`.
 
 This is deliberate. A circuit breaker that doesn't share state across the call sites hitting the same dependency isn't protecting anything; a rate limiter with per-call-site buckets isn't limiting anything.
+
+When one downstream dependency needs independent strategy state per endpoint, tenant, or other key,
+use a [partitioned shield](partitioning.md) to create and retain one shield instance per partition.
 
 ```csharp
 // One breaker guarding one downstream dependency, shared by two shaped pipelines:

--- a/docs/docs/custom-strategies.md
+++ b/docs/docs/custom-strategies.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 11
 ---
 
 # Custom Strategies

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -52,6 +52,9 @@ Registry semantics worth knowing:
 - Ordinary factory registrations run lazily on first resolve and the result is cached — so every consumer shares one instance (and its strategy state), exactly like instance registrations.
 - `AddShield` registers the `IKevlarRegistry` for you (`AddKevlar()` exists if you ever need just the registry).
 
+Use [`AddPartitionedShield`](partitioning.md#dependency-injection) when one registration must retain
+independent shield state per tenant, endpoint, or other key while remaining bounded.
+
 ## Binding shields from configuration
 
 `AddShield(name, IConfiguration)` builds a shield from a configuration section, so retry counts, timeouts and breaker thresholds are tunable per environment without a redeploy:

--- a/docs/docs/grpc.md
+++ b/docs/docs/grpc.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # gRPC Integration

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 12
 ---
 
 # For Library Authors

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 14
 ---
 
 # Observability

--- a/docs/docs/partitioning.md
+++ b/docs/docs/partitioning.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 5
 ---
 
 # Partitioned shields

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 16
 ---
 
 # Performance

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 19
 ---
 
 # Coming from Polly?

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -120,6 +120,9 @@ var writes  = Shield.Timeout(TimeSpan.FromSeconds(5)).Wrap(breaker);
 
 See [Composition](../composition.md#the-state-sharing-rule).
 
+For independent breaker state per tenant or endpoint, create the breaker inside a
+[partitioned shield](../partitioning.md).
+
 ## What counts as a failure
 
 Whatever the current [handling clause](../handling-failures.md) says — including handled *results* on typed shields, so an HTTP breaker can trip on 5xx responses without a single exception being thrown.

--- a/docs/docs/strategies/rate-limit.md
+++ b/docs/docs/strategies/rate-limit.md
@@ -91,7 +91,8 @@ await shield.ExecuteWithContextAsync(
 
 The partition callback receives the live pooled `KevlarContext`; read it only during the callback
 and never retain it. One `PartitionedRateLimiter<KevlarContext>` instance shares partition state
-across every shield using it, including shields returned by Kevlar's `PartitionedShield<TKey>`.
+across every shield using it, including shields returned by Kevlar's
+[`PartitionedShield<TKey>`](../partitioning.md).
 Partition retention follows the limiter implementation; keep attacker-controlled key cardinality
 bounded. The caller owns and disposes the partitioned limiter and its child limiters; Kevlar owns
 only each returned lease.

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 18
 sidebar_label: Stress Tests
 ---
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 15
 ---
 
 # Testing Your Shields

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
       ],
     },
     'composition',
+    'partitioning',
     'executing',
     'dependency-injection',
     'http',

--- a/scripts/Verify-Docs.ps1
+++ b/scripts/Verify-Docs.ps1
@@ -1,0 +1,133 @@
+[CmdletBinding()]
+param(
+    [string]$DocsPath,
+    [string]$SidebarPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path $PSScriptRoot -Parent
+if (-not $DocsPath)
+{
+    $DocsPath = Join-Path $repositoryRoot 'docs/docs'
+}
+
+if (-not $SidebarPath)
+{
+    $SidebarPath = Join-Path $repositoryRoot 'docs/sidebars.ts'
+}
+
+$resolvedDocsPath = (Resolve-Path -LiteralPath $DocsPath).Path
+$resolvedSidebarPath = (Resolve-Path -LiteralPath $SidebarPath).Path
+$sidebarSource = Get-Content -LiteralPath $resolvedSidebarPath -Raw
+$sidebarIds = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+$sidebarEntryPattern = [regex]"'(?<id>[^']+)'"
+
+foreach ($sidebarMatch in $sidebarEntryPattern.Matches($sidebarSource))
+{
+    [void]$sidebarIds.Add($sidebarMatch.Groups['id'].Value)
+}
+
+$documents = Get-ChildItem -LiteralPath $resolvedDocsPath -Recurse -File |
+    Where-Object Extension -in '.md', '.mdx' |
+    Sort-Object FullName
+$visibleDocuments = [System.Collections.Generic.List[object]]::new()
+$errors = [System.Collections.Generic.List[string]]::new()
+
+foreach ($document in $documents)
+{
+    $relativePath = [IO.Path]::GetRelativePath($resolvedDocsPath, $document.FullName).Replace('\', '/')
+    $documentId = $relativePath.Substring(0, $relativePath.Length - $document.Extension.Length)
+    $lines = @(Get-Content -LiteralPath $document.FullName)
+    $frontMatterEnd = -1
+
+    if ($lines.Count -gt 0 -and $lines[0].Trim() -eq '---')
+    {
+        for ($lineIndex = 1; $lineIndex -lt $lines.Count; $lineIndex++)
+        {
+            if ($lines[$lineIndex].Trim() -eq '---')
+            {
+                $frontMatterEnd = $lineIndex
+                break
+            }
+        }
+    }
+
+    $frontMatter = if ($frontMatterEnd -gt 1) { $lines[1..($frontMatterEnd - 1)] } else { @() }
+    $hidden = $frontMatter | Where-Object { $_ -match '^\s*(?:draft|unlisted):\s*true\s*$' }
+    if ($hidden)
+    {
+        continue
+    }
+
+    $sidebarPosition = $null
+    foreach ($line in $frontMatter)
+    {
+        if ($line -match '^\s*sidebar_position:\s*(\d+)\s*$')
+        {
+            $sidebarPosition = [int]$Matches[1]
+            break
+        }
+    }
+
+    $visibleDocuments.Add([pscustomobject]@{
+        Id = $documentId
+        Path = $relativePath
+        Directory = [IO.Path]::GetDirectoryName($relativePath).Replace('\', '/')
+        SidebarPosition = $sidebarPosition
+        Lines = $lines
+    })
+
+    if (-not $sidebarIds.Contains($documentId))
+    {
+        $errors.Add("Orphaned document '$relativePath' is not listed in docs/sidebars.ts.")
+    }
+}
+
+$positionedDocuments = $visibleDocuments | Where-Object { $null -ne $_.SidebarPosition }
+$duplicatePositions = $positionedDocuments |
+    Group-Object Directory, SidebarPosition |
+    Where-Object Count -gt 1
+
+foreach ($duplicate in $duplicatePositions)
+{
+    $paths = ($duplicate.Group.Path | Sort-Object) -join ', '
+    $errors.Add("Duplicate sidebar_position $($duplicate.Group[0].SidebarPosition) in '$($duplicate.Group[0].Directory)': $paths.")
+}
+
+$partitionLinkPattern = [regex]'\[[^\]]*(?:AddPartitionedShield|PartitionedVoidShield|PartitionedShield)[^\]]*\]\((?:\.\./)*partitioning\.md(?:#[^)]+)?\)'
+$partitionMentionPattern = [regex]'\b(?:AddPartitionedShield|PartitionedVoidShield|PartitionedShield)\b'
+
+foreach ($document in $visibleDocuments | Where-Object Path -ne 'partitioning.md')
+{
+    $insideFence = $false
+
+    for ($lineIndex = 0; $lineIndex -lt $document.Lines.Count; $lineIndex++)
+    {
+        $line = $document.Lines[$lineIndex]
+        if ($line -match '^\s*```')
+        {
+            $insideFence = -not $insideFence
+            continue
+        }
+
+        if ($insideFence)
+        {
+            continue
+        }
+
+        $withoutValidLinks = $partitionLinkPattern.Replace($line, '')
+        if ($partitionMentionPattern.IsMatch($withoutValidLinks))
+        {
+            $errors.Add("Unlinked partitioning API mention at $($document.Path):$($lineIndex + 1).")
+        }
+    }
+}
+
+if ($errors.Count -gt 0)
+{
+    $errors | ForEach-Object { Write-Error $_ -ErrorAction Continue }
+    exit 1
+}
+
+Write-Host "Verified $($visibleDocuments.Count) documentation pages: sidebar coverage, positions, and partitioning links are valid."


### PR DESCRIPTION
## Summary
- expose the partitioning guide in the sidebar and cross-link it from related guidance
- assign unique sidebar positions across the docs
- add a CI verifier for sidebar coverage, position uniqueness, and partitioning API links

## Test plan
- [x] `pwsh scripts/Verify-Docs.ps1`
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet pack Kevlar.slnx -c Release --no-build`
- [x] `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0`
- [x] `npm ci` in `docs/`
- [x] `npm run build` in `docs/`

## Screenshot
Browser automation backend was unavailable locally; production Docusaurus build completed successfully.

Closes #236