### PR TITLE
refactor(options): seal sibling types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,10 @@ renamed to `WhenResultIsDefault`/`OrResultIsDefault` because their "default" is 
 not the default *handling* that the neighbouring `WhenAnyError()` restores. (An earlier pre-release
 build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the reading unambiguous.)
 
-- `RetryOptions<TResult>` no longer inherits `RetryOptions`. Both types retain the same scalar
-  property names and defaults, but helpers that accepted `RetryOptions` must configure typed retry
-  options separately. Typed callback getters now return the exact delegates assigned to them.
-- Typed circuit-breaker and hedging configuration now uses `CircuitBreakerOptions<TResult>` and
-  `HedgeOptions<TResult>` so result predicates remain strongly typed.
+- Retry, circuit-breaker, hedge, and fallback options are sealed sibling types. Each typed/untyped
+  pair retains the same shared property names and scalar defaults, but helpers that accept an
+  untyped options type must configure typed options separately. Typed callbacks and result
+  predicates keep their exact compile-time types.
 - `HedgingOptions`/`HedgingOptions<TResult>` were renamed to `HedgeOptions`/`HedgeOptions<TResult>`
   so the strategy method and its options type share a stem, like `Retry`/`RetryOptions` and
   `Timeout`/`TimeoutOptions`. `Kevlar.Extensions.Http`'s `StandardHedgingShieldOptions` and

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -70,6 +70,10 @@ function Get-ExpectedSymbolAssets([string]$PackageId)
     {
         $frameworks += 'net8.0'
     }
+    elseif ($PackageId -eq 'Kevlar.Extensions.Grpc')
+    {
+        $frameworks += 'netstandard2.1'
+    }
 
     return @($frameworks | ForEach-Object { "lib/$_/$PackageId.pdb" })
 }

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -154,7 +154,9 @@ public static class HttpShield
         target.OnRetryAsync = source.OnRetryAsync;
     }
 
-    private static void Copy(CircuitBreakerOptions source, CircuitBreakerOptions target)
+    private static void Copy(
+        CircuitBreakerOptions source,
+        CircuitBreakerOptions<HttpResponseMessage> target)
     {
         target.ConsecutiveFailures = source.ConsecutiveFailures;
         target.FailureRatio = source.FailureRatio;

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -364,3 +364,35 @@ override Kevlar.KevlarKey<T>.Equals(object? obj) -> bool
 override Kevlar.KevlarKey<T>.GetHashCode() -> int
 static Kevlar.KevlarKey<T>.operator !=(Kevlar.KevlarKey<T> left, Kevlar.KevlarKey<T> right) -> bool
 static Kevlar.KevlarKey<T>.operator ==(Kevlar.KevlarKey<T> left, Kevlar.KevlarKey<T> right) -> bool
+Kevlar.CircuitBreakerOptions<TResult>.BreakDuration.get -> System.TimeSpan
+Kevlar.CircuitBreakerOptions<TResult>.BreakDuration.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.BreakDurationGenerator.get -> System.Func<Kevlar.CircuitBreakerBreakDurationEvent, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Kevlar.CircuitBreakerOptions<TResult>.BreakDurationGenerator.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.ConsecutiveFailures.get -> int?
+Kevlar.CircuitBreakerOptions<TResult>.ConsecutiveFailures.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.FailureRatio.get -> double?
+Kevlar.CircuitBreakerOptions<TResult>.FailureRatio.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.CircuitBreakerOptions<TResult>.HandlesException.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.MinimumThroughput.get -> int
+Kevlar.CircuitBreakerOptions<TResult>.MinimumThroughput.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.Monitor.get -> Kevlar.CircuitBreakerMonitor?
+Kevlar.CircuitBreakerOptions<TResult>.Monitor.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.OnStateChanged.get -> System.Action<Kevlar.CircuitStateChangedEvent>?
+Kevlar.CircuitBreakerOptions<TResult>.OnStateChanged.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.OnStateChangedAsync.get -> System.Func<Kevlar.CircuitStateChangedEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.CircuitBreakerOptions<TResult>.OnStateChangedAsync.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.SamplingWindow.get -> System.TimeSpan
+Kevlar.CircuitBreakerOptions<TResult>.SamplingWindow.set -> void
+Kevlar.HedgeOptions<TResult>.ActionGenerator.get -> Kevlar.HedgeActionGenerator?
+Kevlar.HedgeOptions<TResult>.ActionGenerator.set -> void
+Kevlar.HedgeOptions<TResult>.Delay.get -> System.TimeSpan
+Kevlar.HedgeOptions<TResult>.Delay.set -> void
+Kevlar.HedgeOptions<TResult>.HandlesException.get -> System.Func<System.Exception!, bool>?
+Kevlar.HedgeOptions<TResult>.HandlesException.set -> void
+Kevlar.HedgeOptions<TResult>.MaxAttempts.get -> int
+Kevlar.HedgeOptions<TResult>.MaxAttempts.set -> void
+Kevlar.HedgeOptions<TResult>.OnHedge.get -> System.Action<Kevlar.HedgeEvent>?
+Kevlar.HedgeOptions<TResult>.OnHedge.set -> void
+Kevlar.HedgeOptions<TResult>.OnHedgeAsync.get -> System.Func<Kevlar.HedgeEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.HedgeOptions<TResult>.OnHedgeAsync.set -> void

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -162,7 +162,7 @@ public sealed class Shield<TResult>
         var options = new CircuitBreakerOptions<TResult>();
         configure(options);
         var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
-        return Append(new CircuitBreakerStrategy(options, judge));
+        return Append(CircuitBreakerStrategy.Create(options, judge));
     }
 
     /// <summary>Limits throughput to <paramref name="permits"/> executions per <paramref name="perWindow"/> (token bucket).</summary>
