### PR TITLE
docs: structure changelog for 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          fetch-depth: 0  # Required for changelog compare-link validation
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,17 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: npx --yes --package renovate -- renovate-config-validator renovate.json
 
+      - name: Verify changelog and release notes
+        if: matrix.os == 'ubuntu-latest'
+        shell: pwsh
+        run: |
+          ./scripts/Verify-Changelog.ps1
+          $heading = Select-String CHANGELOG.md -Pattern '^## \[([0-9]+\.[0-9]+\.[0-9]+)\]' | Select-Object -First 1
+          if ($null -eq $heading) { throw 'No release heading found.' }
+          $version = $heading.Matches[0].Groups[1].Value
+          $notes = ./scripts/Verify-Changelog.ps1 -ReleaseVersion $version
+          if ([string]::IsNullOrWhiteSpace(($notes | Out-String))) { throw "$version release notes are empty." }
+
       - name: Compile and execute documentation snippets
         if: matrix.os == 'ubuntu-latest'
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,13 +223,12 @@ jobs:
       - name: Verify changelog and release notes
         if: matrix.os == 'ubuntu-latest'
         shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ steps.gitversion.outputs.semVer }}
         run: |
           ./scripts/Verify-Changelog.ps1
-          $heading = Select-String CHANGELOG.md -Pattern '^## \[([0-9]+\.[0-9]+\.[0-9]+)\]' | Select-Object -First 1
-          if ($null -eq $heading) { throw 'No release heading found.' }
-          $version = $heading.Matches[0].Groups[1].Value
-          $notes = ./scripts/Verify-Changelog.ps1 -ReleaseVersion $version
-          if ([string]::IsNullOrWhiteSpace(($notes | Out-String))) { throw "$version release notes are empty." }
+          $notes = ./scripts/Get-ReleaseNotes.ps1 -Version $env:RELEASE_VERSION
+          if ([string]::IsNullOrWhiteSpace(($notes | Out-String))) { throw "$env:RELEASE_VERSION release notes are empty." }
 
       - name: Compile and execute documentation snippets
         if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
-- `VoidShield` and `PartitionedVoidShield<TKey>` provide compile-time-safe void execution across
-  core, dependency injection, rate limiting, testing, wrapping, and state snapshots.
 - Result clauses include `WhenResultIsNull`, `OrResultIsNull`, `WhenResultIsDefault`, and
   `OrResultIsDefault` for nullable, value-type, and generic results.
 - Reactive strategy options can replace ambient handling with `HandlesException` and typed
@@ -30,15 +28,23 @@ All notable changes to this project are documented here. The format follows
   result-aware pipelines.
 - Context-only synchronous and asynchronous execution overloads expose `KevlarContext` without
   requiring seeded state.
-- Analyzer rules KEV001–KEV004 and KEV006–KEV011 cover ignored cancellation, ineffective handling,
-  invalid ordering, untyped hedging, discarded builders and fluent calls, inherited handling,
-  implicit default handling, and suspicious default-value matching.
+- Analyzer rules KEV001–KEV011 cover ignored cancellation, ineffective handling, invalid ordering,
+  state lifetime, void fallback/result mismatches, untyped hedging, discarded builders and fluent
+  calls, inherited and implicit default handling, and suspicious default-value matching.
+- Circuit-open, rate-limit, concurrency-limit, and timeout rejections derive from
+  `ExecutionRejectedException`, which provides their common `RetryAfter` property. Concrete public
+  exception types expose conventional constructors while retaining metadata-specific overloads.
 
 ### Changed
 
 - `Kevlar.Testing` and `Kevlar.Extensions.RateLimiting` require the exact matching `Kevlar` package
   version. NuGet reports version-skew combinations as `NU1608` instead of allowing incompatible
   package combinations.
+- HTTP retry and hedging stop after the first outcome when a request method or body cannot be
+  replayed safely. The original response or exception is preserved without a retry delay or
+  callback, while other resilience stages still observe the attempt.
+- Runtime dependency floors remain compatible with .NET 8-era Microsoft.Extensions,
+  System.Threading.RateLimiting, and TimeProvider packages; Reservoir is bounded to `[1.4.0, 2.0.0)`.
 - Typed constant fallbacks use `FallbackTo(value)`; delegate factories continue to use
   `Fallback(...)`. Null fallback values are no longer ambiguous with delegate overloads.
 - Handling clauses use `When...` to start and `Or...` to continue. `Shield.For<TResult>()` returns a
@@ -46,6 +52,8 @@ All notable changes to this project are documented here. The format follows
 - Typed and untyped retry, circuit-breaker, hedge, and fallback options are sealed sibling types
   with matching shared properties instead of inheritance. Shared configurator helpers need a
   separate typed counterpart such as `Action<RetryOptions<TResult>>`.
+- The `Hedge` method, options, testing descriptor, strategy kind, and standard HTTP registration
+  use one consistent `Hedge` stem.
 - `Shield.Wrap(...)` and `Shield.Compose(...)` seal ambient handling. Strategies appended after
   composition use default handling until another clause is declared.
 - `RetryForever` has explicit parameterless and `Backoff` overloads; explicit `null` is rejected.
@@ -56,7 +64,7 @@ All notable changes to this project are documented here. The format follows
   base delays are accepted beyond that limit, then computed delays clamp to their configured cap or
   the default one-day cap; custom delays clamp to the runtime timer limit.
 - Custom strategies can declare `InvokesContinuationAtMostOnce`; the aggregate is exposed on
-  `Shield`, `Shield<TResult>`, and `VoidShield`.
+  `Shield` and `Shield<TResult>`.
 - Every NuGet package embeds the canonical icon, links release notes, and carries a package README
   with status badges. `Kevlar.Analyzers` is a development dependency.
 - Queue capacity uses `QueueLimit` consistently across core strategies, adapters, dependency
@@ -70,9 +78,13 @@ All notable changes to this project are documented here. The format follows
 | Before | After |
 |---|---|
 | `WhenDefault()` | `WhenResultIsDefault()` |
+| `OrDefault()` | `OrResultIsDefault()` |
 | `OrWhen(predicate)` | `Or(predicate)` |
 | `HedgingOptions` | `HedgeOptions` |
-| untyped `Fallback(...)` returned `Shield` | untyped `Fallback(...)` returns `VoidShield` |
+| `HedgingStrategyDescriptor` | `HedgeStrategyDescriptor` |
+| `StrategyKind.Hedging` | `StrategyKind.Hedge` |
+| `StandardHedgingShieldOptions` | `StandardHedgeShieldOptions` |
+| `AddStandardHedgingShield(...)` | `AddStandardHedgeShield(...)` |
 | `FallbackWithNotifications(...)` or typed `onFallback` parameters | `Fallback(..., configure)` with `OnFallback` / `OnFallbackAsync` |
 | shared `Action<RetryOptions>` used by typed shields | separate `Action<RetryOptions<TResult>>` configurator |
 | `RetryForever(backoff: null)` | `RetryForever()` |
@@ -87,7 +99,7 @@ _ = Shield.For<int>().WhenResultIsDefault().FallbackTo(-1);
 _ = Shield.When<InvalidOperationException>().Or<TimeoutException>().RetryForever();
 _ = Shield.When<InvalidOperationException>().RetryForever(Backoff.None);
 _ = new HedgeOptions();
