### PR TITLE
fix(build): ship native net8 assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,17 @@ jobs:
         run: dotnet build Kevlar.slnx -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
 
       - name: Unit tests
+        shell: pwsh
         run: |
           dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict --report-trx --report-trx-filename unit-net8.trx --results-directory artifacts/test-results/unit
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict --report-trx --report-trx-filename unit-net10.trx --results-directory artifacts/test-results/unit
 
       - name: Chaos tests
+        shell: pwsh
         run: |
           dotnet run --project tests/Kevlar.Chaos.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 25 --zero-tests-policy strict --report-trx --report-trx-filename chaos-net8.trx --results-directory artifacts/test-results/chaos
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet run --project tests/Kevlar.Chaos.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 25 --zero-tests-policy strict --report-trx --report-trx-filename chaos-net10.trx --results-directory artifacts/test-results/chaos
 
       - name: Compatibility asset tests
@@ -104,13 +108,17 @@ jobs:
         run: dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 65 --zero-tests-policy strict --report-trx --report-trx-filename analyzers.trx --results-directory artifacts/test-results/analyzers
 
       - name: Testing package tests
+        shell: pwsh
         run: |
           dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict --report-trx --report-trx-filename testing-net8.trx --results-directory artifacts/test-results/testing
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict --report-trx --report-trx-filename testing-net10.trx --results-directory artifacts/test-results/testing
 
       - name: Rate limiting adapter tests
+        shell: pwsh
         run: |
           dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 20 --zero-tests-policy strict --report-trx --report-trx-filename rate-limiting-net8.trx --results-directory artifacts/test-results/rate-limiting
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 20 --zero-tests-policy strict --report-trx --report-trx-filename rate-limiting-net10.trx --results-directory artifacts/test-results/rate-limiting
 
       - name: Upload test reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   allocation-gates:
-    name: Allocation gates (.NET 10, Ubuntu)
+    name: Allocation gates (.NET 8/10, Ubuntu)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -33,9 +33,9 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Run allocation gates
-        run: >-
-          dotnet run --project tests/Kevlar.AllocationTests -c Release --
-          --timeout 5m --minimum-expected-tests 3 --zero-tests-policy strict
+        run: |
+          dotnet run --project tests/Kevlar.AllocationTests -c Release -f net8.0 -- --timeout 5m --minimum-expected-tests 3 --zero-tests-policy strict
+          dotnet run --project tests/Kevlar.AllocationTests -c Release -f net10.0 -- --timeout 5m --minimum-expected-tests 3 --zero-tests-policy strict
 
   build-and-test:
     strategy:
@@ -75,13 +75,21 @@ jobs:
         run: dotnet build Kevlar.slnx -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
 
       - name: Unit tests
-        run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict --report-trx --report-trx-filename unit.trx --results-directory artifacts/test-results/unit
+        run: |
+          dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict --report-trx --report-trx-filename unit-net8.trx --results-directory artifacts/test-results/unit
+          dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict --report-trx --report-trx-filename unit-net10.trx --results-directory artifacts/test-results/unit
 
       - name: Chaos tests
-        run: dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 25 --zero-tests-policy strict --report-trx --report-trx-filename chaos.trx --results-directory artifacts/test-results/chaos
+        run: |
+          dotnet run --project tests/Kevlar.Chaos.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 25 --zero-tests-policy strict --report-trx --report-trx-filename chaos-net8.trx --results-directory artifacts/test-results/chaos
+          dotnet run --project tests/Kevlar.Chaos.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 25 --zero-tests-policy strict --report-trx --report-trx-filename chaos-net10.trx --results-directory artifacts/test-results/chaos
 
       - name: Compatibility asset tests
-        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 10 --zero-tests-policy strict --report-trx --report-trx-filename netstandard.trx --results-directory artifacts/test-results/netstandard
+        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 10 --zero-tests-policy strict --report-trx --report-trx-filename netstandard.trx --results-directory artifacts/test-results/netstandard
+
+      - name: .NET Framework compatibility asset tests
+        if: matrix.os == 'windows-latest'
+        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release -f net48 --no-build
 
       - name: Modern gRPC compatibility asset tests
         run: dotnet run --project tests/Kevlar.NetStandard21.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 4 --zero-tests-policy strict --report-trx --report-trx-filename netstandard21.trx --results-directory artifacts/test-results/netstandard21
@@ -96,10 +104,14 @@ jobs:
         run: dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 65 --zero-tests-policy strict --report-trx --report-trx-filename analyzers.trx --results-directory artifacts/test-results/analyzers
 
       - name: Testing package tests
