### PR TITLE
build: pin assembly identity policy

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,16 @@
     <DeterministicSourcePaths Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</DeterministicSourcePaths>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Keep binary identity stable within a package major; regexes strip prerelease labels. -->
+    <_KevlarVersionForAssembly Condition="'$(Version)' != ''">$(Version)</_KevlarVersionForAssembly>
+    <_KevlarVersionForAssembly Condition="'$(_KevlarVersionForAssembly)' == '' and '$(VersionPrefix)' != ''">$(VersionPrefix)</_KevlarVersionForAssembly>
+    <_KevlarVersionForAssembly Condition="'$(_KevlarVersionForAssembly)' == ''">1.0.0</_KevlarVersionForAssembly>
+    <_KevlarAssemblyMajor>$([System.Text.RegularExpressions.Regex]::Match('$(_KevlarVersionForAssembly)', '^[0-9]+').Value)</_KevlarAssemblyMajor>
+    <_KevlarFileVersion>$([System.Text.RegularExpressions.Regex]::Match('$(_KevlarVersionForAssembly)', '^[0-9]+\.[0-9]+\.[0-9]+').Value).0</_KevlarFileVersion>
+    <AssemblyVersion>$(_KevlarAssemblyMajor).0.0.0</AssemblyVersion>
+    <FileVersion>$(_KevlarFileVersion)</FileVersion>
+    <!-- Ignore GitVersion's richer build metadata so SourceLink appends the commit exactly once. -->
+    <InformationalVersion Condition="'$(Version)' != ''">$(Version)</InformationalVersion>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
   </PropertyGroup>