-VoidShield recovery = Shield.Fallback(static _ => ValueTask.CompletedTask);
+Shield recovery = Shield.Fallback(static _ => ValueTask.CompletedTask);
 _ = Shield.Empty.Wrap(Shield.Retry(1));
 ```
 
@@ -101,8 +113,9 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
 
 - Circuit-breaker validation identifies the conflicting properties and reports public parameter
   names.
-- Invalid fallback ordering is rejected at pipeline construction time; the void-only pipeline type
-  rejects incompatible result-returning calls at compile time.
+- Invalid fallback ordering is rejected at pipeline construction time. A shield containing a void
+  fallback rejects result-returning execution at the execution boundary, and KEV005 diagnoses
+  statically visible calls.
 - Custom backoff arithmetic cannot create negative or unbounded runtime delays.
 
 [Unreleased]: https://github.com/thomhurst/Kevlar/compare/v1.0.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ All notable changes to this project are documented here. The format follows
   result-aware pipelines.
 - Context-only synchronous and asynchronous execution overloads expose `KevlarContext` without
   requiring seeded state.
-- Analyzer rules KEV001–KEV004 and KEV006–KEV010 cover ignored cancellation, ineffective handling,
-  unsafe timeout matching, invalid ordering, untyped hedging, discarded builders and fluent calls,
-  inherited handling, and suspicious default-value matching.
+- Analyzer rules KEV001–KEV004 and KEV006–KEV011 cover ignored cancellation, ineffective handling,
+  invalid ordering, untyped hedging, discarded builders and fluent calls, inherited handling,
+  implicit default handling, and suspicious default-value matching.
 
 ### Changed
 
@@ -44,14 +44,25 @@ All notable changes to this project are documented here. The format follows
 - Handling clauses use `When...` to start and `Or...` to continue. `Shield.For<TResult>()` returns a
   `Shield<TResult>` directly.
 - Typed and untyped retry, circuit-breaker, hedge, and fallback options are sealed sibling types
-  with matching shared properties instead of inheritance.
+  with matching shared properties instead of inheritance. Shared configurator helpers need a
+  separate typed counterpart such as `Action<RetryOptions<TResult>>`.
 - `Shield.Wrap(...)` and `Shield.Compose(...)` seal ambient handling. Strategies appended after
   composition use default handling until another clause is declared.
 - `RetryForever` has explicit parameterless and `Backoff` overloads; explicit `null` is rejected.
 - Clause builders are immutable. Each `Or...` call returns a new builder and leaves the source
   builder unchanged.
 - Debug builds reject access to a pooled `KevlarContext` after it has been returned.
-- Backoff factories validate timer limits, and custom backoff results are clamped to safe bounds.
+- `Backoff.Constant` and explicit `maxDelay` values validate timer limits. Linear and exponential
+  base delays are accepted beyond that limit, then computed delays clamp to their configured cap or
+  the default one-day cap; custom delays clamp to the runtime timer limit.
+- Custom strategies can declare `InvokesContinuationAtMostOnce`; the aggregate is exposed on
+  `Shield`, `Shield<TResult>`, and `VoidShield`.
+- Every NuGet package embeds the canonical icon, links release notes, and carries a package README
+  with status badges. `Kevlar.Analyzers` is a development dependency.
+- Queue capacity uses `QueueLimit` consistently across core strategies, adapters, dependency
+  injection, and testing descriptors; shorthand parameters use `queueLimit`.
+- `Outcome<T>.Exception` recognizes `KevlarProxyException` by type instead of reading
+  `Exception.Data` on ordinary exception access.
 
 **Upgrading from 0.x**
 
@@ -62,8 +73,11 @@ All notable changes to this project are documented here. The format follows
 | `OrWhen(predicate)` | `Or(predicate)` |
 | `HedgingOptions` | `HedgeOptions` |
 | untyped `Fallback(...)` returned `Shield` | untyped `Fallback(...)` returns `VoidShield` |
+| `FallbackWithNotifications(...)` or typed `onFallback` parameters | `Fallback(..., configure)` with `OnFallback` / `OnFallbackAsync` |
+| shared `Action<RetryOptions>` used by typed shields | separate `Action<RetryOptions<TResult>>` configurator |
 | `RetryForever(backoff: null)` | `RetryForever()` |
 | ambient handling flowed past `Wrap`/`Compose` | `Wrap`/`Compose` seals the clause |
+| `maxQueue` / `MaxQueue` | `queueLimit` / `QueueLimit` |
 <!-- upgrade-from-0.x:end -->
 
 The replacement forms compile together:
@@ -87,8 +101,8 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
 
 - Circuit-breaker validation identifies the conflicting properties and reports public parameter
   names.
-- Fallback ordering and result compatibility failures are rejected at compile time through the
-  void-only pipeline type.
+- Invalid fallback ordering is rejected at pipeline construction time; the void-only pipeline type
+  rejects incompatible result-returning calls at compile time.
 - Custom backoff arithmetic cannot create negative or unbounded runtime delays.
 
 [Unreleased]: https://github.com/thomhurst/Kevlar/compare/v1.0.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ All notable changes to this project are documented here. The format follows
 - `Backoff.Constant` and explicit `maxDelay` values validate timer limits. Linear and exponential
   base delays are accepted beyond that limit, then computed delays clamp to their configured cap or
   the default one-day cap; custom delays clamp to the runtime timer limit.
+- Retry jitter configuration uses the `Jitter` enum. The former Boolean `false` maps to
+  `Jitter.None`; `true` maps to `Jitter.Equal`.
 - Custom strategies can declare `InvokesContinuationAtMostOnce`; the aggregate is exposed on
   `Shield` and `Shield<TResult>`.
 - Every NuGet package embeds the canonical icon, links release notes, and carries a package README
@@ -108,6 +110,9 @@ All notable changes to this project are documented here. The format follows
 | `RetryForever(backoff: null)` | `RetryForever()` |
 | ambient handling flowed past `Wrap`/`Compose` | `Wrap`/`Compose` seals the clause |
 | `maxQueue` / `MaxQueue` | `queueLimit` / `QueueLimit` |
+| `jitter: false` / `RetryDefinition.Jitter = false` | `jitter: Jitter.None` / `RetryDefinition.Jitter = Jitter.None` |
+| `jitter: true` / `RetryDefinition.Jitter = true` | `jitter: Jitter.Equal` / `RetryDefinition.Jitter = Jitter.Equal` |
+| `RetryEvent.Attempt` / `RetryEvent<TResult>.Attempt` / `HedgeEvent.Attempt` | `AttemptNumber` |
 <!-- upgrade-from-0.x:end -->
 
 The replacement forms compile together:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project are documented here. The format follows
   manual monitor transitions carry a detached context at index `-1`. Typed circuit-breaker
   duration generators receive `CircuitBreakerBreakDurationEvent<TResult>` with a directly stored
   outcome and failure statistics. Typed retry events likewise store their outcome without boxing.
+- Hedging supports synchronous and asynchronous per-attempt delay generators with access to the
+  attempt number, execution context, and elapsed time. Standard endpoint-aware HTTP hedging
+  exposes the same adaptive delay hooks, and `Kevlar.Testing` reports whether one is configured.
 - `HedgeOptions<TResult>.ActionGenerator` is now a strongly typed delegate. Assign the generator
   directly instead of wrapping it with `HedgeActionGenerator.Create<TResult>(...)`; the erased
   wrapper remains available on untyped `HedgeOptions`. Typed generator events now expose the latest
@@ -30,6 +33,14 @@ All notable changes to this project are documented here. The format follows
 - Typed constant-value `Fallback(value)` is now `FallbackTo(value)` on `Shield<TResult>` and
   `ShieldBuilder<TResult>`. Delegate factories remain `Fallback(...)`. This makes null fallback
   values explicit and avoids ambiguity between value and delegate overloads.
+- Named DI registrations now expose symmetric configuration overloads, typed
+  `IShieldProvider<TResult>` snapshots, and `AddReloadingShield<TResult>`.
+- The System.Threading.RateLimiting adapter now uses `UseRateLimiter(...)`,
+  `RateLimiterAdapterRejectedEvent`, and `RateLimiterAdapterRejectedException`. The distinct names
+  separate adapter-backed strategies from Kevlar's built-in `RateLimit(...)` strategy.
+- `StandardHttpShieldOptions.CircuitBreaker` now uses
+  `CircuitBreakerOptions<HttpResponseMessage>`, exposing typed result predicates for the standard
+  HTTP breaker.
 
 ## [1.0.0] - 2026-08-24
 
@@ -98,6 +109,10 @@ All notable changes to this project are documented here. The format follows
 | `WhenDefault()` | `WhenResultIsDefault()` |
 | `OrDefault()` | `OrResultIsDefault()` |
 | `OrWhen(predicate)` | `Or(predicate)` |
+| `builder.When<TException>()` / `builder.When<TException>(predicate)` | `builder.Or<TException>()` / `builder.Or<TException>(predicate)` |
+| `builder.When(predicate)` | `builder.Or(predicate)` |
+| `builder.WhenResult(predicate)` / `builder.WhenResult(value)` | `builder.OrResult(predicate)` / `builder.OrResult(value)` |
+| `builder.WhenDefault()` | `builder.OrResultIsDefault()` |
 | `HedgingOptions` | `HedgeOptions` |
 | `HedgingStrategyDescriptor` | `HedgeStrategyDescriptor` |
 | `StrategyKind.Hedging` | `StrategyKind.Hedge` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ All notable changes to this project are documented here. The format follows
   manual monitor transitions carry a detached context at index `-1`. Typed circuit-breaker
   duration generators receive `CircuitBreakerBreakDurationEvent<TResult>` with a directly stored
   outcome and failure statistics. Typed retry events likewise store their outcome without boxing.
+- `HedgeOptions<TResult>.ActionGenerator` is now a strongly typed delegate. Assign the generator
+  directly instead of wrapping it with `HedgeActionGenerator.Create<TResult>(...)`; the erased
+  wrapper remains available on untyped `HedgeOptions`. Typed generator events now expose the latest
+  available `Outcome<TResult>`.
+- Untyped `Fallback(...)` continues to return `Shield`. The pre-release untyped shield type family
+  and its satellite overloads were removed. Result-returning execution through a void fallback is
+  guarded by the restored `KEV005` analyzer; use `Shield.For<TResult>().Fallback(...)` for
+  result-producing recovery.
+- Configure fallback notifications through `Fallback(..., configure)`. The pre-release
+  notification-specific methods and typed `onFallback` parameters were removed, including the
+  migration-only error overloads that briefly replaced them. Every fallback shape now has exactly
+  two overloads — bare and `Action<FallbackOptions>`/`Action<FallbackOptions<TResult>>` — on
+  `Shield`, `Shield<TResult>`, `ShieldBuilder`, and `ShieldBuilder<TResult>`.
+- Typed constant-value `Fallback(value)` is now `FallbackTo(value)` on `Shield<TResult>` and
+  `ShieldBuilder<TResult>`. Delegate factories remain `Fallback(...)`. This makes null fallback
+  values explicit and avoids ambiguity between value and delegate overloads.
 
 ## [1.0.0] - 2026-08-24
 
@@ -85,6 +101,8 @@ All notable changes to this project are documented here. The format follows
 | `StrategyKind.Hedging` | `StrategyKind.Hedge` |
 | `StandardHedgingShieldOptions` | `StandardHedgeShieldOptions` |
 | `AddStandardHedgingShield(...)` | `AddStandardHedgeShield(...)` |
+| `VoidShield` / `VoidShieldBuilder` | `Shield` / `ShieldBuilder`; use `Shield.For<TResult>()` when recovery produces a result |
+| `PartitionedVoidShield<TKey>` | `PartitionedShield<TKey>` |
 | `FallbackWithNotifications(...)` or typed `onFallback` parameters | `Fallback(..., configure)` with `OnFallback` / `OnFallbackAsync` |
 | shared `Action<RetryOptions>` used by typed shields | separate `Action<RetryOptions<TResult>>` configurator |
 | `RetryForever(backoff: null)` | `RetryForever()` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ All notable changes to this project are documented here. The format follows
   result-aware pipelines.
 - Context-only synchronous and asynchronous execution overloads expose `KevlarContext` without
   requiring seeded state.
+- Handling-clause builders now match their shield counterparts for configured timeouts, direct
+  custom strategies, and void fallbacks that do not need the handled exception.
 - Analyzer rules KEV001–KEV011 cover ignored cancellation, ineffective handling, invalid ordering,
   state lifetime, void fallback/result mismatches, untyped hedging, discarded builders and fluent
   calls, inherited and implicit default handling, and suspicious default-value matching.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ All notable changes to this project are documented here. The format follows
 | `builder.When(predicate)` | `builder.Or(predicate)` |
 | `builder.WhenResult(predicate)` / `builder.WhenResult(value)` | `builder.OrResult(predicate)` / `builder.OrResult(value)` |
 | `builder.WhenDefault()` | `builder.OrResultIsDefault()` |
+| `Shield.For<TResult>().Or<TException>()` / `.Or(predicate)` | `Shield.For<TResult>().When<TException>()` / `.When(predicate)` |
+| `ShieldBuilder<TResult> builder = Shield.For<TResult>()` | `Shield<TResult> shield = Shield.For<TResult>()` |
 | `HedgingOptions` | `HedgeOptions` |
 | `HedgingStrategyDescriptor` | `HedgeStrategyDescriptor` |
 | `StrategyKind.Hedging` | `StrategyKind.Hedge` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## Unreleased
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Breaking changes
+## [Unreleased]
+
+### Changed
 
 - Strategy callback events now expose their position through public
   `KevlarContext.StrategyIndex`; the duplicate properties on limiter rejection events were removed.
@@ -10,159 +14,82 @@
   manual monitor transitions carry a detached context at index `-1`. Typed circuit-breaker
   duration generators receive `CircuitBreakerBreakDurationEvent<TResult>` with a directly stored
   outcome and failure statistics. Typed retry events likewise store their outcome without boxing.
-- `HedgeOptions<TResult>.ActionGenerator` is now a strongly typed delegate. Assign the generator
-  directly instead of wrapping it with `HedgeActionGenerator.Create<TResult>(...)`; the erased
-  wrapper remains available on untyped `HedgeOptions`. Typed generator events now expose the latest
-  available `Outcome<TResult>`.
-- Untyped `Fallback(...)` continues to return `Shield`. The pre-release `VoidShield`,
-  `VoidShieldBuilder`, and `PartitionedVoidShield<TKey>` types and their satellite overloads were
-  removed. Result-returning execution through a void fallback is guarded by the restored `KEV005`
-  analyzer; use `Shield.For<TResult>().Fallback(...)` for result-producing recovery.
-- Configure fallback notifications through `Fallback(..., configure)`. The pre-release `FallbackWithNotifications` methods and typed `onFallback` parameters were removed, including the migration-only error overloads that briefly replaced them. Every fallback shape now has exactly two overloads — bare and `Action<FallbackOptions>`/`Action<FallbackOptions<TResult>>` — on `Shield`, `Shield<TResult>`, `ShieldBuilder` and `ShieldBuilder<TResult>`.
-- Typed constant-value `Fallback(value)` is now `FallbackTo(value)` on `Shield<TResult>` and
-  `ShieldBuilder<TResult>`. Delegate factories remain `Fallback(...)`. This makes null fallback
-  values explicit and avoids ambiguity between value and delegate overloads.
-- The System.Threading.RateLimiting adapter now uses `UseRateLimiter(...)`,
-  `RateLimiterAdapterRejectedEvent`, and `RateLimiterAdapterRejectedException`. The distinct names
-  separate adapter-backed strategies from Kevlar's built-in `RateLimit(...)` strategy.
-- `StandardHttpShieldOptions.CircuitBreaker` now uses
-  `CircuitBreakerOptions<HttpResponseMessage>`, exposing typed result predicates for the standard
-  HTTP breaker.
 
-Handling clauses now use one spelling per position. `When…` starts a clause on `Shield` or
-`Shield<TResult>`; only `Or…` continues it on a builder. `Shield.For<TResult>()` now returns
-`Shield<TResult>` directly.
-
-| Before | After |
-|---|---|
-| `Shield.When<A>().When<B>()` | `Shield.When<A>().Or<B>()` |
-| `Shield.For<T>().Or<A>()` | `Shield.For<T>().When<A>()` |
-| `ShieldBuilder<T> builder = Shield.For<T>()` | `Shield<T> shield = Shield.For<T>()` |
-| `builder.OrWhen(predicate)` | `builder.Or(predicate)` |
-| `Shield.For<T>().WhenDefault()` | `Shield.For<T>().WhenResultIsDefault()` |
-| `builder.OrDefault()` | `builder.OrResultIsDefault()` |
-| `Shield.For<T>().Fallback(value)` | `Shield.For<T>().FallbackTo(value)` |
-| `ConcurrencyLimit(..., maxQueue: n)` / `options.MaxQueue` | `ConcurrencyLimit(..., queueLimit: n)` / `options.QueueLimit` |
-| `HedgingOptions` | `HedgeOptions` |
-| `HedgingStrategyDescriptor` | `HedgeStrategyDescriptor` |
-| `StrategyKind.Hedging` | `StrategyKind.Hedge` |
-| `StandardHedgingShieldOptions` | `StandardHedgeShieldOptions` |
-| `AddStandardHedgingShield(...)` | `AddStandardHedgeShield(...)` |
-| adapter `.RateLimit(limiter)` | `.UseRateLimiter(limiter)` |
-| `RateLimiterRejectedEvent` | `RateLimiterAdapterRejectedEvent` |
-| adapter `RateLimitExceededException` | `RateLimiterAdapterRejectedException` |
-| `StandardHttpShieldOptions.CircuitBreaker` as `CircuitBreakerOptions` | `CircuitBreakerOptions<HttpResponseMessage>` |
-
-`OrWhen` is gone: `Or(Func<Exception, bool>)` now mirrors `When(Func<Exception, bool>)`, so the
-untyped predicate has the same spelling in both clause positions. `WhenDefault`/`OrDefault` were
-renamed to `WhenResultIsDefault`/`OrResultIsDefault` because their "default" is `default(TResult)`,
-not the default *handling* that the neighbouring `WhenAnyError()` restores. (An earlier pre-release
-build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the reading unambiguous.)
-
-- Retry, circuit-breaker, hedge, and fallback options are sealed sibling types. Each typed/untyped
-  pair retains the same shared property names and scalar defaults, but helpers that accept an
-  untyped options type must configure typed options separately. Typed callbacks and result
-  predicates keep their exact compile-time types.
-- The `Hedge` method, options, testing descriptors, strategy kind, and standard HTTP registration
-  now share one `Hedge` stem, like `Retry`/`RetryOptions` and `Timeout`/`TimeoutOptions`.
-- Circuit-open, rate-limit, concurrency-limit, and timeout rejections now derive from
-  `ExecutionRejectedException`, which provides their common `RetryAfter` property. Concrete public
-  exception types expose the conventional `()`, `(string)`, and `(string, Exception)` constructors;
-  the metadata-specific constructors remain available.
-
-### Changed
-
-- Hedging now supports synchronous and asynchronous per-attempt delay generators with access to
-  the attempt number, execution context, and elapsed time. Standard endpoint-aware HTTP hedging
-  exposes the same adaptive delay hooks, and `Kevlar.Testing` reports whether one is configured.
-- Named DI registrations now expose symmetric configuration overloads, typed
-  `IShieldProvider<TResult>` snapshots, and `AddReloadingShield<TResult>`.
-- Handling-clause builders now match their shield counterparts for configured timeouts, direct
-  custom strategies, and void fallbacks that do not need the handled exception.
-- Every NuGet package now embeds the canonical Kevlar icon, links release notes, and carries a
-  NuGet-safe README with status badges. `Kevlar.Analyzers` is marked as a development dependency
-  so it does not flow from a packed consumer library.
-- `Kevlar.Testing` and `Kevlar.Extensions.RateLimiting` now require the exact matching `Kevlar`
-  package version. These packages still use core implementation details for structured inspection
-  and metrics, so NuGet now reports unsafe version-skew combinations as `NU1608` (and rejects them
-  when NuGet warnings are errors) instead of silently allowing runtime compatibility failures.
-- `Outcome<T>.Exception` now recognizes `KevlarProxyException` with a type check instead of reading
-  `Exception.Data` on every access. Adapter packages can preserve internal transport bookkeeping
-  while exposing the original failure without allocating an exception data dictionary.
-- HTTP retry and hedging now stop after the first outcome when a request method or body cannot be
-  replayed safely. The original response or exception is preserved without a retry delay or
-  callback, while timeout, circuit-breaker, and concurrency stages still observe the attempt.
-  `NoBuffer` can replay inherently re-readable and already-buffered content.
-- Custom strategies can override `Strategy.InvokesContinuationAtMostOnce`; the same aggregate
-  value is now exposed on `Shield<TResult>` as well as `Shield`.
-- **Breaking:** `Shield.Wrap(...)` and `Shield.Compose(...)` now seal ambient handling clauses. Reactive strategies appended after composition use default handling unless a new clause is declared. Existing strategies inside composed shields keep their original handling.
-- `Backoff.Custom` documents the clamping the retry path already applied to its delegate's result: a
-  negative delay becomes zero, a delay above the runtime timer limit becomes that limit, and the
-  retry's own `MaxDelay` caps what is left.
-- The composition guide states that `outer.Wrap(inner)` and `Shield.Compose(outer, inner)` are the
-  same operation — same strategy order, same first non-null name and `TimeProvider`, same sealed
-  clause — so there is no semantic difference to hunt for.
-- Setting both `CircuitBreakerOptions.ConsecutiveFailures` and `FailureRatio` still throws, but the
-  message now names both properties and states the fix. `ConsecutiveFailures` range errors report
-  that property as the parameter name instead of `options`.
-- `HandlesException`/`HandlesResult` documentation on every options type now leads with the fact
-  that the property makes its strategy ignore the ambient `When…` clause, and points at
-  `HandlingClause`. `ShieldBuilder`/`ShieldBuilder<TResult>` document the override from the clause side.
-- `ShieldBuilder` and `ShieldBuilder<TResult>` are immutable. Every `Or…`/`OrResult…`/
-  `OrResultIsDefault` returns a *new* builder carrying the terms so far plus the one just added, and
-  leaves the builder it was called on untouched. Branching two chains from one stored builder is now
-  safe — each branch gets only its own terms — and a shield already built from a builder still keeps
-  the clause it was built with. The corollary is that only the builder an `Or…` *returns* carries
-  the new term; `builder.Or<T>();` written as a statement adds nothing, which `KEV007` reports.
-- **Breaking:** `RetryForever` is now two overloads — `RetryForever()` and `RetryForever(Backoff)` —
-  on `Shield` (static), `ShieldExtensions`, `Shield<TResult>`, `ShieldBuilder` and
-  `ShieldBuilder<TResult>`, replacing the single `RetryForever(Backoff? backoff = null)`. This
-  matches `Retry(int, Backoff)`, whose `Backoff` was already non-nullable. The parameterless
-  overload still uses `Backoff.Default`; passing `null` explicitly is no longer legal.
+## [1.0.0] - 2026-08-24
 
 ### Added
 
-- `WhenResultIsNull()` / `OrResultIsNull()` on `ShieldResultExtensions`: the null-result clause
-  `WhenResultIsDefault`/`OrResultIsDefault` was really written for, constrained to reference types
-  (`where TResult : class?`) so it cannot be written where `default` is an ordinary value. They
-  render as `[when null result]`. `WhenResultIsDefault`/`OrResultIsDefault` stay, for value types
-  and generic code.
-- `KEV010`: an informational hint on `WhenResultIsDefault`/`OrResultIsDefault` written for a
-  non-nullable value type, where `default(T)` — `0`, `false`, an empty struct — is as often a
-  legitimate result as a failure. `Nullable<T>` results and generic code are not flagged, and like
-  `KEV009` the hint never fails a build.
-- `KEV009`: an informational hint marking each reactive strategy that inherits a handling clause
-  declared earlier in its chain, so the clause's span is visible in the editor. It is `Info`
-  severity — the inheritance is by design, and the hint never fails a build. Proactive strategies
-  and strategies with a local `HandlesException`/`HandlesResult` override are never flagged.
-- `KEV008`: a fluent chaining call written as a statement, such as `shield.Retry(3);`. Shields are
-  immutable, so the new shield the call returns is thrown away and nothing is configured.
-  Discarded clause builders keep reporting as `KEV007`.
-- Pipeline descriptions show handling. `ToString()`/`Describe()` now prefixes each run of strategies
-  sharing a non-default clause with `[when …]` — for example
-  `[when HttpRequestException | TimeoutExceededException] Retry(3, no delay) → CircuitBreaker(5 consecutive, break 30s)`
-  — and marks a strategy whose options replaced the clause locally with `(local handling)`. Shields
-  that use only default handling describe exactly as before.
-- Debug builds of Kevlar enforce the pooled-context contract: after a `KevlarContext` goes back to
-  the pool, its `CancellationToken`, `Properties`, `ShieldName`, `TimeProvider` and `IsSynchronous`
-  throw `InvalidOperationException` until it is rented again. Release builds are unchanged and carry
-  no extra check.
-- `KEV007`: a `When…`/`Or…` handling clause that never reaches a reactive strategy — the
-  `ShieldBuilder` is discarded, or a later `When…`/`WhenAnyError()` replaces the clause while only
-  proactive strategies stood between them.
-- `Shield.Fallback(…)` static factories, mirroring the four untyped `ShieldExtensions.Fallback`
-  overloads, so a fallback can start a chain like every other strategy. Fallback-first is the
-  valid order: it recovers what the strategies chained inside it could not.
-- `Shield<TResult>.Compose(params Shield<TResult>[])`, the result-aware counterpart of
-  `Shield.Compose`. Same semantics: first shield outermost, first non-null name and
-  `TimeProvider` win, ambient handling clauses sealed.
-- Reactive strategy options can replace ambient handling locally with `HandlesException` and, on
-  typed options, `HandlesResult`. Testing descriptors expose `HasHandlingOverride`.
-- Context-only `ExecuteWithContext`/`ExecuteWithContextAsync` overloads that take just the
-  context-aware action, for callers that read `KevlarContext` without seeding properties. Available
-  on `Shield` and `Shield<TResult>`, synchronous and asynchronous, `ValueTask` and `Task`.
-- `KEV006` warns when `Hedge(...)` is added to an untyped `Shield`, `ShieldBuilder`, or the static
-  `Shield.Hedge` factory: hedging runs the action concurrently more than once, so it must be
-  idempotent unless a typed shield's result clause can pick the winning attempt.
-- Every `Retry` overload and `MaxRetries` documents that the value counts retries, not attempts:
-  `Retry(3)` makes up to 4 total attempts.
+- `VoidShield` and `PartitionedVoidShield<TKey>` provide compile-time-safe void execution across
+  core, dependency injection, rate limiting, testing, wrapping, and state snapshots.
+- Result clauses include `WhenResultIsNull`, `OrResultIsNull`, `WhenResultIsDefault`, and
+  `OrResultIsDefault` for nullable, value-type, and generic results.
+- Reactive strategy options can replace ambient handling with `HandlesException` and typed
+  `HandlesResult` predicates; testing descriptors expose the override.
+- Pipeline descriptions display inherited handling clauses and local handling overrides.
+- `Shield.Fallback(...)` can start an untyped chain, and `Shield<TResult>.Compose(...)` composes
+  result-aware pipelines.
+- Context-only synchronous and asynchronous execution overloads expose `KevlarContext` without
+  requiring seeded state.
+- Analyzer rules KEV001–KEV004 and KEV006–KEV010 cover ignored cancellation, ineffective handling,
+  unsafe timeout matching, invalid ordering, untyped hedging, discarded builders and fluent calls,
+  inherited handling, and suspicious default-value matching.
+
+### Changed
+
+- `Kevlar.Testing` and `Kevlar.Extensions.RateLimiting` require the exact matching `Kevlar` package
+  version. NuGet reports version-skew combinations as `NU1608` instead of allowing incompatible
+  package combinations.
+- Typed constant fallbacks use `FallbackTo(value)`; delegate factories continue to use
+  `Fallback(...)`. Null fallback values are no longer ambiguous with delegate overloads.
+- Handling clauses use `When...` to start and `Or...` to continue. `Shield.For<TResult>()` returns a
+  `Shield<TResult>` directly.
+- Typed and untyped retry, circuit-breaker, hedge, and fallback options are sealed sibling types
+  with matching shared properties instead of inheritance.
+- `Shield.Wrap(...)` and `Shield.Compose(...)` seal ambient handling. Strategies appended after
+  composition use default handling until another clause is declared.
+- `RetryForever` has explicit parameterless and `Backoff` overloads; explicit `null` is rejected.
+- Clause builders are immutable. Each `Or...` call returns a new builder and leaves the source
+  builder unchanged.
+- Debug builds reject access to a pooled `KevlarContext` after it has been returned.
+- Backoff factories validate timer limits, and custom backoff results are clamped to safe bounds.
+
+**Upgrading from 0.x**
+
+<!-- upgrade-from-0.x:start -->
+| Before | After |
+|---|---|
+| `WhenDefault()` | `WhenResultIsDefault()` |
+| `OrWhen(predicate)` | `Or(predicate)` |
+| `HedgingOptions` | `HedgeOptions` |
+| untyped `Fallback(...)` returned `Shield` | untyped `Fallback(...)` returns `VoidShield` |
+| `RetryForever(backoff: null)` | `RetryForever()` |
+| ambient handling flowed past `Wrap`/`Compose` | `Wrap`/`Compose` seals the clause |
+<!-- upgrade-from-0.x:end -->
+
+The replacement forms compile together:
+
+```csharp
+_ = Shield.For<int>().WhenResultIsDefault().FallbackTo(-1);
+_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().RetryForever();
+_ = Shield.When<InvalidOperationException>().RetryForever(Backoff.None);
+_ = new HedgeOptions();
+VoidShield recovery = Shield.Fallback(static _ => ValueTask.CompletedTask);
+_ = Shield.Empty.Wrap(Shield.Retry(1));
+```
+
+### Removed
+
+- Typed constant-value `Fallback(value)` overloads; use `FallbackTo(value)`.
+- Nullable `RetryForever(Backoff? backoff = null)` overloads; use either explicit replacement.
+- Mutable clause-builder behavior where ignored return values changed later chains.
+
+### Fixed
+
+- Circuit-breaker validation identifies the conflicting properties and reports public parameter
+  names.
+- Fallback ordering and result compatibility failures are rejected at compile time through the
+  void-only pipeline type.
+- Custom backoff arithmetic cannot create negative or unbounded runtime delays.
+
+[Unreleased]: https://github.com/thomhurst/Kevlar/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/thomhurst/Kevlar/compare/v0.10.0...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,9 +110,11 @@ All notable changes to this project are documented here. The format follows
 | `RetryForever(backoff: null)` | `RetryForever()` |
 | ambient handling flowed past `Wrap`/`Compose` | `Wrap`/`Compose` seals the clause |
 | `maxQueue` / `MaxQueue` | `queueLimit` / `QueueLimit` |
+| `Kevlar.Extensions.DependencyInjection.BackoffKind` | `Kevlar.BackoffKind` |
 | `jitter: false` / `RetryDefinition.Jitter = false` | `jitter: Jitter.None` / `RetryDefinition.Jitter = Jitter.None` |
 | `jitter: true` / `RetryDefinition.Jitter = true` | `jitter: Jitter.Equal` / `RetryDefinition.Jitter = Jitter.Equal` |
-| `RetryEvent.Attempt` / `RetryEvent<TResult>.Attempt` / `HedgeEvent.Attempt` | `AttemptNumber` |
+| `RetryEvent.Attempt` / `RetryEvent<TResult>.Attempt` | `RetryNumber` |
+| `HedgeEvent.Attempt` | `AttemptNumber` |
 <!-- upgrade-from-0.x:end -->
 
 The replacement forms compile together:
@@ -131,6 +133,7 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
 - Typed constant-value `Fallback(value)` overloads; use `FallbackTo(value)`.
 - Nullable `RetryForever(Backoff? backoff = null)` overloads; use either explicit replacement.
 - Mutable clause-builder behavior where ignored return values changed later chains.
+- Public `StrategyNode`; pipeline nodes are implementation details and are now internal.
 
 ### Fixed
 

--- a/scripts/Get-ReleaseNotes.ps1
+++ b/scripts/Get-ReleaseNotes.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [ValidatePattern('^[0-9]+\.[0-9]+\.[0-9]+$')]
+    [ValidatePattern('^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$')]
     [string]$Version,
 
     [string]$ChangelogPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'CHANGELOG.md'),
@@ -14,8 +14,9 @@ Set-StrictMode -Version Latest
 
 $lines = @(Get-Content -LiteralPath $ChangelogPath)
 $start = -1
+$releaseVersion = $Version.Split('+', 2)[0].Split('-', 2)[0]
 
-foreach ($heading in @("## [$Version]", '## [Unreleased]', '## Unreleased'))
+foreach ($heading in @("## [$releaseVersion]", '## [Unreleased]', '## Unreleased'))
 {
     for ($index = 0; $index -lt $lines.Count; $index++)
     {

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -10,6 +10,7 @@ $repositoryRoot = Split-Path -Parent $PSScriptRoot
 $changelogPath = Join-Path $repositoryRoot 'CHANGELOG.md'
 $lines = @(Get-Content -LiteralPath $changelogPath)
 $errors = [System.Collections.Generic.List[string]]::new()
+$allowedSections = @('Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security')
 
 function Get-ReleaseNotes([object]$Release, [string[]]$ChangelogLines)
 {
@@ -29,6 +30,32 @@ function Get-ReleaseNotes([object]$Release, [string[]]$ChangelogLines)
     }
 
     ($ChangelogLines[($Release.Index + 1)..($end - 1)] -join [Environment]::NewLine).Trim()
+}
+
+function Test-ReleaseHasEntry([object]$Release, [string[]]$ChangelogLines)
+{
+    $insideAllowedSection = $false
+    for ($index = $Release.Index + 1; $index -lt $ChangelogLines.Count; $index++)
+    {
+        $line = $ChangelogLines[$index]
+        if ($line -match '^## ' -or $line -match '^\[(?:Unreleased|[0-9])')
+        {
+            break
+        }
+
+        if ($line -match '^### (?<section>.+)$')
+        {
+            $insideAllowedSection = $allowedSections -contains $Matches['section']
+            continue
+        }
+
+        if ($insideAllowedSection -and $line -match '^\s*[-*]\s+\S')
+        {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 $unreleasedIndex = [Array]::IndexOf($lines, '## [Unreleased]')
@@ -142,9 +169,9 @@ for ($index = 0; $index -lt $releases.Count; $index++)
         }
     }
 
-    if ([string]::IsNullOrWhiteSpace((Get-ReleaseNotes $release $lines)))
+    if (-not (Test-ReleaseHasEntry $release $lines))
     {
-        $errors.Add("Release $($release.Version) has no notes.")
+        $errors.Add("Release $($release.Version) has no entry under an allowed section.")
     }
 }
 
@@ -158,7 +185,6 @@ if ($releases.Count -gt 0)
     }
 }
 
-$allowedSections = @('Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security')
 foreach ($line in $lines | Where-Object { $_ -match '^### ' })
 {
     $section = $line.Substring(4)
@@ -168,15 +194,32 @@ foreach ($line in $lines | Where-Object { $_ -match '^### ' })
     }
 }
 
-$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bKEV005\b|\bHedgingOptions\b'
+$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b'
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(
     Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
         ForEach-Object FullName)
 foreach ($document in $documents)
 {
+    $documentLines = @(Get-Content -LiteralPath $document)
+    $relativePath = [IO.Path]::GetRelativePath($repositoryRoot, $document).Replace('\', '/')
+    $startMarkers = @($documentLines | Select-String -Pattern '^<!-- upgrade-from-0\.x:start -->$')
+    $endMarkers = @($documentLines | Select-String -Pattern '^<!-- upgrade-from-0\.x:end -->$')
+    if ($startMarkers.Count -ne $endMarkers.Count -or $startMarkers.Count -gt 1)
+    {
+        $errors.Add("$relativePath has unbalanced or duplicate upgrade-table markers: $($startMarkers.Count) start and $($endMarkers.Count) end markers.")
+    }
+    elseif ($startMarkers.Count -eq 1 -and $startMarkers[0].LineNumber -ge $endMarkers[0].LineNumber)
+    {
+        $errors.Add("$relativePath upgrade-table markers are out of order.")
+    }
+    elseif ($document -eq $changelogPath -and $startMarkers.Count -eq 0)
+    {
+        $errors.Add('CHANGELOG.md is missing its upgrade-table marker pair.')
+    }
+
     $insideUpgradeTable = $false
     $lineNumber = 0
-    foreach ($line in Get-Content -LiteralPath $document)
+    foreach ($line in $documentLines)
     {
         $lineNumber++
         if ($line -eq '<!-- upgrade-from-0.x:start -->')
@@ -191,7 +234,6 @@ foreach ($document in $documents)
         }
         if (-not $insideUpgradeTable -and $deadApiPattern.IsMatch($line))
         {
-            $relativePath = [IO.Path]::GetRelativePath($repositoryRoot, $document).Replace('\', '/')
             $errors.Add("$relativePath`:$lineNumber contains a dead pre-release API name.")
         }
     }

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -194,7 +194,7 @@ foreach ($line in $lines | Where-Object { $_ -match '^### ' })
     }
 }
 