-        run: dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict --report-trx --report-trx-filename testing.trx --results-directory artifacts/test-results/testing
+        run: |
+          dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict --report-trx --report-trx-filename testing-net8.trx --results-directory artifacts/test-results/testing
+          dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict --report-trx --report-trx-filename testing-net10.trx --results-directory artifacts/test-results/testing
 
       - name: Rate limiting adapter tests
-        run: dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 20 --zero-tests-policy strict --report-trx --report-trx-filename rate-limiting.trx --results-directory artifacts/test-results/rate-limiting
+        run: |
+          dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release -f net8.0 --no-build -- --timeout 5m --minimum-expected-tests 20 --zero-tests-policy strict --report-trx --report-trx-filename rate-limiting-net8.trx --results-directory artifacts/test-results/rate-limiting
+          dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 20 --zero-tests-policy strict --report-trx --report-trx-filename rate-limiting-net10.trx --results-directory artifacts/test-results/rate-limiting
 
       - name: Upload test reports
         if: always()
@@ -187,13 +199,13 @@ jobs:
         run: mkdir -p artifacts/coverage/raw
 
       - name: Collect unit coverage
-        run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/unit.cobertura.xml --coverage-output-format cobertura
+        run: dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/unit.cobertura.xml --coverage-output-format cobertura
 
       - name: Collect chaos coverage
-        run: dotnet run --project tests/Kevlar.Chaos.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 25 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/chaos.cobertura.xml --coverage-output-format cobertura
+        run: dotnet run --project tests/Kevlar.Chaos.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 25 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/chaos.cobertura.xml --coverage-output-format cobertura
 
       - name: Collect compatibility asset coverage
-        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 10 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/netstandard.cobertura.xml --coverage-output-format cobertura
+        run: dotnet run --project tests/Kevlar.NetStandard.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 10 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/netstandard.cobertura.xml --coverage-output-format cobertura
 
       - name: Collect modern gRPC compatibility asset coverage
         run: dotnet run --project tests/Kevlar.NetStandard21.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 4 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/netstandard21.cobertura.xml --coverage-output-format cobertura
@@ -205,10 +217,10 @@ jobs:
         run: dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 65 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/analyzers.cobertura.xml --coverage-output-format cobertura
 
       - name: Collect testing package coverage
-        run: dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/testing.cobertura.xml --coverage-output-format cobertura
+        run: dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/testing.cobertura.xml --coverage-output-format cobertura
 
       - name: Collect rate limiting adapter coverage
-        run: dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 20 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/rate-limiting.cobertura.xml --coverage-output-format cobertura
+        run: dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release -f net10.0 --no-build -- --timeout 5m --minimum-expected-tests 20 --zero-tests-policy strict --coverage --coverage-settings .github/coverage.runsettings --coverage-output ${{ github.workspace }}/artifacts/coverage/raw/rate-limiting.cobertura.xml --coverage-output-format cobertura
 
       - name: Merge coverage reports
         run: dotnet reportgenerator '-reports:artifacts/coverage/raw/*.cobertura.xml' '-targetdir:artifacts/coverage/report' '-reporttypes:Cobertura;Html'

--- a/.github/workflows/model-tests.yml
+++ b/.github/workflows/model-tests.yml
@@ -43,4 +43,4 @@ jobs:
         run: dotnet build Kevlar.slnx -c Release
 
       - name: Run deterministic model sweep
-        run: dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 10m --minimum-expected-tests 5 --zero-tests-policy strict --treenode-filter "/*/*/StrategyModelTests/*"
+        run: dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 10m --minimum-expected-tests 5 --zero-tests-policy strict --treenode-filter "/*/*/StrategyModelTests/*"

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -42,7 +42,7 @@ fail-fast rejections, and fatal runtime failures—print exactly as before, with
 
 ## Metrics
 
-Kevlar publishes core metrics through a `System.Diagnostics.Metrics.Meter` named `Kevlar`, version `1.0`. The current core package contains instrumented code in its `net10.0` asset; `net8.0` and `net9.0` applications resolve its inert `netstandard2.0` asset. `Kevlar.Chaos` separately publishes its injection counter from its `net8.0` and `net10.0` assets through a meter named `Kevlar.Chaos`, version `1.0`.
+Kevlar publishes core metrics through a `System.Diagnostics.Metrics.Meter` named `Kevlar`, version `1.0`. The core and runtime extension packages contain instrumented `net8.0` and `net10.0` assets; only `netstandard2.0` consumers receive inert metric implementations. `Kevlar.Chaos` separately publishes its injection counter from its `net8.0` and `net10.0` assets through a meter named `Kevlar.Chaos`, version `1.0`.
 
 Register the core meter with OpenTelemetry:
 
