### PR TITLE
fix(api): disambiguate typed fallback values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   `ShieldBuilder.Fallback(...)` similarly returns `VoidShield`; its later `When...` clauses use
   `VoidShieldBuilder`. Use `Shield.For<TResult>().Fallback(...)` for result-producing recovery.
 - Configure fallback notifications through `Fallback(..., configure)`. The pre-release `FallbackWithNotifications` methods and typed `onFallback` parameters were removed, including the migration-only error overloads that briefly replaced them. Every fallback shape now has exactly two overloads — bare and `Action<FallbackOptions>`/`Action<FallbackOptions<TResult>>` — on `Shield`, `Shield<TResult>`, `ShieldBuilder` and `ShieldBuilder<TResult>`.
+- Typed constant-value `Fallback(value)` is now `FallbackTo(value)` on `Shield<TResult>` and
+  `ShieldBuilder<TResult>`. Delegate factories remain `Fallback(...)`. This makes null fallback
+  values explicit and avoids ambiguity between value and delegate overloads.
 
 Handling clauses now use one spelling per position. `When…` starts a clause on `Shield` or
 `Shield<TResult>`; only `Or…` continues it on a builder. `Shield.For<TResult>()` now returns
@@ -24,6 +27,7 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 | `builder.OrWhen(predicate)` | `builder.Or(predicate)` |
 | `Shield.For<T>().WhenDefault()` | `Shield.For<T>().WhenResultIsDefault()` |
 | `builder.OrDefault()` | `builder.OrResultIsDefault()` |
+| `Shield.For<T>().Fallback(value)` | `Shield.For<T>().FallbackTo(value)` |
 
 `OrWhen` is gone: `Or(Func<Exception, bool>)` now mirrors `When(Func<Exception, bool>)`, so the
 untyped predicate has the same spelling in both clause positions. `WhenDefault`/`OrDefault` were

--- a/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
@@ -19,21 +19,21 @@ public class FallbackBenchmarks
 
     private static readonly Shield<int> KevlarFallback = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(7);
+        .FallbackTo(7);
 
     private static readonly Shield<int> KevlarSyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(7, static options => options.OnFallback = static _ => { });
