### PR TITLE
build(deps): lower shipped floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,10 @@ jobs:
           PACKAGE_VERSION: ${{ steps.gitversion.outputs.semVer }}
         run: ./scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version $env:PACKAGE_VERSION
 
+      - name: Validate Renovate configuration
+        if: matrix.os == 'ubuntu-latest'
+        run: npx --yes --package renovate -- renovate-config-validator renovate.json
+
       - name: Compile and execute documentation snippets
         if: matrix.os == 'ubuntu-latest'
         shell: pwsh

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,16 +8,17 @@
     <!-- Core (netstandard2.0 only) -->
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
-    <PackageVersion Include="Reservoir" Version="1.4.0" />
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
+    <PackageVersion Include="Reservoir" Version="[1.4.0,2.0.0)" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
 
     <!-- Satellites -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
-    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
     <PackageVersion Include="Grpc.Core.Api" Version="2.83.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.83.0" />
 
@@ -27,7 +28,6 @@
 
     <!-- Tests -->
     <PackageVersion Include="TUnit" Version="1.65.51" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <TestBclTimeProviderVersion>10.0.11</TestBclTimeProviderVersion>
+    <TestExtensionsHttpVersion>10.0.11</TestExtensionsHttpVersion>
+    <TestExtensionsTimeProviderVersion>10.9.0</TestExtensionsTimeProviderVersion>
+    <TestRateLimitingVersion>10.0.11</TestRateLimitingVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,21 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Keep shipped dependency floors on .NET 8",
+      "matchManagers": ["nuget"],
+      "matchFileNames": ["Directory.Packages.props"],
+      "matchPackageNames": [
+        "Microsoft.Bcl.TimeProvider",
+        "Microsoft.Extensions.Configuration.Abstractions",
+        "Microsoft.Extensions.DependencyInjection.Abstractions",
+        "Microsoft.Extensions.Http",
+        "Microsoft.Extensions.Primitives",
+        "Microsoft.Extensions.TimeProvider.Testing",
+        "System.Threading.RateLimiting"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
+  ]
 }

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -43,6 +43,17 @@ function Get-NodeText([System.Xml.XmlNode]$Node, [string]$XPath)
     return $match.InnerText
 }
 