@@ -60,14 +60,14 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics
 
 | Instrument | Type | Unit | Minimum target | Measures | Attributes |
 |---|---|---|---|---|---|
-| `kevlar.executions` | Counter | `{execution}` | `net10.0` | completed public execution calls, including empty shields and pre-cancelled calls | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
-| `kevlar.retries` | Counter | `{retry}` | `net10.0` | retry attempts | `kevlar.shield.name` |
-| `kevlar.timeouts` | Counter | `{timeout}` | `net10.0` | executions cancelled by a timeout strategy | `kevlar.shield.name` |
-| `kevlar.hedges` | Counter | `{hedge}` | `net10.0` | extra hedged attempts launched | `kevlar.shield.name` |
-| `kevlar.fallbacks` | Counter | `{fallback}` | `net10.0` | outcomes replaced by a fallback | `kevlar.shield.name` |
-| `kevlar.rejections` | Counter | `{rejection}` | `net10.0` | fail-fast rejections | `kevlar.shield.name`, `kevlar.rejection.type` (`circuit_open`/`rate_limit`/`concurrency_limit`) |
-| `kevlar.circuit_breaker.transitions` | Counter | `{transition}` | `net10.0` | circuit state changes | `kevlar.circuit_breaker.state.from`, `kevlar.circuit_breaker.state.to` (`closed`/`open`/`half_open`/`isolated`) |
-| `kevlar.execution.duration` | Histogram | `s` | `net10.0` | completed public execution duration | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
+| `kevlar.executions` | Counter | `{execution}` | `net8.0` | completed public execution calls, including empty shields and pre-cancelled calls | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
+| `kevlar.retries` | Counter | `{retry}` | `net8.0` | retry attempts | `kevlar.shield.name` |
+| `kevlar.timeouts` | Counter | `{timeout}` | `net8.0` | executions cancelled by a timeout strategy | `kevlar.shield.name` |
+| `kevlar.hedges` | Counter | `{hedge}` | `net8.0` | extra hedged attempts launched | `kevlar.shield.name` |
+| `kevlar.fallbacks` | Counter | `{fallback}` | `net8.0` | outcomes replaced by a fallback | `kevlar.shield.name` |
+| `kevlar.rejections` | Counter | `{rejection}` | `net8.0` | fail-fast rejections | `kevlar.shield.name`, `kevlar.rejection.type` (`circuit_open`/`rate_limit`/`concurrency_limit`) |
+| `kevlar.circuit_breaker.transitions` | Counter | `{transition}` | `net8.0` | circuit state changes | `kevlar.circuit_breaker.state.from`, `kevlar.circuit_breaker.state.to` (`closed`/`open`/`half_open`/`isolated`) |
+| `kevlar.execution.duration` | Histogram | `s` | `net8.0` | completed public execution duration | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
 | `kevlar.circuit_breaker.state` | Gauge | `{state}` | `net10.0` | last observed circuit state: closed `0`, open `1`, half-open `2`, isolated `3` | `kevlar.shield.name`, `kevlar.strategy.index` |
 | `kevlar.concurrency_limit.inflight` | Gauge | `{execution}` | `net10.0` | executions holding a permit | `kevlar.shield.name`, `kevlar.strategy.index` |
 | `kevlar.concurrency_limit.queued` | Gauge | `{execution}` | `net10.0` | executions waiting for a permit | `kevlar.shield.name`, `kevlar.strategy.index` |
@@ -78,7 +78,7 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics
 
 Each public execution call records exactly one `kevlar.executions` measurement after its final outcome: recovery through fallback is `success`; exceptions, caller cancellation, timeout, and strategy rejection are `failure`. Retry and hedge attempts do not add execution measurements of their own.
 
