### PR TITLE
fix(packaging): pin friend dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
   `AddStandardHedgingShield` are unchanged.
 ### Changed
 
+- `Kevlar.Testing` and `Kevlar.Extensions.RateLimiting` now require the exact matching `Kevlar`
+  package version. These packages still use core implementation details for structured inspection
+  and metrics, so NuGet now reports unsafe version-skew combinations as `NU1608` (and rejects them
+  when NuGet warnings are errors) instead of silently allowing runtime compatibility failures.
 - Custom strategies can override `Strategy.InvokesContinuationAtMostOnce`; the same aggregate
   value is now exposed on `Shield<TResult>` as well as `Shield` and `VoidShield`.
 - **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,14 @@
+<Project>
+
+  <Target Name="PinKevlarDependencyVersion"
+          AfterTargets="_GetProjectReferenceVersions"
+          Condition="'$(PinKevlarDependencyVersion)' == 'true'">
+    <ItemGroup>
+      <_ProjectReferencesWithVersions Update="@(_ProjectReferencesWithVersions)"
+                                      Condition="'%(Filename)' == 'Kevlar'">
+        <ProjectVersion>[%(_ProjectReferencesWithVersions.ProjectVersion)]</ProjectVersion>
+      </_ProjectReferencesWithVersions>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -281,6 +281,15 @@ foreach ($packageId in $expectedDependencies.Keys)
             foreach ($dependency in $dependencies)
             {
                 Assert-Set "$packageId $framework $($dependency.GetAttribute('id')) excluded assets" ($dependency.GetAttribute('exclude') -split ',') @('Build', 'Analyzers')
+
+                if ($dependency.GetAttribute('id') -eq 'Kevlar' -and
+                    $packageId -in @('Kevlar.Testing', 'Kevlar.Extensions.RateLimiting'))
+                {
+                    Assert-Equal `
+                        "$packageId $framework Kevlar dependency version" `
+                        $dependency.GetAttribute('version') `
+                        "[$Version]"
+                }
             }
         }
 
@@ -482,6 +491,54 @@ try
 "@
     $nugetConfigPath = Join-Path $temporaryRoot 'NuGet.Config'
     Write-TextFile $nugetConfigPath $nugetConfig
+
+    $skewVersion = '999.0.0-skew'
+    $skewFeed = Join-Path $temporaryRoot 'skew-feed'
+    [System.IO.Directory]::CreateDirectory($skewFeed) | Out-Null
+    Get-ChildItem -LiteralPath $packageDirectory -Filter '*.nupkg' -File |
+        Copy-Item -Destination $skewFeed
+    Invoke-DotNet @(
+        'pack', (Join-Path $repositoryRoot 'src/Kevlar/Kevlar.csproj'),
+        '-c', 'Release',
+        '--no-build',
+        "-p:Version=$skewVersion",
+        '-p:CI=true',
+        "-p:PackageOutputPath=$skewFeed")
+
+    $escapedSkewFeed = [System.Security.SecurityElement]::Escape($skewFeed)
+    $skewNugetConfig = $nugetConfig.Replace($escapedPackageDirectory, $escapedSkewFeed)
+    $skewNugetConfigPath = Join-Path $temporaryRoot 'NuGet.Skew.Config'
+    Write-TextFile $skewNugetConfigPath $skewNugetConfig
+    $skewConsumerDirectory = Join-Path $temporaryRoot 'version-skew'
+    $skewConsumerProject = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Kevlar" Version="$skewVersion" />
+    <PackageReference Include="Kevlar.Testing" Version="$Version" />
+  </ItemGroup>
+</Project>
+"@
+    $skewConsumerProjectPath = Join-Path $skewConsumerDirectory 'VersionSkew.csproj'
+    Write-TextFile $skewConsumerProjectPath $skewConsumerProject
+    $skewRestoreOutput = (& dotnet restore `
+        $skewConsumerProjectPath `
+        --configfile $skewNugetConfigPath `
+        --no-cache `
+        --force-evaluate 2>&1 | Out-String)
+    if ($LASTEXITCODE -eq 0)
+    {
+        throw "NuGet accepted Kevlar.Testing $Version with incompatible Kevlar $skewVersion.`n$skewRestoreOutput"
+    }
+
+    if ($skewRestoreOutput -notmatch '\bNU1608\b' -or
+        $skewRestoreOutput -notmatch [regex]::Escape("Kevlar.Testing $Version"))
+    {
+        throw "Version-skew restore did not report the expected exact-dependency conflict.`n$skewRestoreOutput"
+    }
 
     $runtimeProgram = @'
 using Kevlar;

--- a/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
+++ b/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <Description>System.Threading.RateLimiting adapters for Kevlar shields, including partitioned and custom asynchronous lease acquisition.</Description>
     <PackageTags>resilience;rate-limiting;system-threading-ratelimiting;kevlar</PackageTags>
+    <PinKevlarDependencyVersion>true</PinKevlarDependencyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kevlar.Testing/Kevlar.Testing.csproj
+++ b/src/Kevlar.Testing/Kevlar.Testing.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <Description>Pipeline inspection, assertions, and deterministic time helpers for testing Kevlar shields.</Description>
     <PackageTags>resilience;testing;assertions;pipeline-inspection;fake-time;kevlar</PackageTags>
+    <PinKevlarDependencyVersion>true</PinKevlarDependencyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- exact-pin `Kevlar.Testing` and `Kevlar.Extensions.RateLimiting` to the matching `Kevlar` package version while their friend-assembly coupling remains
- verify every relevant nuspec dependency group emits `[version]`
- simulate a higher direct core dependency and require the resulting `NU1608` conflict to fail under warnings-as-errors

## Why exact pinning

Removing IVT from `Kevlar.Testing` would require duplicating the complete typed descriptor and live state-snapshot model as a new public core API. The issue explicitly permits exact pinning as the compatibility fallback; this keeps the existing API surface stable while making the internal coupling visible to NuGet.

## Validation
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] core tests: 845 passed
- [x] Testing tests: 51 passed
- [x] rate-limiting tests: 24 passed
- [x] full `scripts/Verify-Packages.ps1`
  - exact dependency ranges
  - incompatible-version `NU1608` rejection under warnings-as-errors
  - deterministic assemblies and SourceLink
  - net8/net10 package consumers
  - trimmed/single-file publish compatibility
  - analyzer consumer

Closes #189