+function Get-CentralPackageVersion([System.Xml.XmlNode]$Project, [string]$PackageId)
+{
+    $version = Get-NodeText $Project "/Project/ItemGroup/PackageVersion[@Include='$PackageId']/@Version"
+    if ([string]::IsNullOrWhiteSpace($version))
+    {
+        throw "Could not resolve $PackageId from Directory.Packages.props."
+    }
+
+    return $version
+}
+
 function Write-TextFile([string]$Path, [string]$Contents)
 {
     [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($Path)) | Out-Null
@@ -234,12 +245,8 @@ Assert-Equal 'InformationalVersion build property' $buildProperties.Informationa
 
 $centralPackagesPath = Join-Path $PSScriptRoot '..\Directory.Packages.props'
 [xml]$centralPackages = Get-Content -LiteralPath $centralPackagesPath -Raw
-$configurationVersion = Get-NodeText $centralPackages "/Project/ItemGroup/PackageVersion[@Include='Microsoft.Extensions.Configuration']/@Version"
-$dependencyInjectionVersion = Get-NodeText $centralPackages "/Project/ItemGroup/PackageVersion[@Include='Microsoft.Extensions.DependencyInjection']/@Version"
-if ($null -eq $configurationVersion -or $null -eq $dependencyInjectionVersion)
-{
-    throw 'Could not resolve Microsoft.Extensions package versions from Directory.Packages.props.'
-}
+$configurationVersion = Get-CentralPackageVersion $centralPackages 'Microsoft.Extensions.Configuration'
+$dependencyInjectionVersion = Get-CentralPackageVersion $centralPackages 'Microsoft.Extensions.DependencyInjection'
 
 $expectedDependencies = @{
     'Kevlar' = @{
@@ -285,6 +292,21 @@ $expectedDependencies = @{
     'Kevlar.Analyzers' = @{
         '.NETStandard2.0' = @()
     }
+}
+
+$expectedDependencyVersions = @{}
+foreach ($dependencyId in @(
+    'Microsoft.Bcl.TimeProvider',
+    'Microsoft.Extensions.Configuration.Abstractions',
+    'Microsoft.Extensions.DependencyInjection.Abstractions',
+    'Microsoft.Extensions.Http',
+    'Microsoft.Extensions.Primitives',
+    'Microsoft.Extensions.TimeProvider.Testing',
+    'Reservoir',
+    'System.Threading.RateLimiting'))
+{
+    $expectedDependencyVersions[$dependencyId] =
+        (Get-CentralPackageVersion $centralPackages $dependencyId) -replace ',\s*', ', '
 }
 
 $packageFiles = @(Get-ChildItem -LiteralPath $packageDirectory -Filter '*.nupkg' -File)
@@ -378,14 +400,21 @@ foreach ($packageId in $expectedDependencies.Keys)
             foreach ($dependency in $dependencies)
             {
                 Assert-Set "$packageId $framework $($dependency.GetAttribute('id')) excluded assets" ($dependency.GetAttribute('exclude') -split ',') @('Build', 'Analyzers')
-
-                if ($dependency.GetAttribute('id') -eq 'Kevlar' -and
+                $dependencyId = $dependency.GetAttribute('id')
+                if ($dependencyId -eq 'Kevlar' -and
                     $packageId -in @('Kevlar.Testing', 'Kevlar.Extensions.RateLimiting'))
                 {
                     Assert-Equal `
                         "$packageId $framework Kevlar dependency version" `
                         $dependency.GetAttribute('version') `
                         "[$Version]"
+                }
+                elseif ($expectedDependencyVersions.ContainsKey($dependencyId))
+                {
+                    Assert-Equal `
+                        "$packageId $framework $dependencyId version" `
+                        $dependency.GetAttribute('version') `
+                        $expectedDependencyVersions[$dependencyId]
                 }
             }
         }
@@ -653,6 +682,7 @@ using Kevlar.Extensions.Grpc;
 using Kevlar.Extensions.Http;
 using Kevlar.Extensions.RateLimiting;
 using Kevlar.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
@@ -747,6 +777,21 @@ if (injections != 1)
 IServiceCollection services = new ServiceCollection();
 services.AddShield("consumer", shield);
 services.AddHttpClient("consumer").AddStandardShield();
+var configuration = new ConfigurationBuilder()
+    .AddInMemoryCollection(new Dictionary<string, string?>
+    {
+        ["Retry:MaxRetries"] = "0",
+        ["Retry:Backoff"] = "None",
+    })
+    .Build();
+services.AddReloadingShield("reloading", configuration);
+using var provider = services.BuildServiceProvider();
+var registry = provider.GetRequiredService<IKevlarRegistry>();
+if (!ReferenceEquals(registry.GetShield("consumer"), shield)
+    || registry.GetShield("reloading").ToString() != "reloading: Retry(0, no delay)")
+{
+    throw new InvalidOperationException("Dependency injection package execution failed.");
+}
 _ = new ShieldUnaryClientInterceptor(GrpcShield.WhenTransient().Retry(1));
 using var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
 {
@@ -778,6 +823,7 @@ sealed class ExpectedConsumerException : Exception;
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors>`$(WarningsAsErrors);NU1605;NU1608</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Kevlar" Version="$Version" />
@@ -787,6 +833,10 @@ sealed class ExpectedConsumerException : Exception;
     <PackageReference Include="Kevlar.Extensions.RateLimiting" Version="$Version" />
     <PackageReference Include="Kevlar.Testing" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Grpc" Version="$Version" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="8.0.0" />
   </ItemGroup>
 </Project>
 "@

--- a/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
+++ b/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
+++ b/tests/Kevlar.Chaos.Tests/Kevlar.Chaos.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="$(TestExtensionsTimeProviderVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Kevlar.Extensions.RateLimiting" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Testing" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Polly" />
   </ItemGroup>

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Kevlar.Extensions.RateLimiting" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Testing" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="$(TestExtensionsTimeProviderVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="Polly" />
   </ItemGroup>

--- a/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
+++ b/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.RateLimiting" VersionOverride="10.0.11" />
+    <PackageReference Include="System.Threading.RateLimiting" VersionOverride="$(TestRateLimitingVersion)" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
 

--- a/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
+++ b/tests/Kevlar.Extensions.RateLimiting.Tests/Kevlar.Extensions.RateLimiting.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Threading.RateLimiting" VersionOverride="10.0.11" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
 

--- a/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
+++ b/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="$(TestBclTimeProviderVersion)" />
     <PackageReference Include="TUnit" Condition="'$(TargetFramework)' != 'net48'" />
   </ItemGroup>
 

--- a/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
+++ b/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="10.0.11" />
     <PackageReference Include="TUnit" Condition="'$(TargetFramework)' != 'net48'" />
   </ItemGroup>
 

--- a/tests/Kevlar.NetStandard21.Tests/Kevlar.NetStandard21.Tests.csproj
+++ b/tests/Kevlar.NetStandard21.Tests/Kevlar.NetStandard21.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="10.0.11" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
 

--- a/tests/Kevlar.NetStandard21.Tests/Kevlar.NetStandard21.Tests.csproj
+++ b/tests/Kevlar.NetStandard21.Tests/Kevlar.NetStandard21.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="$(TestBclTimeProviderVersion)" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
 

--- a/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
+++ b/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
+++ b/tests/Kevlar.Testing.Tests/Kevlar.Testing.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="TUnit" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="$(TestExtensionsTimeProviderVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Kevlar.Tests/Kevlar.Tests.csproj
+++ b/tests/Kevlar.Tests/Kevlar.Tests.csproj
@@ -9,10 +9,10 @@
   <ItemGroup>
     <PackageReference Include="TUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
-    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Kevlar.Tests/Kevlar.Tests.csproj
+++ b/tests/Kevlar.Tests/Kevlar.Tests.csproj
@@ -9,10 +9,10 @@
   <ItemGroup>
     <PackageReference Include="TUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="$(TestExtensionsTimeProviderVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
-    <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="$(TestExtensionsHttpVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #190.

## Behavior
- lowers shipped Microsoft.Extensions, RateLimiting, and TimeProvider dependency floors to .NET 8 versions
- bounds Reservoir to `[1.4.0, 2.0.0)`
- keeps test projects on .NET 10 packages through `VersionOverride`
- prevents Renovate major/minor updates from raising shipped floors
- verifies exact nuspec floors and a warning-clean net8 consumer using HTTP, DI/reloading, registry lookup, and rate limiting

## Validation
- `dotnet build Kevlar.slnx -c Release`
- core tests: 845 passed
- integration tests: 131 passed
- analyzer tests: 78 passed
- Testing tests: 51 passed
- Chaos tests: 33 passed
- rate-limiting tests: 24 passed
- allocation tests: 3 passed
- netstandard tests: 10 + 4 passed
- Renovate config validated with the official CLI
- full package verifier passed before final rebase, including the pinned net8 consumer and publish compatibility; final rerun reached only transient raw.githubusercontent.com propagation for the newly pushed SourceLink commit