### PR TITLE
fix(breaker): ignore unhandled exceptions

### DIFF
--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -75,8 +75,10 @@ Closed ──(threshold crossed)──► Open ──(BreakDuration elapses)─�
 - **HalfOpen** — after the break duration, exactly **one** probe execution is allowed through. Success closes the circuit and resets metrics; failure re-opens it for another `BreakDuration`. Concurrent callers during the probe are rejected (`RetryAfter == null`).
 - **Isolated** — manually forced open via the monitor; rejected until `Reset()`.
 
-:::info Cancellation doesn't move the circuit
-A cancelled execution says nothing about downstream health — it counts as neither success nor failure.
+:::info Unhandled exceptions don't move the circuit
+An exception outside the breaker's handling clause says nothing about downstream health — it counts
+as neither success nor failure. This includes caller cancellation unless the clause explicitly
+handles it. An unhandled half-open probe releases the probe slot without closing the circuit.
 :::
 
 ## Observing and controlling: `CircuitBreakerMonitor`

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -105,14 +105,14 @@ internal sealed class CircuitBreakerStrategy : Strategy
         {
             _core.RecordFailure(context.TimeProvider, outcome.Exception);
         }
-        else if (outcome.Exception is OperationCanceledException && context.CancellationToken.IsCancellationRequested)
+        else if (outcome.Exception is null)
         {
-            // A cancelled execution says nothing about downstream health; don't move the circuit.
-            _core.AbandonProbe(admittedProbeGeneration);
+            _core.RecordSuccess(context.TimeProvider);
         }
         else
         {
-            _core.RecordSuccess(context.TimeProvider);
+            // An unhandled exception says nothing about downstream health; don't move the circuit.
+            _core.AbandonProbe(admittedProbeGeneration);
         }
 
         if (recordState)
@@ -308,14 +308,14 @@ internal sealed class CircuitBreakerStrategy : Strategy
         {
             recording = _core.RecordFailureAsync(context.TimeProvider, in outcome, context);
         }
-        else if (outcome.Exception is OperationCanceledException && context.CancellationToken.IsCancellationRequested)
+        else if (outcome.Exception is null)
         {
-            _core.AbandonProbe(admittedProbeGeneration);
-            recording = default;
+            recording = _core.RecordSuccessAsync(context.TimeProvider);
         }
         else
         {
-            recording = _core.RecordSuccessAsync(context.TimeProvider);
+            _core.AbandonProbe(admittedProbeGeneration);
+            recording = default;
         }
 
         if (!recording.IsCompletedSuccessfully)

--- a/tests/Kevlar.Tests/CircuitBreakerEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerEdgeCaseTests.cs
@@ -181,7 +181,28 @@ public class CircuitBreakerEdgeCaseTests
     }
 
     [Test]
-    public async Task Unhandled_Exceptions_Count_As_Successes_For_The_Circuit()
+    public async Task Unhandled_Exception_Does_Not_Reset_Consecutive_Failures()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 3;
+                options.BreakDuration = TimeSpan.FromMinutes(1);
+                options.Monitor = monitor;
+            });
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ArgumentException());
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Sync_Unhandled_Exception_Does_Not_Reset_Consecutive_Failures()
     {
         var monitor = new CircuitBreakerMonitor();
         var shield = Shield
@@ -193,20 +214,85 @@ public class CircuitBreakerEdgeCaseTests
                 options.Monitor = monitor;
             });
 
-        // Handled, unhandled, handled, unhandled... the unhandled ArgumentException resets
-        // the consecutive count each time, so the circuit never opens.
-        for (var i = 0; i < 3; i++)
-        {
-            await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
-            await shield.ExecuteOutcomeAsync<int>(_ => throw new ArgumentException());
-        }
+        await Assert.That(() => shield.Execute<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => shield.Execute<int>(_ => throw new ArgumentException()))
+            .Throws<ArgumentException>();
+        await Assert.That(() => shield.Execute<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
 
-        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Async_Configured_Unhandled_Exception_Does_Not_Reset_Failures()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 2;
+                options.BreakDuration = TimeSpan.FromMinutes(1);
+                options.Monitor = monitor;
+                options.OnStateChangedAsync = static _ => default;
+            });
 
         await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ArgumentException());
         await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
 
         await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Unhandled_Exception_Does_Not_Count_Toward_Ratio_Throughput()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .CircuitBreaker(options =>
+            {
+                options.FailureRatio = 0.8;
+                options.MinimumThroughput = 3;
+                options.SamplingWindow = TimeSpan.FromMinutes(1);
+                options.BreakDuration = TimeSpan.FromMinutes(1);
+                options.Monitor = monitor;
+            });
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ArgumentException());
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
+    public async Task Unhandled_HalfOpen_Exception_Releases_The_Probe_Slot()
+    {
+        var fakeTime = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield
+            .When<InvalidOperationException>()
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.BreakDuration = TimeSpan.FromSeconds(1);
+                options.Monitor = monitor;
+            })
+            .WithTimeProvider(fakeTime);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        fakeTime.Advance(TimeSpan.FromSeconds(1));
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new ArgumentException());
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ReloadingShieldTests.cs
+++ b/tests/Kevlar.Tests/ReloadingShieldTests.cs
@@ -281,10 +281,14 @@ public class ReloadingShieldTests
             .AddReloadingShield("dynamic", configuration)
             .BuildServiceProvider();
         var shieldProvider = services.GetRequiredKeyedService<IShieldProvider>("dynamic");
