### PR TITLE
refactor(backoff)!: unify kind +semver: major

### DIFF
--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -130,6 +130,42 @@ function Get-AssemblyDetails([System.IO.Compression.ZipArchiveEntry]$Entry)
     }
 }
 
+function Assert-TypeNotDefined(
+    [string]$Name,
+    [System.IO.Compression.ZipArchiveEntry]$Entry,
+    [string]$TypeName)
+{
+    $stream = $Entry.Open()
+    $buffer = [System.IO.MemoryStream]::new()
+    try
+    {
+        $stream.CopyTo($buffer)
+        $buffer.Position = 0
+        $reader = [System.Reflection.PortableExecutable.PEReader]::new($buffer)
+        try
+        {
+            $metadata = [System.Reflection.Metadata.PEReaderExtensions]::GetMetadataReader($reader)
+            foreach ($handle in $metadata.TypeDefinitions)
+            {
+                $definition = $metadata.GetTypeDefinition($handle)
+                if ($metadata.GetString($definition.Name) -eq $TypeName)
+                {
+                    throw "$Name defines duplicate type '$TypeName'."
+                }
+            }
+        }
+        finally
+        {
+            $reader.Dispose()
+        }
+    }
+    finally
+    {
+        $buffer.Dispose()
+        $stream.Dispose()
+    }
+}
+
 function Get-ArchiveEntryHash([string]$ArchivePath, [string]$EntryPath)
 {
     $archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
@@ -383,6 +419,10 @@ foreach ($packageId in $expectedDependencies.Keys)
             Assert-Equal "$packageId $($assemblyEntry.FullName) AssemblyVersion" $details.AssemblyVersion $expectedAssemblyVersion
             Assert-Equal "$packageId $($assemblyEntry.FullName) FileVersion" $details.FileVersion $expectedFileVersion
             Assert-Equal "$packageId $($assemblyEntry.FullName) InformationalVersion" $details.InformationalVersion $expectedInformationalVersion
+            if ($packageId -in @('Kevlar.Extensions.DependencyInjection', 'Kevlar.Testing'))
+            {
+                Assert-TypeNotDefined "$packageId $($assemblyEntry.FullName)" $assemblyEntry 'BackoffKind'
+            }
         }
     }
     finally

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -231,7 +231,7 @@ public static class KevlarServiceCollectionExtensions
             {
                 retryDefinition.MaxRetries = maxRetries;
             }
-            if (ReadEnum<BackoffKind>(retry, nameof(RetryDefinition.Backoff)) is { } backoff)
+            if (ReadBackoffKind(retry, nameof(RetryDefinition.Backoff)) is { } backoff)
             {
                 retryDefinition.Backoff = backoff;
             }
@@ -356,6 +356,23 @@ public static class KevlarServiceCollectionExtensions
         Read(configuration, key) is { } value
             ? ParseEnum<TEnum>(configuration, key, value)
             : null;
