### PR TITLE
feat(strategy): expose invocation semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
   `AddStandardHedgingShield` are unchanged.
 ### Changed
 
+- Custom strategies can override `Strategy.InvokesContinuationAtMostOnce`; the same aggregate
+  value is now exposed on `Shield<TResult>` as well as `Shield` and `VoidShield`.
 - **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.
 - `Backoff.Custom` documents the clamping the retry path already applied to its delegate's result: a
   negative delay becomes zero, a delay above the runtime timer limit becomes that limit, and the

--- a/docs/docs/custom-strategies.md
+++ b/docs/docs/custom-strategies.md
@@ -33,6 +33,8 @@ Override `Describe()` so `shield.ToString()` names your strategy meaningfully in
 <!-- doc-test-strategy-member -->
 ```csharp
 public override string Describe() => "Logging";
+
+protected override bool InvokesContinuationAtMostOnce => true;
 ```
 
 ## The contract
@@ -57,6 +59,11 @@ The power is in how many times you call `next`:
 | zero | short-circuit | circuit breaker (open), rate limit, concurrency limit rejection |
 | one | decorator | timeout, fallback, logging, metrics |
 | many | repeater | retry, hedging |
+
+Override `InvokesContinuationAtMostOnce` with `true` only when every execution path calls `next`
+zero or one time. This lets consumers such as the gRPC interceptors safely expose response headers
+before the response completes. Keep the conservative `false` default for retry, hedging, loops, or
+any strategy that may call `next` more than once.
 
 ## Failures are outcomes, not throws
 

--- a/src/Kevlar.Chaos/Internal/ChaosStrategy.cs
+++ b/src/Kevlar.Chaos/Internal/ChaosStrategy.cs
@@ -17,6 +17,8 @@ internal abstract class ChaosStrategy : Strategy
     private readonly Action<ChaosEvent>? _onInjected;
     private long _randomState;
 
