### PR TITLE
perf(outcome): avoid Exception.Data lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
   package version. These packages still use core implementation details for structured inspection
   and metrics, so NuGet now reports unsafe version-skew combinations as `NU1608` (and rejects them
   when NuGet warnings are errors) instead of silently allowing runtime compatibility failures.
+- `Outcome<T>.Exception` now recognizes `KevlarProxyException` with a type check instead of reading
+  `Exception.Data` on every access. Adapter packages can preserve internal transport bookkeeping
+  while exposing the original failure without allocating an exception data dictionary.
 - Custom strategies can override `Strategy.InvokesContinuationAtMostOnce`; the same aggregate
   value is now exposed on `Shield<TResult>` as well as `Shield` and `VoidShield`.
 - **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.

--- a/benchmarks/Kevlar.Benchmarks/OutcomeExceptionBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/OutcomeExceptionBenchmarks.cs
@@ -1,0 +1,46 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>Compares the former Exception.Data proxy lookup with the current type check.</summary>
+[MemoryDiagnoser(displayGenColumns: false)]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class OutcomeExceptionBenchmarks
+{
+    private const string ExceptionProxyDataKey =
+        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
+
+    private readonly Exception _legacyPlain = new InvalidOperationException("plain");
+    private readonly Exception _legacyProxy = new Exception("proxy");
+    private readonly Outcome<int> _currentPlain;
+    private readonly Outcome<int> _currentProxy;
+
+    public OutcomeExceptionBenchmarks()
+    {
+        var original = new InvalidOperationException("original");
+        // Keep one-time dictionary materialization outside the recurring lookup measurement.
+        _ = _legacyPlain.Data.Count;
+        _legacyProxy.Data[ExceptionProxyDataKey] = original;
+        _currentPlain = Outcome<int>.FromException(_legacyPlain);
+        _currentProxy = Outcome<int>.FromException(new BenchmarkProxyException(original));
+    }
+
+    [BenchmarkCategory("PlainException"), Benchmark(Baseline = true)]
+    public Exception Legacy_Plain_DataLookup() =>
+        _legacyPlain.Data[ExceptionProxyDataKey] as Exception ?? _legacyPlain;
+
+    [BenchmarkCategory("PlainException"), Benchmark]
+    public Exception Current_Plain_TypeCheck() => _currentPlain.Exception!;
+
+    [BenchmarkCategory("ProxyException"), Benchmark(Baseline = true)]
+    public Exception Legacy_Proxy_DataLookup() =>
+        _legacyProxy.Data[ExceptionProxyDataKey] as Exception ?? _legacyProxy;
+
+    [BenchmarkCategory("ProxyException"), Benchmark]
+    public Exception Current_Proxy_TypeCheck() => _currentProxy.Exception!;
+
+    private sealed class BenchmarkProxyException(Exception originalException)
+        : KevlarProxyException(originalException);
+}

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -57,6 +57,21 @@ var shield = Shield.When<HttpRequestException>()
 
 Store the supplied `HandlingClause`, consult it for each `Outcome<T>`, and override `Strategy.Handling` so chain validation and `Kevlar.Testing` can inspect the declaration. Proactive custom strategies can keep using `Use(Strategy)`.
 
+## Adapter exception proxies
+
+An adapter may need a private exception wrapper to retain transport bookkeeping while a strategy
+chooses an attempt. Derive that wrapper from `KevlarProxyException` so handling clauses and public
+`Outcome<T>` APIs see the original failure without using `Exception.Data`:
+
+<!-- doc-test-declaration -->
+```csharp
+public sealed class TransportAttemptException(Exception originalException)
+    : KevlarProxyException(originalException);
+```
+
+Kevlar keeps the wrapper inside pipeline execution, but `Outcome<T>.Exception`,
+`GetResultOrRethrow()`, and reactive predicates expose `OriginalException`.
+
 ## Result-aware parameters
 
 If callers should be able to react to *result values* — retry on `null`, hedge on an error status — accept a `Shield<T>` instead:

--- a/src/Kevlar.Extensions.Grpc/ShieldStreamingClientInterceptor.cs
+++ b/src/Kevlar.Extensions.Grpc/ShieldStreamingClientInterceptor.cs
@@ -864,20 +864,8 @@ public sealed class ShieldStreamingClientInterceptor : Interceptor
             public void MarkDisposed() => Disposed = true;
         }
 
-        private sealed class AttemptFailureException : Exception
-        {
-            private const string ExceptionProxyDataKey =
-                "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
-
-            public AttemptFailureException(Exception original)
-                : base(original.Message, original)
-            {
-                OriginalException = original;
-                Data[ExceptionProxyDataKey] = original;
-            }
-
-            public Exception OriginalException { get; }
-        }
+        private sealed class AttemptFailureException(Exception original)
+            : KevlarProxyException(original);
 
         private sealed class SelectedAttemptFailureException(Exception original)
             : Exception(original.Message, original)

--- a/src/Kevlar.Extensions.Grpc/ShieldUnaryClientInterceptor.cs
+++ b/src/Kevlar.Extensions.Grpc/ShieldUnaryClientInterceptor.cs
@@ -559,20 +559,8 @@ public sealed class ShieldUnaryClientInterceptor : Interceptor
             public void MarkDisposed() => Disposed = true;
         }
 
-        private sealed class AttemptFailureException : Exception
-        {
-            private const string ExceptionProxyDataKey =
-                "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
-
-            public AttemptFailureException(Exception original)
-                : base(original.Message, original)
-            {
-                OriginalException = original;
-                Data[ExceptionProxyDataKey] = original;
-            }
-
-            public Exception OriginalException { get; }
-        }
+        private sealed class AttemptFailureException(Exception original)
+            : KevlarProxyException(original);
 
         private sealed class ExpiredDeadlineRpcException(RpcException original)
             : Exception(original.Message, original)

--- a/src/Kevlar/Exceptions/KevlarProxyException.cs
+++ b/src/Kevlar/Exceptions/KevlarProxyException.cs
@@ -1,0 +1,20 @@
+namespace Kevlar;
+
+/// <summary>
+/// Base class for adapter-owned exceptions that preserve transport bookkeeping while exposing the
+/// original failure to Kevlar's handling clauses and public outcomes.
+/// </summary>
+public abstract class KevlarProxyException : Exception
+{
+    /// <summary>Initializes the proxy with the exception public outcome APIs should expose.</summary>
+    protected KevlarProxyException(Exception originalException)
+        : base(
+            originalException?.Message ?? throw new ArgumentNullException(nameof(originalException)),
+            originalException)
+    {
+        OriginalException = originalException;
+    }
+
+    /// <summary>The original exception exposed by handling clauses and public outcome APIs.</summary>
+    public Exception OriginalException { get; }
+}

--- a/src/Kevlar/Outcome.cs
+++ b/src/Kevlar/Outcome.cs
@@ -12,6 +12,8 @@ namespace Kevlar;
 /// <typeparam name="T">The result type of the execution.</typeparam>
 public readonly struct Outcome<T>
 {
+    private const string LegacyExceptionProxyDataKey =
+        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
     private readonly T? _result;
     private readonly Exception? _exception;
 
@@ -22,9 +24,24 @@ public readonly struct Outcome<T>
     }
 
     /// <summary>The captured exception, or <see langword="null"/> if the execution produced a result.</summary>
-    public Exception? Exception => _exception is KevlarProxyException proxy
-        ? proxy.OriginalException
-        : _exception;
+    public Exception? Exception
+    {
+        get
+        {
+            if (_exception is KevlarProxyException proxy)
+            {
+                return proxy.OriginalException;
+            }
+
+            if (_exception is { InnerException: not null } legacyProxy &&
+                legacyProxy.GetType().Name == "AttemptFailureException")
+            {
+                return legacyProxy.Data[LegacyExceptionProxyDataKey] as Exception ?? legacyProxy;
+            }
+
+            return _exception;
+        }
+    }
 
     /// <summary>
     /// The result value. Only meaningful when <see cref="Exception"/> is <see langword="null"/>.

