### PR TITLE
fix(http): preserve non-replayable outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
 - `Outcome<T>.Exception` now recognizes `KevlarProxyException` with a type check instead of reading
   `Exception.Data` on every access. Adapter packages can preserve internal transport bookkeeping
   while exposing the original failure without allocating an exception data dictionary.
+- HTTP retry and hedging now stop after the first outcome when a request method or body cannot be
+  replayed safely. The original response or exception is preserved without a retry delay or
+  callback, while timeout, circuit-breaker, and concurrency stages still observe the attempt.
+  `NoBuffer` can replay inherently re-readable and already-buffered content.
 - Custom strategies can override `Strategy.InvokesContinuationAtMostOnce`; the same aggregate
   value is now exposed on `Shield<TResult>` as well as `Shield` and `VoidShield`.
 - **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -229,8 +229,9 @@ the original request and the returned response.
 Replay behavior depends on the request:
 
 - `NoBuffer` (default) reuses inherently re-readable content such as `ByteArrayContent`,
-  `StringContent`, `FormUrlEncodedContent`, and `JsonContent`. Content already loaded into its HTTP
-  buffer is also reusable. One-shot content such as `StreamContent` is sent once.
+  `StringContent`, and `FormUrlEncodedContent`. Positive-length content already loaded into its HTTP
+  buffer is also reusable. A fresh `JsonContent` or one-shot content such as `StreamContent` is sent
+  once; call `LoadIntoBufferAsync()` first, select `Buffer`, or provide a `RequestFactory` to replay it.
 - `Buffer` serializes content once before sending, bounded by `MaximumBufferSize`, then gives each
   attempt its own `ByteArrayContent`. Oversize or partial serialization fails before attempt 1.
 - `RequestFactory` creates a complete fresh request per attempt. Use it for one-shot streams,

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -226,10 +226,11 @@ clones that preserve method, URI, HTTP version and version policy, request heade
 and content headers. The handler owns every clone and every nonselected response; the caller owns
 the original request and the returned response.
 
-Content replay is explicit:
+Replay behavior depends on the request:
 
-- `NoBuffer` (default) does no up-front body work. A request with content may be sent once; another
-  attempt throws `HttpRequestReplayException` before reaching the transport.
+- `NoBuffer` (default) reuses inherently re-readable content such as `ByteArrayContent`,
+  `StringContent`, `FormUrlEncodedContent`, and `JsonContent`. Content already loaded into its HTTP
+  buffer is also reusable. One-shot content such as `StreamContent` is sent once.
 - `Buffer` serializes content once before sending, bounded by `MaximumBufferSize`, then gives each
   attempt its own `ByteArrayContent`. Oversize or partial serialization fails before attempt 1.
 - `RequestFactory` creates a complete fresh request per attempt. Use it for one-shot streams,
@@ -238,7 +239,12 @@ Content replay is explicit:
 
 GET, HEAD, OPTIONS, TRACE, PUT, and DELETE can replay automatically. POST, PATCH, and custom methods
 require `AllowUnsafeMethodReplay = true` or a `RequestFactory`; only opt in when the operation is
-actually idempotent. Timeouts and caller cancellation flow to every attempt and request factory.
+actually idempotent. If method or content cannot be replayed safely, retry and hedging remain
+single-attempt: the original response is returned or the original exception is rethrown without a
+retry delay or callback. Other stages, including timeout, circuit breaker, and concurrency limiting,
+still observe that attempt. `HttpRequestReplayException` is reserved for configuration failures such
+as a null factory result or content exceeding the requested buffer limit. Timeouts and caller
+cancellation flow to every attempt and request factory.
 
 ## Endpoint-aware hedging
 

--- a/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
+++ b/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
@@ -7,6 +7,7 @@ internal sealed class HttpRequestTemplate
     private readonly Version _version;
     private readonly List<KeyValuePair<string, IEnumerable<string>>> _headers;
     private readonly byte[]? _content;
+    private readonly HttpContent? _reusableContent;
     private readonly List<KeyValuePair<string, IEnumerable<string>>>? _contentHeaders;
 #if NETSTANDARD2_0
     private readonly List<KeyValuePair<string, object?>> _properties;
@@ -15,7 +16,10 @@ internal sealed class HttpRequestTemplate
     private readonly HttpVersionPolicy _versionPolicy;
 #endif
 
-    private HttpRequestTemplate(HttpRequestMessage request, byte[]? content)
+    private HttpRequestTemplate(
+        HttpRequestMessage request,
+        byte[]? content,
+        HttpContent? reusableContent)
     {
         _method = request.Method;
         _requestUri = request.RequestUri;
@@ -23,6 +27,7 @@ internal sealed class HttpRequestTemplate
         _headers = request.Headers.Select(static header =>
             new KeyValuePair<string, IEnumerable<string>>(header.Key, header.Value)).ToList();
         _content = content;
+        _reusableContent = reusableContent;
         _contentHeaders = request.Content?.Headers.Select(static header =>
             new KeyValuePair<string, IEnumerable<string>>(header.Key, header.Value)).ToList();
 #if NETSTANDARD2_0
@@ -38,6 +43,7 @@ internal sealed class HttpRequestTemplate
         HttpRequestMessage request,
         HttpContentReplayPolicy policy,
         long maximumBufferSize,
+        bool canReplay,
         CancellationToken cancellationToken)
     {
         byte[]? content = null;
@@ -81,7 +87,10 @@ internal sealed class HttpRequestTemplate
             }
         }
 
-        return new HttpRequestTemplate(request, content);
+        var reusableContent = policy == HttpContentReplayPolicy.NoBuffer && canReplay
+            ? request.Content
+            : null;
+        return new HttpRequestTemplate(request, content, reusableContent);
     }
 
     public HttpRequestMessage CreateRequest(HttpContent? firstAttemptContent = null)
