### PR TITLE
fix(http): cap standard retry delays

### DIFF
--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -188,6 +188,17 @@ Starts a typed `Shield<HttpResponseMessage>` builder with the standard transient
 
 A `DelayGenerator` for retry options: when the failed response carries a `Retry-After` header (delta or date form), the retry waits what the server asked for. The server's suggestion is used only when it's *longer* than the computed backoff; no header → normal backoff applies.
 
+The standard shield caps every retry delay at 10 seconds, so one excessive server suggestion cannot
+impose an unbounded wait. Custom shields can cap server-suggested delays directly:
+
+```csharp
+var shield = HttpShield.WhenTransient()
+    .Retry(options =>
+    {
+        options.DelayGenerator = HttpShield.RetryAfter(TimeSpan.FromSeconds(5));
+    });
+```
+
 ### Registering a shield built elsewhere
 
 ```csharp

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -100,6 +100,7 @@ Note the handling clause: written once, it covers the retry *and* the breaker. I
 ## Semantic differences worth knowing
 
 - **Retry defaults differ.** Polly's default is constant 2s delays with no jitter; Kevlar's is exponential-with-jitter from 250ms capped at 30s. If you relied on Polly's default timing, say so explicitly: `Shield.Retry(3, Backoff.Constant(TimeSpan.FromSeconds(2)))`.
+- **Standard HTTP retry delays are bounded.** `HttpShield.Standard()` honours `Retry-After` but caps every retry delay at 10 seconds by default. Set `StandardHttpShieldOptions.Retry.MaxDelay` to choose another bound.
 - **Handling clauses are ambient within one fluent chain.** A clause applies to every reactive strategy after it until replaced; call `WhenAnyError()` to return subsequent strategies to Kevlar's default. `Wrap` and `Compose` seal clauses at the composition boundary: strategies already inside keep their handling, while strategies appended afterwards use the default unless you declare a new local clause. For a Polly strategy with a distinct `ShouldHandle`, set that strategy's `HandlesException` / `HandlesResult` options; a local override fully replaces the ambient clause.
 - **Default handling excludes cancellation.** With no clause at all, Kevlar handles any exception except `OperationCanceledException` — same spirit as Polly's recommended predicate, but built in.
 - **One shield, every shape.** There's no separate sync/async pipeline type: `shield.Execute(...)` and `shield.ExecuteAsync(...)` are the same instance. (Hedging is async-only, as in Polly.)

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -90,6 +90,33 @@ public static class HttpShield
         return suggested is { } value && value > retry.Delay ? value : null;
     }
 
+    /// <summary>
+    /// Creates a <see cref="RetryOptions{TResult}.DelayGenerator"/> that honours
+    /// <c>Retry-After</c> while capping the server suggestion at <paramref name="maxDelay"/>.
+    /// The computed backoff is never shortened.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="maxDelay"/> is negative.
+    /// </exception>
+    public static Func<RetryEvent<HttpResponseMessage>, TimeSpan?> RetryAfter(TimeSpan maxDelay)
+    {
+        if (maxDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxDelay), "maxDelay must not be negative.");
+        }
+
+        return retry =>
+        {
+            var suggested = RetryAfter(retry);
+            if (suggested is not { } value || value <= maxDelay)
+            {
+                return suggested;
+            }
+
+            return maxDelay > retry.Delay ? maxDelay : null;
+        };
+    }
+
     private static void Validate(StandardHttpShieldOptions options)
     {
         ValidateTimeout(options.TotalTimeout, nameof(StandardHttpShieldOptions.TotalTimeout));

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -88,6 +88,7 @@ Kevlar.Extensions.Http.StandardHttpShieldOptions.StandardHttpShieldOptions() -> 
 Kevlar.Extensions.Http.StandardHttpShieldOptions.TotalTimeout.get -> Kevlar.TimeoutOptions!
 Kevlar.Extensions.Http.StandardHttpShieldOptions.TotalTimeout.set -> void
 static Kevlar.Extensions.Http.HttpShield.Standard(Kevlar.Extensions.Http.StandardHttpShieldOptions! options) -> Kevlar.Shield<System.Net.Http.HttpResponseMessage!>!
+static Kevlar.Extensions.Http.HttpShield.RetryAfter(System.TimeSpan maxDelay) -> System.Func<Kevlar.RetryEvent<System.Net.Http.HttpResponseMessage!>, System.TimeSpan?>!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<Kevlar.Extensions.Http.StandardHttpShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<System.IServiceProvider!, Kevlar.Extensions.Http.StandardHttpShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
@@ -13,6 +13,7 @@ public sealed class StandardHttpShieldOptions
     public RetryOptions<HttpResponseMessage> Retry { get; set; } = new()
     {
         DelayGenerator = HttpShield.RetryAfter,
+        MaxDelay = TimeSpan.FromSeconds(10),
     };
 
     /// <summary>

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -121,10 +121,89 @@ public class HttpContractTests
     }
 
     [Test]
+    public async Task RetryAfter_Max_Overload_Caps_Server_Delay()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+
+        var delay = await ObserveRetryDelay(
+            timeProvider,
+            () => response,
+            HttpShield.RetryAfter(TimeSpan.FromSeconds(5)));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task RetryAfter_Max_Overload_Does_Not_Shorten_Backoff()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(30));
+
+        var delay = await ObserveRetryDelay(
+            timeProvider,
+            () => response,
+            HttpShield.RetryAfter(TimeSpan.FromSeconds(5)),
+            backoff: TimeSpan.FromSeconds(7));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromSeconds(7));
+    }
+
+    [Test]
+    public async Task RetryAfter_Max_Overload_Rejects_Negative_Cap()
+    {
+        var exception = await Assert.That(
+            () => HttpShield.RetryAfter(TimeSpan.FromTicks(-1)))
+            .Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(exception!.ParamName).IsEqualTo("maxDelay");
+    }
+
+    [Test]
+    public async Task Standard_Caps_RetryAfter_To_Ten_Seconds()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var calls = 0;
+        TimeSpan? observed = null;
+        var options = new StandardHttpShieldOptions();
+        options.Retry.Backoff = Backoff.None;
+        options.Retry.OnRetry = retry => observed = retry.Delay;
+        var shield = HttpShield.Standard(options).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync(_ =>
+        {
+            calls++;
+            var response = new HttpResponseMessage(
+                calls == 1 ? HttpStatusCode.TooManyRequests : HttpStatusCode.OK);
+            if (calls == 1)
+            {
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(120));
+            }
+
+            return new ValueTask<HttpResponseMessage>(response);
+        }).AsTask();
+
+        await WaitUntilAsync(() => observed.HasValue);
+        await Assert.That(observed).IsEqualTo(TimeSpan.FromSeconds(10));
+        timeProvider.Advance(observed!.Value);
+
+        using var result = await execution;
+        await Assert.That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Standard_Default_Retry_MaxDelay_Is_Ten_Seconds() =>
+        await Assert.That(new StandardHttpShieldOptions().Retry.MaxDelay)
+            .IsEqualTo(TimeSpan.FromSeconds(10));
+
+    [Test]
     public async Task Standard_Has_The_Documented_Pipeline() =>
         await Assert.That(HttpShield.Standard().ToString()).IsEqualTo(
             "Timeout(30s) → [when HttpRequestException | TimeoutExceededException | result predicate] "
-            + "Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
+            + "Retry(3, exponential 250ms ×2 +jitter ≤30s, ≤10s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
 
     [Test]
     public async Task Configured_Standard_Has_Custom_Stages()
@@ -728,7 +807,9 @@ public class HttpContractTests
 
     private static async Task<TimeSpan> ObserveRetryDelay(
         FakeTimeProvider timeProvider,
-        Func<HttpResponseMessage> firstAttempt)
+        Func<HttpResponseMessage> firstAttempt,
+        Func<RetryEvent<HttpResponseMessage>, TimeSpan?>? delayGenerator = null,
+        TimeSpan? backoff = null)
     {
         TimeSpan? observed = null;
         var calls = 0;
@@ -736,8 +817,8 @@ public class HttpContractTests
             .Retry(options =>
             {
                 options.MaxRetries = 1;
-                options.Backoff = Backoff.Constant(TimeSpan.FromSeconds(3));
-                options.DelayGenerator = HttpShield.RetryAfter;
+                options.Backoff = Backoff.Constant(backoff ?? TimeSpan.FromSeconds(3));
+                options.DelayGenerator = delayGenerator ?? HttpShield.RetryAfter;
                 options.OnRetry = retry => observed = retry.Delay;
             })
             .WithTimeProvider(timeProvider);

--- a/tests/Kevlar.Tests/ReloadingShieldTests.cs
+++ b/tests/Kevlar.Tests/ReloadingShieldTests.cs
@@ -281,10 +281,14 @@ public class ReloadingShieldTests
             .AddReloadingShield("dynamic", configuration)
             .BuildServiceProvider();
         var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
-        _ = shieldProvider.Current;
+        const int Iterations = 10_000;
+        for (var iteration = 0; iteration < Iterations; iteration++)
+        {
+            _ = shieldProvider.Current;
+        }
 
         var before = GC.GetAllocatedBytesForCurrentThread();
-        for (var iteration = 0; iteration < 10_000; iteration++)
+        for (var iteration = 0; iteration < Iterations; iteration++)
         {
             _ = shieldProvider.Current;
         }


### PR DESCRIPTION
## Summary

- cap every Standard HTTP retry delay at 10 seconds through `RetryOptions.MaxDelay`
- add `HttpShield.RetryAfter(TimeSpan maxDelay)` for custom server-suggestion caps without shortening a larger computed backoff
- document the Standard bound and Polly migration difference
- pin cap, backoff, validation, default, and pipeline-description behavior

The issue allows either a bounded delay or returning the response early. This uses the bounded-delay path because the current retry contract has no safe stop-and-retain-result sentinel; adding one would broaden into the retry-control work tracked separately.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (850 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (131 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (10 passed)
- `dotnet run --project tests/Kevlar.NetStandard21.Tests -c Release --no-build -- --timeout 5m` (4 passed)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-docs217` (119 snippets; behavior passed)
- `npm ci --prefix docs`
- `npm run build --prefix docs`

Depends on #258, whose repair commits are included in this branch.

Closes #217