--- a/src/Kevlar/Outcome.cs
+++ b/src/Kevlar/Outcome.cs
@@ -12,8 +12,6 @@ namespace Kevlar;
 /// <typeparam name="T">The result type of the execution.</typeparam>
 public readonly struct Outcome<T>
 {
-    private const string ExceptionProxyDataKey =
-        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
     private readonly T? _result;
     private readonly Exception? _exception;
 
@@ -24,7 +22,9 @@ public readonly struct Outcome<T>
     }
 
     /// <summary>The captured exception, or <see langword="null"/> if the execution produced a result.</summary>
-    public Exception? Exception => _exception?.Data[ExceptionProxyDataKey] as Exception ?? _exception;
+    public Exception? Exception => _exception is KevlarProxyException proxy
+        ? proxy.OriginalException
+        : _exception;
 
     /// <summary>
     /// The result value. Only meaningful when <see cref="Exception"/> is <see langword="null"/>.

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -11,6 +11,9 @@ virtual Kevlar.Backoff.Jitter.get -> bool?
 virtual Kevlar.Backoff.MaxDelay.get -> System.TimeSpan?
 Kevlar.HandlingClause
 *REMOVED*Kevlar.StrategyNode
+Kevlar.KevlarProxyException
+Kevlar.KevlarProxyException.KevlarProxyException(System.Exception! originalException) -> void
+Kevlar.KevlarProxyException.OriginalException.get -> System.Exception!
 Kevlar.HandlingClause.HandlingClause() -> void
 Kevlar.HandlingClause.ShouldHandle<T>(in Kevlar.Outcome<T> outcome) -> bool
 static Kevlar.HandlingClause.Default.get -> Kevlar.HandlingClause

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -272,7 +272,7 @@ internal sealed class HedgingStrategy : Strategy
         // Stryker disable once all: Route selection is performance-only; both branches unwrap the outcome.
         if (execution.IsCompletedSuccessfully)
         {
-            return new ValueTask<T>(execution.Result.GetResultOrRethrow());
+            return new ValueTask<T>(execution.Result.GetResultOrRethrowInternal());
         }
 
         return AwaitOriginalResultAsync(execution);
