### PR TITLE
fix(timeout): classify wrapped cancellations

### DIFF
--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -43,10 +43,10 @@ Two behaviours worth knowing:
 When cancellation signals overlap, the outcome is decided after the delegate completes:
 
 1. If the caller's token is cancelled, caller cancellation wins. The resulting `OperationCanceledException` carries the caller's token.
-2. Otherwise, if the timeout fired and the delegate's `OperationCanceledException` carries the exact token handed to the delegate, the outcome becomes `TimeoutExceededException`.
-3. An `OperationCanceledException` for any other token is preserved unchanged.
+2. Otherwise, if the timeout fired, any `OperationCanceledException` from the delegate becomes `TimeoutExceededException`; the original cancellation is available as `InnerException`.
+3. If neither the caller nor timeout has fired, an `OperationCanceledException` is preserved unchanged.
 
-This token-identity rule also applies to nested timeouts. A cancelled outer timeout is treated as the inner timeout's caller, so only the winning scope reports `OnTimeout`. The strategy restores the prior context token and completes timer cleanup before invoking `OnTimeout`; if the callback throws, that exception is surfaced without contaminating later executions.
+This caller-first rule also applies to nested timeouts. A cancelled outer timeout is treated as the inner timeout's caller, so only the winning scope reports `OnTimeout`. The strategy restores the prior context token and completes timer cleanup before invoking `OnTimeout`; if the callback throws, that exception is surfaced without contaminating later executions.
 
 ## Dynamic timeouts and asynchronous notifications
 

--- a/src/Kevlar/Exceptions/TimeoutExceededException.cs
+++ b/src/Kevlar/Exceptions/TimeoutExceededException.cs
@@ -5,9 +5,16 @@ public sealed class TimeoutExceededException : KevlarException
 {
     /// <summary>Initializes the exception for the given timeout.</summary>
     public TimeoutExceededException(TimeSpan timeout)
-        : base($"The execution did not complete within the timeout of {timeout.TotalSeconds:0.###}s.")
+        : base(FormatMessage(timeout))
+        => Timeout = timeout;
+
+    internal TimeoutExceededException(TimeSpan timeout, OperationCanceledException innerException)
+        : base(FormatMessage(timeout), innerException)
         => Timeout = timeout;
 
     /// <summary>The timeout that was exceeded.</summary>
     public TimeSpan Timeout { get; }
+
+    private static string FormatMessage(TimeSpan timeout) =>
+        $"The execution did not complete within the timeout of {timeout.TotalSeconds:0.###}s.";
 }

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -219,8 +219,7 @@ internal sealed class TimeoutStrategy : Strategy
                 priorToken)));
         }
 
-        var timedOut = timeoutSource.IsCancellationRequested
-            && cancellationException.CancellationToken == timeoutSource.Token;
+        var timedOut = timeoutSource.IsCancellationRequested;
         timeoutSource.Dispose();
 
         if (timedOut)
@@ -234,14 +233,14 @@ internal sealed class TimeoutStrategy : Strategy
                 var notification = _onTimeoutAsync(timeoutEvent);
                 if (!notification.IsCompletedSuccessfully)
                 {
-                    return AwaitTimeoutNotificationAsync<T>(notification, timeout);
+                    return AwaitTimeoutNotificationAsync<T>(notification, timeout, cancellationException);
                 }
 
                 notification.GetAwaiter().GetResult();
             }
 
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(
-                new TimeoutExceededException(timeout)));
+                new TimeoutExceededException(timeout, cancellationException)));
         }
 
         return new ValueTask<Outcome<T>>(outcome);
@@ -249,10 +248,11 @@ internal sealed class TimeoutStrategy : Strategy
 
     private static async ValueTask<Outcome<T>> AwaitTimeoutNotificationAsync<T>(
         ValueTask notification,
-        TimeSpan timeout)
+        TimeSpan timeout,
+        OperationCanceledException cancellationException)
     {
         await notification.ConfigureAwait(false);
-        return Outcome<T>.FromException(new TimeoutExceededException(timeout));
+        return Outcome<T>.FromException(new TimeoutExceededException(timeout, cancellationException));
     }
 
     private static void ValidateGeneratedTimeout(TimeSpan timeout)