@@ -102,7 +111,8 @@ internal sealed class HttpRequestTemplate
         {
             if (_content is null)
             {
-                if (firstAttemptContent is null)
+                var replayContent = firstAttemptContent ?? _reusableContent;
+                if (replayContent is null)
                 {
                     request.Dispose();
                     throw new HttpRequestReplayException(
@@ -110,7 +120,7 @@ internal sealed class HttpRequestTemplate
                         "Use Buffer with a bounded MaximumBufferSize, or provide RequestFactory.");
                 }
 
-                request.Content = firstAttemptContent;
+                request.Content = replayContent;
             }
             else
             {
@@ -139,6 +149,40 @@ internal sealed class HttpRequestTemplate
     private static HttpRequestReplayException TooLarge(long maximumBufferSize) => new(
         $"Request content exceeds the {maximumBufferSize}-byte replay buffer limit. " +
         "Increase MaximumBufferSize or provide RequestFactory.");
+
+    internal static bool IsInherentlyReplayable(HttpContent content)
+    {
+        var contentType = content.GetType();
+        return contentType == typeof(ByteArrayContent)
+            || contentType == typeof(StringContent)
+            || contentType == typeof(FormUrlEncodedContent);
+    }
+
+    internal static async ValueTask<bool> IsAlreadyBufferedAsync(HttpContent content)
+    {
+        if (content.Headers.ContentLength is not { } contentLength)
+        {
+            return false;
+        }
+
+        if (contentLength == 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            // HttpContent returns immediately when its buffer already exists. Otherwise the known,
+            // positive length exceeds this zero-byte probe before serialization begins. A declared
+            // zero is not probed because a false header could let serialization consume source bytes.
+            await content.LoadIntoBufferAsync(0).ConfigureAwait(false);
+            return true;
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+    }
 
 #if !NET9_0_OR_GREATER
     private static async Task<T> AwaitWithCancellationAsync<T>(

--- a/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
+++ b/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
@@ -174,7 +174,17 @@ internal sealed class HttpRequestTemplate
 
     internal static async ValueTask<bool> IsAlreadyBufferedAsync(HttpContent content)
     {
-        if (content.Headers.ContentLength is not { } contentLength)
+        long? declaredLength;
+        try
+        {
+            declaredLength = content.Headers.ContentLength;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        if (declaredLength is not { } contentLength)
         {
             return false;
         }

--- a/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
+++ b/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
@@ -19,17 +19,20 @@ internal sealed class HttpRequestTemplate
     private HttpRequestTemplate(
         HttpRequestMessage request,
         byte[]? content,
-        HttpContent? reusableContent)
+        HttpContent? reusableContent,
+        bool includeContent)
     {
         _method = request.Method;
         _requestUri = request.RequestUri;
         _version = request.Version;
         _headers = request.Headers.Select(static header =>
-            new KeyValuePair<string, IEnumerable<string>>(header.Key, header.Value)).ToList();
+            new KeyValuePair<string, IEnumerable<string>>(header.Key, header.Value.ToArray())).ToList();
         _content = content;
         _reusableContent = reusableContent;
-        _contentHeaders = request.Content?.Headers.Select(static header =>
-            new KeyValuePair<string, IEnumerable<string>>(header.Key, header.Value)).ToList();
+        _contentHeaders = includeContent
+            ? request.Content?.Headers.Select(static header =>
+                new KeyValuePair<string, IEnumerable<string>>(header.Key, header.Value.ToArray())).ToList()
+            : null;
 #if NETSTANDARD2_0
         _properties = request.Properties.ToList();
 #else
@@ -44,10 +47,13 @@ internal sealed class HttpRequestTemplate
         HttpContentReplayPolicy policy,
         long maximumBufferSize,
         bool canReplay,
+        bool includeContent,
         CancellationToken cancellationToken)
     {
         byte[]? content = null;
-        if (request.Content is not null && policy == HttpContentReplayPolicy.Buffer)
+        if (includeContent
+            && request.Content is not null
+            && policy == HttpContentReplayPolicy.Buffer)
         {
             if (request.Content.Headers.ContentLength is { } length && length > maximumBufferSize)
             {
@@ -87,10 +93,18 @@ internal sealed class HttpRequestTemplate
             }
         }
 
-        var reusableContent = policy == HttpContentReplayPolicy.NoBuffer && canReplay
-            ? request.Content
-            : null;
-        return new HttpRequestTemplate(request, content, reusableContent);
+        HttpContent? reusableContent = null;
+        if (policy == HttpContentReplayPolicy.NoBuffer
+            && canReplay
+            && includeContent
+            && request.Content is { } requestContent
+            && (IsInherentlyReplayable(requestContent)
+                || await IsAlreadyBufferedAsync(requestContent).ConfigureAwait(false)))
+        {
+            reusableContent = requestContent;
+        }
+
+        return new HttpRequestTemplate(request, content, reusableContent, includeContent);
     }
 
     public HttpRequestMessage CreateRequest(HttpContent? firstAttemptContent = null)
@@ -120,7 +134,7 @@ internal sealed class HttpRequestTemplate
                         "Use Buffer with a bounded MaximumBufferSize, or provide RequestFactory.");
                 }
 
-                request.Content = replayContent;
+                request.Content = new ReplayableContent(replayContent, _contentHeaders);
             }
             else
             {
@@ -180,6 +194,47 @@ internal sealed class HttpRequestTemplate
         }
         catch (HttpRequestException)
         {
+            return false;
+        }
+    }
+
+    private sealed class ReplayableContent : HttpContent
+    {
+        private readonly HttpContent _content;
+
+        public ReplayableContent(
+            HttpContent content,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers)
+        {
+            _content = content;
+            foreach (var header in headers)
+            {
+                _ = Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            System.Net.TransportContext? context) =>
+            _content.CopyToAsync(stream);
+
+#if NET8_0_OR_GREATER
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            System.Net.TransportContext? context,
+            CancellationToken cancellationToken) =>
+            _content.CopyToAsync(stream, cancellationToken);
+#endif
+
+        protected override bool TryComputeLength(out long length)
+        {
+            if (_content.Headers.ContentLength is { } contentLength)
+            {
+                length = contentLength;
+                return true;
+            }
+
+            length = 0;
             return false;
         }
     }

--- a/src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj
+++ b/src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <Description>HttpClientFactory integration for Kevlar: resilient HTTP handlers with transient-fault handling, Retry-After aware retries and a production-ready standard pipeline.</Description>
     <PackageTags>resilience;http;httpclient;httpclientfactory;kevlar</PackageTags>
+    <PinKevlarDependencyVersion>true</PinKevlarDependencyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -125,6 +125,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
 
         private Task<HttpRequestTemplate>? _template;
         private Task<HttpResponseMessage>? _singleAttempt;
+        private Task<HttpResponseMessage>? _singleTransportAttempt;
         private CancellationTokenSource? _templateCancellation;
         private HttpResponseMessage? _terminalResponse;
         private CancellationToken _lastAttemptToken;
@@ -234,12 +235,13 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
 
                 var endpointShield = endpoint is null ? null : _pipeline.GetEndpointShield(endpoint);
                 var response = endpointShield is null
-                    ? await _handler.BaseSendAsync(request, cancellationToken).ConfigureAwait(false)
+                    ? await SendTransportAsync(request, cancellationToken).ConfigureAwait(false)
                     : await endpointShield.ExecuteWithContextAsync(
-                        (Execution: this, Handler: _handler, Request: request),
+                        (Execution: this, Request: request),
                         static (state, properties) => state.Execution.InitializeProperties(properties),
-                        static (state, context) => new ValueTask<HttpResponseMessage>(
-                            state.Handler.BaseSendAsync(state.Request, context.CancellationToken)),
+                        static (state, context) => state.Execution.SendTransportAsync(
+                            state.Request,
+                            context.CancellationToken),
                         cancellationToken).ConfigureAwait(false);
                 RegisterResponse(response);
                 return response;
@@ -256,6 +258,26 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
                     request.Dispose();
                 }
             }
+        }
+
+        private ValueTask<HttpResponseMessage> SendTransportAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (_canReplay)
+            {
+                return new ValueTask<HttpResponseMessage>(
+                    _handler.BaseSendAsync(request, cancellationToken));
+            }
+
+            Task<HttpResponseMessage> singleTransportAttempt;
+            lock (_gate)
+            {
+                singleTransportAttempt = _singleTransportAttempt ??=
+                    _handler.BaseSendAsync(request, cancellationToken);
+            }
+
+            return new ValueTask<HttpResponseMessage>(singleTransportAttempt);
         }
 
         public void Complete(HttpResponseMessage? terminalResponse)