-$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b|\bVoidShield\b|\bVoidShieldBuilder\b|\bPartitionedVoidShield\b|\bmaxQueue\b|\bMaxQueue\b'
+$deadApiPattern = [regex]'FallbackWithNotifications|\bonFallback\s*:|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b|\bVoidShield\b|\bVoidShieldBuilder\b|\bPartitionedVoidShield\b|\bmaxQueue\b|\bMaxQueue\b'
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(
     Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
         ForEach-Object FullName)

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -64,6 +64,10 @@ if ($unreleasedHeadingCount -ne 1)
 {
     $errors.Add("CHANGELOG.md must contain exactly one ## [Unreleased] heading; found $unreleasedHeadingCount.")
 }
+elseif (-not (Test-ReleaseHasEntry ([pscustomobject]@{ Index = $unreleasedIndex }) $lines))
+{
+    $errors.Add('Unreleased has no entry under an allowed section.')
+}
 
 $versionComponentPattern = '(?:0|[1-9][0-9]*)'
 $releasePattern = [regex]"^## \[(?<version>$versionComponentPattern\.$versionComponentPattern\.$versionComponentPattern)\] - (?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})$"

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -38,12 +38,18 @@ if ($unreleasedIndex -lt 0)
 }
 
 $releasePattern = [regex]'^## \[(?<version>[0-9]+\.[0-9]+\.[0-9]+)\] - (?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})$'