-        _ = shieldProvider.Current;
+        const int Iterations = 10_000;
+        for (var iteration = 0; iteration < Iterations; iteration++)
+        {
+            _ = shieldProvider.Current;
+        }
 
         var before = GC.GetAllocatedBytesForCurrentThread();
-        for (var iteration = 0; iteration < 10_000; iteration++)
+        for (var iteration = 0; iteration < Iterations; iteration++)
         {
             _ = shieldProvider.Current;
         }

--- a/tests/Kevlar.Tests/StrategyModelTests.cs
+++ b/tests/Kevlar.Tests/StrategyModelTests.cs
@@ -48,12 +48,15 @@ public class StrategyModelTests
     {
         var timeProvider = new ModelTimeProvider();
         var monitor = new CircuitBreakerMonitor();
-        var shield = Shield.CircuitBreaker(options =>
-        {
-            options.ConsecutiveFailures = 2;
-            options.BreakDuration = TimeSpan.FromSeconds(3);
-            options.Monitor = monitor;
-        }).WithTimeProvider(timeProvider);
+        var shield = Shield
+            .When<ModelFailureException>()
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 2;
+                options.BreakDuration = TimeSpan.FromSeconds(3);
+                options.Monitor = monitor;
+            })
+            .WithTimeProvider(timeProvider);
         var state = CircuitState.Closed;
         var consecutiveFailures = 0;
         var elapsedSeconds = 0;
@@ -90,6 +93,7 @@ public class StrategyModelTests
 
                 case CircuitCommandKind.Succeed:
                 case CircuitCommandKind.Fail:
+                case CircuitCommandKind.Unhandled:
                     var shouldSucceed = command.Kind == CircuitCommandKind.Succeed;
                     var invoked = false;
                     var outcome = await shield.ExecuteOutcomeAsync<int>(_ =>
@@ -97,10 +101,13 @@ public class StrategyModelTests
                         invoked = true;
                         return shouldSucceed
                             ? new ValueTask<int>(42)
-                            : throw new ModelFailureException();
+                            : command.Kind == CircuitCommandKind.Fail
+                                ? throw new ModelFailureException()
+                                : throw new ArgumentException("unhandled");
                     });
 
                     var expectedInvocation = state == CircuitState.Closed
+                        || state == CircuitState.HalfOpen
                         || (state == CircuitState.Open && elapsedSeconds >= openUntil);
                     Ensure(invoked == expectedInvocation, index, command, "delegate admission differs");
 
@@ -116,10 +123,11 @@ public class StrategyModelTests
                         consecutiveFailures = 0;
                         Ensure(outcome.IsSuccess && outcome.Result == 42, index, command, "success outcome differs");
                     }
-                    else
+                    else if (command.Kind == CircuitCommandKind.Fail)
                     {
-                        if (state == CircuitState.Open)
+                        if (state is CircuitState.Open or CircuitState.HalfOpen)
                         {
+                            state = CircuitState.Open;
                             openUntil = elapsedSeconds + 3;
                         }
                         else if (++consecutiveFailures >= 2)
@@ -129,6 +137,15 @@ public class StrategyModelTests
                         }
 
                         Ensure(outcome.Exception is ModelFailureException, index, command, "failure outcome differs");
+                    }
+                    else
+                    {
+                        if (state == CircuitState.Open)
+                        {
+                            state = CircuitState.HalfOpen;
+                        }
+
+                        Ensure(outcome.Exception is ArgumentException, index, command, "unhandled outcome differs");
                     }
 
                     break;
@@ -379,6 +396,7 @@ public class StrategyModelTests
     {
         Succeed,
         Fail,
+        Unhandled,
         Advance,
         MoveUtcBackward,
         Isolate,


### PR DESCRIPTION
## Summary

- record only handled failures and genuine successful outcomes in circuit-breaker state
- leave consecutive and ratio history unchanged for unhandled exceptions
- release half-open probe admission without closing the circuit when a probe throws an unhandled exception
- cover normal async, sync, configured-async, ratio, half-open, and deterministic model transitions
- document that exceptions outside the handling clause do not move breaker state

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (849 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (131 passed)
- deterministic model sweep filter (5 passed)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-docs187` (118 snippets; behavior passed)
- `npm ci --prefix docs`
- `npm run build --prefix docs`

## Benchmarks

`CircuitBreakerBenchmarks` on .NET 10, closed success path:

| Path | Before | After | Allocation |
|---|---:|---:|---:|
| ratio breaker | 124.7 ns | 123.1 ns | 0 B → 0 B |
| async callback configured | 145.3 ns | 144.3 ns | 0 B → 0 B |

Depends on #258, whose repair commits are included in this branch.

Closes #187