--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -1,3 +1,5 @@
+using Kevlar.Internal;
+
 namespace Kevlar.Extensions.Http;
 
 /// <summary>A <see cref="DelegatingHandler"/> with safe per-attempt request replay.</summary>
@@ -44,17 +46,21 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
     {
         if (request is null) { throw new ArgumentNullException(nameof(request)); }
 
+        cancellationToken.ThrowIfCancellationRequested();
         var pipeline = _reloadingPipeline?.Current ?? _pipeline;
+        var canReplay = await CanReplayAsync(request, pipeline.Options).ConfigureAwait(false);
         var execution = new RequestExecution(
             this,
             request,
             pipeline,
+            canReplay,
             cancellationToken);
         try
         {
-            var response = await pipeline.Policy.ExecuteAsync(
+            var response = await pipeline.Policy.ExecuteWithContextAsync(
                 execution,
-                static (state, token) => state.SendAttemptAsync(token),
+                static (state, properties) => state.InitializeProperties(properties),
+                static (state, context) => state.SendAttemptAsync(context.CancellationToken),
                 cancellationToken).ConfigureAwait(false);
             execution.Complete(response);
             return response;
@@ -64,6 +70,31 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             execution.Complete(terminalResponse: null);
             throw;
         }
+    }
+
+    private static async ValueTask<bool> CanReplayAsync(
+        HttpRequestMessage request,
+        ShieldHttpHandlerOptions options)
+    {
+        if (options.RequestFactory is not null)
+        {
+            return true;
+        }
+
+        if (!RequestExecution.IsReplaySafeMethod(request.Method)
+            && !options.AllowUnsafeMethodReplay)
+        {
+            return false;
+        }
+
+        if (request.Content is not { } content
+            || options.ContentReplayPolicy == HttpContentReplayPolicy.Buffer
+            || HttpRequestTemplate.IsInherentlyReplayable(content))
+        {
+            return true;
+        }
+
+        return await HttpRequestTemplate.IsAlreadyBufferedAsync(content).ConfigureAwait(false);
     }
 
     private Task<HttpResponseMessage> BaseSendAsync(
@@ -88,6 +119,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         private readonly ShieldDelegatingHandler _handler;
         private readonly HttpShieldPipeline _pipeline;
         private readonly HttpRequestMessage _original;
+        private readonly bool _canReplay;
         private readonly CancellationToken _executionCancellationToken;
         private readonly List<HttpResponseMessage> _responses = [];
         private readonly Uri[]? _endpointOrder;
@@ -104,23 +136,33 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             ShieldDelegatingHandler handler,
             HttpRequestMessage original,
             HttpShieldPipeline pipeline,
+            bool canReplay,
             CancellationToken executionCancellationToken)
         {
             _handler = handler;
             _pipeline = pipeline;
             _original = original;
+            _canReplay = canReplay;
             _executionCancellationToken = executionCancellationToken;
             _endpointOrder = pipeline.CreateEndpointOrder();
         }
 
         private ShieldHttpHandlerOptions Options => _pipeline.Options;
 
+        public void InitializeProperties(KevlarProperties properties)
+        {
+            if (!_canReplay)
+            {
+                properties.Set(ExecutionPropertyKeys.SuppressAdditionalAttempts, true);
+            }
+        }
+
         private ValueTask PrepareAsync(CancellationToken cancellationToken)
         {
             if (Options.RequestFactory is null
                 && (_endpointOrder is not null
                     || (_original.Content is not null
-                        && Options.ContentReplayPolicy == HttpContentReplayPolicy.Buffer)))
+                        && _canReplay)))
             {
                 return new ValueTask(GetTemplateAsync(cancellationToken));
             }
@@ -145,16 +187,6 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             if (attempt > 0 && isSequentialReplay)
             {
                 DisposePriorResponses();
-            }
-
-            if (attempt > 0
-                && !IsReplaySafeMethod(_original.Method)
-                && !Options.AllowUnsafeMethodReplay
-                && Options.RequestFactory is null)
-            {
-                throw new HttpRequestReplayException(
-                    $"HTTP {_original.Method} is not replayed automatically. Set AllowUnsafeMethodReplay " +
-                    "only when the operation is idempotent, or provide RequestFactory.");
             }
 
             HttpRequestMessage request;
@@ -186,10 +218,11 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
                 var endpointShield = endpoint is null ? null : _pipeline.GetEndpointShield(endpoint);
                 var response = endpointShield is null
                     ? await _handler.BaseSendAsync(request, cancellationToken).ConfigureAwait(false)
-                    : await endpointShield.ExecuteAsync(
-                        (Handler: _handler, Request: request),
-                        static (state, token) => new ValueTask<HttpResponseMessage>(
-                            state.Handler.BaseSendAsync(state.Request, token)),
+                    : await endpointShield.ExecuteWithContextAsync(
+                        (Execution: this, Handler: _handler, Request: request),
+                        static (state, properties) => state.Execution.InitializeProperties(properties),
+                        static (state, context) => new ValueTask<HttpResponseMessage>(
+                            state.Handler.BaseSendAsync(state.Request, context.CancellationToken)),
                         cancellationToken).ConfigureAwait(false);
                 RegisterResponse(response);
                 return response;
@@ -294,6 +327,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
                     _original,
                     Options.ContentReplayPolicy,
                     Options.MaximumBufferSize,
+                    _canReplay,
                     creationCancellation.Token).ConfigureAwait(false);
                 creation.TrySetResult(template);
             }
@@ -390,7 +424,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             request.RequestUri = routed.Uri;
         }
 
-        private static bool IsReplaySafeMethod(HttpMethod method) =>
+        internal static bool IsReplaySafeMethod(HttpMethod method) =>
             method.Method is "GET" or "HEAD" or "OPTIONS" or "TRACE" or "PUT" or "DELETE";
 
         private static void DisposeResponses(List<HttpResponseMessage>? responses)

--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -1,5 +1,3 @@
-using Kevlar.Internal;
-
 namespace Kevlar.Extensions.Http;
 
 /// <summary>A <see cref="DelegatingHandler"/> with safe per-attempt request replay.</summary>
@@ -9,6 +7,9 @@ namespace Kevlar.Extensions.Http;
 /// </remarks>
 public sealed class ShieldDelegatingHandler : DelegatingHandler
 {
+    private static readonly KevlarKey<bool> SuppressAdditionalAttempts =
+        new("Kevlar.SuppressAdditionalAttempts");
+
     private readonly HttpShieldPipeline _pipeline;
     private readonly ReloadingHttpShieldPipeline? _reloadingPipeline;
 
@@ -153,7 +154,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         {
             if (!_canReplay)
             {
-                properties.Set(ExecutionPropertyKeys.SuppressAdditionalAttempts, true);
+                properties.Set(SuppressAdditionalAttempts, true);
             }
         }
 

--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -126,6 +126,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         private readonly Uri[]? _endpointOrder;
 
         private Task<HttpRequestTemplate>? _template;
+        private Task<HttpResponseMessage>? _singleAttempt;
         private CancellationTokenSource? _templateCancellation;
         private HttpResponseMessage? _terminalResponse;
         private CancellationToken _lastAttemptToken;
@@ -171,7 +172,24 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             return default;
         }
 