+$versionHeadingCandidatePattern = [regex]'^##\s*\[[0-9]+\.[0-9]+\.[0-9]+'
 $releases = [System.Collections.Generic.List[object]]::new()
 for ($index = 0; $index -lt $lines.Count; $index++)
 {
     $match = $releasePattern.Match($lines[$index])
     if (-not $match.Success)
     {
+        if ($versionHeadingCandidatePattern.IsMatch($lines[$index]))
+        {
+            $errors.Add("Malformed versioned release heading '$($lines[$index])'. Expected '## [x.y.z] - yyyy-MM-dd'.")
+        }
+
         continue
     }
 
@@ -79,6 +85,16 @@ if ($LASTEXITCODE -ne 0)
     throw 'Unable to read git tags.'
 }
 
+$stableTags = @($tags | ForEach-Object {
+    if ($_ -match '^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$')
+    {
+        [pscustomobject]@{
+            Name = $_
+            Version = [Version]$Matches['version']
+        }
+    }
+})
+
 for ($index = 0; $index -lt $releases.Count; $index++)
 {
     $release = $releases[$index]
@@ -87,10 +103,32 @@ for ($index = 0; $index -lt $releases.Count; $index++)
         $errors.Add("Release $($release.Version) has no matching v$($release.Version) tag.")
     }
 