+        .FallbackTo(7, static options => options.OnFallback = static _ => { });
 
     private static readonly Shield<int> KevlarCompletedAsyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(
+        .FallbackTo(
             7,
             static options => options.OnFallbackAsync = static _ => ValueTask.CompletedTask);
 
     private static readonly Shield<int> KevlarYieldingAsyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(
+        .FallbackTo(
             7,
             static options => options.OnFallbackAsync = static async _ => await Task.Yield());
 

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -63,7 +63,7 @@ time. Put fallback first so it wraps the reactive strategy:
 
 ```csharp
 var shield = Shield.For<int>()
-    .Fallback(-1)
+    .FallbackTo(-1)
     .Retry(3);
 ```
 
@@ -74,7 +74,7 @@ is intentional:
 var shield = Shield.For<int>()
     .Retry(3)
     .When<TimeoutExceededException>()
-    .Fallback(-1);
+    .FallbackTo(-1);
 ```
 
 No automatic code fix is supplied for `KEV002` or `KEV003`: changing sync control flow or strategy

--- a/docs/docs/chaos.md
+++ b/docs/docs/chaos.md
@@ -63,7 +63,7 @@ var unavailable = ChaosShield.Outcome<int>(options =>
 
 var shield = Shield.For<int>()
     .WhenResult(-1)
-    .Fallback(0)
+    .FallbackTo(0)
     .Wrap(unavailable);
 
 var value = await shield.ExecuteAsync(static _ => new ValueTask<int>(42));

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -139,11 +139,11 @@ One ordering is always a bug: a `Fallback` chained *after* (inside) a retry, hed
 
 <!-- doc-test-run: invalid-composition -->
 ```csharp
-Shield.For<int>().Retry(3).Fallback(-1);
+Shield.For<int>().Retry(3).FallbackTo(-1);
 // InvalidOperationException: … makes Retry(3, …) unreachable.
 // Chain the Fallback first (the first strategy is the outermost) …
 
-Shield.For<int>().Fallback(-1).Retry(3);   // ✔ retry runs inside, fallback recovers after it gives up
+Shield.For<int>().FallbackTo(-1).Retry(3);   // ✔ retry runs inside, fallback recovers after it gives up
 ```
 
 A fallback with its own *narrower* clause is still allowed inside — that's a deliberate layered recovery, not a mistake.

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -11,7 +11,7 @@ Result-producing fallbacks live on **typed** shields — reach one via `Shield.F
 ```csharp
 var shield = Shield.For<Config>()
     .When<HttpRequestException>()
-    .Fallback(Config.Default);
+    .FallbackTo(Config.Default);
 ```
 
 Void executions get their own fallback on the plain `Shield` — run an alternative action instead of producing a value:
@@ -52,8 +52,8 @@ await shield.ExecuteAsync(static _ => ValueTask.CompletedTask); // valid
 
 <!-- doc-test-ignore: Alternative fluent fragments require the typed builder introduced by the surrounding prose. -->
 ```csharp
-// 1. A constant value:
-.Fallback(Config.Default)
+// 1. A constant value (FallbackTo avoids null/delegate overload ambiguity):
+.FallbackTo(Config.Default)
 
 // 2. Computed (async), no failure context needed:
 .Fallback(ct => new ValueTask<Config>(cache.Get()))
@@ -66,16 +66,18 @@ await shield.ExecuteAsync(static _ => ValueTask.CompletedTask); // valid
 })
 ```
 
-Every overload also has an options configurator for fallback notifications:
+Every value and factory shape also has an options configurator for fallback notifications:
 
 <!-- doc-test-ignore: Fluent fragment requires the typed builder introduced by the surrounding prose. -->
 ```csharp
-.Fallback(Config.Default,
+.FallbackTo(Config.Default,
     options => options.OnFallback = e => metrics.Increment("config.fallback"))
 ```
 
-Each shape has exactly two overloads — bare and `configure`. There is no positional `onFallback`
-parameter: assign the callback to `options.OnFallback` as shown above.
+`FallbackTo` handles constant values; `Fallback` handles computed and outcome-aware factories. Each
+shape has bare and `configure` overloads. This split means `.FallbackTo(null)` binds unambiguously
+for reference and nullable result types. There is no positional `onFallback` parameter: assign the
+callback to `options.OnFallback` as shown above.
 
 The `FallbackEvent<T>` carries the failure that triggered it as a typed `Outcome<T>` — `Outcome.Exception` when an exception was handled, `Outcome.Result` when a result value was. No casting, no boxing.
 
@@ -91,7 +93,7 @@ Configure both synchronous and awaited notification work in the same lambda:
 ```csharp
 var shield = Shield.For<Config>()
     .When<HttpRequestException>()
-    .Fallback(
+    .FallbackTo(
         Config.Default,
         options =>
         {
@@ -140,7 +142,7 @@ Cancellation can be recovered explicitly when that is intentional:
 ```csharp
 var shield = Shield.For<Config>()
     .When<OperationCanceledException>()
-    .Fallback(Config.Default);
+    .FallbackTo(Config.Default);
 ```
 
 Async typed and void fallback delegates receive the active `CancellationToken`. Caller
@@ -157,7 +159,7 @@ Fallback is usually **outermost** — the last line of defence after retries and
 var shield = Shield.For<Quote>()
     .When<HttpRequestException>()
     .Or<CircuitOpenException>()      // catch the breaker's rejection too
-    .Fallback(Quote.Unavailable)
+    .FallbackTo(Quote.Unavailable)
     .Retry(3)
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 ```

--- a/scripts/Verify-PublishCompatibility.ps1
+++ b/scripts/Verify-PublishCompatibility.ps1
@@ -172,7 +172,7 @@ var broken = await Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).ExecuteAsyn
 var limited = await Shield.RateLimit(1, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
 var isolated = await Shield.ConcurrencyLimit(1).ExecuteAsync(static _ => new ValueTask<int>(42));
 var hedged = await Shield.Hedge(2, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
-var fallback = await Shield.For<int>().When<InvalidOperationException>().Fallback(42)
+var fallback = await Shield.For<int>().When<InvalidOperationException>().FallbackTo(42)
     .ExecuteAsync<int>(static _ => throw new InvalidOperationException());
 using var frameworkLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
 {

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -144,7 +144,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 invocation.Syntax.GetLocation()));
         }
 
-        if (IsKevlarFluentMethod(invocation.TargetMethod, knownTypes, "Fallback")
+        if (IsFallbackMethod(invocation.TargetMethod, knownTypes)
             && HasLocalHandlingOverride(invocation, context) is false
             && FindInPipeline(
                 GetReceiver(invocation),
@@ -361,8 +361,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     /// inherits is already spelled out at the call site.
     /// </summary>
     private static bool IsClauseConsumingStrategy(IMethodSymbol method, KnownTypes knownTypes) =>
-        (method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker" or "Fallback")
-        && IsKevlarFluentMethod(method, knownTypes);
+        IsFallbackMethod(method, knownTypes)
+        || ((method.Name is "Retry" or "RetryForever" or "Hedge" or "CircuitBreaker")
+            && IsKevlarFluentMethod(method, knownTypes));
+
+    private static bool IsFallbackMethod(IMethodSymbol method, KnownTypes knownTypes) =>
+        IsKevlarFluentMethod(method, knownTypes, "Fallback")
+        || IsKevlarFluentMethod(method, knownTypes, "FallbackTo");
 
     /// <summary>Renders a clause declaration the way it was written, e.g. <c>When&lt;HttpRequestException&gt;…</c>.</summary>
     private static string DescribeClause(IInvocationOperation invocation) =>
@@ -1026,7 +1031,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             if (!FindInPipeline(
                 operands[fallbackIndex],
                 context,
-                candidate => IsKevlarFluentMethod(candidate.TargetMethod, knownTypes, "Fallback")
+                candidate => IsFallbackMethod(candidate.TargetMethod, knownTypes)
                     && HasLocalHandlingOverride(candidate, context) is false,
                 knownTypes,
                 stopAtHandlingClause: true,

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -107,15 +107,15 @@ Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Thre
 Kevlar.Shield<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.FallbackTo(TResult fallbackValue) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.FallbackTo(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.VoidShield!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.FallbackTo(TResult fallbackValue) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.FallbackTo(TResult fallbackValue, System.Action<Kevlar.FallbackOptions<TResult>!>! configure) -> Kevlar.Shield<TResult>!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.VoidShield!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.VoidShield!
 Kevlar.HedgeActionGenerator

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -126,7 +126,7 @@ public sealed class Shield
     /// Starts a pipeline with a fallback that runs <paramref name="fallback"/> in place of handled
     /// failures, receiving the handled exception. Applies to void executions only; result-returning
     /// executions fail with a descriptive <see cref="InvalidOperationException"/> — use
-    /// <c>Shield.For&lt;T&gt;().Fallback(…)</c> for those.
+    /// <c>Shield.For&lt;T&gt;().FallbackTo(…)</c> for constant values or its typed <c>Fallback(…)</c> overloads for factories.
     /// </summary>
     /// <remarks>
     /// A fallback is legitimately the outermost strategy: it recovers what everything chained
@@ -148,7 +148,7 @@ public sealed class Shield
     /// <summary>
     /// Starts a pipeline with a fallback that runs <paramref name="fallback"/> in place of handled
     /// failures. Returns a <see cref="VoidShield"/>, which exposes only void execution overloads.
-    /// Use <c>Shield.For&lt;T&gt;().Fallback(…)</c> for result-producing recovery.
+    /// Use <c>Shield.For&lt;T&gt;().FallbackTo(…)</c> for constant values or its typed <c>Fallback(…)</c> overloads for factories.
     /// </summary>
     public static VoidShield Fallback(Func<CancellationToken, ValueTask> fallback) =>
         ShieldExtensions.Fallback(Empty, fallback);

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -128,7 +128,7 @@ public sealed class ShieldBuilder
     /// <summary>
     /// Runs <paramref name="fallback"/> in place of handled failures and returns a
     /// <see cref="VoidShield"/> exposing only void execution overloads. Result-producing recovery
-    /// needs <c>Shield.For&lt;T&gt;().Fallback(…)</c>.
+    /// needs <c>Shield.For&lt;T&gt;().FallbackTo(…)</c> for a constant value or a typed <c>Fallback(…)</c> factory.
     /// </summary>
     public VoidShield Fallback(Func<Exception, CancellationToken, ValueTask> fallback) => Seal().Fallback(fallback);
 

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -142,11 +142,11 @@ public sealed class ShieldBuilder<TResult>
     public Shield<TResult> Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
-    public Shield<TResult> Fallback(TResult fallbackValue) => Seal().Fallback(fallbackValue);
+    public Shield<TResult> FallbackTo(TResult fallbackValue) => Seal().FallbackTo(fallbackValue);
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
-    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure) =>
-        Seal().Fallback(fallbackValue, configure);
+    public Shield<TResult> FallbackTo(TResult fallbackValue, Action<FallbackOptions<TResult>> configure) =>
+        Seal().FallbackTo(fallbackValue, configure);
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
     public Shield<TResult> Fallback(Func<CancellationToken, ValueTask<TResult>> fallback) => Seal().Fallback(fallback);

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -273,7 +273,7 @@ public static class ShieldExtensions
     /// <summary>
     /// Runs <paramref name="fallback"/> in place of handled failures, receiving the handled
     /// exception. Returns a <see cref="VoidShield"/>, which exposes only void execution overloads.
-    /// Use <c>Shield.For&lt;T&gt;().Fallback(…)</c> for result-producing recovery.
+    /// Use <c>Shield.For&lt;T&gt;().FallbackTo(…)</c> for constant values or its typed <c>Fallback(…)</c> overloads for factories.
     /// </summary>
     public static VoidShield Fallback(this Shield shield, Func<Exception, CancellationToken, ValueTask> fallback)
     {
@@ -309,7 +309,7 @@ public static class ShieldExtensions
     /// <summary>
     /// Runs <paramref name="fallback"/> in place of handled failures. Returns a
     /// <see cref="VoidShield"/>, which exposes only void execution overloads. Use
-    /// <c>Shield.For&lt;T&gt;().Fallback(…)</c> for result-producing recovery.
+    /// <c>Shield.For&lt;T&gt;().FallbackTo(…)</c> for constant values or its typed <c>Fallback(…)</c> overloads for factories.
     /// </summary>
     public static VoidShield Fallback(this Shield shield, Func<CancellationToken, ValueTask> fallback)
     {

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -208,12 +208,12 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
-    public Shield<TResult> Fallback(TResult fallbackValue) =>
+    public Shield<TResult> FallbackTo(TResult fallbackValue) =>
         Append(new FallbackStrategy<TResult>((_, _) => new ValueTask<TResult>(fallbackValue), JudgeOrDefault, null, null));
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
     /// <remarks>Runs <see cref="FallbackOptions{TResult}.OnFallback"/>, then <see cref="FallbackOptions{TResult}.OnFallbackAsync"/>, before recovery. A notification failure skips recovery.</remarks>
-    public Shield<TResult> Fallback(TResult fallbackValue, Action<FallbackOptions<TResult>> configure)
+    public Shield<TResult> FallbackTo(TResult fallbackValue, Action<FallbackOptions<TResult>> configure)
     {
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions<TResult>();

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -37,7 +37,14 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
     bool IFallbackStrategyInspection.HasNotification =>
         _onFallback is not null || _onFallbackAsync is not null;
 
-    public override string Describe() => "Fallback";
+    public override string Describe()
+    {
+        // Keep FallbackTo's execution delegate identical to the original captured-lambda fast path.
+        // Description runs off-path, so identifying its compiler-generated method adds no execution cost.
+        return _fallback.Method.Name.StartsWith("<FallbackTo>", StringComparison.Ordinal)
+            ? "Fallback(value)"
+            : "Fallback";
+    }
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -48,7 +48,7 @@ public class AllocationBudgetTests
     });
     private readonly Shield<int> _fallback = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(7);
+        .FallbackTo(7);
     private readonly Shield _rateLimit = Shield.RateLimit(1_000_000_000, TimeSpan.FromSeconds(1));
     private readonly Shield _rateLimitWithRejectionHooks = Shield.RateLimit(options =>
     {
@@ -87,13 +87,13 @@ public class AllocationBudgetTests
     private readonly Shield _openBreaker = Shield.CircuitBreaker(1, TimeSpan.FromDays(1));
     private readonly Shield<int> _triggeredFallback = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(7);
+        .FallbackTo(7);
     private readonly Shield<int> _fallbackWithSyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(7, static options => options.OnFallback = static _ => { });
+        .FallbackTo(7, static options => options.OnFallback = static _ => { });
     private readonly Shield<int> _fallbackWithAsyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
-        .Fallback(
+        .FallbackTo(
             7,
             static options => options.OnFallbackAsync = static _ => ValueTask.CompletedTask);
     private readonly Shield _parallelHedge = Shield.Hedge(2, TimeSpan.Zero);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -16,16 +16,16 @@ public class PipelineHazardAnalyzerTests
             {
                 public void Configure()
                 {
-                    _ = Shield.For<int>().Fallback(42);
+                    _ = Shield.For<int>().FallbackTo(42);
                     _ = Shield.For<int>().Fallback(_ => new ValueTask<int>(42));
                     _ = Shield.For<int>().Fallback((_, _) => new ValueTask<int>(42));
-                    _ = Shield.For<int>().Fallback(42, options => options.OnFallback = _ => { });
+                    _ = Shield.For<int>().FallbackTo(42, options => options.OnFallback = _ => { });
                     _ = Shield.For<int>().Fallback(_ => new ValueTask<int>(42), options => options.OnFallback = _ => { });
                     _ = Shield.For<int>().Fallback((_, _) => new ValueTask<int>(42), options => options.OnFallback = _ => { });
-                    _ = Shield.For<int>().When<Exception>().Fallback(42);
+                    _ = Shield.For<int>().When<Exception>().FallbackTo(42);
                     _ = Shield.For<int>().When<Exception>().Fallback(_ => new ValueTask<int>(42));
                     _ = Shield.For<int>().When<Exception>().Fallback((_, _) => new ValueTask<int>(42));
-                    _ = Shield.For<int>().When<Exception>().Fallback(42, options => options.OnFallback = _ => { });
+                    _ = Shield.For<int>().When<Exception>().FallbackTo(42, options => options.OnFallback = _ => { });
                     _ = Shield.For<int>().When<Exception>().Fallback(_ => new ValueTask<int>(42), options => options.OnFallback = _ => { });
                     _ = Shield.For<int>().When<Exception>().Fallback((_, _) => new ValueTask<int>(42), options => options.OnFallback = _ => { });
                 }
@@ -43,8 +43,8 @@ public class PipelineHazardAnalyzerTests
                 public void Configure()
                 {
                     Action<FallbackEvent<int>> callback = _ => { };
-                    _ = Shield.For<int>().Fallback(42, callback);
-                    _ = Shield.For<int>().When<Exception>().Fallback(42, callback);
+                    _ = Shield.For<int>().FallbackTo(42, callback);
+                    _ = Shield.For<int>().When<Exception>().FallbackTo(42, callback);
                 }
             }
             """));
@@ -143,7 +143,7 @@ public class PipelineHazardAnalyzerTests
         {
             "_ = Shield.Retry(2).Execute(_ => 1);",
             "await Shield.Timeout(TimeSpan.FromSeconds(1)).ExecuteAsync(_ => new ValueTask<int>(1));",
-            "await Shield.For<int>().Fallback(0).ExecuteOutcomeAsync(_ => new ValueTask<int>(1));",
+            "await Shield.For<int>().FallbackTo(0).ExecuteOutcomeAsync(_ => new ValueTask<int>(1));",
             "var shield = Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)); _ = shield.Execute(_ => 1); _ = shield.Execute(_ => 2);",
             "var shield = CreateShield(); _ = shield.Execute(_ => 1);",
             "var partitions = new PartitionedShield<string>(_ => Shield.Empty); _ = partitions.GetShield(\"one\"); _ = partitions.GetShield(\"two\").Execute(_ => 1);",
@@ -588,7 +588,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
             "_ = Shield.When<InvalidOperationException>().Fallback(static (_, _) => default);",
-            "_ = Shield.For<int>().WhenResult(static value => value < 0).Fallback(0);",
+            "_ = Shield.For<int>().WhenResult(static value => value < 0).FallbackTo(0);",
             "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
             "var clause = Shield.When<InvalidOperationException>(); _ = clause.Retry(1);",
             "var clause = Shield.When<InvalidOperationException>(); _ = clause.Or<TimeoutException>().Retry(1);",
@@ -649,7 +649,7 @@ public class PipelineHazardAnalyzerTests
             "Shield.Empty.For<int>();",
             "Shield.For<int>().Retry(3);",
             "Shield.When<InvalidOperationException>().Retry(3);",
-            "Shield.For<int>().WhenResult(static value => value < 0).Fallback(0);",
+            "Shield.For<int>().WhenResult(static value => value < 0).FallbackTo(0);",
             "Shield.Compose(Shield.Empty, Shield.Empty);",
             "var shield = Shield.Empty; shield.Timeout(TimeSpan.FromSeconds(1));",
         };
@@ -736,35 +736,35 @@ public class PipelineHazardAnalyzerTests
     {
         var cases = new[]
         {
-            "_ = Shield.For<int>().Retry(1).Fallback(0);",
-            "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero).Fallback(0);",
-            "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).Fallback(0);",
-            "_ = Shield.For<int>().CircuitBreaker(options => options.ConsecutiveFailures = 2).Fallback(0);",
-            "_ = Shield.For<int>().CircuitBreaker(options => options.BreakDuration = TimeSpan.FromSeconds(1)).Fallback(0);",
-            "_ = Shield.For<int>().CircuitBreaker(options => options.HandlesException = null).Fallback(0);",
-            "_ = Shield.For<int>().CircuitBreaker(options => options.OnStateChanged = _ => options.HandlesException = exception => exception is TimeoutException).Fallback(0);",
-            "_ = Shield.For<int>().WhenResult(0).Retry(1).Fallback(0);",
-            "_ = Shield.For<int>().Retry(1).Fallback(0, static options => options.OnFallback = static _ => { });",
+            "_ = Shield.For<int>().Retry(1).FallbackTo(0);",
+            "_ = Shield.For<int>().Hedge(2, TimeSpan.Zero).FallbackTo(0);",
+            "_ = Shield.For<int>().CircuitBreaker(2, TimeSpan.FromSeconds(1)).FallbackTo(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.ConsecutiveFailures = 2).FallbackTo(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.BreakDuration = TimeSpan.FromSeconds(1)).FallbackTo(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.HandlesException = null).FallbackTo(0);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.OnStateChanged = _ => options.HandlesException = exception => exception is TimeoutException).FallbackTo(0);",
+            "_ = Shield.For<int>().WhenResult(0).Retry(1).FallbackTo(0);",
+            "_ = Shield.For<int>().Retry(1).FallbackTo(0, static options => options.OnFallback = static _ => { });",
             "_ = Shield.Retry(1).Fallback(static _ => ValueTask.CompletedTask, static options => options.OnFallback = static _ => { });",
-            "_ = Shield.For<int>().Retry(1).WhenAnyError().Fallback(0);",
-            "_ = Shield.For<int>().Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero).WhenAnyError().Fallback(0);",
-            "_ = Shield.For<int>().Retry(1).When<ArgumentException>().Timeout(TimeSpan.Zero).When<InvalidOperationException>().Timeout(TimeSpan.Zero).WhenAnyError().Fallback(0);",
-            "var shield = Shield.For<int>().Retry(1); var alias = shield; _ = alias.Fallback(0);",
-            "Shield<int>? shield = Shield.For<int>().Retry(1); _ = shield?.Fallback(0);",
+            "_ = Shield.For<int>().Retry(1).WhenAnyError().FallbackTo(0);",
+            "_ = Shield.For<int>().Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero).WhenAnyError().FallbackTo(0);",
+            "_ = Shield.For<int>().Retry(1).When<ArgumentException>().Timeout(TimeSpan.Zero).When<InvalidOperationException>().Timeout(TimeSpan.Zero).WhenAnyError().FallbackTo(0);",
+            "var shield = Shield.For<int>().Retry(1); var alias = shield; _ = alias.FallbackTo(0);",
+            "Shield<int>? shield = Shield.For<int>().Retry(1); _ = shield?.FallbackTo(0);",
             "_ = ShieldExtensions.Fallback(ShieldExtensions.Retry(Shield.Empty, 1), static _ => ValueTask.CompletedTask);",
-            "_ = Shield.For<int>().Retry(1).Wrap(Shield.Empty).Fallback(0);",
-            "_ = Shield.For<int>().Retry(1).Wrap(Shield.Timeout(TimeSpan.FromSeconds(1))).Fallback(0);",
-            "_ = Shield<int>.Empty.Wrap(Shield.Retry(1)).Fallback(0);",
-            "_ = Shield.Compose(Shield.Retry(1)).For<int>().Fallback(0);",
-            "_ = Shield.Compose(Shield.Timeout(TimeSpan.FromSeconds(1)), Shield.Retry(1)).For<int>().Fallback(0);",
-            "_ = Shield.Compose([Shield.Retry(1)]).For<int>().Fallback(0);",
-            "var parts = new[] { Shield.Retry(1) }; _ = Shield.Compose(parts).For<int>().Fallback(0);",
-            "_ = Shield.For<int>().Retry(1).Wrap(Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1))).Fallback(0);",
-            "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Wrap(Shield.Retry(1)).Fallback(0);",
-            "_ = Shield.Compose(Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)), Shield.Retry(1)).For<int>().Fallback(0);",
-            "_ = Shield.For<int>().Retry(1).When<ArgumentException>().Timeout(TimeSpan.Zero).Wrap(Shield.Empty).Fallback(0);",
-            "_ = Shield.Compose(Shield.Retry(1).When<ArgumentException>().Timeout(TimeSpan.Zero), Shield.Empty).For<int>().Fallback(0);",
-            "var retry = Shield.Retry(1); var fallback = Shield.For<int>().Fallback(0); _ = retry.Wrap(fallback);",
+            "_ = Shield.For<int>().Retry(1).Wrap(Shield.Empty).FallbackTo(0);",
+            "_ = Shield.For<int>().Retry(1).Wrap(Shield.Timeout(TimeSpan.FromSeconds(1))).FallbackTo(0);",
+            "_ = Shield<int>.Empty.Wrap(Shield.Retry(1)).FallbackTo(0);",
+            "_ = Shield.Compose(Shield.Retry(1)).For<int>().FallbackTo(0);",
+            "_ = Shield.Compose(Shield.Timeout(TimeSpan.FromSeconds(1)), Shield.Retry(1)).For<int>().FallbackTo(0);",
+            "_ = Shield.Compose([Shield.Retry(1)]).For<int>().FallbackTo(0);",
+            "var parts = new[] { Shield.Retry(1) }; _ = Shield.Compose(parts).For<int>().FallbackTo(0);",
+            "_ = Shield.For<int>().Retry(1).Wrap(Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1))).FallbackTo(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Wrap(Shield.Retry(1)).FallbackTo(0);",
+            "_ = Shield.Compose(Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)), Shield.Retry(1)).For<int>().FallbackTo(0);",
+            "_ = Shield.For<int>().Retry(1).When<ArgumentException>().Timeout(TimeSpan.Zero).Wrap(Shield.Empty).FallbackTo(0);",
+            "_ = Shield.Compose(Shield.Retry(1).When<ArgumentException>().Timeout(TimeSpan.Zero), Shield.Empty).For<int>().FallbackTo(0);",
+            "var retry = Shield.Retry(1); var fallback = Shield.For<int>().FallbackTo(0); _ = retry.Wrap(fallback);",
             "var retry = Shield.Retry(1); var fallback = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); _ = retry.Wrap(fallback);",
         };
 
@@ -782,13 +782,13 @@ public class PipelineHazardAnalyzerTests
 
             public class TestSubject
             {
-                public Shield<int> Build() => KShield.For<int>().Retry(1).Fallback(0);
+                public Shield<int> Build() => KShield.For<int>().Retry(1).FallbackTo(0);
             }
             """);
         var genericDiagnostics = await AnalyzeSourceAsync("""
             public class TestSubject
             {
-                public Shield<T> Build<T>() => Shield.For<T>().Retry(1).Fallback((T)default!);
+                public Shield<T> Build<T>() => Shield.For<T>().Retry(1).FallbackTo((T)default!);
             }
             """);
 
@@ -800,7 +800,7 @@ public class PipelineHazardAnalyzerTests
     public async Task KEV003_Skips_Reactive_Strategy_With_Local_Handling_Override()
     {
         var diagnostics = await AnalyzeBodyAsync(
-            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException = exception => exception is TimeoutException).Fallback(0);");
+            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException = exception => exception is TimeoutException).FallbackTo(0);");
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -810,8 +810,8 @@ public class PipelineHazardAnalyzerTests
     {
         var cases = new[]
         {
-            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException ??= exception => exception is TimeoutException).Fallback(0);",
-            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException += exception => exception is TimeoutException).Fallback(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException ??= exception => exception is TimeoutException).FallbackTo(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException += exception => exception is TimeoutException).FallbackTo(0);",
         };
 
         foreach (var body in cases)
@@ -825,7 +825,7 @@ public class PipelineHazardAnalyzerTests
     public async Task KEV003_Skips_Fallback_With_Local_Handling_Override()
     {
         var diagnostics = await AnalyzeBodyAsync(
-            "_ = Shield.For<int>().Retry(1).Fallback(0, options => options.HandlesException = exception => exception is TimeoutException);");
+            "_ = Shield.For<int>().Retry(1).FallbackTo(0, options => options.HandlesException = exception => exception is TimeoutException);");
 
         await Assert.That(diagnostics).IsEmpty();
     }
@@ -836,9 +836,9 @@ public class PipelineHazardAnalyzerTests
         var diagnostics = await AnalyzeBodyAsync(
             """
             Action<CircuitBreakerOptions<int>> configure = ConfigureBreaker;
-            _ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).Fallback(0);
-            _ = Shield.For<int>().CircuitBreaker(configure).Fallback(0);
-            _ = Shield.For<int>().Retry(1).Fallback(0, ConfigureFallback);
+            _ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).FallbackTo(0);
+            _ = Shield.For<int>().CircuitBreaker(configure).FallbackTo(0);
+            _ = Shield.For<int>().Retry(1).FallbackTo(0, ConfigureFallback);
             """,
             """
             private static void ConfigureBreaker(CircuitBreakerOptions<int> options) =>
@@ -855,7 +855,7 @@ public class PipelineHazardAnalyzerTests
     public async Task KEV003_Follows_Source_Configurator_Helper_Calls()
     {
         var diagnostics = await AnalyzeBodyAsync(
-            "_ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).Fallback(0);",
+            "_ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).FallbackTo(0);",
             """
             private static void ConfigureBreaker(CircuitBreakerOptions<int> options) =>
                 ApplyHandling(options);
@@ -871,7 +871,7 @@ public class PipelineHazardAnalyzerTests
     public async Task KEV003_Propagates_Unknown_From_Nested_Configurator_Call()
     {
         var diagnostics = await AnalyzeBodyAsync(
-            "_ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).Fallback(0);",
+            "_ = Shield.For<int>().CircuitBreaker(ConfigureBreaker).FallbackTo(0);",
             """
             private static Action<CircuitBreakerOptions<int>> SharedConfigure { get; } =
                 options => options.HandlesException = exception => exception is TimeoutException;
@@ -893,7 +893,7 @@ public class PipelineHazardAnalyzerTests
                 Shield.For<int>()
                     .When<InvalidOperationException>()
                     .CircuitBreaker(configure)
-                    .Fallback(0);
+                    .FallbackTo(0);
             """);
 
         await Assert.That(diagnostics).IsEmpty();
@@ -904,22 +904,22 @@ public class PipelineHazardAnalyzerTests
     {
         var cases = new[]
         {
-            "_ = Shield.For<int>().Fallback(0).Retry(1);",
-            "_ = Shield.For<int>().Retry(1).When<InvalidOperationException>().Fallback(0);",
-            "_ = Shield.For<int>().When<InvalidOperationException>().Retry(1).WhenAnyError().Fallback(0);",
-            "_ = Shield.For<int>().When<ArgumentException>().Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero).CircuitBreaker(2, TimeSpan.FromSeconds(1)).WhenAnyError().Fallback(0);",
-            "_ = Shield.For<int>().Timeout(TimeSpan.FromSeconds(1)).Fallback(0);",
-            "var shield = CreateShield(); _ = shield.Fallback(0);",
-            "var shield = Shield.For<int>().Retry(1); shield = Shield<int>.Empty; _ = shield.Fallback(0);",
-            "_ = Shield.For<int>().WhenResult(0).Retry(1).Wrap(Shield.Empty).Fallback(0);",
-            "_ = Shield.Compose(Shield.When<InvalidOperationException>().Retry(1), Shield.Empty).For<int>().Fallback(0);",
-            "var clause = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = outer.Wrap(clause).Fallback(0);",
-            "var clause = Shield.When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = Shield.Compose(outer, clause).For<int>().Fallback(0);",
-            "var parts = new[] { Shield.Retry(1) }; parts[0] = Shield.Empty; _ = Shield.Compose(parts).For<int>().Fallback(0);",
-            "var builder = Shield.For<int>().When<InvalidOperationException>(); var retry = builder.Retry(1); _ = retry.Wrap(builder.Timeout(TimeSpan.Zero)).Fallback(0);",
+            "_ = Shield.For<int>().FallbackTo(0).Retry(1);",
+            "_ = Shield.For<int>().Retry(1).When<InvalidOperationException>().FallbackTo(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Retry(1).WhenAnyError().FallbackTo(0);",
+            "_ = Shield.For<int>().When<ArgumentException>().Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero).CircuitBreaker(2, TimeSpan.FromSeconds(1)).WhenAnyError().FallbackTo(0);",
+            "_ = Shield.For<int>().Timeout(TimeSpan.FromSeconds(1)).FallbackTo(0);",
+            "var shield = CreateShield(); _ = shield.FallbackTo(0);",
+            "var shield = Shield.For<int>().Retry(1); shield = Shield<int>.Empty; _ = shield.FallbackTo(0);",
+            "_ = Shield.For<int>().WhenResult(0).Retry(1).Wrap(Shield.Empty).FallbackTo(0);",
+            "_ = Shield.Compose(Shield.When<InvalidOperationException>().Retry(1), Shield.Empty).For<int>().FallbackTo(0);",
+            "var clause = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = outer.Wrap(clause).FallbackTo(0);",
+            "var clause = Shield.When<InvalidOperationException>().Timeout(TimeSpan.Zero); var outer = clause.Retry(1); _ = Shield.Compose(outer, clause).For<int>().FallbackTo(0);",
+            "var parts = new[] { Shield.Retry(1) }; parts[0] = Shield.Empty; _ = Shield.Compose(parts).For<int>().FallbackTo(0);",
+            "var builder = Shield.For<int>().When<InvalidOperationException>(); var retry = builder.Retry(1); _ = retry.Wrap(builder.Timeout(TimeSpan.Zero)).FallbackTo(0);",
             "var fallback = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); var retry = Shield.Retry(1); _ = fallback.Wrap(retry);",
-            "var retry = Shield.When<InvalidOperationException>().Retry(1); var fallback = Shield.For<int>().When<TimeoutException>().Fallback(0); _ = retry.Wrap(fallback);",
-            "var outer = Shield.Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero); var fallback = Shield.For<int>().When<InvalidOperationException>().Fallback(0); _ = outer.Wrap(fallback);",
+            "var retry = Shield.When<InvalidOperationException>().Retry(1); var fallback = Shield.For<int>().When<TimeoutException>().FallbackTo(0); _ = retry.Wrap(fallback);",
+            "var outer = Shield.Retry(1).When<InvalidOperationException>().Timeout(TimeSpan.Zero); var fallback = Shield.For<int>().When<InvalidOperationException>().FallbackTo(0); _ = outer.Wrap(fallback);",
         };
 
         foreach (var body in cases)
@@ -938,7 +938,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.When<InvalidOperationException>().Retry(1).RetryForever(Backoff.None);",
             "_ = Shield.For<int>().WhenResult(0).Retry(1).Hedge(2, TimeSpan.Zero);",
-            "_ = Shield.For<int>().When<InvalidOperationException>().Fallback(0).Retry(1);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().FallbackTo(0).Retry(1);",
             "_ = Shield.For<int>().WhenResultIsDefault().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "var outer = Shield.When<InvalidOperationException>().Retry(1); _ = outer.CircuitBreaker(2, TimeSpan.FromSeconds(1));",
         };
@@ -1034,7 +1034,7 @@ public class PipelineHazardAnalyzerTests
         {
             "_ = Shield.For<int>().WhenResultIsDefault().Retry(1);",
             "_ = Shield.For<bool>().WhenResultIsDefault().Retry(1);",
-            "_ = Shield.For<TimeSpan>().WhenResultIsDefault().Fallback(TimeSpan.MaxValue);",
+            "_ = Shield.For<TimeSpan>().WhenResultIsDefault().FallbackTo(TimeSpan.MaxValue);",
             "_ = Shield.For<int>().When<InvalidOperationException>().OrResultIsDefault().Retry(1);",
             "_ = Shield.For<int>().WhenResultIsDefault().Or<InvalidOperationException>().Retry(1);",
             "var clause = Shield.For<int>().WhenResultIsDefault(); _ = clause.Retry(1);",
@@ -1109,7 +1109,7 @@ public class PipelineHazardAnalyzerTests
             }
             """);
         var generated = await AnalyzeBodyAsync(
-            "_ = Shield.Hedge(2, TimeSpan.Zero).Execute(_ => 1); _ = Shield.For<int>().Retry(1).Fallback(0);",
+            "_ = Shield.Hedge(2, TimeSpan.Zero).Execute(_ => 1); _ = Shield.For<int>().Retry(1).FallbackTo(0);",
             isGenerated: true);
 
         await Assert.That(unrelated).IsEmpty();

--- a/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
@@ -144,7 +144,7 @@ public class ChaosStrategyTests
         });
         var shield = Shield.For<Payload>()
             .WhenResult(value => ReferenceEquals(value, injected))
-            .Fallback(recovered)
+            .FallbackTo(recovered)
             .Wrap(chaos);
 
         var chaosOutcome = await chaos.ExecuteOutcomeAsync(_ => new ValueTask<Payload>(new Payload("real")));

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -111,7 +111,7 @@ public class PipelineDescriptorTests
     {
         var outer = Shield.For<int>()
             .WhenResult(-1)
-            .Fallback(42)
+            .FallbackTo(42)
             .Retry(2, Backoff.None)
             .WithName("typed");
         var composed = outer.Wrap(Shield.Timeout(TimeSpan.FromSeconds(3)));
@@ -130,7 +130,7 @@ public class PipelineDescriptorTests
         await Assert.That(fallback.HasNotification).IsFalse();
 
         var configuredFallback = Shield.For<int>()
-            .Fallback(42, static options => options.OnFallback = static _ => { })
+            .FallbackTo(42, static options => options.OnFallback = static _ => { })
             .GetDescriptor()
             .AssertContainsSingle<FallbackStrategyDescriptor>();
         await Assert.That(configuredFallback.HasNotification).IsTrue();

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -30,7 +30,7 @@ public class TelemetryRecorderTests
         using var recorder = new TelemetryRecorder(captureMetrics: false);
         var typed = Shield.For<int>()
             .WhenResult(static result => result < 0)
-            .Fallback(42, options => options.OnFallback = recorder.Record)
+            .FallbackTo(42, options => options.OnFallback = recorder.Record)
             .Retry(options =>
             {
                 options.MaxRetries = 1;
@@ -219,7 +219,7 @@ public class TelemetryRecorderTests
 
         await Shield.Hedge(2, TimeSpan.Zero).WithName(name).ExecuteOutcomeAsync<int>(static _ =>
             ValueTask.FromException<int>(new InvalidOperationException()));
-        await Shield.For<int>().When<InvalidOperationException>().Fallback(42).WithName(name)
+        await Shield.For<int>().When<InvalidOperationException>().FallbackTo(42).WithName(name)
             .ExecuteAsync<int>(static _ => throw new InvalidOperationException());
 
         var breaker = Shield.CircuitBreaker(1, TimeSpan.FromMinutes(1)).WithName(name);

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Kevlar.Tests;
+
+public class ApiShapeTests
+{
+    [Test]
+    public async Task FallbackTo_Accepts_Null_Without_Overload_Ambiguity()
+    {
+        var compilation = CreateCompilation(
+            """
+            using Kevlar;
+            using System.Net.Http;
+
+            public static class Consumer
+            {
+                public static void Build()
+                {
+                    _ = Shield.For<string?>().FallbackTo(null);
+                    _ = Shield.For<int?>().FallbackTo(null);
+                    _ = Shield.For<HttpResponseMessage?>().FallbackTo(null);
+                    _ = Shield.For<string?>().When<System.Exception>().FallbackTo(null);
+                }
+            }
+            """);
+
+        var errors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(static diagnostic => $"{diagnostic.Id}: {diagnostic.GetMessage()}")
+            .ToArray();
+
+        await Assert.That(errors).IsEmpty();
+    }
+
+    [Test]
+    public async Task Legacy_Fallback_Null_Remains_Ambiguous_Between_Delegate_Overloads()
+    {
+        var compilation = CreateCompilation(
+            """
+            using Kevlar;
+
+            public static class Consumer
+            {
+                public static void Build() => _ = Shield.For<string?>().Fallback(null);
+            }
+            """);
+
+        var errors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        await Assert.That(errors).HasSingleItem();
+        await Assert.That(errors[0].Id).IsEqualTo("CS0121");
+    }
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(static path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Append(MetadataReference.CreateFromFile(typeof(Shield).Assembly.Location));
+
+        return CSharpCompilation.Create(
+            "FallbackApiShape",
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/tests/Kevlar.Tests/ChainValidationTests.cs
+++ b/tests/Kevlar.Tests/ChainValidationTests.cs
@@ -9,21 +9,21 @@ public class ChainValidationTests
     [Test]
     public async Task Fallback_Inside_A_Retry_With_The_Same_Clause_Throws()
     {
-        await Assert.That(() => { _ = Shield.For<int>().When<InvalidOperationException>().Retry(2, Backoff.None).Fallback(-1); })
+        await Assert.That(() => { _ = Shield.For<int>().When<InvalidOperationException>().Retry(2, Backoff.None).FallbackTo(-1); })
             .Throws<InvalidOperationException>();
     }
 
     [Test]
     public async Task Fallback_Inside_A_Default_Clause_Retry_Throws()
     {
-        await Assert.That(() => { _ = Shield.For<int>().Retry(2, Backoff.None).Fallback(-1); })
+        await Assert.That(() => { _ = Shield.For<int>().Retry(2, Backoff.None).FallbackTo(-1); })
             .Throws<InvalidOperationException>();
     }
 
     [Test]
     public async Task Fallback_Inside_A_Breaker_With_The_Same_Clause_Throws()
     {
-        await Assert.That(() => { _ = Shield.For<int>().CircuitBreaker(5, TimeSpan.FromSeconds(30)).Fallback(-1); })
+        await Assert.That(() => { _ = Shield.For<int>().CircuitBreaker(5, TimeSpan.FromSeconds(30)).FallbackTo(-1); })
             .Throws<InvalidOperationException>();
     }
 
@@ -40,7 +40,7 @@ public class ChainValidationTests
         InvalidOperationException? error = null;
         try
         {
-            _ = Shield.For<int>().Retry(2, Backoff.None).Fallback(-1);
+            _ = Shield.For<int>().Retry(2, Backoff.None).FallbackTo(-1);
         }
         catch (InvalidOperationException caught)
         {
@@ -56,7 +56,7 @@ public class ChainValidationTests
     public async Task Fallback_Before_The_Retry_Is_The_Valid_Order()
     {
         var attempts = 0;
-        var shield = Shield.For<int>().Fallback(-1).Retry(2, Backoff.None);
+        var shield = Shield.For<int>().FallbackTo(-1).Retry(2, Backoff.None);
 
         var recovered = await shield.ExecuteAsync(_ =>
         {
@@ -77,7 +77,7 @@ public class ChainValidationTests
             .When<TimeoutExceededException>()
             .Retry(2, Backoff.None)
             .When<ArgumentException>()
-            .Fallback(-1);
+            .FallbackTo(-1);
 
         // The fallback recovers ArgumentException; the retry only ever sees timeouts.
         var recovered = await shield.ExecuteAsync(_ =>
@@ -95,7 +95,7 @@ public class ChainValidationTests
     {
         var withClause = Shield.For<int>().WhenResult(0).Timeout(TimeSpan.FromMinutes(1));
         var retryPart = withClause.Retry(1, Backoff.None);
-        var fallbackPart = withClause.Fallback(-1);
+        var fallbackPart = withClause.FallbackTo(-1);
 
         await Assert.That(() => { _ = retryPart.Wrap(fallbackPart); }).Throws<InvalidOperationException>();
     }

--- a/tests/Kevlar.Tests/CompositionContractTests.cs
+++ b/tests/Kevlar.Tests/CompositionContractTests.cs
@@ -119,7 +119,7 @@ public class CompositionContractTests
             WrapKind.TypedTyped => typedOuter.Wrap(typedInner),
             _ => throw new ArgumentOutOfRangeException(nameof(kind)),
         };
-        var result = await typedWrapped.Fallback(42).ExecuteAsync(_ => throw new InvalidOperationException());
+        var result = await typedWrapped.FallbackTo(42).ExecuteAsync(_ => throw new InvalidOperationException());
 
         await Assert.That(typedWrapped.Ambient).IsNull();
         await Assert.That(result).IsEqualTo(42);
@@ -229,8 +229,8 @@ public class CompositionContractTests
     {
         string? nullValue = null;
         var defaultValue = default(int);
-        var nullShield = Shield.For<string?>().WhenResult(nullValue).Fallback("null");
-        var defaultShield = Shield.For<int>().WhenResult(defaultValue).Fallback(42);
+        var nullShield = Shield.For<string?>().WhenResult(nullValue).FallbackTo("null");
+        var defaultShield = Shield.For<int>().WhenResult(defaultValue).FallbackTo(42);
 
         var nullResult = await nullShield.ExecuteAsync(_ => new ValueTask<string?>((string?)null));
         var defaultResult = await defaultShield.ExecuteAsync(_ => new ValueTask<int>(0));

--- a/tests/Kevlar.Tests/CompositionEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/CompositionEdgeCaseTests.cs
@@ -89,7 +89,7 @@ public class CompositionEdgeCaseTests
     public async Task Wrapping_A_Typed_Policy_Seals_Its_Result_Handling_For_Later_Strategies()
     {
         var typed = Shield.For<int>().WhenResult(value => value < 0).Timeout(TimeSpan.FromMinutes(1));
-        var combined = Shield.Timeout(TimeSpan.FromMinutes(1)).Wrap(typed).Fallback(99);
+        var combined = Shield.Timeout(TimeSpan.FromMinutes(1)).Wrap(typed).FallbackTo(99);
 
         // Composition sealed the result clause, so the default fallback ignores successful results.
         var result = await combined.ExecuteAsync(_ => new ValueTask<int>(-5));
@@ -104,7 +104,7 @@ public class CompositionEdgeCaseTests
             .When<ArgumentException>()
             .Timeout(TimeSpan.FromMinutes(1))
             .For<string>()
-            .Fallback("recovered");
+            .FallbackTo("recovered");
 
         // The ArgumentException clause carries across For<T>(): the fallback recovers matching
         // exceptions and lets everything else surface untouched.
@@ -208,7 +208,7 @@ public class CompositionEdgeCaseTests
     {
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(-1)
+            .FallbackTo(-1)
             .Retry(2, Backoff.None)
             .CircuitBreaker(10, TimeSpan.FromMinutes(1))
             .Timeout(TimeSpan.FromMinutes(1))

--- a/tests/Kevlar.Tests/CompositionTests.cs
+++ b/tests/Kevlar.Tests/CompositionTests.cs
@@ -134,7 +134,7 @@ public class CompositionTests
     public async Task NonGeneric_Policy_Wraps_A_Typed_Policy()
     {
         var attempts = 0;
-        var typed = Shield.For<string>().When<InvalidOperationException>().Fallback("fallback");
+        var typed = Shield.For<string>().When<InvalidOperationException>().FallbackTo("fallback");
         var combined = Shield.Retry(1, Backoff.None).Wrap(typed);
 
         // Fallback is inner, so it recovers before the outer retry ever sees a failure.

--- a/tests/Kevlar.Tests/CustomStrategyContractTests.cs
+++ b/tests/Kevlar.Tests/CustomStrategyContractTests.cs
@@ -61,7 +61,7 @@ public class CustomStrategyContractTests
         var actionCalls = 0;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
+            .FallbackTo(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
             .Use(new ThrowingStrategy(failure));
 
         var result = await shield.ExecuteAsync(_ =>
@@ -103,7 +103,7 @@ public class CustomStrategyContractTests
         Exception? observed = null;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
+            .FallbackTo(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
             .Use(new AsynchronouslyFaultingStrategy(failure));
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(0));
@@ -119,7 +119,7 @@ public class CustomStrategyContractTests
         Exception? observed = null;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
+            .FallbackTo(42, options => options.OnFallback = fallback => observed = fallback.Outcome.Exception)
             .Use(new FailureStrategy(failure));
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(0));
@@ -284,7 +284,7 @@ public class CustomStrategyContractTests
             _ = Shield.For<int>()
                 .When<ArgumentException>()
                 .Use(clause => new HandlingAwareStrategy(clause))
-                .Fallback(0);
+                .FallbackTo(0);
         }).Throws<InvalidOperationException>();
     }
 

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -97,7 +97,7 @@ public class DependencyInjectionContractTests
         var first = Shield.Retry(1, Backoff.None);
         var last = Shield.Timeout(TimeSpan.FromSeconds(1));
         var firstTyped = Shield<int>.Empty;
-        var lastTyped = Shield.For<int>().Fallback(42);
+        var lastTyped = Shield.For<int>().FallbackTo(42);
         var firstVoid = Shield.Fallback(static _ => ValueTask.CompletedTask);
         var lastVoid = Shield.Fallback(static _ => ValueTask.FromException(
             new InvalidOperationException("last")));

--- a/tests/Kevlar.Tests/DependencyInjectionTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionTests.cs
@@ -66,7 +66,7 @@ public class DependencyInjectionTests
     {
         var services = new ServiceCollection()
             .AddShield("shared", Shield.Retry(1, Backoff.None))
-            .AddShield("shared", Shield.For<int>().WhenResult(-1).Fallback(0))
+            .AddShield("shared", Shield.For<int>().WhenResult(-1).FallbackTo(0))
             .BuildServiceProvider();
 
         var registry = services.GetRequiredService<IKevlarRegistry>();
@@ -143,7 +143,7 @@ public class DependencyInjectionTests
             .AddPartitionedShield<string>("shared", (_, _) => Shield.Empty)
             .AddPartitionedShield<string, int>(
                 "shared",
-                (_, _) => Shield.For<int>().WhenResult(-1).Fallback(0));
+                (_, _) => Shield.For<int>().WhenResult(-1).FallbackTo(0));
         using var provider = services.BuildServiceProvider();
 
         var untyped = provider.GetRequiredKeyedService<PartitionedShield<string>>("shared");

--- a/tests/Kevlar.Tests/DescribeTests.cs
+++ b/tests/Kevlar.Tests/DescribeTests.cs
@@ -78,9 +78,9 @@ public class DescribeTests
     [Test]
     public async Task Typed_Shields_And_Fallbacks_Describe_Themselves()
     {
-        var shield = Shield.For<int>().WhenResult(0).Fallback(-1).Retry(1, Backoff.None);
+        var shield = Shield.For<int>().WhenResult(0).FallbackTo(-1).Retry(1, Backoff.None);
 
-        await Assert.That(shield.ToString()).IsEqualTo("[when result 0] Fallback → Retry(1, no delay)");
+        await Assert.That(shield.ToString()).IsEqualTo("[when result 0] Fallback(value) → Retry(1, no delay)");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/FallbackAsyncHookTests.cs
+++ b/tests/Kevlar.Tests/FallbackAsyncHookTests.cs
@@ -111,7 +111,7 @@ public class FallbackAsyncHookTests
     {
         using var cancellation = new CancellationTokenSource();
         var hookCancellation = new OperationCanceledException("hook cancelled", cancellation.Token);
-        var shield = Shield.For<int>().Fallback(
+        var shield = Shield.For<int>().FallbackTo(
             42,
             options => options.OnFallbackAsync = _ => ValueTask.FromException(hookCancellation));
 
@@ -166,7 +166,7 @@ public class FallbackAsyncHookTests
         Shield<int>? shield = null;
         shield = Shield<int>.Empty
             .WithName("fallback-hook")
-            .Fallback(
+            .FallbackTo(
                 42,
                 options =>
                 {
@@ -283,7 +283,7 @@ public class FallbackAsyncHookTests
     {
         var configureCalls = 0;
         var firstCalls = 0;
-        var shield = Shield.For<int>().Fallback(
+        var shield = Shield.For<int>().FallbackTo(
             42,
             options =>
             {

--- a/tests/Kevlar.Tests/FallbackContractTests.cs
+++ b/tests/Kevlar.Tests/FallbackContractTests.cs
@@ -239,7 +239,7 @@ public class FallbackContractTests
     {
         await Assert.That(() =>
         {
-            _ = Shield.For<int>().Hedge(2, TimeSpan.Zero).Fallback(-1);
+            _ = Shield.For<int>().Hedge(2, TimeSpan.Zero).FallbackTo(-1);
         }).Throws<InvalidOperationException>();
         await Assert.That(() =>
         {
@@ -311,7 +311,7 @@ public class FallbackContractTests
     {
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42);
+            .FallbackTo(42);
 
         var synchronous = shield.Execute(_ => throw new InvalidOperationException());
         var asynchronous = await shield.ExecuteAsync<int>(_ =>

--- a/tests/Kevlar.Tests/FallbackEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/FallbackEdgeCaseTests.cs
@@ -62,7 +62,7 @@ public class FallbackEdgeCaseTests
     [Test]
     public async Task Cancellation_Is_Not_Replaced_By_The_Fallback()
     {
-        var shield = Shield.For<int>().Fallback(99);
+        var shield = Shield.For<int>().FallbackTo(99);
 
         // The default handling ignores OperationCanceledException, so the fallback stays out of it.
         await Assert.That(async () => await shield.ExecuteAsync(_ => throw new OperationCanceledException()))
@@ -92,7 +92,7 @@ public class FallbackEdgeCaseTests
         Exception? seenException = null;
         var shield = Shield.For<int>()
             .WhenResult(-1)
-            .Fallback(0, options => options.OnFallback = fallback =>
+            .FallbackTo(0, options => options.OnFallback = fallback =>
             {
                 seenResult = fallback.Outcome.Result;
                 seenException = fallback.Outcome.Exception;
@@ -110,7 +110,7 @@ public class FallbackEdgeCaseTests
     {
         var original = new InvalidOperationException("original");
         Exception? seenException = null;
-        var shield = Shield.For<int>().Fallback(
+        var shield = Shield.For<int>().FallbackTo(
             0,
             options => options.OnFallback = fallback => seenException = fallback.Outcome.Exception);
 
@@ -135,7 +135,7 @@ public class FallbackEdgeCaseTests
     [Test]
     public async Task Fallback_Works_On_The_Synchronous_Path()
     {
-        var shield = Shield.For<string>().Fallback("fell-back");
+        var shield = Shield.For<string>().FallbackTo("fell-back");
 
         var result = shield.Execute(_ => throw new InvalidOperationException());
 
@@ -146,7 +146,7 @@ public class FallbackEdgeCaseTests
     public async Task Fallback_Around_A_Circuit_Breaker_Swallows_Rejections()
     {
         var shield = Shield.For<int>()
-            .Fallback(-1)
+            .FallbackTo(-1)
             .CircuitBreaker(1, TimeSpan.FromMinutes(1));
 
         // First execution trips the breaker; the fallback replaces the original failure.

--- a/tests/Kevlar.Tests/FallbackTests.cs
+++ b/tests/Kevlar.Tests/FallbackTests.cs
@@ -5,7 +5,7 @@ public class FallbackTests
     [Test]
     public async Task Fallback_Value_Replaces_Exceptions()
     {
-        var shield = Shield.For<string>().When<InvalidOperationException>().Fallback("fallback");
+        var shield = Shield.For<string>().When<InvalidOperationException>().FallbackTo("fallback");
 
         var result = await shield.ExecuteAsync(_ => throw new InvalidOperationException());
 
@@ -33,7 +33,7 @@ public class FallbackTests
     [Test]
     public async Task Fallback_Applies_To_Handled_Results()
     {
-        var shield = Shield.For<int>().WhenResult(-1).Fallback(0);
+        var shield = Shield.For<int>().WhenResult(-1).FallbackTo(0);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(-1));
 
@@ -43,7 +43,7 @@ public class FallbackTests
     [Test]
     public async Task Fallback_Is_Not_Used_On_Success()
     {
-        var shield = Shield.For<int>().WhenResult(-1).Fallback(0);
+        var shield = Shield.For<int>().WhenResult(-1).FallbackTo(0);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
 
@@ -53,7 +53,7 @@ public class FallbackTests
     [Test]
     public async Task Unhandled_Exceptions_Bypass_The_Fallback()
     {
-        var shield = Shield.For<string>().When<InvalidOperationException>().Fallback("fallback");
+        var shield = Shield.For<string>().When<InvalidOperationException>().FallbackTo("fallback");
 
         await Assert.That(async () => await shield.ExecuteAsync(_ => throw new ArgumentException()))
             .Throws<ArgumentException>();
@@ -65,7 +65,7 @@ public class FallbackTests
         var fired = false;
         var shield = Shield.For<int>()
             .WhenResult(-1)
-            .Fallback(0, options => options.OnFallback = _ => fired = true);
+            .FallbackTo(0, options => options.OnFallback = _ => fired = true);
 
         await shield.ExecuteAsync(_ => new ValueTask<int>(-1));
 
@@ -78,7 +78,7 @@ public class FallbackTests
         var attempts = 0;
         var shield = Shield.For<string>()
             .When<InvalidOperationException>()
-            .Fallback("gave up")
+            .FallbackTo("gave up")
             .Retry(2, Backoff.None);
 
         var result = await shield.ExecuteAsync(_ =>

--- a/tests/Kevlar.Tests/FallbackToTests.cs
+++ b/tests/Kevlar.Tests/FallbackToTests.cs
@@ -1,0 +1,84 @@
+namespace Kevlar.Tests;
+
+public class FallbackToTests
+{
+    [Test]
+    public async Task FallbackTo_Null_Returns_Null_For_Reference_Result()
+    {
+        var shield = Shield.For<string?>().FallbackTo(null);
+
+        var result = await shield.ExecuteAsync(_ => throw new InvalidOperationException());
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task FallbackTo_Default_Struct_Returns_Default()
+    {
+        var shield = Shield.For<DateTime>().FallbackTo(default);
+
+        var result = await shield.ExecuteAsync(_ => throw new InvalidOperationException());
+
+        await Assert.That(result).IsEqualTo(default(DateTime));
+    }
+
+    [Test]
+    public async Task FallbackTo_Value_Fires_OnFallback_With_Outcome()
+    {
+        Exception? observed = null;
+        var shield = Shield.For<int>().FallbackTo(
+            42,
+            options => options.OnFallback = @event => observed = @event.Outcome.Exception);
+
+        var result = await shield.ExecuteAsync(_ => throw new InvalidOperationException("original"));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observed!.Message).IsEqualTo("original");
+    }
+
+    [Test]
+    public async Task FallbackTo_Is_Not_Invoked_On_Success()
+    {
+        var fired = false;
+        var shield = Shield.For<int>().FallbackTo(
+            42,
+            options => options.OnFallback = _ => fired = true);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(7));
+
+        await Assert.That(result).IsEqualTo(7);
+        await Assert.That(fired).IsFalse();
+    }
+
+    [Test]
+    public async Task FallbackTo_Respects_Ambient_Clause()
+    {
+        var shield = Shield.For<int>()
+            .When<HttpRequestException>()
+            .FallbackTo(42);
+
+        await Assert.That(async () => await shield.ExecuteAsync(_ => throw new ArgumentException()))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task FallbackTo_Works_With_Sync_And_Outcome_Execution()
+    {
+        var shield = Shield.For<int>().FallbackTo(42);
+
+        var synchronous = shield.Execute(_ => throw new InvalidOperationException());
+        var outcome = await shield.ExecuteOutcomeAsync(_ => throw new InvalidOperationException());
+
+        await Assert.That(synchronous).IsEqualTo(42);
+        await Assert.That(outcome.IsSuccess).IsTrue();
+        await Assert.That(outcome.Result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task FallbackTo_Describes_Value_Fallback()
+    {
+        var shield = Shield.For<int>().FallbackTo(42);
+
+        await Assert.That(shield.ToString()).IsEqualTo("Fallback(value)");
+    }
+}

--- a/tests/Kevlar.Tests/Kevlar.Tests.csproj
+++ b/tests/Kevlar.Tests/Kevlar.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -385,7 +385,7 @@ public class MetricsTests
         var attempts = 0;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42)
+            .FallbackTo(42)
             .Retry(2, Backoff.None)
             .WithName(name);
 
@@ -411,7 +411,7 @@ public class MetricsTests
         var asyncObservedMetric = false;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(
+            .FallbackTo(
                 42,
                 options =>
                 {
@@ -497,7 +497,7 @@ public class MetricsTests
         using var listener = new KevlarMeterListener();
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(-1)
+            .FallbackTo(-1)
             .CircuitBreaker(1, TimeSpan.FromMinutes(1))
             .WithName("metrics-fallback");
 

--- a/tests/Kevlar.Tests/PartitionedShieldTests.cs
+++ b/tests/Kevlar.Tests/PartitionedShieldTests.cs
@@ -132,7 +132,7 @@ public class PartitionedShieldTests
     public async Task Typed_Partitions_Preserve_Result_Aware_State()
     {
         var provider = new PartitionedShield<string, int>(_ =>
-            Shield.For<int>().WhenResult(-1).Fallback(0));
+            Shield.For<int>().WhenResult(-1).FallbackTo(0));
 
         var result = await provider.GetShield("typed")
             .ExecuteAsync(_ => new ValueTask<int>(-1));

--- a/tests/Kevlar.Tests/StrategyHandlingOverrideTests.cs
+++ b/tests/Kevlar.Tests/StrategyHandlingOverrideTests.cs
@@ -130,7 +130,7 @@ public class StrategyHandlingOverrideTests
         var attempts = 0;
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(42)
+            .FallbackTo(42)
             .Retry(options =>
             {
                 options.MaxRetries = 1;
@@ -160,7 +160,7 @@ public class StrategyHandlingOverrideTests
     {
         var shield = Shield.For<int>()
             .When<InvalidOperationException>()
-            .Fallback(0, options =>
+            .FallbackTo(0, options =>
             {
                 options.HandlesResult = result => result < 0;
             });
@@ -175,7 +175,7 @@ public class StrategyHandlingOverrideTests
     {
         var shield = Shield.For<int>()
             .Retry(options => options.HandlesException = exception => exception is InvalidOperationException)
-            .Fallback(0, options =>
+            .FallbackTo(0, options =>
             {
                 options.HandlesException = exception => exception is InvalidOperationException;
             });
@@ -183,7 +183,7 @@ public class StrategyHandlingOverrideTests
         await Assert.That(shield).IsNotNull();
         await Assert.That(() => Shield.For<int>()
             .Retry(1)
-            .Fallback(0))
+            .FallbackTo(0))
             .Throws<InvalidOperationException>();
     }
 }

--- a/tests/Kevlar.Tests/StrategyInspectionTests.cs
+++ b/tests/Kevlar.Tests/StrategyInspectionTests.cs
@@ -82,11 +82,11 @@ public class StrategyInspectionTests
         await Assert.That(fixedCircuit.Core.HasMonitor).IsFalse();
         await Assert.That(fixedCircuit.Core.HasNotification).IsFalse();
 
-        var notifiedFallback = GetInspection(Shield.For<int>().Fallback(42, static options => options.OnFallback = static _ => { }));
-        var asyncNotifiedFallback = GetInspection(Shield.For<int>().Fallback(
+        var notifiedFallback = GetInspection(Shield.For<int>().FallbackTo(42, static options => options.OnFallback = static _ => { }));
+        var asyncNotifiedFallback = GetInspection(Shield.For<int>().FallbackTo(
             42,
             static options => options.OnFallbackAsync = static _ => default));
-        var fixedFallback = GetInspection(Shield.For<int>().Fallback(42));
+        var fixedFallback = GetInspection(Shield.For<int>().FallbackTo(42));
         var voidFallback = GetInspection(
             Shield.When<InvalidOperationException>().Fallback(static (_, _) => default));
         var notifiedVoidFallback = GetInspection(

--- a/tests/Kevlar.Tests/StrategyModelTests.cs
+++ b/tests/Kevlar.Tests/StrategyModelTests.cs
@@ -357,7 +357,7 @@ public class StrategyModelTests
         var shouldFail = commands.Count > 0 && commands[^1].Fail;
         var shield = Shield.For<int>()
             .When<ModelFailureException>()
-            .Fallback(99)
+            .FallbackTo(99)
             .Wrap(observers);
         var result = await shield.ExecuteAsync(_ => shouldFail
             ? throw new ModelFailureException()

--- a/tests/Kevlar.Tests/SyncExecutionTests.cs
+++ b/tests/Kevlar.Tests/SyncExecutionTests.cs
@@ -128,7 +128,7 @@ public class SyncExecutionTests
         // fallback replaces the final failure.
         var shield = Shield.For<string>()
             .When<InvalidOperationException>()
-            .Fallback("fallback")
+            .FallbackTo("fallback")
             .Retry(2, Backoff.None);
 
         var result = shield.Execute(_ =>


### PR DESCRIPTION
## Summary
- rename typed constant-value `Fallback(value)` overloads to `FallbackTo(value)`
- preserve delegate factories under `Fallback` and teach KEV008 about both spellings
- add compile-time null coverage, runtime coverage, API contracts, docs, and migration notes

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (814 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (75 passed)
- `dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m` (43 passed)
- `dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m` (31 passed)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (3 passed)
- `pwsh ./scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/packages -Version 1.0.0-loop` (118 compiled; behavior passed)
- `npm run build --prefix docs`

## Benchmark

| Case | Before | After | Allocation |
|---|---:|---:|---:|
| PassThrough | 108.3 ns | 104.2 ns | 0 B |
| Triggered | 2797.5 ns | 2627.6 ns | 200 B |

Closes #204