-The `kevlar.shield.name` attribute appears only for shields named via `WithName` — name the shields you plan to chart. Optional chaos scope attributes are also omitted when unset. Instrument and attribute names use the product-specific `kevlar` namespace; count units use singular UCUM annotations.
+The `kevlar.shield.name` attribute appears only for shields named via `WithName` — name the shields you plan to chart. `WithName("")` emits the attribute with an empty value; an unnamed shield omits it. Optional chaos scope attributes are also omitted when unset. Instrument and attribute names use the product-specific `kevlar` namespace; count units use singular UCUM annotations. Counters and the duration histogram are active in the native `net8.0` and `net10.0` assets; the shipped state gauges require `net10.0`. On `netstandard2.0` targets the instruments are inert because the metrics API is not available in-box.
 
 The gauges are synchronous last-value measurements emitted when strategy state changes. They aggregate by shield name and carry a bounded `kevlar.strategy.index` attribute (the strategy's zero-based pipeline position), so independent stateful strategies in one named pipeline remain distinct. Shared strategies update up to 64 observed name/index aliases; additional aliases omit state-gauge measurements to bound memory, transition work, and series growth. The gauges do not use observable callbacks or global strategy registries, so telemetry never keeps an abandoned shield alive.
 

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -391,11 +391,14 @@ if ($LASTEXITCODE -ne 0)
     throw "Documentation snippet restore failed with exit code $LASTEXITCODE."
 }
 
-& dotnet run --project $projectPath -c Release --no-restore `
-    "-p:KevlarPackageVersion=$Version" `
-    "-p:GeneratedSnippetsPath=$generatedPath"
-
-if ($LASTEXITCODE -ne 0)
+foreach ($framework in @('net8.0', 'net10.0'))
 {
-    throw "Documentation snippet project failed with exit code $LASTEXITCODE."
+    & dotnet run --project $projectPath -c Release --framework $framework --no-restore `
+        "-p:KevlarPackageVersion=$Version" `
+        "-p:GeneratedSnippetsPath=$generatedPath"
+
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "Documentation snippet project failed for $framework with exit code $LASTEXITCODE."
+    }
 }

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -65,10 +65,10 @@ function Get-ExpectedSymbolAssets([string]$PackageId)
         return @('analyzers/dotnet/cs/Kevlar.Analyzers.pdb')
     }
 
-    $frameworks = @('net10.0', 'netstandard2.0')
-    if ($PackageId -in @('Kevlar.Chaos', 'Kevlar.Testing'))
+    $frameworks = @('net10.0', 'net8.0', 'netstandard2.0')
+    if ($PackageId -eq 'Kevlar.Extensions.Grpc')
     {
-        $frameworks += 'net8.0'
+        $frameworks += 'netstandard2.1'
     }
     elseif ($PackageId -eq 'Kevlar.Extensions.Grpc')
     {
@@ -244,18 +244,22 @@ if ($null -eq $configurationVersion -or $null -eq $dependencyInjectionVersion)
 $expectedDependencies = @{
     'Kevlar' = @{
         'net10.0' = @('Reservoir')
+        'net8.0' = @('Reservoir')
         '.NETStandard2.0' = @('Microsoft.Bcl.TimeProvider', 'Reservoir', 'System.Threading.Tasks.Extensions')
     }
     'Kevlar.Extensions.DependencyInjection' = @{
         'net10.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Primitives')
+        'net8.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Primitives')
         '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Primitives')
     }
     'Kevlar.Extensions.Http' = @{
         'net10.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.Http', 'Microsoft.Extensions.Primitives')
+        'net8.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.Http', 'Microsoft.Extensions.Primitives')
         '.NETStandard2.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.Http', 'Microsoft.Extensions.Primitives')
     }
     'Kevlar.Extensions.RateLimiting' = @{
         'net10.0' = @('Kevlar', 'System.Threading.RateLimiting')
+        'net8.0' = @('Kevlar', 'System.Threading.RateLimiting')
         '.NETStandard2.0' = @('Kevlar', 'System.Threading.RateLimiting')
     }
     'Kevlar.Chaos' = @{
@@ -274,6 +278,7 @@ $expectedDependencies = @{
     }
     'Kevlar.Extensions.Grpc' = @{
         'net10.0' = @('Grpc.Core.Api', 'Grpc.Net.ClientFactory', 'Kevlar', 'Kevlar.Extensions.DependencyInjection')
+        'net8.0' = @('Grpc.Core.Api', 'Grpc.Net.ClientFactory', 'Kevlar', 'Kevlar.Extensions.DependencyInjection')
         '.NETStandard2.1' = @('Grpc.Core.Api', 'Grpc.Net.ClientFactory', 'Kevlar', 'Kevlar.Extensions.DependencyInjection')
         '.NETStandard2.0' = @('Grpc.Core.Api', 'Grpc.Net.ClientFactory', 'Kevlar', 'Kevlar.Extensions.DependencyInjection')
     }
@@ -416,17 +421,12 @@ foreach ($packageId in $expectedDependencies.Keys)
             $expectedAssets = @(
                 "lib/net10.0/$packageId.dll",
                 "lib/net10.0/$packageId.xml",
+                "lib/net8.0/$packageId.dll",
+                "lib/net8.0/$packageId.xml",
                 "lib/netstandard2.0/$packageId.dll",
                 "lib/netstandard2.0/$packageId.xml"
             )
-            if ($packageId -in @('Kevlar.Chaos', 'Kevlar.Testing'))
-            {
-                $expectedAssets += @(
-                    "lib/net8.0/$packageId.dll",
-                    "lib/net8.0/$packageId.xml"
-                )
-            }
-            elseif ($packageId -eq 'Kevlar.Extensions.Grpc')
+            if ($packageId -eq 'Kevlar.Extensions.Grpc')
             {
                 $expectedAssets += @(
                     "lib/netstandard2.1/$packageId.dll",
@@ -681,18 +681,54 @@ catch (ExpectedConsumerException exception)
     }
 }
 
+var executions = 0;
+var retries = 0;
 var injections = 0;
 using var listener = new MeterListener();
 listener.InstrumentPublished = (instrument, activeListener) =>
 {
-    if (instrument.Meter.Name == ChaosDiagnostics.MeterName
-        && instrument.Name == "kevlar.chaos.injections")
+    if (instrument.Meter.Name is KevlarDiagnostics.MeterName or ChaosDiagnostics.MeterName)
     {
         activeListener.EnableMeasurementEvents(instrument);
     }
 };
-listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => injections += (int)measurement);
+listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+{
+    if (instrument.Name == "kevlar.executions")
+    {
+        executions += (int)measurement;
+    }
+    else if (instrument.Name == "kevlar.retries")
+    {
+        retries += (int)measurement;
+    }
+    else if (instrument.Name == "kevlar.chaos.injections")
+    {
+        injections += (int)measurement;
+    }
+});
 listener.Start();
