### PR TITLE
build(packaging): ship symbol packages

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "dotnet-stryker"
       ],
       "rollForward": false
+    },
+    "sourcelink": {
+      "version": "3.1.1",
+      "commands": [
+        "sourcelink"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: dotnet pack Kevlar.slnx -c Release --no-build -p:Version=${{ steps.gitversion.outputs.semVer }}
 
+      - name: Restore local tools
+        if: matrix.os == 'ubuntu-latest'
+        run: dotnet tool restore
+
       - name: Install NativeAOT prerequisites
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install --yes clang zlib1g-dev
@@ -125,7 +129,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nuget-packages
-          path: artifacts/package/release/*.nupkg
+          path: |
+            artifacts/package/release/*.nupkg
+            artifacts/package/release/*.snupkg
+          if-no-files-found: error
 
   coverage:
     name: Coverage
@@ -227,6 +234,15 @@ jobs:
           name: nuget-packages
           path: packages
 
+      - name: Verify publish artifacts
+        shell: pwsh
+        run: |
+          $packageIds = @(Get-ChildItem packages -Filter *.nupkg | ForEach-Object { $_.BaseName -replace '\.[0-9].*$', '' } | Sort-Object)
+          $symbolPackageIds = @(Get-ChildItem packages -Filter *.snupkg | ForEach-Object { $_.BaseName -replace '\.[0-9].*$', '' } | Sort-Object)
+          if ($packageIds.Count -ne 8 -or ($packageIds -join ',') -ne ($symbolPackageIds -join ',')) {
+            throw "Expected 8 matching nupkg/snupkg artifacts; got nupkg=[$($packageIds -join ', ')], snupkg=[$($symbolPackageIds -join ', ')]."
+          }
+
       - name: NuGet login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: login
@@ -239,4 +255,4 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "v${{ steps.gitversion.outputs.semVer }}" --target ${{ github.sha }} --generate-notes packages/*.nupkg
+        run: gh release create "v${{ steps.gitversion.outputs.semVer }}" --target ${{ github.sha }} --generate-notes packages/*.nupkg packages/*.snupkg

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -58,12 +58,88 @@ function Invoke-DotNet([string[]]$Arguments)
     }
 }
 
+function Get-ExpectedSymbolAssets([string]$PackageId)
+{
+    if ($PackageId -eq 'Kevlar.Analyzers')
+    {
+        return @('analyzers/dotnet/cs/Kevlar.Analyzers.pdb')
+    }
+
+    $frameworks = @('net10.0', 'netstandard2.0')
+    if ($PackageId -in @('Kevlar.Chaos', 'Kevlar.Testing'))
+    {
+        $frameworks += 'net8.0'
+    }
+
+    return @($frameworks | ForEach-Object { "lib/$_/$PackageId.pdb" })
+}
+
+function Assert-DeterministicAssembly(
+    [string]$Name,
+    [System.IO.Compression.ZipArchiveEntry]$Entry)
+{
+    $stream = $Entry.Open()
+    $buffer = [System.IO.MemoryStream]::new()
+    try
+    {
+        $stream.CopyTo($buffer)
+        $buffer.Position = 0
+        $reader = [System.Reflection.PortableExecutable.PEReader]::new($buffer)
+        try
+        {
+            $debugEntryTypes = @($reader.ReadDebugDirectory() | ForEach-Object Type)
+            if ($debugEntryTypes -notcontains [System.Reflection.PortableExecutable.DebugDirectoryEntryType]::Reproducible)
+            {
+                throw "$Name is missing the deterministic PE marker."
+            }
+        }
+        finally
+        {
+            $reader.Dispose()
+        }
+    }
+    finally
+    {
+        $buffer.Dispose()
+        $stream.Dispose()
+    }
+}
+
+function Get-ArchiveEntryHash([string]$ArchivePath, [string]$EntryPath)
+{
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
+    try
+    {
+        $entry = $archive.GetEntry($EntryPath)
+        if ($null -eq $entry)
+        {
+            throw "Archive '$ArchivePath' does not contain '$EntryPath'."
+        }
+
+        $stream = $entry.Open()
+        $hash = [System.Security.Cryptography.SHA256]::Create()
+        try
+        {
+            return [Convert]::ToHexString($hash.ComputeHash($stream))
+        }
+        finally
+        {
+            $hash.Dispose()
+            $stream.Dispose()
+        }
+    }
+    finally
+    {
+        $archive.Dispose()
+    }
+}
+
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
 $buildPropertiesJson = & dotnet msbuild `
     (Join-Path $repositoryRoot 'src/Kevlar/Kevlar.csproj') `
     -nologo `
     -p:CI=true `
-    -getProperty:Deterministic,ContinuousIntegrationBuild,DeterministicSourcePaths,PublishRepositoryUrl,EmbedUntrackedSources
+    -getProperty:Deterministic,ContinuousIntegrationBuild,DeterministicSourcePaths,PublishRepositoryUrl,EmbedUntrackedSources,IncludeSymbols,SymbolPackageFormat
 if ($LASTEXITCODE -ne 0)
 {
     throw 'Unable to inspect deterministic build properties.'
@@ -75,6 +151,8 @@ Assert-Equal 'ContinuousIntegrationBuild' $buildProperties.ContinuousIntegration
 Assert-Equal 'DeterministicSourcePaths' $buildProperties.DeterministicSourcePaths 'true'
 Assert-Equal 'PublishRepositoryUrl' $buildProperties.PublishRepositoryUrl 'true'
 Assert-Equal 'EmbedUntrackedSources' $buildProperties.EmbedUntrackedSources 'true'
+Assert-Equal 'IncludeSymbols' $buildProperties.IncludeSymbols 'true'
+Assert-Equal 'SymbolPackageFormat' $buildProperties.SymbolPackageFormat 'snupkg'
 
 $packageDirectory = (Resolve-Path -LiteralPath $PackagesPath).Path
 $expectedRepositoryCommit = (& git rev-parse HEAD).Trim()
@@ -134,6 +212,8 @@ $expectedDependencies = @{
 
 $packageFiles = @(Get-ChildItem -LiteralPath $packageDirectory -Filter '*.nupkg' -File)
 Assert-Set 'package IDs' ($packageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) @($expectedDependencies.Keys | ForEach-Object { $_ })
+$symbolPackageFiles = @(Get-ChildItem -LiteralPath $packageDirectory -Filter '*.snupkg' -File)
+Assert-Set 'symbol package IDs' ($symbolPackageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) @($expectedDependencies.Keys | ForEach-Object { $_ })
 
 foreach ($packageId in $expectedDependencies.Keys)
 {
@@ -141,6 +221,12 @@ foreach ($packageId in $expectedDependencies.Keys)
     if (-not (Test-Path -LiteralPath $packageFile -PathType Leaf))
     {
         throw "Missing package '$packageFile'."
+    }
+
+    $symbolPackageFile = Join-Path $packageDirectory "$packageId.$Version.snupkg"
+    if (-not (Test-Path -LiteralPath $symbolPackageFile -PathType Leaf))
+    {
+        throw "Missing symbol package '$symbolPackageFile'."
     }
 
     $archive = [System.IO.Compression.ZipFile]::OpenRead($packageFile)
@@ -207,6 +293,9 @@ foreach ($packageId in $expectedDependencies.Keys)
         {
             $assemblyEntries = @($entries | Where-Object { $_ -like '*.dll' })
             Assert-Set "$packageId assemblies" $assemblyEntries @('analyzers/dotnet/cs/Kevlar.Analyzers.dll')
+            Assert-Set "$packageId analyzer assets" `
+                ($entries | Where-Object { $_ -like 'analyzers/dotnet/cs/*' }) `
+                @('analyzers/dotnet/cs/Kevlar.Analyzers.dll', 'analyzers/dotnet/cs/Kevlar.Analyzers.pdb')
             if ($entries | Where-Object { $_ -match '^(lib|build|buildTransitive|tools)/' })
             {
                 throw "$packageId contains an unexpected runtime or build asset."
@@ -233,10 +322,52 @@ foreach ($packageId in $expectedDependencies.Keys)
                 throw "$packageId contains an unexpected analyzer or build asset."
             }
         }
+
+        foreach ($assemblyEntry in $archive.Entries | Where-Object { $_.FullName -like '*.dll' })
+        {
+            Assert-DeterministicAssembly "$packageId $($assemblyEntry.FullName)" $assemblyEntry
+        }
     }
     finally
     {
         $archive.Dispose()
+    }
+
+    $symbolArchive = [System.IO.Compression.ZipFile]::OpenRead($symbolPackageFile)
+    try
+    {
+        $symbolEntries = @($symbolArchive.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+        Assert-Set "$packageId symbol assets" `
+            ($symbolEntries | Where-Object { $_ -like '*.pdb' }) `
+            (Get-ExpectedSymbolAssets $packageId)
+
+        $symbolNuspecEntry = @($symbolArchive.Entries | Where-Object { $_.FullName -like '*.nuspec' })
+        Assert-Equal "$packageId symbol nuspec count" $symbolNuspecEntry.Count 1
+        $symbolNuspecReader = [System.IO.StreamReader]::new($symbolNuspecEntry[0].Open())
+        try
+        {
+            [xml]$symbolNuspec = $symbolNuspecReader.ReadToEnd()
+        }
+        finally
+        {
+            $symbolNuspecReader.Dispose()
+        }
+
+        $symbolMetadata = $symbolNuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']")
+        if ($null -eq $symbolMetadata)
+        {
+            throw "$packageId symbol package has no nuspec metadata."
+        }
+
+        Assert-Equal "$packageId symbol ID" (Get-NodeText $symbolMetadata "*[local-name()='id']") $packageId
+        Assert-Equal "$packageId symbol version" (Get-NodeText $symbolMetadata "*[local-name()='version']") $Version
+        Assert-Equal "$packageId symbol package type" `
+            (Get-NodeText $symbolMetadata "*[local-name()='packageTypes']/*[local-name()='packageType']/@name") `
+            'SymbolsPackage'
+    }
+    finally
+    {
+        $symbolArchive.Dispose()
     }
 }
 
@@ -247,6 +378,76 @@ $env:NUGET_PACKAGES = Join-Path $temporaryRoot '.packages'
 
 try
 {
+    $symbolRoot = Join-Path $temporaryRoot 'symbols'
+    [System.IO.Directory]::CreateDirectory($symbolRoot) | Out-Null
+    foreach ($packageId in $expectedDependencies.Keys)
+    {
+        $symbolPackageFile = Join-Path $packageDirectory "$packageId.$Version.snupkg"
+        $symbolArchive = [System.IO.Compression.ZipFile]::OpenRead($symbolPackageFile)
+        try
+        {
+            foreach ($symbolAsset in Get-ExpectedSymbolAssets $packageId)
+            {
+                $entry = $symbolArchive.GetEntry($symbolAsset)
+                if ($null -eq $entry)
+                {
+                    throw "$packageId symbol package does not contain '$symbolAsset'."
+                }
+
+                $pdbPath = Join-Path $symbolRoot $symbolAsset
+                [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($pdbPath)) | Out-Null
+                [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $pdbPath, $true)
+
+                $sourceLinkJson = (& dotnet sourcelink print-json $pdbPath 2>&1 | Out-String)
+                if ($LASTEXITCODE -ne 0)
+                {
+                    throw "Unable to read SourceLink data from '$symbolAsset'.`n$sourceLinkJson"
+                }
+
+                $sourceLink = $sourceLinkJson | ConvertFrom-Json
+                Assert-Set `
+                    "$symbolAsset SourceLink URLs" `
+                    @($sourceLink.documents.PSObject.Properties.Value) `
+                    @("https://raw.githubusercontent.com/thomhurst/Kevlar/$expectedRepositoryCommit/*")
+
+                Invoke-DotNet @('sourcelink', 'test', $pdbPath)
+            }
+        }
+        finally
+        {
+            $symbolArchive.Dispose()
+        }
+    }
+
+    $repeatPackages = Join-Path $temporaryRoot 'repeat-packages'
+    Invoke-DotNet @(
+        'build', (Join-Path $repositoryRoot 'Kevlar.slnx'),
+        '-c', 'Release',
+        '--no-restore',
+        '-t:Rebuild',
+        "-p:Version=$Version",
+        '-p:CI=true')
+    Invoke-DotNet @(
+        'pack', (Join-Path $repositoryRoot 'Kevlar.slnx'),
+        '-c', 'Release',
+        '--no-build',
+        "-p:Version=$Version",
+        '-p:CI=true',
+        "-p:PackageOutputPath=$repeatPackages")
+
+    foreach ($packageId in $expectedDependencies.Keys)
+    {
+        $packageFile = Join-Path $packageDirectory "$packageId.$Version.nupkg"
+        $repeatPackageFile = Join-Path $repeatPackages "$packageId.$Version.nupkg"
+        foreach ($assemblyAsset in (Get-ExpectedSymbolAssets $packageId) -replace '\.pdb$', '.dll')
+        {
+            Assert-Equal `
+                "$packageId deterministic assembly $assemblyAsset" `
+                (Get-ArchiveEntryHash $repeatPackageFile $assemblyAsset) `
+                (Get-ArchiveEntryHash $packageFile $assemblyAsset)
+        }
+    }
+
     $escapedPackageDirectory = [System.Security.SecurityElement]::Escape($packageDirectory)
     $nugetConfig = @"
 <?xml version="1.0" encoding="utf-8"?>
@@ -280,6 +481,7 @@ using Kevlar.Extensions.RateLimiting;
 using Kevlar.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
 using System.Threading.RateLimiting;
 
 var shield = Shield.Empty;
@@ -290,6 +492,19 @@ var value = await shield.ExecuteAsync(static cancellationToken =>
 if (value != 42)
 {
     throw new InvalidOperationException("Core package execution failed.");
+}
+
+try
+{
+    ThrowFromKevlar();
+    throw new InvalidOperationException("Expected the packaged shield to throw.");
+}
+catch (ExpectedConsumerException exception)
+{
+    if (exception.StackTrace is null || !exception.StackTrace.Contains("Kevlar/Internal/ShieldEngine.cs:line ", StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException($"Packaged symbols did not produce Kevlar source line information:{Environment.NewLine}{exception.StackTrace}");
+    }
 }
 
 var injections = 0;
@@ -334,6 +549,12 @@ if (await Shield.Empty.RateLimit(limiter).ExecuteAsync(static _ => new ValueTask
     throw new InvalidOperationException("Rate limiting adapter execution failed.");
 }
 Console.WriteLine("Kevlar package consumer passed.");
+
+[MethodImpl(MethodImplOptions.NoInlining)]
+static void ThrowFromKevlar() =>
+    Shield.Retry(0).Execute(static _ => throw new ExpectedConsumerException());
+
+sealed class ExpectedConsumerException : Exception;
 '@
 
     foreach ($framework in @('net8.0', 'net10.0'))
@@ -363,7 +584,12 @@ Console.WriteLine("Kevlar package consumer passed.");
         Write-TextFile $projectPath $consumerProject
         Write-TextFile (Join-Path $consumerDirectory 'Program.cs') $runtimeProgram
         Invoke-DotNet @('restore', $projectPath, '--configfile', $nugetConfigPath, '--no-cache', '--force-evaluate')
-        Invoke-DotNet @('run', '--project', $projectPath, '-c', 'Release', '--no-restore')
+        Invoke-DotNet @('build', $projectPath, '-c', 'Release', '--no-restore')
+        $kevlarPdbFramework = if ($framework -eq 'net10.0') { 'net10.0' } else { 'netstandard2.0' }
+        Copy-Item `
+            -LiteralPath (Join-Path $symbolRoot "lib/$kevlarPdbFramework/Kevlar.pdb") `
+            -Destination (Join-Path $consumerDirectory "bin/Release/$framework/Kevlar.pdb")
+        Invoke-DotNet @('run', '--project', $projectPath, '-c', 'Release', '--no-build', '--no-restore')
     }
 
     & (Join-Path $PSScriptRoot 'Verify-PublishCompatibility.ps1') `
@@ -421,7 +647,7 @@ await Shield.Empty.ExecuteAsync(cancellationToken => ValueTask.CompletedTask);
         throw "Analyzer consumer produced errors other than KEV001:`n$($unexpectedAnalyzerErrors -join [Environment]::NewLine)"
     }
 
-    Write-Host 'All package layout, metadata, consumer, and analyzer checks passed.'
+    Write-Host 'All package layout, symbols, determinism, SourceLink, consumer, and analyzer checks passed.'
 }
 finally
 {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,8 @@
 
   <PropertyGroup>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <NoWarn>$(NoWarn);RS0026</NoWarn>
   </PropertyGroup>
 

--- a/src/Kevlar.Analyzers/Kevlar.Analyzers.csproj
+++ b/src/Kevlar.Analyzers/Kevlar.Analyzers.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Generate portable-PDB symbol packages for all eight NuGet packages, including the analyzer.
- Upload, validate, publish, and release matching `.snupkg` artifacts.
- Extend package verification with exact SourceLink URLs/checksums, deterministic PE/repack checks, and consumer source-line stack traces.

## Validation

- `dotnet tool restore`
- `dotnet build Kevlar.slnx -c Release -p:Version=1.0.0-test.191 -p:CI=true`
- `dotnet pack Kevlar.slnx -c Release --no-build -p:Version=1.0.0-test.191 -p:CI=true`
- `./scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/verify-191 -Version 1.0.0-test.191`

The package verifier validated all 8 nupkg/snupkg pairs, 17 portable PDBs, SourceLink downloads/checksums, byte-identical rebuilt DLLs, net8/net10 source-line stack traces, analyzer delivery, and publish compatibility.

Closes #191