+    protected override bool InvokesContinuationAtMostOnce => true;
+
     protected ChaosStrategy(ChaosOptions options)
     {
         if (options is null)

--- a/src/Kevlar.Extensions.RateLimiting/RateLimiterStrategy.cs
+++ b/src/Kevlar.Extensions.RateLimiting/RateLimiterStrategy.cs
@@ -15,7 +15,7 @@ internal sealed class RateLimiterStrategy : Strategy
     private readonly Func<RateLimiterRejectedEvent, ValueTask>? _onRejectedAsync;
     private readonly string _kind;
 
-    internal override bool InvokesContinuationAtMostOnce => true;
+    protected internal override bool InvokesContinuationAtMostOnce => true;
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Kevlar.Shield<TResult>.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>!
 Kevlar.ShieldBuilder.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield!
 Kevlar.ShieldBuilder<TResult>.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield<TResult>!
 virtual Kevlar.Strategy.Handling.get -> Kevlar.HandlingClause?
+virtual Kevlar.Strategy.InvokesContinuationAtMostOnce.get -> bool
+Kevlar.Shield<TResult>.InvokesContinuationAtMostOnce.get -> bool
 Kevlar.CircuitBreakerBreakDurationEvent
 Kevlar.CircuitBreakerBreakDurationEvent.CircuitBreakerBreakDurationEvent() -> void
 Kevlar.CircuitBreakerBreakDurationEvent.Context.get -> Kevlar.KevlarContext!

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -43,7 +43,7 @@ public sealed class Shield
 
     /// <summary>
     /// Gets whether every strategy guarantees invoking the execution continuation at most once.
-    /// Custom strategies are treated conservatively as potentially multi-attempt.
+    /// Custom strategies may opt in through <see cref="Strategy.InvokesContinuationAtMostOnce"/>.
     /// </summary>
     public bool InvokesContinuationAtMostOnce =>
         Strategies.All(static strategy => strategy.InvokesContinuationAtMostOnce);

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -32,6 +32,13 @@ public sealed class Shield<TResult>
     /// <summary>A shield with no strategies: executions pass straight through.</summary>
     public static Shield<TResult> Empty { get; } = new([], null, null, null);
 
+    /// <summary>
+    /// Gets whether every strategy guarantees invoking the execution continuation at most once.
+    /// Custom strategies may opt in through <see cref="Strategy.InvokesContinuationAtMostOnce"/>.
+    /// </summary>
+    public bool InvokesContinuationAtMostOnce =>
+        Strategies.All(static strategy => strategy.InvokesContinuationAtMostOnce);
+
     internal OutcomeJudge JudgeOrDefault => Ambient ?? OutcomeJudge.Default;
 
     internal TimeProvider TimeOrSystem => Time ?? TimeProvider.System;

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -7,7 +7,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
 {
     private readonly Lock _metricsNamesGate = new();
     private readonly HashSet<StrategyMetricAlias> _metricsAliases = [];
-    internal override bool InvokesContinuationAtMostOnce => true;
+    protected internal override bool InvokesContinuationAtMostOnce => true;
     private readonly CircuitBreakerCore _core;
     private readonly OutcomeJudge _judge;
 

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -20,7 +20,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private long _pending;
     private long _metricsState;
 
-    internal override bool InvokesContinuationAtMostOnce => true;
+    protected internal override bool InvokesContinuationAtMostOnce => true;
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -5,7 +5,7 @@ namespace Kevlar.Strategies;
 
 internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyInspection
 {
-    internal override bool InvokesContinuationAtMostOnce => true;
+    protected internal override bool InvokesContinuationAtMostOnce => true;
 
     private readonly Func<Outcome<TResult>, KevlarContext, ValueTask<TResult>> _fallback;
     private readonly OutcomeJudge _judge;
@@ -130,7 +130,7 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
 /// </summary>
 internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspection
 {
-    internal override bool InvokesContinuationAtMostOnce => true;
+    protected internal override bool InvokesContinuationAtMostOnce => true;
 
     private readonly Func<Exception, CancellationToken, ValueTask> _fallback;
     private readonly OutcomeJudge _judge;

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -37,7 +37,7 @@ internal sealed class HedgingStrategy : Strategy
 
     internal bool HasNotification => _onHedge is not null;
 
-    internal override bool InvokesContinuationAtMostOnce => _maxAttempts == 1;
+    protected internal override bool InvokesContinuationAtMostOnce => _maxAttempts == 1;
 
     public override string Describe() => $"Hedge({_maxAttempts} attempts, delay {DescribeHelper.Time(_delay)})";
 

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -13,7 +13,7 @@ namespace Kevlar.Strategies;
 /// </summary>
 internal sealed class RateLimitStrategy : Strategy
 {
-    internal override bool InvokesContinuationAtMostOnce => true;
+    protected internal override bool InvokesContinuationAtMostOnce => true;
 
     private static readonly double SecondsPerSystemTimestamp = 1d / Stopwatch.Frequency;
 

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -89,7 +89,7 @@ internal sealed class RetryStrategy : Strategy
 
     internal bool HasNotification => _onRetry is not null || _onRetryAsync is not null;
 
-    internal override bool InvokesContinuationAtMostOnce => _maxRetries == 0;
+    protected internal override bool InvokesContinuationAtMostOnce => _maxRetries == 0;
 
     public override string Describe()
     {

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -10,7 +10,7 @@ namespace Kevlar.Strategies;
 /// </summary>
 internal sealed class TimeoutStrategy : Strategy
 {
-    internal override bool InvokesContinuationAtMostOnce => true;
+    protected internal override bool InvokesContinuationAtMostOnce => true;
 
     private readonly TimeSpan _timeout;
     private readonly Func<KevlarContext, ValueTask<TimeSpan>>? _timeoutGenerator;

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -21,7 +21,15 @@ namespace Kevlar;
 /// </remarks>
 public abstract class Strategy
 {
-    internal virtual bool InvokesContinuationAtMostOnce => false;
+    /// <summary>
+    /// Gets whether this strategy guarantees invoking its continuation at most once per execution.
+    /// </summary>
+    /// <remarks>
+    /// Override and return <see langword="true"/> only when every path invokes <c>next</c> zero or
+    /// one time. Strategies that retry, hedge, loop, or otherwise may invoke <c>next</c> more than
+    /// once must retain the conservative default.
+    /// </remarks>
+    protected internal virtual bool InvokesContinuationAtMostOnce => false;
 
     /// <summary>
     /// The handling clause this reactive strategy acts on, or <see langword="null"/> for a

--- a/src/Kevlar/VoidShield.cs
+++ b/src/Kevlar/VoidShield.cs
@@ -27,7 +27,7 @@ public sealed class VoidShield
 
     /// <summary>
     /// Gets whether every strategy guarantees invoking the execution continuation at most once.
-    /// Custom strategies are treated conservatively as potentially multi-attempt.
+    /// Custom strategies may opt in through <see cref="Strategy.InvokesContinuationAtMostOnce"/>.
     /// </summary>
     public bool InvokesContinuationAtMostOnce => _pipeline.InvokesContinuationAtMostOnce;
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -9,6 +9,23 @@ namespace Kevlar.Analyzers.Tests;
 public class PipelineHazardAnalyzerTests
 {
     [Test]
+    public async Task Custom_Strategy_Can_Declare_Single_Invocation_Without_Diagnostics()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class SingleInvocationStrategy : Strategy
+            {
+                protected override bool InvokesContinuationAtMostOnce => true;
+
+                public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+                    Continuation<T, TState> next,
+                    KevlarContext context) => next.InvokeAsync(context);
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task Typed_Fallback_Keeps_Only_The_Bare_And_Configure_Tiers()
     {
         var supported = CreateCompilation(CreateSource("""

--- a/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/ChaosStrategyTests.cs
@@ -7,6 +7,15 @@ namespace Kevlar.Chaos.Tests;
 public class ChaosStrategyTests
 {
     [Test]
+    public async Task Chaos_Strategies_Report_At_Most_One_Continuation_Invocation()
+    {
+        await Assert.That(ChaosShield.Fault(_ => { }).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(ChaosShield.Latency(_ => { }).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(ChaosShield.Behavior(_ => { }).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(ChaosShield.Outcome<int>(_ => { }).InvokesContinuationAtMostOnce).IsTrue();
+    }
+
+    [Test]
     public async Task Chaos_Is_Disabled_By_Default_For_Every_Injection_Type()
     {
         var behaviorCalls = 0;

--- a/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
@@ -64,6 +64,23 @@ public class GrpcResilienceTests
     }
 
     [Test]
+    public async Task Custom_Single_Invoke_Strategy_Keeps_Early_Header_Forwarding()
+    {
+        await using var server = await GrpcTestServer.StartAsync();
+        var shield = Shield.Use(new SingleInvocationStrategy())
+            .Timeout(TimeSpan.FromMinutes(1));
+        using var call = server.Client(shield).UnaryAsync(
+            new TestRequest { Scenario = "headers_wait" });
+
+        var headers = await call.ResponseHeadersAsync.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(headers.GetValue("attempt")).IsEqualTo("1");
+
+        server.State.Release();
+        var response = await call.ResponseAsync.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(response.Attempt).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Transient_Helper_Retries_Only_Opted_In_Statuses()
     {
         await using var server = await GrpcTestServer.StartAsync();
@@ -1076,6 +1093,15 @@ public class GrpcResilienceTests
             _ = await next.InvokeAsync(context).ConfigureAwait(false);
             return first;
         }
+    }
+
+    private sealed class SingleInvocationStrategy : Strategy
+    {
+        protected override bool InvokesContinuationAtMostOnce => true;
+
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
     }
 
     private sealed class GrpcTestServer : IAsyncDisposable

--- a/tests/Kevlar.Tests/ShieldInvocationSemanticsTests.cs
+++ b/tests/Kevlar.Tests/ShieldInvocationSemanticsTests.cs
@@ -23,6 +23,9 @@ public class ShieldInvocationSemanticsTests
 
         await Assert.That(Shield.Empty.Fallback(_ => ValueTask.CompletedTask).InvokesContinuationAtMostOnce)
             .IsTrue();
+        await Assert.That(Shield.For<int>().Fallback(0).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(Shield.For<int>().Retry(0, Backoff.None).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(Shield.For<int>().Hedge(1, TimeSpan.Zero).InvokesContinuationAtMostOnce).IsTrue();
     }
 
     [Test]
@@ -40,10 +43,50 @@ public class ShieldInvocationSemanticsTests
         {
             await Assert.That(shield.InvokesContinuationAtMostOnce).IsFalse();
         }
+
+        await Assert.That(Shield.For<int>().Retry(1, Backoff.None).InvokesContinuationAtMostOnce).IsFalse();
+        await Assert.That(Shield.For<int>().Hedge(2, TimeSpan.Zero).InvokesContinuationAtMostOnce).IsFalse();
+    }
+
+    [Test]
+    public async Task Custom_Strategy_Can_Declare_Single_Invocation()
+    {
+        var strategy = new SingleInvocationStrategy();
+
+        await Assert.That(Shield.Use(strategy).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(Shield<int>.Empty.Use(strategy).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(
+            Shield.Fallback(static _ => ValueTask.CompletedTask)
+                .Use(strategy)
+                .InvokesContinuationAtMostOnce)
+            .IsTrue();
+        await Assert.That(Shield.Use(strategy).Retry(1, Backoff.None).InvokesContinuationAtMostOnce)
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task Wrap_And_Compose_Propagate_Invocation_Semantics()
+    {
+        var single = Shield.Use(new SingleInvocationStrategy());
+        var repeated = Shield.Retry(1, Backoff.None);
+
+        await Assert.That(single.Wrap(single).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(single.Wrap(repeated).InvokesContinuationAtMostOnce).IsFalse();
+        await Assert.That(Shield.Compose(single, single).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(Shield.Compose(single, repeated).InvokesContinuationAtMostOnce).IsFalse();
     }
 
     private sealed class CustomStrategy : Strategy
     {
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
+    }
+
+    private sealed class SingleInvocationStrategy : Strategy
+    {
+        protected internal override bool InvokesContinuationAtMostOnce => true;
+
         public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
             Continuation<T, TState> next,
             KevlarContext context) => next.InvokeAsync(context);


### PR DESCRIPTION
## Summary
- expose `Strategy.InvokesContinuationAtMostOnce` to custom strategies
- add the aggregate property to `Shield<TResult>` and update built-in/satellite override accessibility
- mark all Chaos strategies as at-most-once
- preserve gRPC early-header forwarding for opted-in custom strategies
- document the strict opt-in contract

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (809 passed)
- `dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m` (32 passed)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (76 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (124 passed)
- `dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build -- --timeout 5m` (23 passed)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/packages -Version 1.0.0-loop206` (118 compiled; behavior passed)
- `npm run build` in `docs/`

Closes #206