--- a/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using Kevlar.Extensions.Http;
 using Kevlar.IntegrationTests.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -73,6 +74,26 @@ public class HttpResilienceTests
         await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("recovered");
         await Assert.That(stopwatch.Elapsed < TimeSpan.FromSeconds(4)).IsTrue();
         await Assert.That(server.CallCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Attempt_Timeout_Retries_A_Transport_Wrapped_Cancellation()
+    {
+        var handler = new WrappedCancellationHandler();
+        using var client = new HttpClient(handler)
+        {
+            Timeout = System.Threading.Timeout.InfiniteTimeSpan,
+        };
+        var shield = Shield.For<HttpResponseMessage>()
+            .When<TimeoutExceededException>()
+            .Retry(1, Backoff.None)
+            .Timeout(TimeSpan.FromMilliseconds(20));
+
+        using var response = await shield.ExecuteAsync(cancellationToken =>
+            new ValueTask<HttpResponseMessage>(client.GetAsync("http://localhost/", cancellationToken)));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(handler.Attempts).IsEqualTo(2);
     }
 
     [Test]
@@ -275,4 +296,29 @@ public class HttpResilienceTests
     }
 
     private sealed class FactoryMarker;
+
+    private sealed class WrappedCancellationHandler : HttpMessageHandler
+    {
+        public int Attempts { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Attempts++;
+            if (Attempts == 1)
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new TaskCanceledException("transport wrapper");
+                }
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
 }

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -311,6 +311,28 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Wrapped_Cancellations_Are_Counted_As_Timeouts()
+    {
+        using var listener = new KevlarMeterListener();
+        var shield = Shield.Timeout(TimeSpan.FromMilliseconds(20)).WithName("metrics-wrapped-timeouts");
+
+        var exception = await Assert.That(async () => await shield.ExecuteAsync(async cancellationToken =>
+        {
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw new TaskCanceledException("transport wrapper");
+            }
+        })).Throws<TimeoutExceededException>();
+
+        await Assert.That(exception!.InnerException).IsTypeOf<TaskCanceledException>();
+        await Assert.That(listener.Total("kevlar.timeouts", "metrics-wrapped-timeouts")).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Rate_Limit_Rejections_Are_Counted_With_Their_Kind()
     {
         using var listener = new KevlarMeterListener();

--- a/tests/Kevlar.Tests/StrategyModelTests.cs
+++ b/tests/Kevlar.Tests/StrategyModelTests.cs
@@ -44,6 +44,100 @@ public class StrategyModelTests
         random => new CompositionCommand(random.Next(1, 1000), random.Next(3) == 0),
         ExecuteCompositionModelAsync);
 