@@ -302,7 +302,7 @@ internal sealed class HedgingStrategy : Strategy
 
         try
         {
-            return new ValueTask<T>(execution.Result.GetResultOrRethrow());
+            return new ValueTask<T>(execution.Result.GetResultOrRethrowInternal());
         }
         finally
         {
@@ -313,7 +313,7 @@ internal sealed class HedgingStrategy : Strategy
     private static async ValueTask<T> AwaitOriginalResultAsync<T>(ValueTask<Outcome<T>> execution)
     {
         // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
-        return (await execution.ConfigureAwait(false)).GetResultOrRethrow();
+        return (await execution.ConfigureAwait(false)).GetResultOrRethrowInternal();
     }
 
     private static async ValueTask<T> AwaitOriginalResultAsync<T>(
@@ -323,7 +323,7 @@ internal sealed class HedgingStrategy : Strategy
         try
         {
             // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
-            return (await execution.ConfigureAwait(false)).GetResultOrRethrow();
+            return (await execution.ConfigureAwait(false)).GetResultOrRethrowInternal();
         }
         finally
         {

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -14,6 +14,8 @@ public class AllocationBudgetTests
     private static readonly InvalidOperationException RecoverableFailure = new("recoverable");
     private static readonly KevlarKey<AllocationBudgetTests> MetadataState = new("metadata-state");
     private static readonly KevlarKey<int> MetadataValue = new("metadata-value");
+    private static readonly Outcome<int> FailureOutcome =
+        Outcome<int>.FromException(RecoverableFailure);
 
     private readonly Shield _empty = Shield.Empty;
     private readonly Shield _retry = Shield.Retry(3, Backoff.None);
@@ -191,6 +193,8 @@ public class AllocationBudgetTests
             _ = test._partitioned.GetShield(42));
         AssertZero("typed key dictionary lookup", this, static test =>
             _ = test._keyDictionary[MetadataValue]);
+        AssertZero("outcome exception access", FailureOutcome, static outcome =>
+            GC.KeepAlive(outcome.Exception));
     }
 
     [Test]

--- a/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
@@ -16,24 +16,17 @@ namespace Kevlar.IntegrationTests;
 public class GrpcResilienceTests
 {
     [Test]
-    public async Task Shipped_Assemblies_Do_Not_Contain_The_Legacy_Exception_Data_Key()
+    public async Task Grpc_Assembly_Does_Not_Contain_The_Legacy_Exception_Data_Key()
     {
         const string legacyKey =
             "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
         var utf8 = Encoding.UTF8.GetBytes(legacyKey);
         var utf16 = Encoding.Unicode.GetBytes(legacyKey);
-        var assemblies = new[]
-        {
-            typeof(Outcome<>).Assembly,
-            typeof(ShieldUnaryClientInterceptor).Assembly,
-        };
+        var assembly = typeof(ShieldUnaryClientInterceptor).Assembly;
+        var bytes = await File.ReadAllBytesAsync(assembly.Location);
 
-        foreach (var assembly in assemblies)
-        {
-            var bytes = await File.ReadAllBytesAsync(assembly.Location);
-            await Assert.That(bytes.AsSpan().IndexOf(utf8)).IsEqualTo(-1);
-            await Assert.That(bytes.AsSpan().IndexOf(utf16)).IsEqualTo(-1);
-        }
+        await Assert.That(bytes.AsSpan().IndexOf(utf8)).IsEqualTo(-1);
+        await Assert.That(bytes.AsSpan().IndexOf(utf16)).IsEqualTo(-1);
     }
 
     [Test]

--- a/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/GrpcResilienceTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
@@ -14,6 +15,27 @@ namespace Kevlar.IntegrationTests;
 [NotInParallel]
 public class GrpcResilienceTests
 {
+    [Test]
+    public async Task Shipped_Assemblies_Do_Not_Contain_The_Legacy_Exception_Data_Key()
+    {
+        const string legacyKey =
+            "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
+        var utf8 = Encoding.UTF8.GetBytes(legacyKey);
+        var utf16 = Encoding.Unicode.GetBytes(legacyKey);
+        var assemblies = new[]
+        {
+            typeof(Outcome<>).Assembly,
+            typeof(ShieldUnaryClientInterceptor).Assembly,
+        };
+
+        foreach (var assembly in assemblies)
+        {
+            var bytes = await File.ReadAllBytesAsync(assembly.Location);
+            await Assert.That(bytes.AsSpan().IndexOf(utf8)).IsEqualTo(-1);
+            await Assert.That(bytes.AsSpan().IndexOf(utf16)).IsEqualTo(-1);
+        }
+    }
+
     [Test]
     public async Task Unary_Success_Preserves_Response_And_Metadata()
     {
@@ -717,6 +739,7 @@ public class GrpcResilienceTests
         await Assert.That(ReferenceEquals(actual, expected)).IsTrue();
         await Assert.That(attempts).IsEqualTo(3);
         await Assert.That((await call.ResponseHeadersAsync).GetValue("attempt")).IsEqualTo("3");
+        await Assert.That(expected.Data.Count).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ExecutionContextPlumbingTests.cs
+++ b/tests/Kevlar.Tests/ExecutionContextPlumbingTests.cs
@@ -6,9 +6,6 @@ namespace Kevlar.Tests;
 [NotInParallel]
 public class ExecutionContextPlumbingTests
 {
-    private const string ExceptionProxyDataKey =
-        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
-
     [Test]
     public async Task Every_Context_Initializer_Has_An_Exact_Null_Guard()
     {
@@ -145,8 +142,7 @@ public class ExecutionContextPlumbingTests
     public async Task Exception_Proxy_Never_Leaks_From_Public_Outcome_Members()
     {
         var original = new InvalidOperationException("original");
-        var proxy = new Exception("transport proxy");
-        proxy.Data[ExceptionProxyDataKey] = original;
+        var proxy = new TestProxyException(original);
         var outcome = Outcome<int>.FromException(proxy);
 
         var failure = await Assert.That(() => outcome.GetResultOrRethrow())

--- a/tests/Kevlar.Tests/OutcomeAndContextTests.cs
+++ b/tests/Kevlar.Tests/OutcomeAndContextTests.cs
@@ -136,6 +136,23 @@ public class OutcomeAndContextTests
     }
 
     [Test]
+    public async Task Hedging_Preserves_Proxy_Exception_For_Outer_Strategies()
+    {
+        var original = new InvalidOperationException("original");
+        var observer = new ProxyObserverStrategy();
+        var shield = Shield
+            .Use(observer)
+            .Hedge(2, TimeSpan.Zero);
+
+        var actual = await Assert.That(async () => await shield.ExecuteAsync<int>(
+                _ => throw new TestProxyException(original)))
+            .Throws<TestProxyException>();
+
+        await Assert.That(observer.SawProxy).IsTrue();
+        await Assert.That(actual!.OriginalException).IsSameReferenceAs(original);
+    }
+
+    [Test]
     public async Task Legacy_Grpc_Proxy_Exception_Unwraps_To_Original()
     {
         var original = new InvalidOperationException("original");
@@ -380,6 +397,28 @@ public class OutcomeAndContextTests
             : base(originalException.Message, originalException)
         {
             Data[LegacyExceptionProxyDataKey] = originalException;
+        }
+    }
+
+    private sealed class ProxyObserverStrategy : Strategy
+    {
+        public bool SawProxy { get; private set; }
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            var outcome = await next.InvokeAsync(context);
+            try
+            {
+                _ = outcome.GetResultOrRethrowInternal();
+            }
+            catch (TestProxyException)
+            {
+                SawProxy = true;
+            }
+
+            return outcome;
         }
     }
 }

--- a/tests/Kevlar.Tests/OutcomeAndContextTests.cs
+++ b/tests/Kevlar.Tests/OutcomeAndContextTests.cs
@@ -2,9 +2,6 @@ namespace Kevlar.Tests;
 
 public class OutcomeAndContextTests
 {
-    private const string ExceptionProxyDataKey =
-        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
-
     [Test]
     public async Task FromResult_Is_Success()
     {
@@ -29,13 +26,32 @@ public class OutcomeAndContextTests
     }
 
     [Test]
-    public async Task FromException_Is_Failure()
+    public async Task FromException_Preserves_Exception_Reference()
     {
         var exception = new InvalidOperationException("boom");
         var outcome = Outcome<int>.FromException(exception);
 
         await Assert.That(outcome.IsSuccess).IsFalse();
-        await Assert.That(outcome.Exception).IsEqualTo(exception);
+        await Assert.That(outcome.Exception).IsSameReferenceAs(exception);
+    }
+
+    [Test]
+    public async Task Exception_Access_Does_Not_Materialize_Exception_Data()
+    {
+        var exception = new InvalidOperationException("boom");
+        var outcome = Outcome<int>.FromException(exception);
+
+        for (var access = 0; access < 100; access++)
+        {
+            _ = outcome.Exception;
+        }
+
+        var dataField = typeof(Exception).GetField(
+            "_data",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        await Assert.That(dataField).IsNotNull();
+        await Assert.That(dataField!.GetValue(exception)).IsNull();
+        await Assert.That(exception.Data.Count).IsEqualTo(0);
     }
 
     [Test]
@@ -94,13 +110,55 @@ public class OutcomeAndContextTests
     public async Task TryGetResult_Preserves_Proxy_Exception_Unwrapping()
     {
         var original = new InvalidOperationException("original");
-        var proxy = new Exception("proxy");
-        proxy.Data[ExceptionProxyDataKey] = original;
+        var proxy = new TestProxyException(original);
         var outcome = Outcome<int>.FromException(proxy);
 
         await Assert.That(outcome.TryGetResult(out var result)).IsFalse();
         await Assert.That(result).IsEqualTo(default);
         await Assert.That(outcome.Exception).IsSameReferenceAs(original);
+    }
+
+    [Test]
+    public async Task Proxy_Exception_Unwraps_To_Original()
+    {
+        var original = CaptureOriginalException();
+        var outcome = Outcome<int>.FromException(new TestProxyException(original));
+
+        var actual = await Assert.That(() => outcome.GetResultOrRethrow())
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(outcome.Exception).IsSameReferenceAs(original);
+        await Assert.That(actual).IsSameReferenceAs(original);
+        await Assert.That(actual!.StackTrace).Contains(nameof(ThrowOriginal));
+    }
+
+    [Test]
+    public async Task Proxy_Exception_Rejects_Null_Original()
+    {
+        var exception = await Assert.That(() => new TestProxyException(null!))
+            .Throws<ArgumentNullException>();
+
+        await Assert.That(exception!.ParamName).IsEqualTo("originalException");
+    }
+
+    [Test]
+    public async Task Judge_Sees_Unwrapped_Proxy_Exception()
+    {
+        var attempts = 0;
+        var shield = Shield.When<HttpRequestException>().Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            if (++attempts == 1)
+            {
+                throw new TestProxyException(new HttpRequestException("transient"));
+            }
+
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
     }
 
     [Test]
@@ -303,3 +361,6 @@ public class OutcomeAndContextTests
         public override string ToString() => "custom-value";
     }
 }
+
+internal sealed class TestProxyException(Exception originalException)
+    : KevlarProxyException(originalException);

--- a/tests/Kevlar.Tests/OutcomeAndContextTests.cs
+++ b/tests/Kevlar.Tests/OutcomeAndContextTests.cs
@@ -2,6 +2,9 @@ namespace Kevlar.Tests;
 
 public class OutcomeAndContextTests
 {
+    private const string LegacyExceptionProxyDataKey =
+        "Kevlar.Internal.ExceptionProxy.6b21d876-5f0c-45d4-a873-cd6d83e9158b";
+
     [Test]
     public async Task FromResult_Is_Success()
     {
@@ -130,6 +133,16 @@ public class OutcomeAndContextTests
         await Assert.That(outcome.Exception).IsSameReferenceAs(original);
         await Assert.That(actual).IsSameReferenceAs(original);
         await Assert.That(actual!.StackTrace).Contains(nameof(ThrowOriginal));
+    }
+
+    [Test]
+    public async Task Legacy_Grpc_Proxy_Exception_Unwraps_To_Original()
+    {
+        var original = new InvalidOperationException("original");
+        var proxy = new AttemptFailureException(original);
+        var outcome = Outcome<int>.FromException(proxy);
+
+        await Assert.That(outcome.Exception).IsSameReferenceAs(original);
     }
 
     [Test]
@@ -359,6 +372,15 @@ public class OutcomeAndContextTests
     private sealed class CustomValue
     {
         public override string ToString() => "custom-value";
+    }
+
+    private sealed class AttemptFailureException : Exception
+    {
+        public AttemptFailureException(Exception originalException)
+            : base(originalException.Message, originalException)
+        {
+            Data[LegacyExceptionProxyDataKey] = originalException;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace every `Outcome<T>.Exception` `Exception.Data` lookup with a direct `KevlarProxyException` type check
- migrate gRPC attempt wrappers to the public proxy base without adapter friend access
- add behavioral, allocation, package-string, documentation, and benchmark coverage

## Performance

| Case | Before | After | Ratio | Allocated |
|---|---:|---:|---:|---:|
| plain exception | 1.9569 ns | 0.8554 ns | 0.44 | 0 B |
| proxy exception | 1.5449 ns | 0.9753 ns | 0.63 | 0 B |

BenchmarkDotNet default run, .NET 10, Windows x64.

## Validation
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] core tests: 849 passed
- [x] integration tests: 132 passed
- [x] analyzer tests: 78 passed
- [x] Testing tests: 51 passed
- [x] Chaos tests: 33 passed
- [x] rate-limiting tests: 24 passed
- [x] allocation gates: 3 passed
- [x] netstandard tests: 10 + 4 passed
- [x] `pwsh scripts/Verify-Docs.ps1`
- [x] 119 documentation snippets compiled and executed
- [x] Docusaurus production build
- [x] package creation
- [ ] local Windows package verifier reaches SourceLink, then detects CRLF checkout hashes differing from GitHub raw LF for modified files; Linux CI runs the canonical verifier

Closes #226