+
+using var recorder = new TelemetryRecorder();
+var attempts = 0;
+var retried = await Shield.Retry(1, Backoff.None).ExecuteAsync<int>(_ =>
+{
+    if (Interlocked.Increment(ref attempts) == 1)
+    {
+        throw new InvalidOperationException("retry once");
+    }
+
+    return new ValueTask<int>(42);
+});
+if (retried != 42 || executions != 1 || retries != 1)
+{
+    throw new InvalidOperationException(
+        $"Core package metrics failed: result {retried}, executions {executions}, retries {retries}.");
+}
+if (!recorder.Metrics.Any(record => record.InstrumentName == "kevlar.executions"))
+{
+    throw new InvalidOperationException("Kevlar.Testing did not capture a core instrument.");
+}
 
 var chaos = ChaosShield.Outcome<int>(options =>
 {
@@ -759,7 +795,7 @@ sealed class ExpectedConsumerException : Exception;
         Write-TextFile (Join-Path $consumerDirectory 'Program.cs') $runtimeProgram
         Invoke-DotNet @('restore', $projectPath, '--configfile', $nugetConfigPath, '--no-cache', '--force-evaluate')
         Invoke-DotNet @('build', $projectPath, '-c', 'Release', '--no-restore')
-        $kevlarPdbFramework = if ($framework -eq 'net10.0') { 'net10.0' } else { 'netstandard2.0' }
+        $kevlarPdbFramework = $framework
         Copy-Item `
             -LiteralPath (Join-Path $symbolRoot "lib/$kevlarPdbFramework/Kevlar.pdb") `
             -Destination (Join-Path $consumerDirectory "bin/Release/$framework/Kevlar.pdb")

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
+++ b/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kevlar.Extensions.DependencyInjection</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>

--- a/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
+++ b/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kevlar.Extensions.Grpc</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>

--- a/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
+++ b/src/Kevlar.Extensions.Http/HttpRequestTemplate.cs
@@ -51,15 +51,18 @@ internal sealed class HttpRequestTemplate
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
-#if NETSTANDARD2_0
+#if NET9_0_OR_GREATER
+                await request.Content.LoadIntoBufferAsync(maximumBufferSize, cancellationToken).ConfigureAwait(false);
+#else
                 await AwaitWithCancellationAsync(
                     request.Content.LoadIntoBufferAsync(maximumBufferSize),
                     cancellationToken).ConfigureAwait(false);
+#endif
+#if NETSTANDARD2_0
                 content = await AwaitWithCancellationAsync(
                     request.Content.ReadAsByteArrayAsync(),
                     cancellationToken).ConfigureAwait(false);
 #else
-                await request.Content.LoadIntoBufferAsync(maximumBufferSize, cancellationToken).ConfigureAwait(false);
                 content = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 #endif
             }
@@ -137,7 +140,7 @@ internal sealed class HttpRequestTemplate
         $"Request content exceeds the {maximumBufferSize}-byte replay buffer limit. " +
         "Increase MaximumBufferSize or provide RequestFactory.");
 