-    $linkPattern = "^\[$([regex]::Escape($release.Version))\]: https://github\.com/thomhurst/Kevlar/compare/\S+$"
-    if (-not ($lines | Where-Object { $_ -match $linkPattern }))
+    $previousTag = if ($index + 1 -lt $releases.Count)
     {
-        $errors.Add("Release $($release.Version) has no compare-link footer.")
+        "v$($releases[$index + 1].Version)"
+    }
+    else
+    {
+        $currentVersion = [Version]$release.Version
+        $previousStableTag = $stableTags |
+            Where-Object Version -lt $currentVersion |
+            Sort-Object Version -Descending |
+            Select-Object -First 1
+        if ($null -eq $previousStableTag) { $null } else { $previousStableTag.Name }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($previousTag))
+    {
+        $errors.Add("Release $($release.Version) has no earlier stable tag for its compare link.")
+    }
+    else
+    {
+        $expectedLink = "[$($release.Version)]: https://github.com/thomhurst/Kevlar/compare/$previousTag...v$($release.Version)"
+        $actualLinks = @($lines | Where-Object { $_.StartsWith("[$($release.Version)]:", [StringComparison]::Ordinal) })
+        if ($actualLinks.Count -ne 1 -or $actualLinks[0] -ne $expectedLink)
+        {
+            $errors.Add("Release $($release.Version) compare link must be '$expectedLink'.")
+        }
     }
 
     if ([string]::IsNullOrWhiteSpace((Get-ReleaseNotes $release $lines)))