+    [Test]
+    public Task Timeout_Matches_Cancellation_Arbitration_Model() => ModelRunner.RunAsync(
+        "timeout cancellation arbitration",
+        commandCount: 20,
+        random => new TimeoutCommand(
+            (TimeoutSignal)random.Next(Enum.GetValues<TimeoutSignal>().Length),
+            (CancellationShape)random.Next(Enum.GetValues<CancellationShape>().Length)),
+        ExecuteTimeoutModelAsync);
+
+    private static async Task ExecuteTimeoutModelAsync(IReadOnlyList<TimeoutCommand> commands)
+    {
+        var timeProvider = new FakeTimeProvider();
+        var shield = Shield.Timeout(TimeSpan.FromSeconds(1)).WithTimeProvider(timeProvider);
+
+        for (var index = 0; index < commands.Count; index++)
+        {
+            var command = commands[index];
+            using var callerCancellation = new CancellationTokenSource();
+            using var foreignCancellation = new CancellationTokenSource();
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var cancellation = command.Shape switch
+            {
+                CancellationShape.ExecutionToken => null,
+                CancellationShape.ForeignToken => new OperationCanceledException(
+                    "foreign cancellation",
+                    foreignCancellation.Token),
+                CancellationShape.NoToken => new OperationCanceledException("unattributed cancellation"),
+                CancellationShape.TaskCanceled => new TaskCanceledException("wrapped cancellation"),
+                _ => throw new ArgumentOutOfRangeException(nameof(command)),
+            };
+
+            var execution = shield.ExecuteOutcomeAsync<int>(async token =>
+            {
+                started.TrySetResult();
+                if (command.Signal != TimeoutSignal.None)
+                {
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+
+                throw cancellation ?? new OperationCanceledException(token);
+            }, callerCancellation.Token).AsTask();
+
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            if (command.Signal == TimeoutSignal.CallerAndTimeout)
+            {
+                callerCancellation.Cancel();
+            }
+
+            if (command.Signal != TimeoutSignal.None)
+            {
+                timeProvider.Advance(TimeSpan.FromSeconds(1));
+            }
+
+            var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+            if (command.Signal == TimeoutSignal.Timeout)
+            {
+                Ensure(outcome.Exception is TimeoutExceededException, index, command, "timeout outcome differs");
+                Ensure(
+                    outcome.Exception?.InnerException is OperationCanceledException,
+                    index,
+                    command,
+                    "timeout inner exception is missing");
+                Ensure(
+                    cancellation is null || ReferenceEquals(outcome.Exception?.InnerException, cancellation),
+                    index,
+                    command,
+                    "timeout inner exception identity differs");
+            }
+            else if (command.Signal == TimeoutSignal.CallerAndTimeout)
+            {
+                Ensure(
+                    outcome.Exception is OperationCanceledException caller
+                    && caller.CancellationToken == callerCancellation.Token,
+                    index,
+                    command,
+                    "caller cancellation did not win");
+            }
+            else
+            {
+                Ensure(outcome.Exception is OperationCanceledException, index, command, "cancellation outcome differs");
+                Ensure(cancellation is null || ReferenceEquals(outcome.Exception, cancellation),
+                    index,
+                    command,
+                    "spontaneous cancellation identity differs");
+            }
+        }
+    }
+
     private static async Task ExecuteCircuitModelAsync(IReadOnlyList<CircuitCommand> commands)
     {
         var timeProvider = new ModelTimeProvider();
@@ -407,6 +501,23 @@ public class StrategyModelTests
     private readonly record struct RetryCommand(bool Success, int DelaySelector);
 
     private readonly record struct CompositionCommand(int Id, bool Fail);
+
+    private enum TimeoutSignal
+    {
+        None,
+        Timeout,
+        CallerAndTimeout,
+    }
+
+    private enum CancellationShape
+    {
+        ExecutionToken,
+        ForeignToken,
+        NoToken,
+        TaskCanceled,
+    }
+
+    private readonly record struct TimeoutCommand(TimeoutSignal Signal, CancellationShape Shape);
 
     private sealed class ModelFailureException : Exception;
 

--- a/tests/Kevlar.Tests/TimeoutArbitrationTests.cs
+++ b/tests/Kevlar.Tests/TimeoutArbitrationTests.cs
@@ -22,7 +22,7 @@ public class TimeoutArbitrationTests
             executionToken = token;
             started.SetResult();
             await release.Task;
-            throw new OperationCanceledException(token);
+            throw new OperationCanceledException("wrapped without token");
         }, callerCancellation.Token).AsTask();
 
         await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -111,25 +111,51 @@ public class TimeoutArbitrationTests
     }
 
     [Test]