+
+    private static BackoffKind? ReadBackoffKind(IConfiguration configuration, string key)
+    {
+        if (Read(configuration, key) is not { } value)
+        {
+            return null;
+        }
+
+        var backoff = ParseEnum<BackoffKind>(configuration, key, value);
+        return backoff != BackoffKind.Custom
+            ? backoff
+            : throw InvalidValue(
+                configuration,
+                key,
+                value,
+                "a configurable BackoffKind (None, Constant, Linear, or Exponential)");
+    }
 
     private static string? ReadNullable(IConfiguration configuration, string key)
     {

--- a/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
@@ -1,3 +1,10 @@
+*REMOVED*Kevlar.Extensions.DependencyInjection.BackoffKind
+*REMOVED*Kevlar.Extensions.DependencyInjection.BackoffKind.Constant = 1 -> Kevlar.Extensions.DependencyInjection.BackoffKind
+*REMOVED*Kevlar.Extensions.DependencyInjection.BackoffKind.Exponential = 3 -> Kevlar.Extensions.DependencyInjection.BackoffKind
+*REMOVED*Kevlar.Extensions.DependencyInjection.BackoffKind.Linear = 2 -> Kevlar.Extensions.DependencyInjection.BackoffKind
+*REMOVED*Kevlar.Extensions.DependencyInjection.BackoffKind.None = 0 -> Kevlar.Extensions.DependencyInjection.BackoffKind
+*REMOVED*Kevlar.Extensions.DependencyInjection.RetryDefinition.Backoff.get -> Kevlar.Extensions.DependencyInjection.BackoffKind
+Kevlar.Extensions.DependencyInjection.RetryDefinition.Backoff.get -> Kevlar.BackoffKind
 Kevlar.Extensions.DependencyInjection.IShieldProvider
 Kevlar.Extensions.DependencyInjection.IShieldProvider.Current.get -> Kevlar.Shield!
 static Kevlar.Extensions.DependencyInjection.KevlarServiceCollectionExtensions.AddReloadingShield(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! name, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
@@ -110,7 +110,10 @@ public sealed class RetryDefinition
     /// <summary>Maximum retries after the initial attempt. Default 3.</summary>
     public int MaxRetries { get; set; } = 3;
 
-    /// <summary>The backoff curve. Default <see cref="BackoffKind.Exponential"/>.</summary>
+    /// <summary>
+    /// The backoff curve. Default <see cref="BackoffKind.Exponential"/>. DI definitions support
+    /// None, Constant, Linear, and Exponential; custom callbacks require the fluent API.
+    /// </summary>
     public BackoffKind Backoff { get; set; } = BackoffKind.Exponential;
 
     /// <summary>
@@ -138,6 +141,8 @@ public sealed class RetryDefinition
             Factor,
             MaxDelay ?? TimeSpan.FromSeconds(30),
             Jitter),
+        BackoffKind.Custom => throw new InvalidOperationException(
+            "RetryDefinition cannot construct BackoffKind.Custom; configure Backoff.Custom with the fluent API."),
         _ => throw new ArgumentOutOfRangeException(nameof(Backoff), Backoff, "Unknown backoff kind."),
     };
 }

--- a/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
@@ -142,22 +142,6 @@ public sealed class RetryDefinition
     };
 }
 
-/// <summary>The backoff curves a <see cref="RetryDefinition"/> can declare.</summary>
-public enum BackoffKind
-{
-    /// <summary>No delay between attempts.</summary>
-    None,
-
-    /// <summary>The same delay before every attempt.</summary>
-    Constant,
-
-    /// <summary>Linearly increasing delay.</summary>
-    Linear,
-
-    /// <summary>Exponentially increasing delay (the default).</summary>
-    Exponential,
-}
-
 /// <summary>The circuit breaker section of a <see cref="ShieldDefinition"/>.</summary>
 public sealed class CircuitBreakerDefinition
 {

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -2,14 +2,8 @@ Kevlar.Testing.BackoffDescriptor
 Kevlar.Testing.BackoffDescriptor.BaseDelay.get -> System.TimeSpan?
 Kevlar.Testing.BackoffDescriptor.Factor.get -> double?
 Kevlar.Testing.BackoffDescriptor.Jitter.get -> bool?
-Kevlar.Testing.BackoffDescriptor.Kind.get -> Kevlar.Testing.BackoffKind
+Kevlar.Testing.BackoffDescriptor.Kind.get -> Kevlar.BackoffKind
 Kevlar.Testing.BackoffDescriptor.MaxDelay.get -> System.TimeSpan?
-Kevlar.Testing.BackoffKind
-Kevlar.Testing.BackoffKind.Constant = 1 -> Kevlar.Testing.BackoffKind
-Kevlar.Testing.BackoffKind.Custom = 4 -> Kevlar.Testing.BackoffKind
-Kevlar.Testing.BackoffKind.Exponential = 3 -> Kevlar.Testing.BackoffKind
-Kevlar.Testing.BackoffKind.Linear = 2 -> Kevlar.Testing.BackoffKind
-Kevlar.Testing.BackoffKind.None = 0 -> Kevlar.Testing.BackoffKind
 Kevlar.Testing.CircuitBreakerStrategyDescriptor
 Kevlar.Testing.CircuitBreakerStrategyDescriptor.BreakDuration.get -> System.TimeSpan
 Kevlar.Testing.CircuitBreakerStrategyDescriptor.ConsecutiveFailures.get -> int?

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -121,15 +121,8 @@ public static class ShieldDescriptorExtensions
             strategy.HasHandlingOverride);
 
     private static BackoffDescriptor DescribeBackoff(Backoff backoff) => new(
-        backoff.ConfigurationKind switch
-        {
-            BackoffConfigurationKind.None => BackoffKind.None,
-            BackoffConfigurationKind.Constant => BackoffKind.Constant,
-            BackoffConfigurationKind.Linear => BackoffKind.Linear,
-            BackoffConfigurationKind.Exponential => BackoffKind.Exponential,
-            _ => BackoffKind.Custom,
-        },
-        backoff.BaseDelay,
+        backoff.Kind,
+        backoff.InitialDelay,
         backoff.Factor,
         backoff.MaxDelay,
         backoff.Jitter);