-#if NETSTANDARD2_0
+#if !NET9_0_OR_GREATER
     private static async Task<T> AwaitWithCancellationAsync<T>(
         Task<T> operation,
         CancellationToken cancellationToken)

--- a/src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj
+++ b/src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kevlar.Extensions.Http</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>

--- a/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
+++ b/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kevlar.Extensions.RateLimiting</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Kevlar</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>

--- a/tests/Kevlar.AllocationTests/Kevlar.AllocationTests.csproj
+++ b/tests/Kevlar.AllocationTests/Kevlar.AllocationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <Optimize>true</Optimize>

--- a/tests/Kevlar.Chaos.Tests/DocsConsistencyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/DocsConsistencyTests.cs
@@ -27,8 +27,7 @@ public class DocsConsistencyTests
             var row = available[name];
             await Assert.That(row.Type).IsEqualTo(InstrumentType(instrument));
             await Assert.That(row.Unit).IsEqualTo(instrument.Unit);
-            await Assert.That(row.MinimumTarget).IsEqualTo(
-                instrument.Meter.Name == ChaosDiagnostics.MeterName ? "net8.0" : "net10.0");
+            await Assert.That(row.MinimumTarget).IsEqualTo(MinimumTarget(instrument));
             await Assert.That(row.Tags).IsEquivalentTo(observer.Tags[name].Keys);
         }
     }
@@ -233,6 +232,9 @@ public class DocsConsistencyTests
 #endif
         _ => throw new InvalidOperationException($"Unsupported instrument type {instrument.GetType()}"),
     };
+
+    private static string MinimumTarget(Instrument instrument) =>
+        instrument is Counter<long> or Histogram<double> ? "net8.0" : "net10.0";
 
     private static bool IsAvailableOnCurrentTarget(string minimumTarget) =>
 #if NET10_0_OR_GREATER

--- a/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
+++ b/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
+++ b/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
+++ b/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
@@ -1,14 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <EnableDefaultCompileItems Condition="'$(TargetFramework)' == 'net48'">false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
-    <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit" Condition="'$(TargetFramework)' != 'net48'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <Compile Include="NetFrameworkCompatibilityTests.cs" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <Compile Remove="NetFrameworkCompatibilityTests.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,9 +28,11 @@
     <ProjectReference Include="..\..\src\Kevlar.Extensions.Http\Kevlar.Extensions.Http.csproj"
                       SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.Grpc\Kevlar.Extensions.Grpc.csproj"
-                      SetTargetFramework="TargetFramework=netstandard2.0" />
+                      SetTargetFramework="TargetFramework=netstandard2.0"
+                      Condition="'$(TargetFramework)' != 'net48'" />
     <ProjectReference Include="..\..\src\Kevlar.Chaos\Kevlar.Chaos.csproj"
-                      SetTargetFramework="TargetFramework=netstandard2.0" />
+                      SetTargetFramework="TargetFramework=netstandard2.0"
+                      Condition="'$(TargetFramework)' != 'net48'" />
   </ItemGroup>
 
 </Project>