-        public async ValueTask<HttpResponseMessage> SendAttemptAsync(CancellationToken cancellationToken)
+        public ValueTask<HttpResponseMessage> SendAttemptAsync(CancellationToken cancellationToken)
+        {
+            if (_canReplay)
+            {
+                return SendAttemptCoreAsync(cancellationToken);
+            }
+
+            Task<HttpResponseMessage> singleAttempt;
+            lock (_gate)
+            {
+                singleAttempt = _singleAttempt ??= SendAttemptCoreAsync(cancellationToken).AsTask();
+            }
+
+            return new ValueTask<HttpResponseMessage>(singleAttempt);
+        }
+
+        private async ValueTask<HttpResponseMessage> SendAttemptCoreAsync(
+            CancellationToken cancellationToken)
         {
             await PrepareAsync(cancellationToken).ConfigureAwait(false);
             int attempt;

--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -7,9 +7,6 @@ namespace Kevlar.Extensions.Http;
 /// </remarks>
 public sealed class ShieldDelegatingHandler : DelegatingHandler
 {
-    private static readonly KevlarKey<bool> SuppressAdditionalAttempts =
-        new("Kevlar.SuppressAdditionalAttempts");
-
     private readonly HttpShieldPipeline _pipeline;
     private readonly ReloadingHttpShieldPipeline? _reloadingPipeline;
 
@@ -121,6 +118,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         private readonly HttpShieldPipeline _pipeline;
         private readonly HttpRequestMessage _original;
         private readonly bool _canReplay;
+        private readonly bool _hadInitialContent;
         private readonly CancellationToken _executionCancellationToken;
         private readonly List<HttpResponseMessage> _responses = [];
         private readonly Uri[]? _endpointOrder;
@@ -145,6 +143,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             _pipeline = pipeline;
             _original = original;
             _canReplay = canReplay;
+            _hadInitialContent = original.Content is not null;
             _executionCancellationToken = executionCancellationToken;
             _endpointOrder = pipeline.CreateEndpointOrder();
         }
@@ -155,7 +154,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         {
             if (!_canReplay)
             {
-                properties.Set(SuppressAdditionalAttempts, true);
+                properties.SuppressAdditionalAttempts = true;
             }
         }
 
@@ -163,8 +162,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         {
             if (Options.RequestFactory is null
                 && (_endpointOrder is not null
-                    || (_original.Content is not null
-                        && _canReplay)))
+                    || (_hadInitialContent && _canReplay)))
             {
                 return new ValueTask(GetTemplateAsync(cancellationToken));
             }
@@ -347,6 +345,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
                     Options.ContentReplayPolicy,
                     Options.MaximumBufferSize,
                     _canReplay,
+                    _hadInitialContent,
                     creationCancellation.Token).ConfigureAwait(false);
                 creation.TrySetResult(template);
             }

--- a/src/Kevlar/Internal/ExecutionPropertyKeys.cs
+++ b/src/Kevlar/Internal/ExecutionPropertyKeys.cs
@@ -1,0 +1,7 @@
+namespace Kevlar.Internal;
+
+internal static class ExecutionPropertyKeys
+{
+    internal static readonly KevlarKey<bool> SuppressAdditionalAttempts =
+        new("Kevlar.SuppressAdditionalAttempts");
+}

--- a/src/Kevlar/Internal/ExecutionPropertyKeys.cs
+++ b/src/Kevlar/Internal/ExecutionPropertyKeys.cs
@@ -1,7 +1,0 @@
-namespace Kevlar.Internal;
-
-internal static class ExecutionPropertyKeys
-{
-    internal static readonly KevlarKey<bool> SuppressAdditionalAttempts =
-        new("Kevlar.SuppressAdditionalAttempts");
-}

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />
     <InternalsVisibleTo Include="Kevlar.Testing" />
-    <InternalsVisibleTo Include="Kevlar.Extensions.Http" />
     <InternalsVisibleTo Include="Kevlar.Extensions.RateLimiting" />
   </ItemGroup>
 

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />
     <InternalsVisibleTo Include="Kevlar.Testing" />
+    <InternalsVisibleTo Include="Kevlar.Extensions.Http" />
     <InternalsVisibleTo Include="Kevlar.Extensions.RateLimiting" />
   </ItemGroup>
 

--- a/src/Kevlar/KevlarProperties.cs
+++ b/src/Kevlar/KevlarProperties.cs
@@ -24,6 +24,8 @@ public sealed class KevlarProperties
     {
     }
 