--- a/src/Kevlar/Backoff.cs
+++ b/src/Kevlar/Backoff.cs
@@ -70,15 +70,20 @@ public abstract class Backoff
     /// <summary>Returns the delay before the given 1-based retry attempt.</summary>
     public abstract TimeSpan GetDelay(int attempt);
 
-    internal abstract BackoffConfigurationKind ConfigurationKind { get; }
+    /// <summary>The stable category of this backoff.</summary>
+    public abstract BackoffKind Kind { get; }
 
-    internal virtual TimeSpan? BaseDelay => null;
+    /// <summary>The constant delay, linear step, or exponential initial delay, when applicable.</summary>
+    public virtual TimeSpan? InitialDelay => null;
 
-    internal virtual double? Factor => null;
+    /// <summary>The exponential multiplier, when applicable.</summary>
+    public virtual double? Factor => null;
 
-    internal virtual TimeSpan? MaxDelay => null;
+    /// <summary>The linear or exponential delay cap, when configured.</summary>
+    public virtual TimeSpan? MaxDelay => null;
 
-    internal virtual bool? Jitter => null;
+    /// <summary>Whether exponential jitter is enabled, when applicable.</summary>
+    public virtual bool? Jitter => null;
 
     private protected static void ValidateAttempt(int attempt) =>
         Throw.IfOutOfRange(attempt < 1, nameof(attempt), "Attempt must be at least 1.");
@@ -117,10 +122,10 @@ public abstract class Backoff
             return _delay;
         }
 
-        internal override BackoffConfigurationKind ConfigurationKind =>
-            _delay == TimeSpan.Zero ? BackoffConfigurationKind.None : BackoffConfigurationKind.Constant;
+        public override BackoffKind Kind =>
+            _delay == TimeSpan.Zero ? BackoffKind.None : BackoffKind.Constant;
 
-        internal override TimeSpan? BaseDelay => _delay;
+        public override TimeSpan? InitialDelay => _delay;
 
         public override string ToString() =>
             _delay == TimeSpan.Zero ? "no delay" : $"constant {DescribeHelper.Time(_delay)}";
@@ -143,11 +148,11 @@ public abstract class Backoff
             return FromTicksClamped((double)_step.Ticks * attempt, _maxDelay);
         }
 
-        internal override BackoffConfigurationKind ConfigurationKind => BackoffConfigurationKind.Linear;
+        public override BackoffKind Kind => BackoffKind.Linear;
 
-        internal override TimeSpan? BaseDelay => _step;
+        public override TimeSpan? InitialDelay => _step;
 
-        internal override TimeSpan? MaxDelay => _maxDelay;
+        public override TimeSpan? MaxDelay => _maxDelay;
 
         public override string ToString()
         {
@@ -184,15 +189,15 @@ public abstract class Backoff
             return FromTicksClamped(ticks, _maxDelay);
         }
 
-        internal override BackoffConfigurationKind ConfigurationKind => BackoffConfigurationKind.Exponential;
+        public override BackoffKind Kind => BackoffKind.Exponential;
 
-        internal override TimeSpan? BaseDelay => _initialDelay;
+        public override TimeSpan? InitialDelay => _initialDelay;
 
-        internal override double? Factor => _factor;
+        public override double? Factor => _factor;
 
-        internal override TimeSpan? MaxDelay => _maxDelay;
+        public override TimeSpan? MaxDelay => _maxDelay;
 
-        internal override bool? Jitter => _jitter;
+        public override bool? Jitter => _jitter;
 
         public override string ToString()
         {
@@ -215,17 +220,8 @@ public abstract class Backoff
             return delay < TimeSpan.Zero ? TimeSpan.Zero : DelayHelper.Clamp(delay);
         }
 