--- a/tests/Kevlar.NetStandard.Tests/NetFrameworkCompatibilityTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/NetFrameworkCompatibilityTests.cs
@@ -1,0 +1,215 @@
+using System.Net;
+using System.Net.Http;
+using Kevlar.Extensions.Http;
+
+namespace Kevlar.NetStandard.Tests;
+
+internal static class NetFrameworkCompatibilityTests
+{
+    public static async Task Main()
+    {
+        await RetryHandlesExceptionsAndResults();
+        await TimeoutUsesBclTimeProvider();
+        await CircuitBreakerTransitions();
+        await RateLimitReportsRetryAfter();
+        await PartitionCapacityEvicts();
+        await OutcomeAndSyncExecutionWork();
+        await HttpRetryPreservesProperties();
+        Console.WriteLine("Kevlar net48 compatibility tests passed.");
+    }
+
+    private static async Task RetryHandlesExceptionsAndResults()
+    {
+        var exceptionAttempts = 0;
+        var exceptionResult = await Shield.Retry(1, Backoff.None).ExecuteAsync<int>(_ =>
+            ++exceptionAttempts == 1
+                ? throw new InvalidOperationException("retry")
+                : new ValueTask<int>(42));
+        Equal(42, exceptionResult, "exception retry result");
+        Equal(2, exceptionAttempts, "exception retry attempts");
+
+        var resultAttempts = 0;
+        var result = await Shield.For<int>()
+            .WhenResult(static value => value < 0)
+            .Retry(1, Backoff.None)
+            .ExecuteAsync(_ => new ValueTask<int>(++resultAttempts == 1 ? -1 : 42));
+        Equal(42, result, "result retry result");
+        Equal(2, resultAttempts, "result retry attempts");
+    }
+
+    private static async Task TimeoutUsesBclTimeProvider()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var execution = Shield.Timeout(TimeSpan.FromSeconds(1))
+            .WithTimeProvider(timeProvider)
+            .ExecuteOutcomeAsync<int>(async cancellationToken =>
+            {
+                started.TrySetResult(true);
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                return 42;
+            }).AsTask();
+        await started.Task;
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        var outcome = await execution;
+        True(outcome.Exception is TimeoutExceededException, "timeout outcome");
+    }
+
+    private static async Task CircuitBreakerTransitions()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var shield = Shield.CircuitBreaker(
+            consecutiveFailures: 1,
+            breakDuration: TimeSpan.FromSeconds(1)).WithTimeProvider(timeProvider);
+
+        _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("trip"));
+        var rejected = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+        True(rejected.Exception is CircuitOpenException, "open circuit rejection");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        Equal(42, await shield.ExecuteAsync(_ => new ValueTask<int>(42)), "half-open recovery");
+        Equal(43, await shield.ExecuteAsync(_ => new ValueTask<int>(43)), "closed circuit execution");
+    }
+
+    private static async Task RateLimitReportsRetryAfter()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var shield = Shield.RateLimit(1, TimeSpan.FromSeconds(10)).WithTimeProvider(timeProvider);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+        var rejected = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+        var exception = rejected.Exception as RateLimitExceededException;
+        True(exception?.RetryAfter > TimeSpan.Zero, "rate-limit retry-after");
+    }
+
+    private static Task PartitionCapacityEvicts()
+    {
+        var partitions = new PartitionedShield<string, int>(
+            static _ => Shield.For<int>().FallbackTo(42),
+            new PartitionedShieldOptions { MaximumPartitions = 1 });
+        _ = partitions.GetShield("first");
+        _ = partitions.GetShield("second");
+
+        Equal(1, partitions.Count, "partition count");
+        Equal(1L, partitions.CapacityEvictionCount, "partition eviction count");
+        return Task.CompletedTask;
+    }
+
+    private static async Task OutcomeAndSyncExecutionWork()
+    {
+        var outcome = await Shield.Empty.ExecuteOutcomeAsync<int>(
+            _ => throw new InvalidOperationException("outcome"));
+        True(outcome.Exception is InvalidOperationException, "async outcome");
+        Equal(42, Shield.Empty.Execute(static _ => 42), "sync execution");
+    }
+
+    private static async Task HttpRetryPreservesProperties()
+    {
+        var marker = new object();
+        var handler = new PropertyRecordingHandler(marker);
+        using var invoker = new HttpMessageInvoker(new ShieldDelegatingHandler(
+            HttpShield.WhenTransient().Retry(1, Backoff.None))
+        {
+            InnerHandler = handler,
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test/");
+#pragma warning disable CS0618
+        request.Properties["marker"] = marker;
+#pragma warning restore CS0618
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+        Equal(HttpStatusCode.OK, response.StatusCode, "HTTP retry response");
+        Equal(2, handler.Attempts, "HTTP retry attempts");
+    }
+
+    private static void Equal<T>(T expected, T actual, string name)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException($"{name}: expected {expected}, got {actual}.");
+        }
+    }
+
+    private static void True(bool condition, string name)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException($"{name} failed.");
+        }
+    }
+
+    private sealed class PropertyRecordingHandler(object marker) : HttpMessageHandler
+    {
+        public int Attempts { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Attempts++;
+#pragma warning disable CS0618
+            True(request.Properties.TryGetValue("marker", out var value)
+                && ReferenceEquals(value, marker), "HTTP request property replay");
+#pragma warning restore CS0618
+            return Task.FromResult(new HttpResponseMessage(
+                Attempts == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
+        }
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private readonly List<ManualTimer> _timers = new();
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(callback, state, _timestamp + dueTime.Ticks);
+            _timers.Add(timer);
+            return timer;
+        }
+
+        public void Advance(TimeSpan elapsed)
+        {
+            _timestamp += elapsed.Ticks;
+            foreach (var timer in _timers.ToArray())
+            {
+                timer.FireIfDue(_timestamp);
+            }
+        }
+
+        private sealed class ManualTimer(
+            TimerCallback callback,
+            object? state,
+            long dueTimestamp) : ITimer
+        {
+            private bool _disposed;
+
+            public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+
+            public void Dispose() => _disposed = true;
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return default;
+            }
+
+            public void FireIfDue(long timestamp)
+            {
+                if (!_disposed && timestamp >= dueTimestamp)
+                {
+                    callback(state);
+                }
+            }
+        }
+    }
+}