-    public async Task Unrelated_Cancellation_After_Timer_Fires_Is_Not_Reclassified()
+    public async Task Timeout_Converts_OperationCanceledException_With_Foreign_Token()
     {
-        var timeProvider = new ManualTimeProvider();
         using var unrelatedCancellation = new CancellationTokenSource();
         var unrelated = new OperationCanceledException("unrelated", unrelatedCancellation.Token);
+
+        await AssertCancellationIsTimeoutAsync(unrelated);
+    }
+
+    [Test]
+    public async Task Timeout_Converts_OperationCanceledException_Without_Token() =>
+        await AssertCancellationIsTimeoutAsync(new OperationCanceledException("cancelled"));
+
+    [Test]
+    public async Task Timeout_Converts_TaskCanceledException_Without_Token() =>
+        await AssertCancellationIsTimeoutAsync(new TaskCanceledException("cancelled"));
+
+    [Test]
+    public async Task Dynamic_Timeout_Converts_OperationCanceledException_Without_Token() =>
+        await AssertCancellationIsTimeoutAsync(
+            new OperationCanceledException("cancelled"),
+            useTimeoutGenerator: true);
+
+    [Test]
+    public async Task Async_Timeout_Notification_Preserves_Original_Cancellation()
+    {
+        var timeProvider = new ManualTimeProvider();
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellation = new OperationCanceledException("wrapped without token");
         var timeoutEvents = 0;
         var shield = Shield.Timeout(options =>
         {
             options.Timeout = TimeSpan.FromSeconds(1);
-            options.OnTimeout = _ => timeoutEvents++;
+            options.OnTimeoutAsync = async _ =>
+            {
+                await Task.Yield();
+                timeoutEvents++;
+            };
         }).WithTimeProvider(timeProvider);
 
         var execution = shield.ExecuteOutcomeAsync<int>(async _ =>
         {
             started.SetResult();
             await release.Task;
-            throw unrelated;
+            throw cancellation;
         }).AsTask();
 
         await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -137,8 +163,103 @@ public class TimeoutArbitrationTests
         release.SetResult();
         var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
 
-        await Assert.That(ReferenceEquals(outcome.Exception, unrelated)).IsTrue();
+        var timeout = outcome.Exception as TimeoutExceededException;
+        await Assert.That(timeout).IsNotNull();
+        await Assert.That(ReferenceEquals(timeout!.InnerException, cancellation)).IsTrue();
+        await Assert.That(timeoutEvents).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task OperationCanceledException_Before_Timeout_Fires_Is_Preserved()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var cancellation = new OperationCanceledException("spontaneous");
+        var timeoutEvents = 0;
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromSeconds(1);
+            options.OnTimeout = _ => timeoutEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(_ => throw cancellation);
+
+        await Assert.That(ReferenceEquals(outcome.Exception, cancellation)).IsTrue();
         await Assert.That(timeoutEvents).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Timeout_Then_Retry_Retries_OperationCanceledException_Without_Token()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var attempts = new AsyncCounter("foreign-token timeout attempts");
+        var shield = Shield
+            .When<TimeoutExceededException>()
+            .Retry(1, Backoff.None)
+            .Timeout(TimeSpan.FromSeconds(1))
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(token =>
+            CancelWithoutTokenAsync(token, attempts)).AsTask();
+
+        await attempts.WaitForAsync(1);
+        timeProvider.Fire(0);
+        await attempts.WaitForAsync(2);
+        timeProvider.Fire(1);
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(outcome.Exception).IsTypeOf<TimeoutExceededException>();
+        await Assert.That(attempts.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Timeout_Then_CircuitBreaker_Counts_OperationCanceledException_Without_Token()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var attempts = new AsyncCounter("foreign-token breaker attempts");
+        var shield = Shield
+            .When<TimeoutExceededException>()
+            .CircuitBreaker(consecutiveFailures: 1, breakDuration: TimeSpan.FromMinutes(1))
+            .Timeout(TimeSpan.FromSeconds(1))
+            .WithTimeProvider(timeProvider);
+
+        var first = shield.ExecuteOutcomeAsync<int>(token =>
+            CancelWithoutTokenAsync(token, attempts)).AsTask();
+
+        await attempts.WaitForAsync(1);
+        timeProvider.Fire(0);
+        var firstOutcome = await first.WaitAsync(TimeSpan.FromSeconds(5));
+        var rejected = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(firstOutcome.Exception).IsTypeOf<TimeoutExceededException>();
+        await Assert.That(rejected.Exception).IsTypeOf<CircuitOpenException>();
+    }
+
+    [Test]
+    public async Task Per_Attempt_Timeout_Retries_Then_Outer_Timeout_Wins()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var attempts = new AsyncCounter("nested timeout attempts");
+        var shield = Shield
+            .Timeout(TimeSpan.FromSeconds(30))
+            .When<TimeoutExceededException>()
+            .Retry(3, Backoff.None)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(token =>
+            CancelWithoutTokenAsync(token, attempts)).AsTask();
+
+        await attempts.WaitForAsync(1);
+        timeProvider.Fire(1);
+        await attempts.WaitForAsync(2);
+        timeProvider.Fire(0);
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var timeout = outcome.Exception as TimeoutExceededException;
+        await Assert.That(timeout).IsNotNull();
+        await Assert.That(timeout!.Timeout).IsEqualTo(TimeSpan.FromSeconds(30));
+        await Assert.That(timeout.InnerException).IsTypeOf<OperationCanceledException>();
+        await Assert.That(attempts.Count).IsEqualTo(2);
     }
 
     [Test]