+    internal bool SuppressAdditionalAttempts { get; set; }
+
     /// <summary>Gets the number of values currently stored in the bag.</summary>
     public int Count
     {
@@ -98,6 +100,7 @@ public sealed class KevlarProperties
 
     internal void Clear()
     {
+        SuppressAdditionalAttempts = false;
         if (_firstItem is null)
         {
             return;
@@ -125,6 +128,7 @@ public sealed class KevlarProperties
 
     internal void CopyTo(KevlarProperties target)
     {
+        target.SuppressAdditionalAttempts = SuppressAdditionalAttempts;
         if (_firstItem is null)
         {
             return;

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -52,7 +52,7 @@ internal sealed class HedgingStrategy : Strategy
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         if (_maxAttempts == 1
-            || context.Properties.GetOrDefault(ExecutionPropertyKeys.SuppressAdditionalAttempts))
+            || context.Properties.SuppressAdditionalAttempts)
         {
             return next.InvokeAsync(context);
         }

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -51,7 +51,8 @@ internal sealed class HedgingStrategy : Strategy
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
-        if (_maxAttempts == 1)
+        if (_maxAttempts == 1
+            || context.Properties.GetOrDefault(ExecutionPropertyKeys.SuppressAdditionalAttempts))
         {
             return next.InvokeAsync(context);
         }

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -196,7 +196,7 @@ internal sealed class RetryStrategy : Strategy
 
     private bool ShouldRetry<T>(in Outcome<T> outcome, int retriesUsed, KevlarContext context) =>
         retriesUsed < _maxRetries
-        && !context.Properties.GetOrDefault(ExecutionPropertyKeys.SuppressAdditionalAttempts)
+        && !context.Properties.SuppressAdditionalAttempts
         && _judge.ShouldHandle(in outcome)
         && !context.CancellationToken.IsCancellationRequested;
 

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -196,6 +196,7 @@ internal sealed class RetryStrategy : Strategy
 
     private bool ShouldRetry<T>(in Outcome<T> outcome, int retriesUsed, KevlarContext context) =>
         retriesUsed < _maxRetries
+        && !context.Properties.GetOrDefault(ExecutionPropertyKeys.SuppressAdditionalAttempts)
         && _judge.ShouldHandle(in outcome)
         && !context.CancellationToken.IsCancellationRequested;
 

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -149,6 +149,49 @@ public class HttpReplayTests
     }
 
     [Test]
+    public async Task False_Zero_ContentLength_Does_Not_Make_Content_Replayable()
+    {
+        var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        var transport = new RecordingHandler(async (_, request, _) =>
+        {
+            _ = await request.Content!.ReadAsByteArrayAsync();
+            return originalResponse;
+        });
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = new StreamContent(new MemoryStream([1, 2, 3])),
+        };
+        request.Content.Headers.ContentLength = 0;
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(ReferenceEquals(response, originalResponse)).IsTrue();
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Custom_MultiInvocation_Strategy_Cannot_Replay_Unsafe_Method()
+    {
+        var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        var transport = new RecordingHandler((attempt, _, _) => Task.FromResult(
+            attempt == 1 ? originalResponse : new HttpResponseMessage(HttpStatusCode.OK)));
+        using var invoker = CreateInvoker(
+            Shield.For<HttpResponseMessage>().Use(new ReturnSecondStrategy()),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/api");
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(ReferenceEquals(response, originalResponse)).IsTrue();
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Put_With_ByteArrayContent_NoBuffer_Is_Retried()
     {
         var bodies = new List<byte[]>();
@@ -1170,6 +1213,17 @@ public class HttpReplayTests
             await Task.Yield();
             cancellationToken.ThrowIfCancellationRequested();
             yield return 2;
+        }
+    }
+
+    private sealed class ReturnSecondStrategy : Strategy
+    {
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            _ = await next.InvokeAsync(context).ConfigureAwait(false);
+            return await next.InvokeAsync(context).ConfigureAwait(false);
         }
     }
 

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using Kevlar.Extensions.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -116,12 +117,17 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task NoBuffer_Rejects_A_OneShot_Content_Second_Send()
+    public async Task Put_With_StreamContent_NoBuffer_Returns_Original_Response()
     {
+        var responseContent = new TrackingContent("original");
+        var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+        {
+            Content = responseContent,
+        };
         var transport = new RecordingHandler(async (_, request, _) =>
         {
             _ = await request.Content!.ReadAsByteArrayAsync();
-            return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            return originalResponse;
         });
         using var invoker = CreateInvoker(
             HttpShield.WhenTransient().Retry(1, Backoff.None),
@@ -131,13 +137,126 @@ public class HttpReplayTests
         {
             Content = new StreamContent(new MemoryStream([1, 2, 3])),
         };
+        request.Content.Headers.ContentLength = 3;
 
-        var exception = await Assert.That(async () =>
-                await invoker.SendAsync(request, CancellationToken.None))
-            .Throws<HttpRequestReplayException>();
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
 
-        await Assert.That(exception!.Message).Contains("RequestFactory");
+        await Assert.That(ReferenceEquals(response, originalResponse)).IsTrue();
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("original");
         await Assert.That(transport.Attempts).IsEqualTo(1);
+        await Assert.That(responseContent.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Put_With_ByteArrayContent_NoBuffer_Is_Retried()
+    {
+        var bodies = new List<byte[]>();
+        var transport = new RecordingHandler(async (attempt, request, _) =>
+        {
+            bodies.Add(await request.Content!.ReadAsByteArrayAsync());
+            return new HttpResponseMessage(
+                attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK);
+        });
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = new ByteArrayContent([1, 2, 3]),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.Attempts).IsEqualTo(2);
+        await Assert.That(bodies.All(static body => body.SequenceEqual(new byte[] { 1, 2, 3 }))).IsTrue();
+    }
+
+    [Test]
+    public async Task ReReadable_NoBuffer_Content_Is_Retried()
+    {
+        Func<HttpContent>[] factories =
+        [
+            static () => new StringContent("payload"),
+            static () => new FormUrlEncodedContent([new("name", "value")]),
+            static () => JsonContent.Create(new { Name = "value" }),
+        ];
+
+        foreach (var factory in factories)
+        {
+            var bodies = new List<string>();
+            var transport = new RecordingHandler(async (attempt, request, _) =>
+            {
+                bodies.Add(await request.Content!.ReadAsStringAsync());
+                return new HttpResponseMessage(
+                    attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK);
+            });
+            using var invoker = CreateInvoker(
+                HttpShield.WhenTransient().Retry(1, Backoff.None),
+                new ShieldHttpHandlerOptions(),
+                transport);
+            using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+            {
+                Content = factory(),
+            };
+
+            using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+            await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(transport.Attempts).IsEqualTo(2);
+            await Assert.That(bodies[1]).IsEqualTo(bodies[0]);
+        }
+    }
+
+    [Test]
+    public async Task Post_With_AllowUnsafeMethodReplay_Is_Retried()
+    {
+        var transport = new RecordingHandler((attempt, _, _) => Task.FromResult(
+            new HttpResponseMessage(
+                attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK)));
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions { AllowUnsafeMethodReplay = true },
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.Attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Already_Buffered_StreamContent_NoBuffer_Is_Retried()
+    {
+        var bodies = new List<byte[]>();
+        var transport = new RecordingHandler(async (attempt, request, _) =>
+        {
+            bodies.Add(await request.Content!.ReadAsByteArrayAsync());
+            return new HttpResponseMessage(
+                attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK);
+        });
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var content = new StreamContent(new MemoryStream([1, 2, 3]));
+        await content.LoadIntoBufferAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = content,
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.Attempts).IsEqualTo(2);
+        await Assert.That(bodies.All(static body => body.SequenceEqual(new byte[] { 1, 2, 3 }))).IsTrue();
     }
 
     [Test]
@@ -595,7 +714,7 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Rejects_Unsafe_Replay_Without_Explicit_Opt_In()
+    public async Task Non_Replayable_Request_Under_Hedging_Sends_Once()
     {
         var failedContent = new TrackingContent("failed");
         var transport = new RecordingHandler((_, _, _) => Task.FromResult(
@@ -612,11 +731,11 @@ public class HttpReplayTests
             Content = new StringContent("payload"),
         };
 
-        _ = await Assert.That(async () => await client.SendAsync(request))
-            .Throws<HttpRequestReplayException>();
+        using var response = await client.SendAsync(request);
 
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
         await Assert.That(transport.Attempts).IsEqualTo(1);
-        await Assert.That(failedContent.DisposeCount).IsEqualTo(1);
+        await Assert.That(failedContent.DisposeCount).IsEqualTo(0);
     }
 
     [Test]
@@ -767,14 +886,16 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Routed_NoBuffer_Content_Is_Sent_Once_Before_Replay_Is_Rejected()
+    public async Task Routed_NonReplayable_Content_Uses_Only_First_Endpoint()
     {
         var bodies = new List<string>();
+        var hosts = new List<string>();
         var contentHeaderCounts = new List<int>();
         var content = new TrackingContent("payload");
         var transport = new RecordingHandler(async (_, request, _) =>
         {
             bodies.Add(await request.Content!.ReadAsStringAsync());
+            hosts.Add(request.RequestUri!.Host);
             contentHeaderCounts.Add(request.Content.Headers.GetValues("x-content").Count());
             return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
         });
@@ -792,14 +913,66 @@ public class HttpReplayTests
         };
         request.Content.Headers.TryAddWithoutValidation("x-content", new[] { "one", "two" });
 
-        _ = await Assert.That(async () =>
-                await invoker.SendAsync(request, CancellationToken.None))
-            .Throws<HttpRequestReplayException>();
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
 
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
         await Assert.That(bodies).IsEquivalentTo(["payload"]);
+        await Assert.That(hosts).IsEquivalentTo(["first.example"]);
         await Assert.That(contentHeaderCounts).IsEquivalentTo([2]);
         await Assert.That(transport.Attempts).IsEqualTo(1);
         await Assert.That(content.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task HttpRequestException_On_NonReplayable_Request_Is_Rethrown_Unchanged()
+    {
+        var expected = new HttpRequestException("original");
+        var transport = new RecordingHandler((_, _, _) => throw expected);
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(3, Backoff.Constant(TimeSpan.FromSeconds(1))),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+
+        var actual = await Assert.That(async () =>
+                await invoker.SendAsync(request, CancellationToken.None))
+            .Throws<HttpRequestException>();
+
+        await Assert.That(ReferenceEquals(actual, expected)).IsTrue();
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task NonReplayable_Request_Counts_As_CircuitBreaker_Failure()
+    {
+        var transport = new RecordingHandler((_, _, _) => Task.FromResult(
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        var shield = HttpShield.WhenTransient()
+            .Retry(3, Backoff.None)
+            .CircuitBreaker(consecutiveFailures: 2, breakDuration: TimeSpan.FromHours(1));
+        using var invoker = CreateInvoker(shield, new ShieldHttpHandlerOptions(), transport);
+
+        for (var requestIndex = 0; requestIndex < 2; requestIndex++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
+            {
+                Content = new StringContent("payload"),
+            };
+            using var response = await invoker.SendAsync(request, CancellationToken.None);
+            await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        }
+
+        using var blockedRequest = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+        _ = await Assert.That(async () =>
+                await invoker.SendAsync(blockedRequest, CancellationToken.None))
+            .Throws<CircuitOpenException>();
+        await Assert.That(transport.Attempts).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -178,6 +178,34 @@ public class HttpReplayTests
     }
 
     [Test]
+    public async Task Throwing_ContentLength_Probe_Allows_One_Shielded_Attempt()
+    {
+        var fallback = new HttpResponseMessage(HttpStatusCode.OK);
+        var transport = new RecordingHandler((_, attemptRequest, _) =>
+        {
+            _ = attemptRequest.Content!.Headers.ContentLength;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        });
+        using var invoker = CreateInvoker(
+            Shield.For<HttpResponseMessage>().When<InvalidOperationException>().Fallback(
+                (_, _) => new ValueTask<HttpResponseMessage>(fallback)),
+            new ShieldHttpHandlerOptions
+            {
+                AllowUnsafeMethodReplay = true,
+            },
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = new ThrowingLengthContent(),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(ReferenceEquals(response, fallback)).IsTrue();
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Custom_MultiInvocation_Strategy_Cannot_Replay_Unsafe_Method()
     {
         var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
@@ -1416,6 +1444,17 @@ public class HttpReplayTests
         {
             length = 0;
             return false;
+        }
+    }
+
+    private sealed class ThrowingLengthContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.CompletedTask;
+
+        protected override bool TryComputeLength(out long length)
+        {
+            throw new InvalidOperationException("Length is unavailable.");
         }
     }
 

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -222,6 +222,87 @@ public class HttpReplayTests
     }
 
     [Test]
+    public async Task Derived_ByteArrayContent_NoBuffer_Returns_Original_Response()
+    {
+        var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        var transport = new RecordingHandler(async (_, request, _) =>
+        {
+            _ = await request.Content!.ReadAsByteArrayAsync();
+            return originalResponse;
+        });
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = new DerivedByteArrayContent([1, 2, 3]),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(ReferenceEquals(response, originalResponse)).IsTrue();
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Content_Attached_By_Inner_Handler_Is_Recreated_For_Retry()
+    {
+        var bodies = new List<byte[]>();
+        var transport = new RecordingHandler(async (attempt, request, _) =>
+        {
+            bodies.Add(await request.Content!.ReadAsByteArrayAsync());
+            return new HttpResponseMessage(
+                attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK);
+        });
+        var contentAttacher = new ContentAttachingHandler([1, 2, 3])
+        {
+            InnerHandler = transport,
+        };
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            contentAttacher);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://origin.example/api");
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(contentAttacher.Attachments).IsEqualTo(2);
+        await Assert.That(bodies.Count).IsEqualTo(2);
+        await Assert.That(bodies.All(static body => body.SequenceEqual(new byte[] { 1, 2, 3 }))).IsTrue();
+    }
+
+    [Test]
+    public async Task NoBuffer_Content_Headers_Are_Isolated_Per_Attempt()
+    {
+        var observedHeaders = new List<string>();
+        var transport = new RecordingHandler((attempt, request, _) =>
+        {
+            observedHeaders.Add(string.Join(",", request.Content!.Headers.GetValues("X-Attempt")));
+            return Task.FromResult(new HttpResponseMessage(
+                attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
+        });
+        var headerAppender = new AttemptHeaderHandler
+        {
+            InnerHandler = transport,
+        };
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            headerAppender);
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = new ByteArrayContent([1, 2, 3]),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(observedHeaders).IsEquivalentTo(["1", "2"]);
+    }
+
+    [Test]
     public async Task ReReadable_NoBuffer_Content_Is_Retried()
     {
         Func<HttpContent>[] factories =
@@ -1198,6 +1279,43 @@ public class HttpReplayTests
             CancellationToken cancellationToken) =>
             send(Interlocked.Increment(ref _attempts), request, cancellationToken);
     }
+
+    private sealed class ContentAttachingHandler(byte[] content) : DelegatingHandler
+    {
+        private int _attachments;
+
+        public int Attachments => Volatile.Read(ref _attachments);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Content is null)
+            {
+                Interlocked.Increment(ref _attachments);
+                request.Content = new StreamContent(new NonSeekableStream(content));
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    private sealed class AttemptHeaderHandler : DelegatingHandler
+    {
+        private int _attempt;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _ = request.Content!.Headers.TryAddWithoutValidation(
+                "X-Attempt",
+                Interlocked.Increment(ref _attempt).ToString(System.Globalization.CultureInfo.InvariantCulture));
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    private sealed class DerivedByteArrayContent(byte[] content) : ByteArrayContent(content);
 
     private sealed class SingleUseAsyncEnumerable : IAsyncEnumerable<int>
     {

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -151,10 +151,11 @@ public class HttpReplayTests
     [Test]
     public async Task False_Zero_ContentLength_Does_Not_Make_Content_Replayable()
     {
+        var bodies = new List<byte[]>();
         var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
         var transport = new RecordingHandler(async (_, request, _) =>
         {
-            _ = await request.Content!.ReadAsByteArrayAsync();
+            bodies.Add(await request.Content!.ReadAsByteArrayAsync());
             return originalResponse;
         });
         using var invoker = CreateInvoker(
@@ -171,6 +172,7 @@ public class HttpReplayTests
 
         await Assert.That(ReferenceEquals(response, originalResponse)).IsTrue();
         await Assert.That(transport.Attempts).IsEqualTo(1);
+        await Assert.That(bodies.Single().SequenceEqual(new byte[] { 1, 2, 3 })).IsTrue();
     }
 
     [Test]

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -119,6 +119,7 @@ public class HttpReplayTests
     [Test]
     public async Task Put_With_StreamContent_NoBuffer_Returns_Original_Response()
     {
+        var bodies = new List<byte[]>();
         var responseContent = new TrackingContent("original");
         var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
         {
@@ -126,7 +127,7 @@ public class HttpReplayTests
         };
         var transport = new RecordingHandler(async (_, request, _) =>
         {
-            _ = await request.Content!.ReadAsByteArrayAsync();
+            bodies.Add(await request.Content!.ReadAsByteArrayAsync());
             return originalResponse;
         });
         using var invoker = CreateInvoker(
@@ -135,7 +136,7 @@ public class HttpReplayTests
             transport);
         using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
         {
-            Content = new StreamContent(new MemoryStream([1, 2, 3])),
+            Content = new StreamContent(new NonSeekableStream([1, 2, 3])),
         };
         request.Content.Headers.ContentLength = 3;
 
@@ -145,6 +146,7 @@ public class HttpReplayTests
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
         await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("original");
         await Assert.That(transport.Attempts).IsEqualTo(1);
+        await Assert.That(bodies.Single().SequenceEqual(new byte[] { 1, 2, 3 })).IsTrue();
         await Assert.That(responseContent.DisposeCount).IsEqualTo(0);
     }
 
@@ -164,7 +166,7 @@ public class HttpReplayTests
             transport);
         using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
         {
-            Content = new StreamContent(new MemoryStream([1, 2, 3])),
+            Content = new StreamContent(new NonSeekableStream([1, 2, 3])),
         };
         request.Content.Headers.ContentLength = 0;
 
@@ -1227,6 +1229,11 @@ public class HttpReplayTests
             _ = await next.InvokeAsync(context).ConfigureAwait(false);
             return await next.InvokeAsync(context).ConfigureAwait(false);
         }
+    }
+
+    private sealed class NonSeekableStream(byte[] bytes) : MemoryStream(bytes)
+    {
+        public override bool CanSeek => false;
     }
 
     private sealed class TrackingContent(string value) : HttpContent

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -224,6 +224,26 @@ public class HttpReplayTests
     }
 
     [Test]
+    public async Task Endpoint_Custom_Strategy_Cannot_Replay_Unsafe_Method()
+    {
+        var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        var transport = new RecordingHandler((attempt, _, _) => Task.FromResult(
+            attempt == 1 ? originalResponse : new HttpResponseMessage(HttpStatusCode.OK)));
+        var options = RoutingOptions(
+            HttpEndpointSelectionMode.Ordered,
+            new HttpEndpoint(new Uri("https://endpoint.example")));
+        options.Routing!.ShieldFactory = _ =>
+            Shield.For<HttpResponseMessage>().Use(new ReturnSecondStrategy());
+        using var invoker = CreateInvoker(Shield<HttpResponseMessage>.Empty, options, transport);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/api");
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(ReferenceEquals(response, originalResponse)).IsTrue();
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Put_With_ByteArrayContent_NoBuffer_Is_Retried()
     {
         var bodies = new List<byte[]>();

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -181,7 +181,6 @@ public class HttpReplayTests
         [
             static () => new StringContent("payload"),
             static () => new FormUrlEncodedContent([new("name", "value")]),
-            static () => JsonContent.Create(new { Name = "value" }),
         ];
 
         foreach (var factory in factories)
@@ -208,6 +207,60 @@ public class HttpReplayTests
             await Assert.That(transport.Attempts).IsEqualTo(2);
             await Assert.That(bodies[1]).IsEqualTo(bodies[0]);
         }
+    }
+
+    [Test]
+    public async Task JsonContent_With_Consumable_Value_NoBuffer_Returns_Original_Response()
+    {
+        var values = new SingleUseAsyncEnumerable();
+        var originalResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+        var transport = new RecordingHandler(async (_, request, _) =>
+        {
+            await request.Content!.CopyToAsync(Stream.Null);
+            return originalResponse;
+        });
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = JsonContent.Create<IAsyncEnumerable<int>>(values),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(ReferenceEquals(response, originalResponse)).IsTrue();
+        await Assert.That(transport.Attempts).IsEqualTo(1);
+        await Assert.That(values.Enumerations).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Buffered_JsonContent_NoBuffer_Is_Retried()
+    {
+        var bodies = new List<string>();
+        var transport = new RecordingHandler(async (attempt, request, _) =>
+        {
+            bodies.Add(await request.Content!.ReadAsStringAsync());
+            return new HttpResponseMessage(
+                attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK);
+        });
+        using var invoker = CreateInvoker(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            new ShieldHttpHandlerOptions(),
+            transport);
+        using var content = JsonContent.Create(new { Name = "value" });
+        await content.LoadIntoBufferAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://origin.example/upload")
+        {
+            Content = content,
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(transport.Attempts).IsEqualTo(2);
+        await Assert.That(bodies[1]).IsEqualTo(bodies[0]);
     }
 
     [Test]
@@ -1097,6 +1150,27 @@ public class HttpReplayTests
             HttpRequestMessage request,
             CancellationToken cancellationToken) =>
             send(Interlocked.Increment(ref _attempts), request, cancellationToken);
+    }
+
+    private sealed class SingleUseAsyncEnumerable : IAsyncEnumerable<int>
+    {
+        private int _enumerations;
+
+        public int Enumerations => Volatile.Read(ref _enumerations);
+
+        public async IAsyncEnumerator<int> GetAsyncEnumerator(
+            CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref _enumerations) != 1)
+            {
+                throw new InvalidOperationException("The sequence can only be consumed once.");
+            }
+
+            yield return 1;
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return 2;
+        }
     }
 
     private sealed class TrackingContent(string value) : HttpContent

--- a/tests/Kevlar.NetStandard.Tests/HttpPropertiesReplayTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/HttpPropertiesReplayTests.cs
@@ -23,6 +23,52 @@ public class HttpPropertiesReplayTests
     }
 
     [Test]
+    public async Task NonReplayable_Post_Returns_Original_Response()
+    {
+        var attempts = 0;
+        using var invoker = new HttpMessageInvoker(new ShieldDelegatingHandler(
+            HttpShield.WhenTransient().Retry(1, Backoff.None))
+        {
+            InnerHandler = new DelegateHandler((_, _) =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            }),
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ReReadable_Put_Content_Retries_Without_Buffering()
+    {
+        var attempts = 0;
+        using var invoker = new HttpMessageInvoker(new ShieldDelegatingHandler(
+            HttpShield.WhenTransient().Retry(1, Backoff.None))
+        {
+            InnerHandler = new DelegateHandler((_, _) => Task.FromResult(
+                new HttpResponseMessage(
+                    ++attempts == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK))),
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Put, "https://example.test/upload")
+        {
+            Content = new ByteArrayContent([1, 2, 3]),
+        };
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Buffered_Retry_Preserves_NetStandard_Request_Properties()
     {
         var marker = new object();
@@ -69,5 +115,13 @@ public class HttpPropertiesReplayTests
                 : HttpStatusCode.OK;
             return Task.FromResult(new HttpResponseMessage(status));
         }
+    }
+
+    private sealed class DelegateHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => send(request, cancellationToken);
     }
 }

--- a/tests/Kevlar.Tests/HedgingTests.cs
+++ b/tests/Kevlar.Tests/HedgingTests.cs
@@ -1,9 +1,38 @@
+using Kevlar.Internal;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
 
 public class HedgingTests
 {
+    [Test]
+    public async Task SuppressAdditionalAttempts_Skips_Hedges_And_Notification()
+    {
+        var attempts = 0;
+        var notifications = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedge = _ => notifications++;
+        });
+
+        var exception = await Assert.That(async () => await shield.ExecuteWithContextAsync<int, int>(
+                0,
+                static (_, properties) =>
+                    properties.Set(ExecutionPropertyKeys.SuppressAdditionalAttempts, true),
+                (_, _) =>
+                {
+                    attempts++;
+                    throw new InvalidOperationException("original");
+                }))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).IsEqualTo("original");
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(notifications).IsEqualTo(0);
+    }
+
     [Test]
     public async Task Handled_Failure_Launches_The_Next_Attempt_Immediately()
     {

--- a/tests/Kevlar.Tests/HedgingTests.cs
+++ b/tests/Kevlar.Tests/HedgingTests.cs
@@ -1,4 +1,3 @@
-using Kevlar.Internal;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
@@ -20,7 +19,7 @@ public class HedgingTests
         var exception = await Assert.That(async () => await shield.ExecuteWithContextAsync<int, int>(
                 0,
                 static (_, properties) =>
-                    properties.Set(ExecutionPropertyKeys.SuppressAdditionalAttempts, true),
+                    properties.SuppressAdditionalAttempts = true,
                 (_, _) =>
                 {
                     attempts++;

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -483,6 +483,35 @@ public class HttpContractTests
     }
 
     [Test]
+    public async Task Post_Without_OptIn_Returns_Original_Response_Without_Retry_Delay()
+    {
+        var now = new DateTimeOffset(2035, 4, 5, 6, 7, 8, TimeSpan.Zero);
+        var timeProvider = new FakeTimeProvider(now);
+        var retryCallbacks = 0;
+        var shield = HttpShield.WhenTransient()
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.Constant(TimeSpan.FromMinutes(1));
+                options.OnRetry = _ => retryCallbacks++;
+            })
+            .WithTimeProvider(timeProvider);
+        using var inner = new DelegateHandler((_, _) => Task.FromResult(
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var client = CreateClient(inner, shield);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/upload")
+        {
+            Content = new StringContent("payload"),
+        };
+
+        using var response = await client.SendAsync(request).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(retryCallbacks).IsEqualTo(0);
+        await Assert.That(timeProvider.GetUtcNow()).IsEqualTo(now);
+    }
+
+    [Test]
     public async Task Standard_ServiceProvider_Configuration_Runs_Once_Per_Handler_Lifetime()
     {
         var marker = new Marker();
@@ -789,7 +818,7 @@ public class HttpContractTests
     }
 
     [Test]
-    public async Task Retry_Does_Not_Rewind_OneShot_Stream_Content()
+    public async Task Retry_Returns_First_Response_For_OneShot_Stream_Content()
     {
         var bodies = new List<byte[]>();
         using var inner = new DelegateHandler(async (request, token) =>
@@ -807,7 +836,9 @@ public class HttpContractTests
             Content = new StreamContent(source),
         };
 
-        await Assert.That(async () => await client.SendAsync(request)).Throws<InvalidOperationException>();
+        using var response = await client.SendAsync(request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
         await Assert.That(bodies[0]).IsEquivalentTo(new byte[] { 1, 2, 3 });
         await Assert.That(bodies.Count).IsEqualTo(1);
     }

--- a/tests/Kevlar.Tests/RetryTests.cs
+++ b/tests/Kevlar.Tests/RetryTests.cs
@@ -1,9 +1,38 @@
+using Kevlar.Internal;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
 
 public class RetryTests
 {
+    [Test]
+    public async Task SuppressAdditionalAttempts_Skips_Retry_And_Notification()
+    {
+        var attempts = 0;
+        var notifications = 0;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 3;
+            options.Backoff = Backoff.None;
+            options.OnRetry = _ => notifications++;
+        });
+
+        var exception = await Assert.That(async () => await shield.ExecuteWithContextAsync<int, int>(
+                0,
+                static (_, properties) =>
+                    properties.Set(ExecutionPropertyKeys.SuppressAdditionalAttempts, true),
+                (_, _) =>
+                {
+                    attempts++;
+                    throw new InvalidOperationException("original");
+                }))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).IsEqualTo("original");
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(notifications).IsEqualTo(0);
+    }
+
     [Test]
     public async Task Retries_Until_Success()
     {

--- a/tests/Kevlar.Tests/RetryTests.cs
+++ b/tests/Kevlar.Tests/RetryTests.cs
@@ -1,4 +1,3 @@
-using Kevlar.Internal;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
@@ -20,7 +19,7 @@ public class RetryTests
         var exception = await Assert.That(async () => await shield.ExecuteWithContextAsync<int, int>(
                 0,
                 static (_, properties) =>
-                    properties.Set(ExecutionPropertyKeys.SuppressAdditionalAttempts, true),
+                    properties.SuppressAdditionalAttempts = true,
                 (_, _) =>
                 {
                     attempts++;
@@ -31,6 +30,22 @@ public class RetryTests
         await Assert.That(exception!.Message).IsEqualTo("original");
         await Assert.That(attempts).IsEqualTo(1);
         await Assert.That(notifications).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Public_Named_Property_Cannot_Suppress_Retry()
+    {
+        var attempts = 0;
+        var result = await Shield.Retry(1, Backoff.None).ExecuteWithContextAsync<int, int>(
+            0,
+            static (_, properties) =>
+                properties.Set(new KevlarKey<bool>("Kevlar.SuppressAdditionalAttempts"), true),
+            (_, _) => new ValueTask<int>(++attempts == 1
+                ? throw new InvalidOperationException("retry")
+                : 42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
     }
 
     [Test]


### PR DESCRIPTION
Closes #186

Non-replayable HTTP requests now stay single-attempt: retry and hedging return the original response or rethrow the original exception without delay/callback. Timeout, circuit breaker, concurrency, and endpoint routing still observe the attempt. `NoBuffer` replays inherently re-readable or already-buffered content.

Also carries the shared main-branch validation repairs from #258 so CI can run; those commits drop once #258 lands.

Validation:
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (848 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (137 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m` (12 passed)
- analyzer, chaos, testing, rate-limiting, allocation, and netstandard2.1 suites (193 passed)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0-loop186` (118 compiled; behavior executed)
- `npm ci && npm run build`
