### PR TITLE
fix(tests): use renamed fallback API

### DIFF
--- a/tests/Kevlar.Tests/ShieldInvocationSemanticsTests.cs
+++ b/tests/Kevlar.Tests/ShieldInvocationSemanticsTests.cs
@@ -23,7 +23,7 @@ public class ShieldInvocationSemanticsTests
 
         await Assert.That(Shield.Empty.Fallback(_ => ValueTask.CompletedTask).InvokesContinuationAtMostOnce)
             .IsTrue();
-        await Assert.That(Shield.For<int>().Fallback(0).InvokesContinuationAtMostOnce).IsTrue();
+        await Assert.That(Shield.For<int>().FallbackTo(0).InvokesContinuationAtMostOnce).IsTrue();
         await Assert.That(Shield.For<int>().Retry(0, Backoff.None).InvokesContinuationAtMostOnce).IsTrue();
         await Assert.That(Shield.For<int>().Hedge(1, TimeSpan.Zero).InvokesContinuationAtMostOnce).IsTrue();
     }


### PR DESCRIPTION
## Summary

- update the invocation-semantics regression test to use the renamed constant fallback API
- restore the `main` build after concurrent merges of #250 and #254

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (831 passed)

Refs #254