@@ -211,7 +211,7 @@ public sealed class Shield<TResult>
         var options = new HedgeOptions<TResult>();
         configure(options);
         var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
-        return Append(new HedgingStrategy(options, judge));
+        return Append(HedgingStrategy.Create(options, judge));
     }
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -5,7 +5,7 @@ namespace Kevlar;
 /// <see cref="ConsecutiveFailures"/> (simple mode) or <see cref="FailureRatio"/>
 /// (sampling mode). When neither is set, the breaker trips after 5 consecutive failures.
 /// </summary>
-public class CircuitBreakerOptions
+public sealed class CircuitBreakerOptions
 {
     /// <summary>
     /// Setting this — or, on <see cref="CircuitBreakerOptions{TResult}"/>, its <c>HandlesResult</c>
@@ -20,7 +20,7 @@ public class CircuitBreakerOptions
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
-    internal virtual bool HasHandlingOverride => HandlesException is not null;
+    internal bool HasHandlingOverride => HandlesException is not null;
 
     /// <summary>Trips the circuit after this many consecutive handled failures.</summary>
     public int? ConsecutiveFailures { get; set; }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
@@ -4,10 +4,17 @@ namespace Kevlar;
 /// Result-typed configuration for a circuit breaker strategy on a
 /// <see cref="Shield{TResult}"/>.
 /// </summary>
-public sealed class CircuitBreakerOptions<TResult> : CircuitBreakerOptions
+/// <remarks>
+/// <see cref="CircuitBreakerOptions{TResult}"/> and <see cref="CircuitBreakerOptions"/> are
+/// standalone sibling types with matching shared property names and defaults.
+/// </remarks>
+public sealed class CircuitBreakerOptions<TResult>
 {
+    /// <inheritdoc cref="CircuitBreakerOptions.HandlesException"/>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
     /// <summary>
-    /// Setting this — or <see cref="CircuitBreakerOptions.HandlesException"/> — makes this circuit
+    /// Setting this — or <see cref="HandlesException"/> — makes this circuit
     /// breaker ignore the ambient <c>When…</c> handling clause; this predicate then selects the
     /// results it handles.
     /// </summary>
@@ -19,6 +26,47 @@ public sealed class CircuitBreakerOptions<TResult> : CircuitBreakerOptions
     /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
-    internal override bool HasHandlingOverride =>
+    internal bool HasHandlingOverride =>
         HandlesException is not null || HandlesResult is not null;
+
+    /// <inheritdoc cref="CircuitBreakerOptions.ConsecutiveFailures"/>
+    public int? ConsecutiveFailures { get; set; }
+
+    /// <inheritdoc cref="CircuitBreakerOptions.FailureRatio"/>
+    public double? FailureRatio { get; set; }
+
+    /// <inheritdoc cref="CircuitBreakerOptions.MinimumThroughput"/>
+    public int MinimumThroughput { get; set; } = 10;
+
+    /// <inheritdoc cref="CircuitBreakerOptions.SamplingWindow"/>
+    public TimeSpan SamplingWindow { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <inheritdoc cref="CircuitBreakerOptions.BreakDuration"/>
+    public TimeSpan BreakDuration { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <inheritdoc cref="CircuitBreakerOptions.BreakDurationGenerator"/>
+    public Func<CircuitBreakerBreakDurationEvent, ValueTask<TimeSpan>>? BreakDurationGenerator { get; set; }
+
+    /// <inheritdoc cref="CircuitBreakerOptions.Monitor"/>
+    public CircuitBreakerMonitor? Monitor { get; set; }
+
+    /// <inheritdoc cref="CircuitBreakerOptions.OnStateChanged"/>
+    public Action<CircuitStateChangedEvent>? OnStateChanged { get; set; }
+
+    /// <inheritdoc cref="CircuitBreakerOptions.OnStateChangedAsync"/>
+    public Func<CircuitStateChangedEvent, ValueTask>? OnStateChangedAsync { get; set; }
+
+    internal CircuitBreakerOptions ToUntyped() => new()
+    {
+        HandlesException = HandlesException,
+        ConsecutiveFailures = ConsecutiveFailures,
+        FailureRatio = FailureRatio,
+        MinimumThroughput = MinimumThroughput,
+        SamplingWindow = SamplingWindow,
+        BreakDuration = BreakDuration,
+        BreakDurationGenerator = BreakDurationGenerator,
+        Monitor = Monitor,
+        OnStateChanged = OnStateChanged,
+        OnStateChangedAsync = OnStateChangedAsync,
+    };
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -12,11 +12,24 @@ internal sealed class CircuitBreakerStrategy : Strategy
     private readonly OutcomeJudge _judge;
 
     public CircuitBreakerStrategy(CircuitBreakerOptions options, OutcomeJudge judge)
+        : this(options, judge, options.HasHandlingOverride)
+    {
+    }
+
+    private CircuitBreakerStrategy(
+        CircuitBreakerOptions options,
+        OutcomeJudge judge,
+        bool hasHandlingOverride)
     {
         _core = new CircuitBreakerCore(options, RecordTransitionState);
         _judge = judge;
-        HasHandlingOverride = options.HasHandlingOverride;
+        HasHandlingOverride = hasHandlingOverride;
     }
+
+    internal static CircuitBreakerStrategy Create<TResult>(
+        CircuitBreakerOptions<TResult> options,
+        OutcomeJudge judge) =>
+        new(options.ToUntyped(), judge, options.HasHandlingOverride);
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -12,7 +12,7 @@ namespace Kevlar;
 /// <see cref="OnHedgeAsync"/>, then <see cref="ActionGenerator"/>. Caller cancellation is checked
 /// before callbacks and again before the generated operation starts.
 /// </remarks>
-public class HedgeOptions
+public sealed class HedgeOptions
 {
     /// <summary>
     /// Setting this — or, on <see cref="HedgeOptions{TResult}"/>, its <c>HandlesResult</c> — makes
@@ -27,7 +27,7 @@ public class HedgeOptions
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
-    internal virtual bool HasHandlingOverride => HandlesException is not null;
+    internal bool HasHandlingOverride => HandlesException is not null;
 
     /// <summary>Total attempts including the original. Default 2.</summary>
     public int MaxAttempts { get; set; } = 2;

--- a/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
@@ -3,10 +3,17 @@ namespace Kevlar;
 /// <summary>
 /// Result-typed configuration for a hedging strategy on a <see cref="Shield{TResult}"/>.
 /// </summary>
-public sealed class HedgeOptions<TResult> : HedgeOptions
+/// <remarks>
+/// <see cref="HedgeOptions{TResult}"/> and <see cref="HedgeOptions"/> are standalone sibling types
+/// with matching shared property names and defaults.
+/// </remarks>
+public sealed class HedgeOptions<TResult>
 {
+    /// <inheritdoc cref="HedgeOptions.HandlesException"/>
+    public Func<Exception, bool>? HandlesException { get; set; }
+
     /// <summary>
-    /// Setting this — or <see cref="HedgeOptions.HandlesException"/> — makes this hedging strategy
+    /// Setting this — or <see cref="HandlesException"/> — makes this hedging strategy
     /// ignore the ambient <c>When…</c> handling clause; this predicate then selects the results it
     /// handles.
     /// </summary>
@@ -18,6 +25,31 @@ public sealed class HedgeOptions<TResult> : HedgeOptions
     /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
-    internal override bool HasHandlingOverride =>
+    internal bool HasHandlingOverride =>
         HandlesException is not null || HandlesResult is not null;
+
+    /// <inheritdoc cref="HedgeOptions.MaxAttempts"/>
+    public int MaxAttempts { get; set; } = 2;
+
+    /// <inheritdoc cref="HedgeOptions.Delay"/>
+    public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <inheritdoc cref="HedgeOptions.OnHedge"/>
+    public Action<HedgeEvent>? OnHedge { get; set; }
+
+    /// <inheritdoc cref="HedgeOptions.OnHedgeAsync"/>
+    public Func<HedgeEvent, ValueTask>? OnHedgeAsync { get; set; }
+
+    /// <inheritdoc cref="HedgeOptions.ActionGenerator"/>
+    public HedgeActionGenerator? ActionGenerator { get; set; }
+
+    internal HedgeOptions ToUntyped() => new()
+    {
+        HandlesException = HandlesException,
+        MaxAttempts = MaxAttempts,
+        Delay = Delay,
+        OnHedge = OnHedge,
+        OnHedgeAsync = OnHedgeAsync,
+        ActionGenerator = ActionGenerator,
+    };
 }

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -13,6 +13,11 @@ internal sealed class HedgingStrategy : Strategy
     private readonly HedgeActionGenerator? _actionGenerator;
 
     public HedgingStrategy(HedgeOptions options, OutcomeJudge judge)
+        : this(options, judge, options.HasHandlingOverride)
+    {
+    }
+
+    private HedgingStrategy(HedgeOptions options, OutcomeJudge judge, bool hasHandlingOverride)
     {
         Throw.IfOutOfRange(options.MaxAttempts < 1, nameof(options), "MaxAttempts must be at least 1.");
         Throw.IfOutOfRange(options.Delay < TimeSpan.Zero && options.Delay != System.Threading.Timeout.InfiniteTimeSpan, nameof(options), "Delay must be non-negative or Timeout.InfiniteTimeSpan.");
@@ -24,8 +29,11 @@ internal sealed class HedgingStrategy : Strategy
         _onHedge = options.OnHedge;
         _onHedgeAsync = options.OnHedgeAsync;
         _actionGenerator = options.ActionGenerator;
-        HasHandlingOverride = options.HasHandlingOverride;
+        HasHandlingOverride = hasHandlingOverride;
     }
+
+    internal static HedgingStrategy Create<TResult>(HedgeOptions<TResult> options, OutcomeJudge judge) =>
+        new(options.ToUntyped(), judge, options.HasHandlingOverride);
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -7,7 +7,7 @@ namespace Kevlar;
 /// If the caller's cancellation token is cancelled by the time the callbacks complete, the retry
 /// stops and surfaces caller cancellation.
 /// </remarks>
-public class RetryOptions
+public sealed class RetryOptions
 {
     /// <summary>
     /// Setting this makes this retry ignore the ambient <c>When…</c> handling clause and handle

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -6,6 +6,34 @@ namespace Kevlar.Tests;
 public class ApiShapeTests
 {
     [Test]
+    public async Task Typed_CircuitBreaker_Requires_Typed_Options_Configurator()
+    {
+        var compilation = CreateCompilation(
+            """
+            using Kevlar;
+            using System;
+
+            public static class Consumer
+            {
+                public static void Build()
+                {
+                    Action<CircuitBreakerOptions> untyped = static options => options.ConsecutiveFailures = 2;
+                    Action<CircuitBreakerOptions<int>> typed = static options => options.ConsecutiveFailures = 2;
+                    _ = Shield.For<int>().CircuitBreaker(typed);
+                    _ = Shield.For<int>().CircuitBreaker(untyped);
+                }
+            }
+            """);
+
+        var errors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        await Assert.That(errors).HasSingleItem();
+        await Assert.That(errors[0].Id).IsEqualTo("CS1503");
+    }
+
+    [Test]
     public async Task FallbackTo_Accepts_Null_Without_Overload_Ambiguity()
     {
         var compilation = CreateCompilation(

--- a/tests/Kevlar.Tests/OptionsShapeTests.cs
+++ b/tests/Kevlar.Tests/OptionsShapeTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+
+namespace Kevlar.Tests;
+
+public class OptionsShapeTests
+{
+    private static readonly (Type Untyped, Type Typed)[] TypedPairs =
+    [
+        (typeof(RetryOptions), typeof(RetryOptions<int>)),
+        (typeof(CircuitBreakerOptions), typeof(CircuitBreakerOptions<int>)),
+        (typeof(HedgeOptions), typeof(HedgeOptions<int>)),
+        (typeof(FallbackOptions), typeof(FallbackOptions<int>)),
+    ];
+
+    [Test]
+    public async Task All_Options_Types_Are_Sealed_Siblings()
+    {
+        var optionTypes = typeof(Shield).Assembly.GetExportedTypes()
+            .Where(static type => type.IsClass && type.Name.Contains("Options", StringComparison.Ordinal))
+            .OrderBy(static type => type.FullName, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var optionType in optionTypes)
+        {
+            await Assert.That(optionType.IsSealed).IsTrue();
+            await Assert.That(optionType.BaseType).IsEqualTo(typeof(object));
+        }
+    }
+
+    [Test]
+    public async Task Typed_And_Untyped_Options_Share_Property_Names()
+    {
+        foreach (var (untypedType, typedType) in TypedPairs)
+        {
+            var typedNames = typedType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Select(static property => property.Name)
+                .ToHashSet(StringComparer.Ordinal);
+            var missingNames = untypedType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Select(static property => property.Name)
+                .Where(name => !typedNames.Contains(name))
+                .ToArray();
+
+            await Assert.That(missingNames).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task Typed_And_Untyped_Options_Share_Scalar_Defaults()
+    {
+        foreach (var (untypedType, typedType) in TypedPairs)
+        {
+            var untyped = Activator.CreateInstance(untypedType)!;
+            var typed = Activator.CreateInstance(typedType)!;
+
+            foreach (var untypedProperty in untypedType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                         .Where(IsScalar))
+            {
+                var typedProperty = typedType.GetProperty(untypedProperty.Name)!;
+                await Assert.That(typedProperty.GetValue(typed))
+                    .IsEqualTo(untypedProperty.GetValue(untyped));
+            }
+        }
+    }
+
+    private static bool IsScalar(PropertyInfo property)
+    {
+        var type = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        return type.IsPrimitive ||
+               type.IsEnum ||
+               type == typeof(decimal) ||
+               type == typeof(string) ||
+               type == typeof(TimeSpan) ||
+               type == typeof(Backoff);
+    }
+}

--- a/tests/Kevlar.Tests/PartitionWrapperLifecycleTests.cs
+++ b/tests/Kevlar.Tests/PartitionWrapperLifecycleTests.cs
@@ -8,7 +8,7 @@ public class PartitionWrapperLifecycleTests
     public async Task Typed_Partition_Wrapper_Exposes_Complete_Cache_Lifecycle()
     {
         var provider = new PartitionedShield<string, int>(
-            static _ => Shield.For<int>().Fallback(42),
+            static _ => Shield.For<int>().FallbackTo(42),
             new PartitionedShieldOptions { MaximumPartitions = 2 });
 
         var first = provider.GetShield("first");

--- a/tests/Kevlar.Tests/TypedBuilderForwardingTests.cs
+++ b/tests/Kevlar.Tests/TypedBuilderForwardingTests.cs
@@ -42,8 +42,8 @@ public class TypedBuilderForwardingTests
                 options.Delay = TimeSpan.Zero;
             }), typeof(HedgingStrategy)),
             (builder.Use(_ => PassThroughStrategy.Instance), typeof(PassThroughStrategy)),
-            (builder.Fallback(42), typeof(FallbackStrategy<int>)),
-            (builder.Fallback(42, _ => fallbackConfigured++), typeof(FallbackStrategy<int>)),
+            (builder.FallbackTo(42), typeof(FallbackStrategy<int>)),
+            (builder.FallbackTo(42, _ => fallbackConfigured++), typeof(FallbackStrategy<int>)),
             (builder.Fallback(static _ => new ValueTask<int>(42)), typeof(FallbackStrategy<int>)),
             (builder.Fallback(
                 static _ => new ValueTask<int>(42),
@@ -105,7 +105,7 @@ public class TypedBuilderForwardingTests
                 calls.Add("third");
                 throw new InvalidOperationException($"predicate must not run for {value}");
             })
-            .Fallback(42);
+            .FallbackTo(42);
 
         var result = await shield.ExecuteAsync(static _ => new ValueTask<int>(2));
 
@@ -130,7 +130,7 @@ public class TypedBuilderForwardingTests
                 calls.Add(2);
                 return value == 0;
             })
-            .Fallback(42);
+            .FallbackTo(42);
 
         var result = await shield.ExecuteAsync(static _ => new ValueTask<int>(7));
 


### PR DESCRIPTION
## Summary
- make every core options class sealed and remove typed CircuitBreaker/Hedge inheritance
- preserve shared typed behavior through internal adapters while keeping result predicates compile-time typed
- update the HTTP standard-shield copier for the sibling shape
- add reflection/default/API-shape regression tests and PublicAPI entries
- include the pending main FallbackTo test repair from #258 so this branch builds against current main

## Validation
- dotnet build Kevlar.slnx -c Release
- Kevlar.Tests: 849 passed
- Kevlar.IntegrationTests: 131 passed
- Kevlar.Analyzers.Tests: 78 passed
- Kevlar.Chaos.Tests: 33 passed
- Kevlar.Testing.Tests: 51 passed
- Kevlar.Extensions.RateLimiting.Tests: 24 passed
- Kevlar.AllocationTests: 3 passed
- Kevlar.NetStandard.Tests: 10 passed
- Kevlar.NetStandard21.Tests: 4 passed
- pwsh scripts/Verify-Docs.ps1
- pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0-loop196 (118 compiled; behavior passed)

Closes #196