### PR TITLE
feat(properties): add typed key collection APIs

### DIFF
--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -78,7 +78,14 @@ var user = await shield.ExecuteWithContextAsync(
     static (state, properties) =>
         properties.Set(state.requestIdKey, state.requestId),
     static (state, context) =>
-        state.client.GetUserAsync(state.id, context.CancellationToken),
+    {
+        if (context.Properties.Contains(state.requestIdKey))
+        {
+            context.Properties.Remove(state.requestIdKey);
+        }
+
+        return state.client.GetUserAsync(state.id, context.CancellationToken);
+    },
     cancellationToken);
 ```
 
@@ -87,6 +94,10 @@ strategy and retry attempt sees the same logical properties. Hedged attempts cop
 properties when each fork launches; later mutations stay isolated between attempts. The action's
 `context.CancellationToken` is the effective token for that attempt, including timeout and hedge
 cancellation.
+
+Use `Contains` and `Remove` when metadata is optional or should not flow to later strategies.
+`Count` reports the entries in the current execution. `KevlarProperties` is not thread-safe; each
+parallel hedge attempt receives its own snapshot, so mutations remain local to that attempt.
 
 When you only need to *read* the context — the shield name, the effective token, the ambient
 `TimeProvider` — there is a shorter overload that skips the state and initializer entirely:

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -147,6 +147,7 @@ public sealed class KevlarContext
     {
 #if DEBUG
         context._returnedToPool = false;
+        context._properties.MarkRented();
 #endif
     }
 
@@ -155,6 +156,7 @@ public sealed class KevlarContext
     {
 #if DEBUG
         context._returnedToPool = true;
+        context._properties.MarkReturned();
 #endif
     }
 

--- a/src/Kevlar/KevlarKey.cs
+++ b/src/Kevlar/KevlarKey.cs
@@ -6,7 +6,7 @@ namespace Kevlar;
 /// A strongly typed key for storing values in <see cref="KevlarProperties"/>.
 /// </summary>
 /// <typeparam name="T">The type of the value stored under this key.</typeparam>
-public readonly struct KevlarKey<T>
+public readonly struct KevlarKey<T> : IEquatable<KevlarKey<T>>
 {
     /// <summary>Creates a key with the given name. Names are case-sensitive.</summary>
     public KevlarKey(string name)
@@ -17,6 +17,21 @@ public readonly struct KevlarKey<T>
 
     /// <summary>The key's name.</summary>
     public string Name { get; }
+
+    /// <inheritdoc />
+    public bool Equals(KevlarKey<T> other) => StringComparer.Ordinal.Equals(Name, other.Name);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is KevlarKey<T> other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => Name is null ? 0 : StringComparer.Ordinal.GetHashCode(Name);
+
+    /// <summary>Returns whether two keys have the same case-sensitive name.</summary>
+    public static bool operator ==(KevlarKey<T> left, KevlarKey<T> right) => left.Equals(right);
+
+    /// <summary>Returns whether two keys have different case-sensitive names.</summary>
+    public static bool operator !=(KevlarKey<T> left, KevlarKey<T> right) => !left.Equals(right);
 
     /// <inheritdoc />
     public override string ToString() => Name ?? string.Empty;

--- a/src/Kevlar/KevlarProperties.cs
+++ b/src/Kevlar/KevlarProperties.cs
@@ -14,14 +14,30 @@ public sealed class KevlarProperties
     private PropertyIdentity _firstIdentity;
     private PropertySlot? _firstItem;
     private Dictionary<PropertyIdentity, PropertySlot>? _items;
+    private int _count;
+
+#if DEBUG
+    private bool _returnedToPool;
+#endif
 
     internal KevlarProperties()
     {
     }
 
+    /// <summary>Gets the number of values currently stored in the bag.</summary>
+    public int Count
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _count;
+        }
+    }
+
     /// <summary>Stores a value under the given key, replacing any existing value.</summary>
     public void Set<T>(KevlarKey<T> key, T value)
     {
+        ThrowIfReturnedToPool();
         var identity = GetIdentity(key);
         Set(identity, value);
     }
@@ -29,6 +45,7 @@ public sealed class KevlarProperties
     /// <summary>Attempts to read the value stored under the given key.</summary>
     public bool TryGet<T>(KevlarKey<T> key, out T value)
     {
+        ThrowIfReturnedToPool();
         var identity = GetIdentity(key);
         if (_firstItem is not null &&
             _firstIdentity == identity &&
@@ -54,12 +71,39 @@ public sealed class KevlarProperties
     public T GetOrDefault<T>(KevlarKey<T> key, T defaultValue = default!) =>
         TryGet(key, out var value) ? value : defaultValue;
 
+    /// <summary>Returns whether a value is stored under the given key.</summary>
+    public bool Contains<T>(KevlarKey<T> key)
+    {
+        ThrowIfReturnedToPool();
+        var identity = GetIdentity(key);
+        return Find(identity) is { HasValue: true };
+    }
+
+    /// <summary>Removes the value stored under the given key.</summary>
+    /// <returns><see langword="true"/> when a value was removed; otherwise <see langword="false"/>.</returns>
+    public bool Remove<T>(KevlarKey<T> key)
+    {
+        ThrowIfReturnedToPool();
+        var identity = GetIdentity(key);
+        var slot = Find(identity);
+        if (slot is not { HasValue: true })
+        {
+            return false;
+        }
+
+        slot.Clear();
+        _count--;
+        return true;
+    }
+
     internal void Clear()
     {
         if (_firstItem is null)
         {
             return;
         }
+
+        _count = 0;
 
         if (_items is { Count: >= RetainedSlotCapacity })
         {
@@ -102,36 +146,90 @@ public sealed class KevlarProperties
         {
             _firstIdentity = identity;
             _firstItem = new PropertySlot<T>(value);
+            _count = 1;
             return;
         }
 
         if (_firstIdentity == identity)
         {
-            ((PropertySlot<T>)_firstItem).Set(value);
+            if (((PropertySlot<T>)_firstItem).Set(value))
+            {
+                _count++;
+            }
+
             return;
         }
 
         var items = _items ??= [];
         if (items.TryGetValue(identity, out var stored))
         {
-            ((PropertySlot<T>)stored).Set(value);
+            if (((PropertySlot<T>)stored).Set(value))
+            {
+                _count++;
+            }
         }
         else
         {
             items.Add(identity, new PropertySlot<T>(value));
+            _count++;
         }
+    }
+
+    private PropertySlot? Find(PropertyIdentity identity)
+    {
+        if (_firstItem is not null && _firstIdentity == identity)
+        {
+            return _firstItem;
+        }
+
+        return _items is not null && _items.TryGetValue(identity, out var stored)
+            ? stored
+            : null;
     }
 
     private static PropertyIdentity GetIdentity<T>(KevlarKey<T> key)
     {
-        Throw.IfNull(key.Name, nameof(key));
+        if (key.Name is null)
+        {
+            throw new InvalidOperationException("KevlarKey<T> must be created with a name");
+        }
+
         return new(key.Name, typeof(T));
+    }
+
+    internal void MarkRented()
+    {
+#if DEBUG
+        _returnedToPool = false;
+#endif
+    }
+
+    internal void MarkReturned()
+    {
+#if DEBUG
+        _returnedToPool = true;
+#endif
+    }
+
+    [System.Diagnostics.Conditional("DEBUG")]
+    private void ThrowIfReturnedToPool()
+    {
+#if DEBUG
+        if (_returnedToPool)
+        {
+            throw new InvalidOperationException(
+                "This KevlarProperties instance belongs to a KevlarContext that has been returned " +
+                "to Kevlar's context pool and is no longer valid.");
+        }
+#endif
     }
 
     private readonly record struct PropertyIdentity(string Name, Type ValueType);
 
     private abstract class PropertySlot
     {
+        public abstract bool HasValue { get; }
+
         public abstract void Clear();
 
         public abstract void CopyTo(KevlarProperties target, PropertyIdentity identity);
@@ -142,10 +240,14 @@ public sealed class KevlarProperties
         private T _value = value;
         private bool _hasValue = true;
 
-        public void Set(T value)
+        public override bool HasValue => _hasValue;
+
+        public bool Set(T value)
         {
+            var wasEmpty = !_hasValue;
             _value = value;
             _hasValue = true;
+            return wasEmpty;
         }
 
         public bool TryGet(out T value)

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -354,3 +354,11 @@ static Kevlar.ShieldTaskExtensions.ExecuteAsync(this Kevlar.VoidShield! shield, 
 static Kevlar.ShieldTaskExtensions.ExecuteAsync<TState>(this Kevlar.VoidShield! shield, TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync(this Kevlar.VoidShield! shield, System.Func<Kevlar.KevlarContext!, System.Threading.Tasks.Task!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 static Kevlar.ShieldTaskExtensions.ExecuteWithContextAsync<TState>(this Kevlar.VoidShield! shield, TState state, System.Action<TState, Kevlar.KevlarProperties!>! initializeProperties, System.Func<TState, Kevlar.KevlarContext!, System.Threading.Tasks.Task!>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+Kevlar.KevlarKey<T>.Equals(Kevlar.KevlarKey<T> other) -> bool
+Kevlar.KevlarProperties.Contains<T>(Kevlar.KevlarKey<T> key) -> bool
+Kevlar.KevlarProperties.Count.get -> int
+Kevlar.KevlarProperties.Remove<T>(Kevlar.KevlarKey<T> key) -> bool
+override Kevlar.KevlarKey<T>.Equals(object? obj) -> bool
+override Kevlar.KevlarKey<T>.GetHashCode() -> int
+static Kevlar.KevlarKey<T>.operator !=(Kevlar.KevlarKey<T> left, Kevlar.KevlarKey<T> right) -> bool
+static Kevlar.KevlarKey<T>.operator ==(Kevlar.KevlarKey<T> left, Kevlar.KevlarKey<T> right) -> bool

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -76,6 +76,10 @@ public class AllocationBudgetTests
     private readonly Shield<int> _primaryWinsHedge = Shield.For<int>()
         .Hedge(2, TimeSpan.FromMinutes(1));
     private readonly PartitionedShield<int> _partitioned = new(static _ => Shield.Empty);
+    private readonly Dictionary<KevlarKey<int>, int> _keyDictionary = new()
+    {
+        [MetadataValue] = 42,
+    };
 
     private readonly Shield _recoveryRetry = Shield.Retry(3, Backoff.None);
     private readonly Shield _recoveryAsyncDelayRetry = Shield.Retry(options =>
@@ -168,6 +172,8 @@ public class AllocationBudgetTests
             test._primaryWinsHedge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("warm partition lookup", this, static test =>
             _ = test._partitioned.GetShield(42));
+        AssertZero("typed key dictionary lookup", this, static test =>
+            _ = test._keyDictionary[MetadataValue]);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/CallerContextTests.cs
+++ b/tests/Kevlar.Tests/CallerContextTests.cs
@@ -80,6 +80,8 @@ public class CallerContextTests
             async (state, context) =>
             {
                 var currentAttempt = Interlocked.Increment(ref attempt);
+                await Assert.That(context.Properties.Contains(AttemptValue)).IsTrue();
+                await Assert.That(context.Properties.Count).IsEqualTo(1);
                 var initial = context.Properties.GetOrDefault(AttemptValue);
                 context.Properties.Set(AttemptValue, currentAttempt);
                 state.Add((context, initial, context.Properties.GetOrDefault(AttemptValue)));

--- a/tests/Kevlar.Tests/KevlarKeyTests.cs
+++ b/tests/Kevlar.Tests/KevlarKeyTests.cs
@@ -1,0 +1,52 @@
+namespace Kevlar.Tests;
+
+public class KevlarKeyTests
+{
+    [Test]
+    public async Task Keys_With_Same_Name_And_Type_Are_Equal()
+    {
+        var first = new KevlarKey<int>("attempt");
+        var second = new KevlarKey<int>("attempt");
+
+        await Assert.That(first == second).IsTrue();
+        await Assert.That(first != second).IsFalse();
+        await Assert.That(first.Equals(second)).IsTrue();
+        await Assert.That(first.Equals((object)second)).IsTrue();
+        await Assert.That(first.GetHashCode()).IsEqualTo(second.GetHashCode());
+    }
+
+    [Test]
+    public async Task Keys_With_Same_Name_And_Different_Type_Are_Not_Equal()
+    {
+        object number = new KevlarKey<int>("shared");
+        object text = new KevlarKey<string>("shared");
+
+        await Assert.That(number.Equals(text)).IsFalse();
+    }
+
+    [Test]
+    public async Task Keys_Are_Case_Sensitive()
+    {
+        var upper = new KevlarKey<int>("Key");
+        var lower = new KevlarKey<int>("key");
+
+        await Assert.That(upper == lower).IsFalse();
+    }
+
+    [Test]
+    public async Task Key_Works_As_Dictionary_Key()
+    {
+        var stored = new KevlarKey<int>("value");
+        var dictionary = new Dictionary<KevlarKey<int>, int> { [stored] = 42 };
+
+        await Assert.That(dictionary[new KevlarKey<int>("value")]).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task ToString_Returns_Name()
+    {
+        var key = new KevlarKey<int>("attempt-count");
+
+        await Assert.That(key.ToString()).IsEqualTo("attempt-count");
+    }
+}

--- a/tests/Kevlar.Tests/KevlarPropertiesTests.cs
+++ b/tests/Kevlar.Tests/KevlarPropertiesTests.cs
@@ -1,0 +1,156 @@
+namespace Kevlar.Tests;
+
+[NotInParallel]
+public class KevlarPropertiesTests
+{
+    private static readonly KevlarKey<int> ValueKey = new("value");
+
+    [Test]
+    public async Task Remove_Returns_True_When_Present_And_Clears_Value()
+    {
+        var properties = new KevlarProperties();
+        properties.Set(ValueKey, 42);
+
+        var removed = properties.Remove(ValueKey);
+
+        await Assert.That(removed).IsTrue();
+        await Assert.That(properties.TryGet(ValueKey, out _)).IsFalse();
+        await Assert.That(properties.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Remove_Returns_False_When_Absent()
+    {
+        var properties = new KevlarProperties();
+
+        await Assert.That(properties.Remove(ValueKey)).IsFalse();
+    }
+
+    [Test]
+    public async Task Contains_Reflects_Set_And_Remove()
+    {
+        var properties = new KevlarProperties();
+
+        await Assert.That(properties.Contains(ValueKey)).IsFalse();
+        properties.Set(ValueKey, 42);
+        await Assert.That(properties.Contains(ValueKey)).IsTrue();
+        properties.Remove(ValueKey);
+        await Assert.That(properties.Contains(ValueKey)).IsFalse();
+    }
+
+    [Test]
+    public async Task Count_Tracks_Entries()
+    {
+        var properties = new KevlarProperties();
+        var otherKey = new KevlarKey<string>("other");
+
+        properties.Set(ValueKey, 1);
+        properties.Set(ValueKey, 2);
+        properties.Set(otherKey, "text");
+        await Assert.That(properties.Count).IsEqualTo(2);
+
+        properties.Remove(ValueKey);
+        await Assert.That(properties.Count).IsEqualTo(1);
+        properties.Set(ValueKey, 3);
+        await Assert.That(properties.Count).IsEqualTo(2);
+        properties.Remove(ValueKey);
+        properties.Remove(otherKey);
+        await Assert.That(properties.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Default_Key_Throws_Clear_Message_On_Use()
+    {
+        var properties = new KevlarProperties();
+        var defaultKey = default(KevlarKey<int>);
+
+        await AssertInvalidKey(() => properties.Set(defaultKey, 1));
+        await AssertInvalidKey(() => properties.TryGet(defaultKey, out _));
+        await AssertInvalidKey(() => properties.GetOrDefault(defaultKey));
+        await AssertInvalidKey(() => properties.Remove(defaultKey));
+        await AssertInvalidKey(() => properties.Contains(defaultKey));
+    }
+
+    [Test]
+    public async Task Properties_Are_Cleared_When_Context_Returns_To_Pool()
+    {
+        await Shield.Empty.ExecuteWithContextAsync(
+            ValueKey,
+            static (key, properties) => properties.Set(key, 42),
+            static (_, _) => ValueTask.CompletedTask);
+
+        var count = -1;
+        await Shield.Empty.ExecuteWithContextAsync(
+            0,
+            (_, properties) => count = properties.Count,
+            static (_, _) => ValueTask.CompletedTask);
+
+        await Assert.That(count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Remove_Is_Visible_To_Later_Strategies_In_Same_Execution()
+    {
+        var remover = new RemovePropertyStrategy(ValueKey);
+        var observer = new ObservePropertyStrategy(ValueKey);
+        var shield = Shield.Empty.Use(remover).Use(observer);
+
+        await shield.ExecuteWithContextAsync(
+            ValueKey,
+            static (key, properties) => properties.Set(key, 42),
+            static (_, _) => ValueTask.CompletedTask);
+
+        await Assert.That(remover.Removed).IsTrue();
+        await Assert.That(observer.Contains).IsFalse();
+    }
+
+    [Test]
+    public async Task Returned_Properties_Reject_Remove_And_Contains_In_Debug_Builds()
+    {
+        KevlarProperties? retained = null;
+        await Shield.Empty.ExecuteWithContextAsync(context =>
+        {
+            retained = context.Properties;
+            return ValueTask.CompletedTask;
+        });
+
+#if DEBUG
+        await Assert.That(() => retained!.Remove(ValueKey)).Throws<InvalidOperationException>();
+        await Assert.That(() => retained!.Contains(ValueKey)).Throws<InvalidOperationException>();
+#else
+        await Assert.That(retained!.Contains(ValueKey)).IsFalse();
+#endif
+    }
+
+    private static async Task AssertInvalidKey(Action action)
+    {
+        var exception = await Assert.That(action).Throws<InvalidOperationException>();
+        await Assert.That(exception!.Message).IsEqualTo("KevlarKey<T> must be created with a name");
+    }
+
+    private sealed class RemovePropertyStrategy(KevlarKey<int> key) : Strategy
+    {
+        public bool Removed { get; private set; }
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            Removed = context.Properties.Remove(key);
+            return next.InvokeAsync(context);
+        }
+    }
+
+    private sealed class ObservePropertyStrategy(KevlarKey<int> key) : Strategy
+    {
+        public bool Contains { get; private set; }
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            Contains = context.Properties.Contains(key);
+            return next.InvokeAsync(context);
+        }
+    }
+}

--- a/tests/Kevlar.Tests/OutcomeAndContextTests.cs
+++ b/tests/Kevlar.Tests/OutcomeAndContextTests.cs
@@ -149,9 +149,9 @@ public class OutcomeAndContextTests
     {
         var properties = CapturedProperties();
 
-        await Assert.That(() => properties.Set(default(KevlarKey<int>), 1)).Throws<ArgumentNullException>();
-        await Assert.That(() => properties.TryGet(default(KevlarKey<int>), out _)).Throws<ArgumentNullException>();
-        await Assert.That(() => properties.GetOrDefault(default(KevlarKey<int>))).Throws<ArgumentNullException>();
+        await Assert.That(() => properties.Set(default(KevlarKey<int>), 1)).Throws<InvalidOperationException>();
+        await Assert.That(() => properties.TryGet(default(KevlarKey<int>), out _)).Throws<InvalidOperationException>();
+        await Assert.That(() => properties.GetOrDefault(default(KevlarKey<int>))).Throws<InvalidOperationException>();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- give `KevlarKey<T>` case-sensitive value equality, hash codes, and operators
- add `Contains`, `Remove`, and active-entry `Count` to `KevlarProperties`
- preserve pooled slot reuse, add clear default-key errors and Debug lifetime guards
- document collection semantics and hedge-fork isolation

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (820 passed)
- `dotnet run --project tests/Kevlar.Tests -c Debug -- --timeout 5m` (820 passed)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (3 passed; typed key dictionary lookup remains 0 B/op)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/packages -Version 1.0.0-loop205` (118 compiled; behavior passed)
- `npm run build` in `docs/`

Closes #205