### PR TITLE
fix(http): retain shared buffer across attempts

### DIFF
--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -94,7 +94,6 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
 
         private Task<HttpRequestTemplate>? _template;
         private CancellationTokenSource? _templateCancellation;
-        private int _templateWaiters;
         private HttpResponseMessage? _terminalResponse;
         private CancellationToken _lastAttemptToken;
         private int _attempt;
@@ -212,6 +211,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         public void Complete(HttpResponseMessage? terminalResponse)
         {
             List<HttpResponseMessage>? discarded = null;
+            CancellationTokenSource? templateCancellation = null;
             lock (_gate)
             {
                 if (_completed)
@@ -230,6 +230,15 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
                 }
 
                 _responses.Clear();
+                if (_template is { IsCompleted: false })
+                {
+                    templateCancellation = _templateCancellation;
+                }
+            }
+
+            if (templateCancellation is not null)
+            {
+                Cancel(templateCancellation);
             }
 
             DisposeResponses(discarded);
@@ -253,7 +262,6 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
                 }
 
                 template = _template;
-                _templateWaiters++;
             }
 
             if (creation is not null)
@@ -273,29 +281,6 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
                     exception.Message,
                     exception,
                     _executionCancellationToken);
-            }
-            finally
-            {
-                CancellationTokenSource? abandon = null;
-                lock (_gate)
-                {
-                    _templateWaiters--;
-#if !NETSTANDARD2_0
-                    if (_templateWaiters == 0
-                        && ReferenceEquals(_template, template)
-                        && !template.IsCompleted)
-                    {
-                        _template = null;
-                        abandon = _templateCancellation;
-                        _templateCancellation = null;
-                    }
-#endif
-                }
-
-                if (abandon is not null)
-                {
-                    Cancel(abandon);
-                }
             }
         }
 
@@ -429,7 +414,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             }
             catch (ObjectDisposedException)
             {
-                // Template completion may dispose the source as the last waiter exits.
+                // Template completion may dispose the source concurrently.
             }
         }
     }

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -305,7 +305,11 @@ public class HttpReplayTests
             {
                 options.MaxAttempts = 2;
                 options.Delay = TimeSpan.FromMilliseconds(250);
-                options.OnHedge = _ => hedgeLaunched.TrySetResult();
+                options.OnHedgeAsync = async _ =>
+                {
+                    hedgeLaunched.TrySetResult();
+                    await attemptTimedOut.Task;
+                };
             })
             .Timeout(options =>
             {


### PR DESCRIPTION
## Summary
- keep request-content buffering alive for the full request execution instead of per-attempt waiter lifetimes
- cancel pending buffering when the overall execution completes or caller cancellation fires
- make the hedge/attempt-timeout race deterministic in the integration test

## Test plan
- [x] deterministic regression fails before fix with 2 serializations
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (123 passed)
- [x] `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (10 passed)
- [x] focused hedge buffering regression repeated 10/10 successfully

## Benchmark
BenchmarkDotNet ShortRun, Windows 11, .NET 10.0.11, `HttpReplayBenchmarks.BufferedContent_WithRetry`:

| | Mean | Allocated |
|---|---:|---:|
| Before | 2.247 μs | 3.17 KB |
| After | 1.959 μs | 3.16 KB |

No throughput or allocation regression observed (~13% lower mean in this short local run).

Closes #248