-        internal override BackoffConfigurationKind ConfigurationKind => BackoffConfigurationKind.Custom;
+        public override BackoffKind Kind => BackoffKind.Custom;
 
         public override string ToString() => "custom backoff";
     }
-}
-
-internal enum BackoffConfigurationKind
-{
-    None,
-    Constant,
-    Linear,
-    Exponential,
-    Custom,
 }

--- a/src/Kevlar/BackoffKind.cs
+++ b/src/Kevlar/BackoffKind.cs
@@ -1,12 +1,12 @@
-namespace Kevlar.Testing;
+namespace Kevlar;
 
-/// <summary>Stable category for an inert backoff descriptor.</summary>
+/// <summary>The built-in and caller-defined backoff categories.</summary>
 public enum BackoffKind
 {
     /// <summary>No delay between attempts.</summary>
     None,
 
-    /// <summary>A constant delay.</summary>
+    /// <summary>The same delay before every attempt.</summary>
     Constant,
 
     /// <summary>A linearly increasing delay.</summary>
@@ -15,6 +15,6 @@ public enum BackoffKind
     /// <summary>An exponentially increasing delay.</summary>
     Exponential,
 
-    /// <summary>A caller-defined delay callback whose executable implementation is not exposed.</summary>
+    /// <summary>A caller-defined delay callback.</summary>
     Custom,
 }

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,3 +1,14 @@
+Kevlar.BackoffKind
+Kevlar.BackoffKind.Constant = 1 -> Kevlar.BackoffKind
+Kevlar.BackoffKind.Custom = 4 -> Kevlar.BackoffKind
+Kevlar.BackoffKind.Exponential = 3 -> Kevlar.BackoffKind
+Kevlar.BackoffKind.Linear = 2 -> Kevlar.BackoffKind
+Kevlar.BackoffKind.None = 0 -> Kevlar.BackoffKind
+abstract Kevlar.Backoff.Kind.get -> Kevlar.BackoffKind
+virtual Kevlar.Backoff.Factor.get -> double?
+virtual Kevlar.Backoff.InitialDelay.get -> System.TimeSpan?
+virtual Kevlar.Backoff.Jitter.get -> bool?
+virtual Kevlar.Backoff.MaxDelay.get -> System.TimeSpan?
 Kevlar.HandlingClause
 *REMOVED*Kevlar.StrategyNode
 Kevlar.HandlingClause.HandlingClause() -> void

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -264,6 +264,27 @@ public class PipelineDescriptorTests
     }
 
     [Test]