--- a/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
+++ b/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -246,12 +246,14 @@ public class TelemetryRecorderTests
             "kevlar.hedges",
             "kevlar.fallbacks",
             "kevlar.rejections",
+#if NET9_0_OR_GREATER
             "kevlar.circuit_breaker.state",
             "kevlar.concurrency_limit.inflight",
             "kevlar.concurrency_limit.queued",
             "kevlar.concurrency_limit.capacity",
             "kevlar.rate_limit.available",
             "kevlar.rate_limit.queued",
+#endif
         };
 
         await Assert.That(expectedNamed.All(namedInstruments.Contains)).IsTrue();

--- a/tests/Kevlar.Testing.Tests/TimeControlTests.cs
+++ b/tests/Kevlar.Testing.Tests/TimeControlTests.cs
@@ -87,6 +87,7 @@ public class TimeControlTests
         await Assert.That(shield.Execute(static _ => 42)).IsEqualTo(42);
     }
 
+#if NET9_0_OR_GREATER
     [Test]
     public async Task Rate_Limit_Replenishment_Completes_Queued_Execution()
     {
@@ -126,7 +127,9 @@ public class TimeControlTests
 
         await Assert.That(await queued).IsEqualTo(2);
     }
+#endif
 
+#if NET9_0_OR_GREATER
     [Test]
     public async Task Concurrency_Queue_Completes_After_Permit_Release()
     {
@@ -151,6 +154,7 @@ public class TimeControlTests
 
         await Assert.That(await queued).IsEqualTo(2);
     }
+#endif
 
     [Test]
     public async Task Hedging_Stagger_Advances_To_The_Next_Attempt()

--- a/tests/Kevlar.Tests/Kevlar.Tests.csproj
+++ b/tests/Kevlar.Tests/Kevlar.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -229,12 +229,14 @@ public class MetricsTests
             ["kevlar.rejections"] = "{rejection}",
             ["kevlar.circuit_breaker.transitions"] = "{transition}",
             ["kevlar.execution.duration"] = "s",
+#if NET9_0_OR_GREATER
             ["kevlar.circuit_breaker.state"] = "{state}",
             ["kevlar.concurrency_limit.inflight"] = "{execution}",
             ["kevlar.concurrency_limit.queued"] = "{execution}",
             ["kevlar.concurrency_limit.capacity"] = "{execution}",
             ["kevlar.rate_limit.available"] = "{permit}",
             ["kevlar.rate_limit.queued"] = "{execution}",
+#endif
         };
 
         await Assert.That(listener.Instruments.Select(instrument => instrument.Name))
@@ -620,6 +622,7 @@ public class MetricsTests
             .IsLessThan(0.05);
     }
 
+#if NET9_0_OR_GREATER
     [Test]
     public async Task Circuit_State_Gauge_Reports_Every_State()
     {
@@ -1449,6 +1452,7 @@ public class MetricsTests
 
         await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
     }
+#endif
 
     private static Dictionary<(CircuitState From, CircuitState To), long> CircuitTransitionTotals(
         KevlarMeterListener listener) =>


### PR DESCRIPTION
## Summary
- ship native 
et8.0 assets for core, DI, HTTP, rate limiting, and gRPC
- multi-target behavioral/allocation/doc suites on net8 and net10, plus a Windows net48 compatibility executable
- verify package layouts, dependencies, SourceLink, runtime core metrics, TelemetryRecorder, trimming, and AOT annotations
- document the precise metrics available from each native asset

## Test plan
- [x] dotnet build Kevlar.slnx -c Release (0 warnings)
- [x] net10 suites: core 845, Testing 51, Chaos 33, rate limiting 24, allocation 3
- [x] net8 suites: core 820, Testing 49, Chaos 33, rate limiting 24, allocation 3
- [x] integration 131, analyzers 78, netstandard2.0 10, netstandard2.1 4
- [x] net48 build and executable compatibility scenarios
- [x] scripts/Verify-Packages.ps1 (layout, symbols, determinism, SourceLink, consumers, trim/AOT)
- [x] scripts/Verify-DocSnippets.ps1 (118 snippets on net8 and net10)
- [x] scripts/Assert-TestSuiteRegistration.ps1

Closes #185