--- a/docs/docs/library-authors.md
+++ b/docs/docs/library-authors.md
@@ -99,3 +99,17 @@ Each attempt the user's retries make still runs through your inner timeout — t
 ## Dependency injection
 
 Nothing extra is needed on your side: a `Shield` constructor parameter resolves like any other dependency. Users on `Microsoft.Extensions.DependencyInjection` can register named shields and bind them from configuration via [`Kevlar.Extensions.DependencyInjection`](dependency-injection.md), then pass them to your library as [keyed services](dependency-injection.md#consuming-as-a-keyed-service).
+
+## Assembly identity and strong naming
+
+Kevlar assemblies are intentionally not strong-named. The core package depends on Reservoir, which
+is not strong-named, and .NET Framework does not allow a strong-named assembly to reference an
+unsigned dependency. Consequently, a strong-named .NET Framework library cannot reference Kevlar.
+Applications and unsigned libraries on .NET Framework, plus all consumers on modern .NET, are not
+affected.
+
+Strong names establish assembly identity, not publisher trust or code security. Adding one would
+change Kevlar's assembly identity and therefore requires a major release. Assembly versions are
+pinned to the package major (`1.0.0.0` throughout the 1.x line), so minor and patch releases do not
+create binding-redirect churn if the signing decision changes in a future major release. See
+[Microsoft's strong-naming guidance](https://learn.microsoft.com/dotnet/standard/library-guidance/strong-naming).

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -109,6 +109,27 @@ function Assert-DeterministicAssembly(
     }
 }
 
+function Get-AssemblyDetails([System.IO.Compression.ZipArchiveEntry]$Entry)
+{
+    $assemblyPath = Join-Path ([System.IO.Path]::GetTempPath()) "$([guid]::NewGuid().ToString('N')).dll"
+    try
+    {
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($Entry, $assemblyPath)
+        $assemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($assemblyPath)
+        $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($assemblyPath)
+        return [pscustomobject]@{
+            AssemblyVersion = $assemblyName.Version.ToString()
+            FileVersion = $versionInfo.FileVersion
+            InformationalVersion = $versionInfo.ProductVersion
+            PublicKeyToken = [Convert]::ToHexString($assemblyName.GetPublicKeyToken()).ToLowerInvariant()
+        }
+    }
+    finally
+    {
+        Remove-Item -LiteralPath $assemblyPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Get-ArchiveEntryHash([string]$ArchivePath, [string]$EntryPath)
 {
     $archive = [System.IO.Compression.ZipFile]::OpenRead($ArchivePath)
@@ -143,7 +164,8 @@ $buildPropertiesJson = & dotnet msbuild `
     (Join-Path $repositoryRoot 'src/Kevlar/Kevlar.csproj') `
     -nologo `
     -p:CI=true `
-    -getProperty:Deterministic,ContinuousIntegrationBuild,DeterministicSourcePaths,PublishRepositoryUrl,EmbedUntrackedSources,IncludeSymbols,SymbolPackageFormat
+    "-p:Version=$Version" `
+    -getProperty:Deterministic,ContinuousIntegrationBuild,DeterministicSourcePaths,PublishRepositoryUrl,EmbedUntrackedSources,IncludeSymbols,SymbolPackageFormat,SignAssembly,AssemblyVersion,FileVersion,InformationalVersion
 if ($LASTEXITCODE -ne 0)
 {
     throw 'Unable to inspect deterministic build properties.'
@@ -157,6 +179,7 @@ Assert-Equal 'PublishRepositoryUrl' $buildProperties.PublishRepositoryUrl 'true'
 Assert-Equal 'EmbedUntrackedSources' $buildProperties.EmbedUntrackedSources 'true'
 Assert-Equal 'IncludeSymbols' $buildProperties.IncludeSymbols 'true'
 Assert-Equal 'SymbolPackageFormat' $buildProperties.SymbolPackageFormat 'snupkg'
+Assert-Equal 'SignAssembly' $buildProperties.SignAssembly 'false'
 
 $packageDirectory = (Resolve-Path -LiteralPath $PackagesPath).Path
 $expectedRepositoryCommit = (& git rev-parse HEAD).Trim()
@@ -164,6 +187,14 @@ if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($expectedRepositoryComm
 {
     throw 'Unable to determine the expected repository commit.'
 }
+
+$numericVersion = [Version](($Version -split '[-+]')[0])
+$expectedAssemblyVersion = "$($numericVersion.Major).0.0.0"
+$expectedFileVersion = "$($numericVersion.Major).$($numericVersion.Minor).$($numericVersion.Build).0"
+$expectedInformationalVersion = "$Version+$expectedRepositoryCommit"
+Assert-Equal 'AssemblyVersion build property' $buildProperties.AssemblyVersion $expectedAssemblyVersion
+Assert-Equal 'FileVersion build property' $buildProperties.FileVersion $expectedFileVersion
+Assert-Equal 'InformationalVersion build property' $buildProperties.InformationalVersion $Version
 
 $centralPackagesPath = Join-Path $PSScriptRoot '..\Directory.Packages.props'
 [xml]$centralPackages = Get-Content -LiteralPath $centralPackagesPath -Raw
@@ -338,6 +369,11 @@ foreach ($packageId in $expectedDependencies.Keys)
         foreach ($assemblyEntry in $archive.Entries | Where-Object { $_.FullName -like '*.dll' })
         {
             Assert-DeterministicAssembly "$packageId $($assemblyEntry.FullName)" $assemblyEntry
+            $details = Get-AssemblyDetails $assemblyEntry
+            Assert-Equal "$packageId $($assemblyEntry.FullName) public key token" $details.PublicKeyToken ''
+            Assert-Equal "$packageId $($assemblyEntry.FullName) AssemblyVersion" $details.AssemblyVersion $expectedAssemblyVersion
+            Assert-Equal "$packageId $($assemblyEntry.FullName) FileVersion" $details.FileVersion $expectedFileVersion
+            Assert-Equal "$packageId $($assemblyEntry.FullName) InformationalVersion" $details.InformationalVersion $expectedInformationalVersion
         }
     }
     finally


### PR DESCRIPTION
Closes #188.

## Decision
Kevlar remains intentionally unsigned for 1.x. `Reservoir` 1.4.0 is unsigned, and .NET Framework strong naming is viral: signing Kevlar while retaining that dependency is not a valid supported configuration. The limitation and major-release migration boundary are now explicit in the library-author docs.

## Behavior
- pins `AssemblyVersion` to `<package-major>.0.0.0`
- keeps `FileVersion` at the numeric package version
- keeps `InformationalVersion` at full SemVer plus commit
- verifies all packed assemblies remain unsigned and carry the exact version policy

Microsoft guidance: https://learn.microsoft.com/dotnet/standard/library-guidance/strong-naming

## Validation
- `dotnet build Kevlar.slnx -c Release -p:Version=1.2.3-alpha.4 -p:CI=true`
- core tests: 845 passed
- integration tests: 131 passed
- analyzer tests: 78 passed
- Testing tests: 51 passed
- Chaos tests: 33 passed
- rate-limiting tests: 24 passed
- allocation tests: 3 passed
- netstandard tests: 10 + 4 passed
- `pwsh scripts/Verify-Docs.ps1`
- `npm run build` in `docs/`
- package identity checks passed for all eight packages; full verification then hit the existing gRPC symbol-manifest mismatch addressed by #258