@@ -301,6 +422,56 @@ public class TimeoutArbitrationTests
                 Observations.Add(new TokenObservation(before, context.CancellationToken));
             }
         }
+    }
+
+    private static async Task AssertCancellationIsTimeoutAsync(
+        OperationCanceledException cancellationException,
+        bool useTimeoutGenerator = false)
+    {
+        var timeProvider = new ManualTimeProvider();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutEvents = 0;
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromSeconds(1);
+            if (useTimeoutGenerator)
+            {
+                options.TimeoutGenerator = static _ =>
+                    new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
+            }
+
+            options.OnTimeout = _ => timeoutEvents++;
+        }).WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteOutcomeAsync<int>(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            throw cancellationException;
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Fire(0);
+        release.SetResult();
+        var outcome = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var timeout = outcome.Exception as TimeoutExceededException;
+        await Assert.That(timeout).IsNotNull();
+        await Assert.That(ReferenceEquals(timeout!.InnerException, cancellationException)).IsTrue();
+        await Assert.That(timeoutEvents).IsEqualTo(1);
+    }
+
+    private static async ValueTask<int> CancelWithoutTokenAsync(
+        CancellationToken cancellationToken,
+        AsyncCounter attempts)
+    {
+        attempts.Signal();
+        var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(static state =>
+            ((TaskCompletionSource)state!).TrySetResult(), cancelled);
+        await cancelled.Task;
+        throw new OperationCanceledException("wrapped without token");
     }
 
     private sealed class ManualTimeProvider : TimeProvider

--- a/tests/Kevlar.Tests/TimeoutTests.cs
+++ b/tests/Kevlar.Tests/TimeoutTests.cs
@@ -121,4 +121,21 @@ public class TimeoutTests
 #pragma warning restore CS0162
         })).Throws<TimeoutExceededException>();
     }
+
+    [Test]
+    public async Task Sync_Execution_Converts_OperationCanceledException_Without_Token()
+    {
+        var shield = Shield.Timeout(TimeSpan.FromMilliseconds(20));
+
+        var exception = await Assert.That(() => shield.Execute(WaitThenCancelWithoutToken))
+            .Throws<TimeoutExceededException>();
+
+        await Assert.That(exception!.InnerException).IsTypeOf<OperationCanceledException>();
+    }
+
+    private static int WaitThenCancelWithoutToken(CancellationToken cancellationToken)
+    {
+        cancellationToken.WaitHandle.WaitOne();
+        throw new OperationCanceledException("wrapped without token");
+    }
 }


### PR DESCRIPTION
## Summary
- classify any OperationCanceledException observed after the timeout source fires as TimeoutExceededException
- preserve caller-cancellation precedence and retain the original cancellation as InnerException
- cover deterministic arbitration, metrics, HTTP integration, and the strategy model

## Performance

| Case | Mean | Allocated |
|---|---:|---:|
| baseline timeout happy path | 207.0 ns | 0 B |
| this change | 192.2 ns | 0 B |

## Test plan
- [x] dotnet build Kevlar.slnx -c Release
- [x] core unit suite (855 passed)
- [x] integration suite (132 passed)
- [x] analyzer suite (76 passed)
- [x] allocation gates (3 passed)
- [x] netstandard2.0 (10 passed) and netstandard2.1 (4 passed)
- [x] deterministic model sweep
- [x] docs verification/build (118 snippets)
- [x] BenchmarkDotNet timeout happy path

Closes #216