+    public async Task Retry_Descriptor_Reports_Core_BackoffKind()
+    {
+        await Assert.That(typeof(BackoffDescriptor).GetProperty(nameof(BackoffDescriptor.Kind))!.PropertyType)
+            .IsEqualTo(typeof(BackoffKind));
+
+        var cases = new[]
+        {
+            Backoff.None,
+            Backoff.Constant(TimeSpan.FromMilliseconds(10)),
+            Backoff.Linear(TimeSpan.FromMilliseconds(10)),
+            Backoff.Exponential(TimeSpan.FromMilliseconds(10), jitter: false),
+            Backoff.Custom(_ => TimeSpan.Zero),
+        };
+
+        foreach (var backoff in cases)
+        {
+            await Assert.That(DescribeBackoff(backoff).Kind).IsEqualTo(backoff.Kind);
+        }
+    }
+
+    [Test]
     public async Task Assertion_Failures_Explain_Expected_And_Actual_Shape()
     {
         var descriptor = Shield.Timeout(TimeSpan.FromSeconds(1)).GetDescriptor();

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -1,10 +1,52 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Kevlar.Extensions.DependencyInjection;
+using Kevlar.Testing;
 
 namespace Kevlar.Tests;
 
 public class ApiShapeTests
 {
+    [Test]
+    public async Task Exactly_One_Public_Type_Named_BackoffKind_Across_All_Assemblies()
+    {
+        var types = new[]
+            {
+                typeof(Shield).Assembly,
+                typeof(ShieldDefinition).Assembly,
+                typeof(ShieldDescriptor).Assembly,
+            }
+            .SelectMany(static assembly => assembly.ExportedTypes)
+            .Where(static type => type.Name == "BackoffKind")
+            .ToArray();
+
+        await Assert.That(types).HasSingleItem();
+        await Assert.That(types[0].FullName).IsEqualTo("Kevlar.BackoffKind");
+    }
+
+    [Test]
+    public async Task BackoffKind_Is_Unambiguous_With_DI_And_Testing_Usings()
+    {
+        var compilation = CreateCompilation(
+            """
+            using Kevlar;
+            using Kevlar.Extensions.DependencyInjection;
+            using Kevlar.Testing;
+
+            public static class Consumer
+            {
+                public static BackoffKind Kind => BackoffKind.Exponential;
+            }
+            """);
+
+        var errors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(static diagnostic => $"{diagnostic.Id}: {diagnostic.GetMessage()}")
+            .ToArray();
+
+        await Assert.That(errors).IsEmpty();
+    }
+
     [Test]
     public async Task Typed_CircuitBreaker_Requires_Typed_Options_Configurator()
     {
@@ -87,7 +129,9 @@ public class ApiShapeTests
         var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
             .Split(Path.PathSeparator)
             .Select(static path => (MetadataReference)MetadataReference.CreateFromFile(path))
-            .Append(MetadataReference.CreateFromFile(typeof(Shield).Assembly.Location));
+            .Append(MetadataReference.CreateFromFile(typeof(Shield).Assembly.Location))
+            .Append(MetadataReference.CreateFromFile(typeof(ShieldDefinition).Assembly.Location))
+            .Append(MetadataReference.CreateFromFile(typeof(ShieldDescriptor).Assembly.Location));
 
         return CSharpCompilation.Create(
             "FallbackApiShape",

--- a/tests/Kevlar.Tests/BackoffConfigurationTests.cs
+++ b/tests/Kevlar.Tests/BackoffConfigurationTests.cs
@@ -1,0 +1,56 @@
+namespace Kevlar.Tests;
+
+public class BackoffConfigurationTests
+{
+    [Test]
+    public async Task Backoff_Exposes_Configuration()
+    {
+        var cases = new[]
+        {
+            new ExpectedConfiguration(Backoff.None, BackoffKind.None, TimeSpan.Zero, null, null, null),
+            new ExpectedConfiguration(
+                Backoff.Constant(TimeSpan.FromMilliseconds(100)),
+                BackoffKind.Constant,
+                TimeSpan.FromMilliseconds(100),
+                null,
+                null,
+                null),
+            new ExpectedConfiguration(
+                Backoff.Linear(TimeSpan.FromMilliseconds(200), TimeSpan.FromSeconds(2)),
+                BackoffKind.Linear,
+                TimeSpan.FromMilliseconds(200),
+                null,
+                TimeSpan.FromSeconds(2),
+                null),
+            new ExpectedConfiguration(
+                Backoff.Exponential(
+                    TimeSpan.FromMilliseconds(250),
+                    factor: 3,
+                    maxDelay: TimeSpan.FromSeconds(30),
+                    jitter: false),
+                BackoffKind.Exponential,
+                TimeSpan.FromMilliseconds(250),
+                3,
+                TimeSpan.FromSeconds(30),
+                false),
+            new ExpectedConfiguration(Backoff.Custom(_ => TimeSpan.Zero), BackoffKind.Custom, null, null, null, null),
+        };
+
+        foreach (var expected in cases)
+        {
+            await Assert.That(expected.Backoff.Kind).IsEqualTo(expected.Kind);
+            await Assert.That(expected.Backoff.InitialDelay).IsEqualTo(expected.InitialDelay);
+            await Assert.That(expected.Backoff.Factor).IsEqualTo(expected.Factor);
+            await Assert.That(expected.Backoff.MaxDelay).IsEqualTo(expected.MaxDelay);
+            await Assert.That(expected.Backoff.Jitter).IsEqualTo(expected.Jitter);
+        }
+    }
+
+    private sealed record ExpectedConfiguration(
+        Backoff Backoff,
+        BackoffKind Kind,
+        TimeSpan? InitialDelay,
+        double? Factor,
+        TimeSpan? MaxDelay,
+        bool? Jitter);
+}

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -93,6 +93,41 @@ public class ConfigurationBindingTests
     }
 
     [Test]
+    [Arguments("none", "no delay")]
+    [Arguments("CONSTANT", "constant 1s")]
+    [Arguments("Linear", "linear 1s steps")]
+    [Arguments("eXpOnEnTiAl", "exponential 1s ×2 ≤30s")]
+    public async Task RetryDefinition_Binds_BackoffKind_From_Configuration(string value, string expected)
+    {
+        var configuration = BuildConfiguration(
+            ("Retry:MaxRetries", "1"),
+            ("Retry:Backoff", value),
+            ("Retry:BaseDelay", "00:00:01"),
+            ("Retry:Jitter", "false"),
+            ("Retry:MaxDelay", ""));
+        var services = new ServiceCollection();
+        services.AddShield("backoff", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("backoff");
+
+        await Assert.That(shield.ToString()).IsEqualTo($"backoff: Retry(1, {expected})");
+    }
+
+    [Test]
+    public async Task Invalid_BackoffKind_Throws_With_Path()
+    {
+        var configuration = BuildConfiguration(("Retry:Backoff", "quadratic"));
+        var services = new ServiceCollection();
+        services.AddShield("invalid", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<InvalidOperationException>()
+            .WithMessage("Configuration value 'quadratic' for 'Retry:Backoff' is not a BackoffKind.");
+    }
+
+    [Test]
     public async Task Exponential_Defaults_Match_The_Fluent_Api()
     {
         var definition = new ShieldDefinition { Retry = new RetryDefinition() };

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -128,6 +128,21 @@ public class ConfigurationBindingTests
     }
 
     [Test]
+    public async Task Custom_BackoffKind_Throws_With_Path()
+    {
+        var configuration = BuildConfiguration(("Retry:Backoff", "Custom"));
+        var services = new ServiceCollection();
+        services.AddShield("invalid", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<InvalidOperationException>()
+            .WithMessage(
+                "Configuration value 'Custom' for 'Retry:Backoff' is not a configurable "
+                + "BackoffKind (None, Constant, Linear, or Exponential).");
+    }
+
+    [Test]
     public async Task Exponential_Defaults_Match_The_Fluent_Api()
     {
         var definition = new ShieldDefinition { Retry = new RetryDefinition() };

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -365,6 +365,21 @@ public class DependencyInjectionContractTests
     }
 
     [Test]
+    public async Task Custom_BackoffKind_Requires_The_Fluent_Api()
+    {
+        var definition = new ShieldDefinition
+        {
+            Retry = new RetryDefinition { Backoff = BackoffKind.Custom },
+        };
+
+        await Assert.That(() => definition.Build())
+            .Throws<InvalidOperationException>()
+            .WithMessage(
+                "RetryDefinition cannot construct BackoffKind.Custom; configure Backoff.Custom "
+                + "with the fluent API.");
+    }
+
+    [Test]
     public async Task Configuration_Is_Read_On_First_Resolution_Then_Remains_Stable()
     {
         var values = new Dictionary<string, string?>

--- a/tests/Kevlar.Tests/Kevlar.Tests.csproj
+++ b/tests/Kevlar.Tests/Kevlar.Tests.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\src\Kevlar\Kevlar.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.DependencyInjection\Kevlar.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.Http\Kevlar.Extensions.Http.csproj" />
+    <ProjectReference Include="..\..\src\Kevlar.Testing\Kevlar.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -259,15 +259,6 @@ public class NumericBoundaryTests
         }
     }
 
-    public enum BackoffKind
-    {
-        None,
-        Constant,
-        Linear,
-        Exponential,
-        Custom,
-    }
-
     private sealed class FixedTimestampTimeProvider(long timestamp, long timestampFrequency) : TimeProvider
     {
         private long _timestamp = timestamp;


### PR DESCRIPTION
Closes #200.

## Behavior
- defines the sole public `Kevlar.BackoffKind` enum in core
- exposes typed, read-only backoff configuration without reflection
- migrates DI and Testing APIs to the core enum
- verifies ambiguity, configuration binding, descriptors, PublicAPI, and packed TypeDefs

## Validation
- `dotnet build Kevlar.slnx -c Release`
- core tests: 853 passed
- integration tests: 131 passed
- analyzer tests: 78 passed
- Testing tests: 52 passed
- Chaos tests: 33 passed
- rate-limiting tests: 24 passed
- allocation tests: 3 passed
- netstandard tests: 10 + 4 passed
- `pwsh scripts/Verify-Docs.ps1`
- package TypeDef verification passed for DI and Testing; the full package verifier then hit the existing gRPC netstandard2.1 symbol-manifest mismatch addressed by #258