### PR TITLE
fix(engine): fault empty async throws

### DIFF
--- a/src/Kevlar/Internal/ShieldEngine.cs
+++ b/src/Kevlar/Internal/ShieldEngine.cs
@@ -20,13 +20,13 @@ internal static class ShieldEngine
 
         if (head is null)
         {
-            if (!KevlarMetrics.ExecutionEnabled && !KevlarMetrics.DurationEnabled)
-            {
-                return action(state, cancellationToken);
-            }
-
             try
             {
+                if (!KevlarMetrics.ExecutionEnabled && !KevlarMetrics.DurationEnabled)
+                {
+                    return action(state, cancellationToken);
+                }
+
                 var execution = action(state, cancellationToken);
                 if (execution.IsCompletedSuccessfully)
                 {
@@ -36,10 +36,10 @@ internal static class ShieldEngine
 
                 return AwaitDirectAsync(execution, shieldName, startedAt);
             }
-            catch
+            catch (Exception exception)
             {
                 RecordExecution(startedAt, shieldName, success: false);
-                throw;
+                return Rethrow<T>(Outcome<T>.FromException(exception));
             }
         }
 

--- a/tests/Kevlar.Tests/ShieldEmptyTests.cs
+++ b/tests/Kevlar.Tests/ShieldEmptyTests.cs
@@ -1,0 +1,135 @@
+namespace Kevlar.Tests;
+
+public class ShieldEmptyTests
+{
+    [Test]
+    public async Task Empty_Synchronous_Throw_Surfaces_As_Faulted_ValueTask()
+    {
+        var failure = new IOException("failure");
+
+        var untyped = Shield.Empty.ExecuteAsync<int>(_ => throw failure);
+        var typed = Shield<int>.Empty.ExecuteAsync(_ => throw failure);
+
+        await Assert.That(untyped.IsFaulted).IsTrue();
+        await Assert.That(typed.IsFaulted).IsTrue();
+        await Assert.That(ReferenceEquals(await CaptureExceptionAsync(untyped), failure)).IsTrue();
+        await Assert.That(ReferenceEquals(await CaptureExceptionAsync(typed), failure)).IsTrue();
+    }
+
+    [Test]
+    public async Task Empty_State_And_Task_Overloads_Return_Faulted_ValueTasks()
+    {
+        var failure = new IOException("failure");
+
+        var valueTaskState = Shield.Empty.ExecuteAsync<int, IOException>(
+            failure,
+            static (exception, _) => throw exception);
+        var task = Shield.Empty.ExecuteAsync(
+            (Func<CancellationToken, Task<int>>)(_ => throw failure));
+        var taskState = Shield.Empty.ExecuteAsync(
+            failure,
+            (Func<IOException, CancellationToken, Task<int>>)(static (exception, _) => throw exception));
+
+        await Assert.That(valueTaskState.IsFaulted).IsTrue();
+        await Assert.That(task.IsFaulted).IsTrue();
+        await Assert.That(taskState.IsFaulted).IsTrue();
+        await Assert.That(ReferenceEquals(await CaptureExceptionAsync(valueTaskState), failure)).IsTrue();
+        await Assert.That(ReferenceEquals(await CaptureExceptionAsync(task), failure)).IsTrue();
+        await Assert.That(ReferenceEquals(await CaptureExceptionAsync(taskState), failure)).IsTrue();
+    }
+
+    [Test]
+    public async Task Empty_And_Retry_Zero_Have_The_Same_Completion_Semantics()
+    {
+        await AssertParityAsync(
+            Shield.Empty.ExecuteAsync(_ => new ValueTask<int>(42)),
+            Shield.Retry(0, Backoff.None).ExecuteAsync(_ => new ValueTask<int>(42)));
+        await AssertParityAsync(
+            Shield.Empty.ExecuteAsync<int>(_ => throw new IOException("empty")),
+            Shield.Retry(0, Backoff.None).ExecuteAsync<int>(_ => throw new IOException("retry")));
+
+        var emptySuccess = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var retrySuccess = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await AssertParityAsync(
+            Shield.Empty.ExecuteAsync(_ => new ValueTask<int>(emptySuccess.Task)),
+            Shield.Retry(0, Backoff.None).ExecuteAsync(_ => new ValueTask<int>(retrySuccess.Task)),
+            () =>
+            {
+                emptySuccess.SetResult(42);
+                retrySuccess.SetResult(42);
+            });
+
+        var emptyFailure = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var retryFailure = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await AssertParityAsync(
+            Shield.Empty.ExecuteAsync(_ => new ValueTask<int>(emptyFailure.Task)),
+            Shield.Retry(0, Backoff.None).ExecuteAsync(_ => new ValueTask<int>(retryFailure.Task)),
+            () =>
+            {
+                emptyFailure.SetException(new IOException("empty"));
+                retryFailure.SetException(new IOException("retry"));
+            });
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await AssertParityAsync(
+            Shield.Empty.ExecuteAsync(_ => new ValueTask<int>(42), cancellation.Token),
+            Shield.Retry(0, Backoff.None).ExecuteAsync(_ => new ValueTask<int>(42), cancellation.Token));
+    }
+
+    [Test]
+    public async Task Empty_Outcome_Captures_A_Synchronous_Throw()
+    {
+        var failure = new IOException("failure");
+
+        var untyped = await Shield.Empty.ExecuteOutcomeAsync<int>(_ => throw failure);
+        var typed = await Shield<int>.Empty.ExecuteOutcomeAsync(_ => throw failure);
+
+        await Assert.That(ReferenceEquals(untyped.Exception, failure)).IsTrue();
+        await Assert.That(ReferenceEquals(typed.Exception, failure)).IsTrue();
+    }
+
+    private static async Task<Exception> CaptureExceptionAsync<T>(ValueTask<T> execution)
+    {
+        try
+        {
+            _ = await execution;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+
+        throw new InvalidOperationException("Execution did not fail.");
+    }
+
+    private static async Task AssertParityAsync(
+        ValueTask<int> empty,
+        ValueTask<int> retry,
+        Action? release = null)
+    {
+        await Assert.That(empty.IsCompleted).IsEqualTo(retry.IsCompleted);
+        await Assert.That(empty.IsFaulted).IsEqualTo(retry.IsFaulted);
+        await Assert.That(empty.IsCanceled).IsEqualTo(retry.IsCanceled);
+
+        release?.Invoke();
+
+        var emptyCompletion = await CaptureCompletionAsync(empty);
+        var retryCompletion = await CaptureCompletionAsync(retry);
+        await Assert.That(emptyCompletion).IsEqualTo(retryCompletion);
+    }
+
+    private static async Task<Completion> CaptureCompletionAsync(ValueTask<int> execution)
+    {
+        try
+        {
+            return new Completion(await execution, null);
+        }
+        catch (Exception exception)
+        {
+            return new Completion(default, exception.GetType());
+        }
+    }
+
+    private readonly record struct Completion(int Result, Type? ExceptionType);
+}

--- a/tests/Kevlar.Tests/ShieldInvocationSemanticsTests.cs
+++ b/tests/Kevlar.Tests/ShieldInvocationSemanticsTests.cs
@@ -23,7 +23,7 @@ public class ShieldInvocationSemanticsTests
 
         await Assert.That(Shield.Empty.Fallback(_ => ValueTask.CompletedTask).InvokesContinuationAtMostOnce)
             .IsTrue();
-        await Assert.That(Shield.For<int>().Fallback(0).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(Shield.For<int>().FallbackTo(0).InvokesContinuationAtMostOnce).IsTrue();
         await Assert.That(Shield.For<int>().Retry(0, Backoff.None).InvokesContinuationAtMostOnce).IsTrue();
         await Assert.That(Shield.For<int>().Hedge(1, TimeSpan.Zero).InvokesContinuationAtMostOnce).IsTrue();
     }


### PR DESCRIPTION
## Summary
- return a faulted `ValueTask` when an empty shield delegate throws synchronously
- cover typed, state-passing, Task-returning, outcome, cancellation, sync/async completion, and Retry(0) parity
- repair the post-merge invocation-semantics test to use the renamed `FallbackTo` API

## Performance
`OverheadBenchmarks.Kevlar_Empty`, ShortRun, .NET 10.0.11, same machine:

| | Mean | Allocated |
|---|---:|---:|
| main | 7.909 ns | 0 B |
| this branch | 14.27 ns | 0 B |

The exception boundary adds 6.36 ns to the empty happy path while preserving its zero-allocation contract. Inline EH was the fastest correct implementation measured; helper and async-state-machine variants measured 15.68 ns and 22.34 ns respectively.

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release` (0 warnings)
- [x] `Kevlar.Tests` (835 passed)
- [x] `Kevlar.IntegrationTests` (123 passed)
- [x] `Kevlar.AllocationTests` (3 passed)
- [x] `Kevlar.NetStandard.Tests` (10 passed)
- [x] BenchmarkDotNet Dry validation and before/after ShortRun

Closes #228