@@ -99,9 +137,14 @@ for ($index = 0; $index -lt $releases.Count; $index++)
     }
 }
 
-if (-not ($lines | Where-Object { $_ -match '^\[Unreleased\]: https://github\.com/thomhurst/Kevlar/compare/\S+$' }))
+if ($releases.Count -gt 0)
 {
-    $errors.Add('Unreleased has no compare-link footer.')
+    $expectedUnreleasedLink = "[Unreleased]: https://github.com/thomhurst/Kevlar/compare/v$($releases[0].Version)...HEAD"
+    $actualUnreleasedLinks = @($lines | Where-Object { $_.StartsWith('[Unreleased]:', [StringComparison]::Ordinal) })
+    if ($actualUnreleasedLinks.Count -ne 1 -or $actualUnreleasedLinks[0] -ne $expectedUnreleasedLink)
+    {
+        $errors.Add("Unreleased compare link must be '$expectedUnreleasedLink'.")
+    }
 }
 
 $allowedSections = @('Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security')
@@ -115,7 +158,7 @@ foreach ($line in $lines | Where-Object { $_ -match '^### ' })
 }
 
 $deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bKEV005\b|\bHedgingOptions\b'
-$documents = @($changelogPath) + @(
+$documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(
     Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
         ForEach-Object FullName)
 foreach ($document in $documents)

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -66,14 +66,13 @@ if ($unreleasedIndex -lt 0)
 
 $versionComponentPattern = '(?:0|[1-9][0-9]*)'
 $releasePattern = [regex]"^## \[(?<version>$versionComponentPattern\.$versionComponentPattern\.$versionComponentPattern)\] - (?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})$"
-$versionHeadingCandidatePattern = [regex]'^##\s*\[?\s*v?\s*[0-9]+\.[0-9]+\.[0-9]+'
 $releases = [System.Collections.Generic.List[object]]::new()
 for ($index = 0; $index -lt $lines.Count; $index++)
 {
     $match = $releasePattern.Match($lines[$index])
     if (-not $match.Success)
     {
-        if ($versionHeadingCandidatePattern.IsMatch($lines[$index]))
+        if ($lines[$index] -match '^##(?:\s|$)' -and $lines[$index] -ne '## [Unreleased]')
         {
             $errors.Add("Malformed versioned release heading '$($lines[$index])'. Expected '## [x.y.z] - yyyy-MM-dd'.")
         }

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -39,7 +39,7 @@ if ($unreleasedIndex -lt 0)
 
 $versionComponentPattern = '(?:0|[1-9][0-9]*)'
 $releasePattern = [regex]"^## \[(?<version>$versionComponentPattern\.$versionComponentPattern\.$versionComponentPattern)\] - (?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})$"
-$versionHeadingCandidatePattern = [regex]'^##\s*\[?\s*[0-9]+\.[0-9]+\.[0-9]+'
+$versionHeadingCandidatePattern = [regex]'^##\s*\[?\s*v?\s*[0-9]+\.[0-9]+\.[0-9]+'
 $releases = [System.Collections.Generic.List[object]]::new()
 for ($index = 0; $index -lt $lines.Count; $index++)
 {

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -1,0 +1,169 @@
+[CmdletBinding()]
+param(
+    [string]$ReleaseVersion
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$changelogPath = Join-Path $repositoryRoot 'CHANGELOG.md'
+$lines = @(Get-Content -LiteralPath $changelogPath)
+$errors = [System.Collections.Generic.List[string]]::new()
+
+function Get-ReleaseNotes([object]$Release, [string[]]$ChangelogLines)
+{
+    $end = $ChangelogLines.Count
+    for ($index = $Release.Index + 1; $index -lt $ChangelogLines.Count; $index++)
+    {
+        if ($ChangelogLines[$index] -match '^## ' -or $ChangelogLines[$index] -match '^\[(?:Unreleased|[0-9])')
+        {
+            $end = $index
+            break
+        }
+    }
+
+    if ($end -le $Release.Index + 1)
+    {
+        return ''
+    }
+
+    ($ChangelogLines[($Release.Index + 1)..($end - 1)] -join [Environment]::NewLine).Trim()
+}
+
+$unreleasedIndex = [Array]::IndexOf($lines, '## [Unreleased]')
+if ($unreleasedIndex -lt 0)
+{
+    $errors.Add('Missing ## [Unreleased] heading.')
+}
+
+$releasePattern = [regex]'^## \[(?<version>[0-9]+\.[0-9]+\.[0-9]+)\] - (?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})$'
+$releases = [System.Collections.Generic.List[object]]::new()
+for ($index = 0; $index -lt $lines.Count; $index++)
+{
+    $match = $releasePattern.Match($lines[$index])
+    if (-not $match.Success)
+    {
+        continue
+    }
+
+    $date = [DateTime]::MinValue
+    if (-not [DateTime]::TryParseExact(
+        $match.Groups['date'].Value,
+        'yyyy-MM-dd',
+        [Globalization.CultureInfo]::InvariantCulture,
+        [Globalization.DateTimeStyles]::None,
+        [ref]$date))
+    {
+        $errors.Add("Invalid release date in '$($lines[$index])'.")
+    }
+
+    $releases.Add([pscustomobject]@{
+        Version = $match.Groups['version'].Value
+        Index = $index
+    })
+}
+
+if ($releases.Count -eq 0)
+{
+    $errors.Add('No versioned release headings found.')
+}
+elseif ($unreleasedIndex -gt $releases[0].Index)
+{
+    $errors.Add('## [Unreleased] must precede every versioned release.')
+}
+
+$tags = @(& git -C $repositoryRoot tag --list 'v*')
+if ($LASTEXITCODE -ne 0)
+{
+    throw 'Unable to read git tags.'
+}
+
+for ($index = 0; $index -lt $releases.Count; $index++)
+{
+    $release = $releases[$index]
+    if ($index -gt 0 -and $tags -notcontains "v$($release.Version)")
+    {
+        $errors.Add("Release $($release.Version) has no matching v$($release.Version) tag.")
+    }
+
+    $linkPattern = "^\[$([regex]::Escape($release.Version))\]: https://github\.com/thomhurst/Kevlar/compare/\S+$"
+    if (-not ($lines | Where-Object { $_ -match $linkPattern }))
+    {
+        $errors.Add("Release $($release.Version) has no compare-link footer.")
+    }
+
+    if ([string]::IsNullOrWhiteSpace((Get-ReleaseNotes $release $lines)))
+    {
+        $errors.Add("Release $($release.Version) has no notes.")
+    }
+}
+
+if (-not ($lines | Where-Object { $_ -match '^\[Unreleased\]: https://github\.com/thomhurst/Kevlar/compare/\S+$' }))
+{
+    $errors.Add('Unreleased has no compare-link footer.')
+}
+
+$allowedSections = @('Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security')
+foreach ($line in $lines | Where-Object { $_ -match '^### ' })
+{
+    $section = $line.Substring(4)
+    if ($allowedSections -notcontains $section)
+    {
+        $errors.Add("Unsupported changelog section '$section'.")
+    }
+}
+
+$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bKEV005\b|\bHedgingOptions\b'
+$documents = @($changelogPath) + @(
+    Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
+        ForEach-Object FullName)
+foreach ($document in $documents)
+{
+    $insideUpgradeTable = $false
+    $lineNumber = 0
+    foreach ($line in Get-Content -LiteralPath $document)
+    {
+        $lineNumber++
+        if ($line -eq '<!-- upgrade-from-0.x:start -->')
+        {
+            $insideUpgradeTable = $true
+            continue
+        }
+        if ($line -eq '<!-- upgrade-from-0.x:end -->')
+        {
+            $insideUpgradeTable = $false
+            continue
+        }
+        if (-not $insideUpgradeTable -and $deadApiPattern.IsMatch($line))
+        {
+            $relativePath = [IO.Path]::GetRelativePath($repositoryRoot, $document).Replace('\', '/')
+            $errors.Add("$relativePath`:$lineNumber contains a dead pre-release API name.")
+        }
+    }
+}
+
+if ($errors.Count -gt 0)
+{
+    throw "Changelog verification failed:`n- $($errors -join "`n- ")"
+}
+
+if ($ReleaseVersion)
+{
+    $release = $releases | Where-Object Version -eq $ReleaseVersion | Select-Object -First 1
+    if ($null -eq $release)
+    {
+        throw "Release $ReleaseVersion was not found in CHANGELOG.md."
+    }
+
+    $notes = Get-ReleaseNotes $release $lines
+    if ([string]::IsNullOrWhiteSpace($notes))
+    {
+        throw "Release $ReleaseVersion has no notes."
+    }
+
+    $notes
+    exit 0
+}
+
+Write-Host "Verified $($releases.Count) changelog release(s) and migration API names."

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -194,7 +194,27 @@ foreach ($line in $lines | Where-Object { $_ -match '^### ' })
     }
 }
 
-$deadApiPattern = [regex]'FallbackWithNotifications|\bonFallback\s*:|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b|\bVoidShield\b|\bVoidShieldBuilder\b|\bPartitionedVoidShield\b|\bmaxQueue\b|\bMaxQueue\b'
+$deadApiPatterns = @(
+    'FallbackWithNotifications'
+    '\bonFallback\s*:'
+    '\bWhenDefault\('
+    '\bOrDefault\('
+    '\bOrWhen\('
+    'WhenResultDefault'
+    'OrResultDefault'
+    '\bHedgingOptions\b'
+    '\bHedgingStrategyDescriptor\b'
+    '\bStrategyKind\.Hedging\b'
+    '\bStandardHedgingShieldOptions\b'
+    '\bAddStandardHedgingShield\b'
+    '\bVoidShield\b'
+    '\bVoidShieldBuilder\b'
+    '\bPartitionedVoidShield\b'
+    '\bmaxQueue\b'
+    '\bMaxQueue\b'
+    '\bKevlar\.Extensions\.DependencyInjection\.BackoffKind\b'
+)
+$deadApiPattern = [regex]($deadApiPatterns -join '|')
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(
     Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
         ForEach-Object FullName)

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -58,10 +58,11 @@ function Test-ReleaseHasEntry([object]$Release, [string[]]$ChangelogLines)
     return $false
 }
 
+$unreleasedHeadingCount = @($lines | Where-Object { $_ -eq '## [Unreleased]' }).Count
 $unreleasedIndex = [Array]::IndexOf($lines, '## [Unreleased]')
-if ($unreleasedIndex -lt 0)
+if ($unreleasedHeadingCount -ne 1)
 {
-    $errors.Add('Missing ## [Unreleased] heading.')
+    $errors.Add("CHANGELOG.md must contain exactly one ## [Unreleased] heading; found $unreleasedHeadingCount.")
 }
 
 $versionComponentPattern = '(?:0|[1-9][0-9]*)'
@@ -193,7 +194,7 @@ foreach ($line in $lines | Where-Object { $_ -match '^### ' })
     }
 }
 
-$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b'
+$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b|\bVoidShield\b|\bVoidShieldBuilder\b|\bPartitionedVoidShield\b'
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(
     Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
         ForEach-Object FullName)

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -217,6 +217,9 @@ $deadApiPatterns = @(
     '\bmaxQueue\b'
     '\bMaxQueue\b'
     '\bKevlar\.Extensions\.DependencyInjection\.BackoffKind\b'
+    '\bRetryEvent\.Attempt\b'
+    '\bRetryEvent<[^>]+>\.Attempt\b'
+    '\bHedgeEvent\.Attempt\b'
 )
 $deadApiPattern = [regex]($deadApiPatterns -join '|')
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -222,7 +222,7 @@ $deadApiPatterns = @(
     '\bHedgeEvent\.Attempt\b'
     '\bRetryForever\s*\(\s*backoff\s*:\s*null\s*\)'
     '\bjitter\s*:\s*(?:true|false)\b'
-    '\bRetryDefinition\s*\.\s*Jitter\s*=\s*(?:true|false)\b'
+    '\bJitter\s*=\s*(?:true|false)\b'
 )
 $deadApiPattern = [regex]($deadApiPatterns -join '|')
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -220,6 +220,9 @@ $deadApiPatterns = @(
     '\bRetryEvent\.Attempt\b'
     '\bRetryEvent<[^>]+>\.Attempt\b'
     '\bHedgeEvent\.Attempt\b'
+    '\bRetryForever\s*\(\s*backoff\s*:\s*null\s*\)'
+    '\bjitter\s*:\s*(?:true|false)\b'
+    '\bRetryDefinition\s*\.\s*Jitter\s*=\s*(?:true|false)\b'
 )
 $deadApiPattern = [regex]($deadApiPatterns -join '|')
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -223,7 +223,7 @@ $deadApiPatterns = @(
     '\bRetryForever\s*\(\s*backoff\s*:\s*null\s*\)'
     '\bjitter\s*:\s*(?:true|false)\b'
     '\bJitter\s*=\s*(?:true|false)\b'
-    '(?i:\.RateLimit\s*\(\s*(?:limiter|[A-Za-z_][A-Za-z0-9_]*limiter)\s*\))'
+    '(?i:\.RateLimit\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*)?(?:limiter|acquireLease)\s*(?:,|\)))'
     '\bRateLimiterRejectedEvent\b'
 )
 $deadApiPattern = [regex]($deadApiPatterns -join '|')

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -37,8 +37,9 @@ if ($unreleasedIndex -lt 0)
     $errors.Add('Missing ## [Unreleased] heading.')
 }
 
-$releasePattern = [regex]'^## \[(?<version>[0-9]+\.[0-9]+\.[0-9]+)\] - (?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})$'
-$versionHeadingCandidatePattern = [regex]'^##\s*\[[0-9]+\.[0-9]+\.[0-9]+'
+$versionComponentPattern = '(?:0|[1-9][0-9]*)'
+$releasePattern = [regex]"^## \[(?<version>$versionComponentPattern\.$versionComponentPattern\.$versionComponentPattern)\] - (?<date>[0-9]{4}-[0-9]{2}-[0-9]{2})$"
+$versionHeadingCandidatePattern = [regex]'^##\s*\[?\s*[0-9]+\.[0-9]+\.[0-9]+'
 $releases = [System.Collections.Generic.List[object]]::new()
 for ($index = 0; $index -lt $lines.Count; $index++)
 {
@@ -77,6 +78,16 @@ if ($releases.Count -eq 0)
 elseif ($unreleasedIndex -gt $releases[0].Index)
 {
     $errors.Add('## [Unreleased] must precede every versioned release.')
+}
+
+for ($index = 1; $index -lt $releases.Count; $index++)
+{
+    $newerVersion = [Version]$releases[$index - 1].Version
+    $olderVersion = [Version]$releases[$index].Version
+    if ($newerVersion -le $olderVersion)
+    {
+        $errors.Add("Release versions must be strictly descending; $newerVersion appears before $olderVersion.")
+    }
 }
 
 $tags = @(& git -C $repositoryRoot tag --list 'v*')

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -223,10 +223,12 @@ $deadApiPatterns = @(
     '\bRetryForever\s*\(\s*backoff\s*:\s*null\s*\)'
     '\bjitter\s*:\s*(?:true|false)\b'
     '\bJitter\s*=\s*(?:true|false)\b'
+    '(?i:\.RateLimit\s*\(\s*(?:limiter|[A-Za-z_][A-Za-z0-9_]*limiter)\s*\))'
+    '\bRateLimiterRejectedEvent\b'
 )
 $deadApiPattern = [regex]($deadApiPatterns -join '|')
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(
-    Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
+    Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs/docs') -Recurse -File -Include '*.md', '*.mdx' |
         ForEach-Object FullName)
 foreach ($document in $documents)
 {

--- a/scripts/Verify-Changelog.ps1
+++ b/scripts/Verify-Changelog.ps1
@@ -194,7 +194,7 @@ foreach ($line in $lines | Where-Object { $_ -match '^### ' })
     }
 }
 
-$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b|\bVoidShield\b|\bVoidShieldBuilder\b|\bPartitionedVoidShield\b'
+$deadApiPattern = [regex]'FallbackWithNotifications|\bWhenDefault\(|\bOrDefault\(|\bOrWhen\(|WhenResultDefault|OrResultDefault|\bHedgingOptions\b|\bHedgingStrategyDescriptor\b|\bStrategyKind\.Hedging\b|\bStandardHedgingShieldOptions\b|\bAddStandardHedgingShield\b|\bVoidShield\b|\bVoidShieldBuilder\b|\bPartitionedVoidShield\b|\bmaxQueue\b|\bMaxQueue\b'
 $documents = @($changelogPath, (Join-Path $repositoryRoot 'README.md')) + @(
     Get-ChildItem -LiteralPath (Join-Path $repositoryRoot 'docs') -Recurse -File -Include '*.md', '*.mdx' |
         ForEach-Object FullName)

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -19,6 +19,7 @@ $nugetConfigPath = Join-Path $generatedDirectory 'NuGet.config'
 $projectPath = Join-Path $repositoryRoot 'tests/Kevlar.DocTests/Kevlar.DocTests.csproj'
 $documentPaths = @(
     (Join-Path $repositoryRoot 'README.md')
+    (Join-Path $repositoryRoot 'CHANGELOG.md')
     Get-ChildItem (Join-Path $repositoryRoot 'docs/docs') -Recurse -File -Include '*.md', '*.mdx' |
         Sort-Object FullName |
         ForEach-Object FullName

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -61,15 +61,35 @@ foreach ($documentPath in $documentPaths)
     $lineOffset = 0
     if ($documentPath -eq $changelogPath)
     {
-        $releaseHeading = $lines |
-            Select-String -Pattern '^## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' |
-            Select-Object -First 1
-        if ($null -eq $releaseHeading)
+        if ($Version -notmatch '^(?<version>[0-9]+\.[0-9]+\.[0-9]+)(?:[-+].+)?$')
         {
-            throw 'No versioned release heading found in CHANGELOG.md.'
+            throw "Package version '$Version' is not a semantic version."
         }
 
-        $lineOffset = $releaseHeading.LineNumber - 1
+        $releaseVersion = $Matches['version']
+        $releaseHeadings = @($lines |
+            Select-String -Pattern "^## \[$([regex]::Escape($releaseVersion))\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$")
+        if ($releaseHeadings.Count -gt 1)
+        {
+            throw "Multiple $releaseVersion release headings found in CHANGELOG.md."
+        }
+
+        $selectedHeading = if ($releaseHeadings.Count -eq 1)
+        {
+            $releaseHeadings[0]
+        }
+        else
+        {
+            $unreleasedHeadings = @($lines | Select-String -SimpleMatch '## [Unreleased]')
+            if ($unreleasedHeadings.Count -ne 1)
+            {
+                throw 'CHANGELOG.md must contain exactly one ## [Unreleased] heading.'
+            }
+
+            $unreleasedHeadings[0]
+        }
+
+        $lineOffset = $selectedHeading.LineNumber - 1
         $end = $lines.Count
         for ($index = $lineOffset + 1; $index -lt $lines.Count; $index++)
         {

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -17,9 +17,10 @@ $generatedDirectory = Join-Path $repositoryRoot 'artifacts/doc-tests/generated'
 $generatedPath = Join-Path $generatedDirectory 'GeneratedSnippets.g.cs'
 $nugetConfigPath = Join-Path $generatedDirectory 'NuGet.config'
 $projectPath = Join-Path $repositoryRoot 'tests/Kevlar.DocTests/Kevlar.DocTests.csproj'
+$changelogPath = Join-Path $repositoryRoot 'CHANGELOG.md'
 $documentPaths = @(
     (Join-Path $repositoryRoot 'README.md')
-    (Join-Path $repositoryRoot 'CHANGELOG.md')
+    $changelogPath
     Get-ChildItem (Join-Path $repositoryRoot 'docs/docs') -Recurse -File -Include '*.md', '*.mdx' |
         Sort-Object FullName |
         ForEach-Object FullName
@@ -57,6 +58,31 @@ foreach ($documentPath in $documentPaths)
 {
     $relativePath = [IO.Path]::GetRelativePath($repositoryRoot, $documentPath).Replace('\', '/')
     $lines = Get-Content -LiteralPath $documentPath
+    $lineOffset = 0
+    if ($documentPath -eq $changelogPath)
+    {
+        $releaseHeading = $lines |
+            Select-String -Pattern '^## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' |
+            Select-Object -First 1
+        if ($null -eq $releaseHeading)
+        {
+            throw 'No versioned release heading found in CHANGELOG.md.'
+        }
+
+        $lineOffset = $releaseHeading.LineNumber - 1
+        $end = $lines.Count
+        for ($index = $lineOffset + 1; $index -lt $lines.Count; $index++)
+        {
+            if ($lines[$index] -match '^## ')
+            {
+                $end = $index
+                break
+            }
+        }
+
+        $lines = $lines[$lineOffset..($end - 1)]
+    }
+
     $csharpOrdinal = 0
 
     for ($lineIndex = 0; $lineIndex -lt $lines.Count; $lineIndex++)
@@ -64,7 +90,8 @@ foreach ($documentPath in $documentPaths)
         if ($lines[$lineIndex] -match '^```csharp\s*$')
         {
             $csharpOrdinal++
-            $startLine = $lineIndex + 2
+            $startLine = $lineOffset + $lineIndex + 2
+            $directive = if ($lineIndex -gt 0) { $lines[$lineIndex - 1].Trim() } else { '' }
             $body = [System.Collections.Generic.List[string]]::new()
             for ($lineIndex++; $lineIndex -lt $lines.Count -and $lines[$lineIndex] -notmatch '^```\s*$'; $lineIndex++)
             {
@@ -76,7 +103,6 @@ foreach ($documentPath in $documentPaths)
                 throw "Unclosed C# fence at ${relativePath}:$startLine."
             }
 
-            $directive = if ($startLine -ge 3) { $lines[$startLine - 3].Trim() } else { '' }
             $ignoreReason = $null
             if ($directive -match '^<!--\s*doc-test-ignore:\s*(.+?)\s*-->$')
             {

--- a/scripts/Verify-ReleaseWorkflow.ps1
+++ b/scripts/Verify-ReleaseWorkflow.ps1
@@ -7,6 +7,31 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 $workflow = Get-Content -LiteralPath $WorkflowPath -Raw
+$changelogStepStart = $workflow.IndexOf('- name: Verify changelog and release notes', [StringComparison]::Ordinal)
+$changelogStepEnd = if ($changelogStepStart -lt 0)
+{
+    -1
+}
+else
+{
+    $workflow.IndexOf('- name:', $changelogStepStart + 1, [StringComparison]::Ordinal)
+}
+if ($changelogStepStart -lt 0 -or $changelogStepEnd -lt 0)
+{
+    throw "Changelog verification step was not found in '$WorkflowPath'."
+}
+
+$changelogStep = $workflow.Substring($changelogStepStart, $changelogStepEnd - $changelogStepStart)
+foreach ($requiredText in @(
+    'RELEASE_VERSION: ${{ steps.gitversion.outputs.semVer }}',
+    './scripts/Get-ReleaseNotes.ps1 -Version $env:RELEASE_VERSION'))
+{
+    if (-not $changelogStep.Contains($requiredText, [StringComparison]::Ordinal))
+    {
+        throw "Changelog verification is missing '$requiredText'."
+    }
+}
+
 $publishStart = $workflow.IndexOf("`n  publish:", [StringComparison]::Ordinal)
 if ($publishStart -lt 0)
 {

--- a/scripts/Verify-ReleaseWorkflow.ps1
+++ b/scripts/Verify-ReleaseWorkflow.ps1
@@ -125,7 +125,7 @@ try
         [Text.UTF8Encoding]::new($false))
 
     & (Join-Path $PSScriptRoot 'Get-ReleaseNotes.ps1') `
-        -Version '1.2.3' `
+        -Version '1.2.3-pr.274.75' `
         -ChangelogPath $fixturePath `
         -OutputPath $outputPath
 
@@ -142,7 +142,7 @@ try
         [Text.UTF8Encoding]::new($false))
 
     & (Join-Path $PSScriptRoot 'Get-ReleaseNotes.ps1') `
-        -Version '2.0.0' `
+        -Version '2.0.0-alpha.1+build.42' `
         -ChangelogPath $fixturePath `
         -OutputPath $outputPath
 


### PR DESCRIPTION
## Summary
- replace pre-release churn with a Keep a Changelog 1.0 snapshot
- add a focused 0.x upgrade table and compile its replacement examples
- validate release headings, tags, compare links, dead API names, and extracted release notes in CI

Closes #193

## Validation
- dotnet build Kevlar.slnx -c Release
- ./scripts/Verify-Changelog.ps1
- ./scripts/Verify-Changelog.ps1 -ReleaseVersion 1.0.0
- ./scripts/Verify-Docs.ps1
- ./scripts/Verify-DocSnippets.ps1 -PackagesPath ./artifacts/issue193-package -Version 1.0.0-changelog