### PR TITLE
refactor(events)!: clarify attempt counters

### DIFF
--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -125,7 +125,7 @@ services.AddHttpClient("api")
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger("HttpResilience");
         options.Retry.OnRetry = retry =>
-            logger.LogWarning("Retry {Attempt}", retry.Attempt);
+            logger.LogWarning("Retry {RetryNumber}", retry.RetryNumber);
     });
 ```
 

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -16,7 +16,7 @@ Shield.Hedge(o =>
 {
     o.MaxAttempts = 2;                        // default 2 (total attempts, incl. the first)
     o.Delay = TimeSpan.FromSeconds(1);        // default 1s
-    o.OnHedge = e => logger.LogInformation("Hedge attempt {Attempt}", e.Attempt);
+    o.OnHedge = e => logger.LogInformation("Hedge attempt {AttemptNumber}", e.AttemptNumber);
     o.OnHedgeAsync = static _ => ValueTask.CompletedTask;
 });
 ```
@@ -27,7 +27,7 @@ Shield.Hedge(o =>
 |---|---|---|
 | `MaxAttempts` | `2` | Total attempts, including the first |
 | `Delay` | `1s` | Wait before launching the next attempt (see special values below) |
-| `OnHedge` | — | Callback when a hedge launches — `e.Attempt` is 1-based, so `2` = first hedge |
+| `OnHedge` | — | Callback when a hedge launches — `e.AttemptNumber` is a 1-based execution number, so `2` = first hedge |
 | `OnHedgeAsync` | — | Awaited callback after `OnHedge` and before the attempt starts |
 | `ActionGenerator` | — | Select a different operation for each additional attempt; `null` uses the original |
 | `HandlesException` | — | Local exception predicate; replaces the ambient clause for this hedge |
@@ -52,7 +52,7 @@ var shield = Shield.For<string>().Hedge(o =>
     o.MaxAttempts = replicas.Length;
     o.Delay = TimeSpan.FromMilliseconds(100);
     o.ActionGenerator = HedgeActionGenerator.Create<string>(hedge =>
-        ct => replicas[hedge.Attempt - 1](ct));
+        ct => replicas[hedge.AttemptNumber - 1](ct));
 });
 
 // The original callback is attempt 1; generated callbacks are attempts 2 and 3.

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -49,7 +49,7 @@ Shield.Retry(o =>
     o.Backoff = Backoff.Custom(attempt => TimeSpan.FromMilliseconds(100 * attempt));
     o.MaxDelay = TimeSpan.FromSeconds(10);
     o.OnRetry = e => logger.LogWarning(e.Exception,
-        "Retry {Attempt} after {Delay}", e.Attempt, e.Delay);
+        "Retry {RetryNumber} after {Delay}", e.RetryNumber, e.Delay);
     o.DelayGenerator = e => /* return a TimeSpan to override the computed delay, or null */ null;
     o.DelayGeneratorAsync = e => new ValueTask<TimeSpan?>(TimeSpan.Zero);
 });
@@ -80,7 +80,28 @@ next attempt is suppressed and caller cancellation surfaces. A generator excepti
 its original identity and skips later hooks. `RetryEvent.Context` is pooled execution state: use it
 only before the returned `ValueTask` completes; never retain it or its property bag.
 
-On an untyped `Shield`, the `RetryEvent` callbacks receive: `Attempt` (1-based retry number), `Delay`, `Exception` (null when a handled *result* triggered the retry), `Result` (the handled result, boxed as `object?`) and `Context`. On a typed `Shield<T>`, the events are `RetryEvent<T>` instead: same `Attempt`/`Delay`/`Context`, plus the handled failure as a typed `Outcome<T>` — `e.Outcome.Result` is your `T`, no casting.
+On an untyped `Shield`, the `RetryEvent` callbacks receive: `RetryNumber` (1-based, so `1` is the first retry after the initial execution), `Delay`, `Exception` (null when a handled *result* triggered the retry), `Result` (the handled result, boxed as `object?`) and `Context`. On a typed `Shield<T>`, the events are `RetryEvent<T>` instead: same `RetryNumber`/`Delay`/`Context`, plus the handled failure as a typed `Outcome<T>` — `e.Outcome.Result` is your `T`, no casting.
+
+<!-- doc-test-run: retry-numbers -->
+```csharp
+var retryNumbers = new List<int>();
+var numberedRetry = Shield.Retry(options =>
+{
+    options.MaxRetries = 3;
+    options.Backoff = Backoff.None;
+    options.OnRetry = retry => retryNumbers.Add(retry.RetryNumber);
+});
+
+try
+{
+    numberedRetry.Execute(static _ => throw new InvalidOperationException());
+}
+catch (InvalidOperationException)
+{
+}
+
+Console.WriteLine(string.Join(",", retryNumbers)); // 1,2,3
+```
 
 ## What gets retried
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -57,7 +57,7 @@ await telemetry.WaitForCallbackCountAsync(1);
 
 var retry = telemetry.Callbacks.Single();
 await TUnit.Assertions.Assert.That(retry.Kind).IsEqualTo(CallbackKind.Retry);
-await TUnit.Assertions.Assert.That(retry.Attempt).IsEqualTo(1);
+await TUnit.Assertions.Assert.That(retry.RetryNumber).IsEqualTo(1);
 await TUnit.Assertions.Assert.That(retry.ShieldName).IsEqualTo("catalog");
 
 var execution = telemetry.Metrics.Single(record =>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -33,7 +33,7 @@ const advancedSample = `var search = Shield.For<HttpResponseMessage>()
         o.DelayGenerator = e =>
             e.Outcome.Result?.Headers.RetryAfter?.Delta;
         o.OnRetry = e => logger.LogWarning(
-            "retry {Attempt} in {Delay}", e.Attempt, e.Delay);
+            "retry {RetryNumber} in {Delay}", e.RetryNumber, e.Delay);
     })
     .CircuitBreaker(o =>
     {

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -303,6 +303,7 @@ $invalidCompositionSnippetIndex = -1
 $timeoutExceededClauseSnippetIndex = -1
 $systemTimeoutClauseTrapSnippetIndex = -1
 $metricsSnippetIndex = -1
+$retryNumbersSnippetIndex = -1
 for ($snippetIndex = 0; $snippetIndex -lt $snippets.Count; $snippetIndex++)
 {
     if ($snippets[$snippetIndex].RunName -eq 'pipeline-description')
@@ -329,28 +330,35 @@ for ($snippetIndex = 0; $snippetIndex -lt $snippets.Count; $snippetIndex++)
     {
         $metricsSnippetIndex = $snippetIndex
     }
+
+    if ($snippets[$snippetIndex].RunName -eq 'retry-numbers')
+    {
+        $retryNumbersSnippetIndex = $snippetIndex
+    }
 }
 
 if ($observableSnippetIndex -lt 0 `
     -or $invalidCompositionSnippetIndex -lt 0 `
     -or $timeoutExceededClauseSnippetIndex -lt 0 `
     -or $systemTimeoutClauseTrapSnippetIndex -lt 0 `
-    -or $metricsSnippetIndex -lt 0)
+    -or $metricsSnippetIndex -lt 0 `
+    -or $retryNumbersSnippetIndex -lt 0)
 {
     throw 'A required executable documentation snippet is missing.'
 }
 
 [void]$builder.AppendLine("            await Snippet$observableSnippetIndex.RunAsync();")
+[void]$builder.AppendLine("            await Snippet$retryNumbersSnippetIndex.RunAsync();")
 [void]$builder.AppendLine('        }')
 [void]$builder.AppendLine('        finally')
 [void]$builder.AppendLine('        {')
 [void]$builder.AppendLine('            Console.SetOut(original);')
 [void]$builder.AppendLine('        }')
 [void]$builder.AppendLine('        var actual = output.ToString().Trim();')
-[void]$builder.AppendLine('        const string expected = "github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)";')
+[void]$builder.AppendLine('        var expected = "github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)" + Environment.NewLine + "1,2,3";')
 [void]$builder.AppendLine('        if (!string.Equals(actual, expected, StringComparison.Ordinal))')
 [void]$builder.AppendLine('        {')
-[void]$builder.AppendLine('            throw new InvalidOperationException($"Documented pipeline output changed. Expected: {expected}; actual: {actual}");')
+[void]$builder.AppendLine('            throw new InvalidOperationException($"Documented executable output changed. Expected: {expected}; actual: {actual}");')
 [void]$builder.AppendLine('        }')
 [void]$builder.AppendLine('        try')
 [void]$builder.AppendLine('        {')

--- a/src/Kevlar.Testing/CallbackRecord.cs
+++ b/src/Kevlar.Testing/CallbackRecord.cs
@@ -7,7 +7,8 @@ public sealed class CallbackRecord
         long sequence,
         CallbackKind kind,
         string? shieldName = null,
-        int? attempt = null,
+        int? retryNumber = null,
+        int? attemptNumber = null,
         TimeSpan? delay = null,
         TimeSpan? timeout = null,
         Exception? exception = null,
@@ -18,7 +19,8 @@ public sealed class CallbackRecord
         Sequence = sequence;
         Kind = kind;
         ShieldName = shieldName;
-        Attempt = attempt;
+        RetryNumber = retryNumber;
+        AttemptNumber = attemptNumber;
         Delay = delay;
         Timeout = timeout;
         Exception = exception;
@@ -36,8 +38,11 @@ public sealed class CallbackRecord
     /// <summary>The shield name copied from the callback context, when available.</summary>
     public string? ShieldName { get; }
 
-    /// <summary>The retry or hedge attempt number, when applicable.</summary>
-    public int? Attempt { get; }
+    /// <summary>The 1-based retry number, when this is a retry callback.</summary>
+    public int? RetryNumber { get; }
+
+    /// <summary>The 1-based execution number, when this is a hedge callback.</summary>
+    public int? AttemptNumber { get; }
 
     /// <summary>The retry delay, when applicable.</summary>
     public TimeSpan? Delay { get; }
@@ -58,5 +63,15 @@ public sealed class CallbackRecord
     public CircuitState? To { get; }
 
     internal CallbackRecord WithSequence(long sequence) => new(
-        sequence, Kind, ShieldName, Attempt, Delay, Timeout, Exception, Result, From, To);
+        sequence,
+        Kind,
+        ShieldName,
+        retryNumber: RetryNumber,
+        attemptNumber: AttemptNumber,
+        delay: Delay,
+        timeout: Timeout,
+        exception: Exception,
+        result: Result,
+        from: From,
+        to: To);
 }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -111,11 +111,12 @@ Kevlar.Testing.CallbackKind.Hedge = 2 -> Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.Retry = 0 -> Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.Timeout = 1 -> Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackRecord
-Kevlar.Testing.CallbackRecord.Attempt.get -> int?
+Kevlar.Testing.CallbackRecord.AttemptNumber.get -> int?
 Kevlar.Testing.CallbackRecord.Delay.get -> System.TimeSpan?
 Kevlar.Testing.CallbackRecord.Exception.get -> System.Exception?
 Kevlar.Testing.CallbackRecord.From.get -> Kevlar.CircuitState?
 Kevlar.Testing.CallbackRecord.Kind.get -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackRecord.RetryNumber.get -> int?
 Kevlar.Testing.CallbackRecord.Result.get -> object?
 Kevlar.Testing.CallbackRecord.Sequence.get -> long
 Kevlar.Testing.CallbackRecord.ShieldName.get -> string?

--- a/src/Kevlar.Testing/TelemetryRecorder.cs
+++ b/src/Kevlar.Testing/TelemetryRecorder.cs
@@ -74,13 +74,13 @@ public sealed class TelemetryRecorder : IDisposable
 
     /// <summary>Records an untyped retry callback.</summary>
     public void Record(RetryEvent item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Retry, item.Context.ShieldName, item.Attempt,
-        item.Delay, exception: item.Exception, result: item.Result));
+        0, CallbackKind.Retry, item.Context.ShieldName, retryNumber: item.RetryNumber,
+        delay: item.Delay, exception: item.Exception, result: item.Result));
 
     /// <summary>Records a typed retry callback.</summary>
     public void Record<TResult>(RetryEvent<TResult> item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Retry, item.Context.ShieldName, item.Attempt,
-        item.Delay, exception: item.Outcome.Exception, result: item.Outcome.Result));
+        0, CallbackKind.Retry, item.Context.ShieldName, retryNumber: item.RetryNumber,
+        delay: item.Delay, exception: item.Outcome.Exception, result: item.Outcome.Result));
 
     /// <summary>Records a timeout callback.</summary>
     public void Record(TimeoutEvent item) => AddCallback(new CallbackRecord(
@@ -88,7 +88,7 @@ public sealed class TelemetryRecorder : IDisposable
 
     /// <summary>Records a hedge callback.</summary>
     public void Record(HedgeEvent item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Hedge, item.Context.ShieldName, item.Attempt));
+        0, CallbackKind.Hedge, item.Context.ShieldName, attemptNumber: item.AttemptNumber));
 
     /// <summary>Records an untyped fallback callback.</summary>
     public void Record(FallbackEvent item) => AddCallback(new CallbackRecord(

--- a/src/Kevlar/PublicAPI.Shipped.txt
+++ b/src/Kevlar/PublicAPI.Shipped.txt
@@ -55,7 +55,7 @@ Kevlar.FallbackEvent<TResult>.Context.get -> Kevlar.KevlarContext!
 Kevlar.FallbackEvent<TResult>.FallbackEvent() -> void
 Kevlar.FallbackEvent<TResult>.Outcome.get -> Kevlar.Outcome<TResult>
 Kevlar.HedgeEvent
-Kevlar.HedgeEvent.AttemptNumber.get -> int
+Kevlar.HedgeEvent.Attempt.get -> int
 Kevlar.HedgeEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.HedgeEvent.HedgeEvent() -> void
 Kevlar.HedgingOptions
@@ -104,14 +104,14 @@ Kevlar.RateLimitOptions.RateLimitOptions() -> void
 Kevlar.RateLimitOptions.Window.get -> System.TimeSpan
 Kevlar.RateLimitOptions.Window.set -> void
 Kevlar.RetryEvent
-Kevlar.RetryEvent.RetryNumber.get -> int
+Kevlar.RetryEvent.Attempt.get -> int
 Kevlar.RetryEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.RetryEvent.Delay.get -> System.TimeSpan
 Kevlar.RetryEvent.Exception.get -> System.Exception?
 Kevlar.RetryEvent.Result.get -> object?
 Kevlar.RetryEvent.RetryEvent() -> void
 Kevlar.RetryEvent<TResult>
-Kevlar.RetryEvent<TResult>.RetryNumber.get -> int
+Kevlar.RetryEvent<TResult>.Attempt.get -> int
 Kevlar.RetryEvent<TResult>.Context.get -> Kevlar.KevlarContext!
 Kevlar.RetryEvent<TResult>.Delay.get -> System.TimeSpan
 Kevlar.RetryEvent<TResult>.Outcome.get -> Kevlar.Outcome<TResult>

--- a/src/Kevlar/PublicAPI.Shipped.txt
+++ b/src/Kevlar/PublicAPI.Shipped.txt
@@ -55,7 +55,7 @@ Kevlar.FallbackEvent<TResult>.Context.get -> Kevlar.KevlarContext!
 Kevlar.FallbackEvent<TResult>.FallbackEvent() -> void
 Kevlar.FallbackEvent<TResult>.Outcome.get -> Kevlar.Outcome<TResult>
 Kevlar.HedgeEvent
-Kevlar.HedgeEvent.Attempt.get -> int
+Kevlar.HedgeEvent.AttemptNumber.get -> int
 Kevlar.HedgeEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.HedgeEvent.HedgeEvent() -> void
 Kevlar.HedgingOptions
@@ -104,14 +104,14 @@ Kevlar.RateLimitOptions.RateLimitOptions() -> void
 Kevlar.RateLimitOptions.Window.get -> System.TimeSpan
 Kevlar.RateLimitOptions.Window.set -> void
 Kevlar.RetryEvent
-Kevlar.RetryEvent.Attempt.get -> int
+Kevlar.RetryEvent.RetryNumber.get -> int
 Kevlar.RetryEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.RetryEvent.Delay.get -> System.TimeSpan
 Kevlar.RetryEvent.Exception.get -> System.Exception?
 Kevlar.RetryEvent.Result.get -> object?
 Kevlar.RetryEvent.RetryEvent() -> void
 Kevlar.RetryEvent<TResult>
-Kevlar.RetryEvent<TResult>.Attempt.get -> int
+Kevlar.RetryEvent<TResult>.RetryNumber.get -> int
 Kevlar.RetryEvent<TResult>.Context.get -> Kevlar.KevlarContext!
 Kevlar.RetryEvent<TResult>.Delay.get -> System.TimeSpan
 Kevlar.RetryEvent<TResult>.Outcome.get -> Kevlar.Outcome<TResult>

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -135,12 +135,12 @@ static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<
 Kevlar.HedgeActionGenerator
 Kevlar.HedgeActionGeneratorEvent
 Kevlar.HedgeActionGeneratorEvent.HedgeActionGeneratorEvent() -> void
-Kevlar.HedgeActionGeneratorEvent.Attempt.get -> int
+Kevlar.HedgeActionGeneratorEvent.AttemptNumber.get -> int
 Kevlar.HedgeActionGeneratorEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.HedgeActionGeneratorEvent.OriginalAction.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>!
 Kevlar.HedgeActionGeneratorEvent<TResult>
 Kevlar.HedgeActionGeneratorEvent<TResult>.HedgeActionGeneratorEvent() -> void
-Kevlar.HedgeActionGeneratorEvent<TResult>.Attempt.get -> int
+Kevlar.HedgeActionGeneratorEvent<TResult>.AttemptNumber.get -> int
 Kevlar.HedgeActionGeneratorEvent<TResult>.Context.get -> Kevlar.KevlarContext!
 Kevlar.HedgeActionGeneratorEvent<TResult>.OriginalAction.get -> System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>!
 Kevlar.HedgeOptions.ActionGenerator.get -> Kevlar.HedgeActionGenerator?

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -421,3 +421,9 @@ Kevlar.ShieldBuilder.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) ->
 Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield<TResult>!
 static Kevlar.Shield.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
+*REMOVED*Kevlar.HedgeEvent.Attempt.get -> int
+*REMOVED*Kevlar.RetryEvent.Attempt.get -> int
+*REMOVED*Kevlar.RetryEvent<TResult>.Attempt.get -> int
+Kevlar.HedgeEvent.AttemptNumber.get -> int
+Kevlar.RetryEvent.RetryNumber.get -> int
+Kevlar.RetryEvent<TResult>.RetryNumber.get -> int

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGenerator.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGenerator.cs
@@ -66,7 +66,7 @@ public sealed class HedgeActionGenerator
         {
             var original = new VoidOriginalActionAdapter(hedgeEvent.OriginalAction);
             var action = generator(new HedgeActionGeneratorEvent(
-                hedgeEvent.Attempt,
+                hedgeEvent.AttemptNumber,
                 hedgeEvent.Context,
                 original.Invoke));
             return action is null ? null : new VoidActionAdapter(action).Invoke;

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEvent.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEvent.cs
@@ -4,17 +4,17 @@ namespace Kevlar;
 public readonly struct HedgeActionGeneratorEvent
 {
     internal HedgeActionGeneratorEvent(
-        int attempt,
+        int attemptNumber,
         KevlarContext context,
         Func<CancellationToken, ValueTask> originalAction)
     {
-        Attempt = attempt;
+        AttemptNumber = attemptNumber;
         Context = context;
         OriginalAction = originalAction;
     }
 
-    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
-    public int Attempt { get; }
+    /// <summary>The 1-based execution number (2 = first hedge).</summary>
+    public int AttemptNumber { get; }
 
     /// <summary>The isolated context that belongs to this attempt.</summary>
     public KevlarContext Context { get; }

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEventOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEventOfT.cs
@@ -4,17 +4,17 @@ namespace Kevlar;
 public readonly struct HedgeActionGeneratorEvent<TResult>
 {
     internal HedgeActionGeneratorEvent(
-        int attempt,
+        int attemptNumber,
         KevlarContext context,
         Func<CancellationToken, ValueTask<TResult>> originalAction)
     {
-        Attempt = attempt;
+        AttemptNumber = attemptNumber;
         Context = context;
         OriginalAction = originalAction;
     }
 
-    /// <summary>The 1-based attempt number (2 = first hedge).</summary>
-    public int Attempt { get; }
+    /// <summary>The 1-based execution number (2 = first hedge).</summary>
+    public int AttemptNumber { get; }
 
     /// <summary>The isolated context that belongs to this attempt.</summary>
     public KevlarContext Context { get; }

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -57,14 +57,14 @@ public sealed class HedgeOptions
 /// <summary>Describes a hedged attempt being launched.</summary>
 public readonly struct HedgeEvent
 {
-    internal HedgeEvent(int attempt, KevlarContext context)
+    internal HedgeEvent(int attemptNumber, KevlarContext context)
     {
-        Attempt = attempt;
+        AttemptNumber = attemptNumber;
         Context = context;
     }
 
     /// <summary>The 1-based number of the attempt being launched (2 = first hedge).</summary>
-    public int Attempt { get; }
+    public int AttemptNumber { get; }
 
     /// <summary>
     /// The ambient execution context. It is pooled; do not retain it after synchronous and

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -144,9 +144,9 @@ public sealed class RetryOptions<TResult>
 /// <summary>Describes a retry that is about to happen.</summary>
 public readonly struct RetryEvent
 {
-    internal RetryEvent(int attempt, TimeSpan delay, Exception? exception, object? result, KevlarContext context)
+    internal RetryEvent(int retryNumber, TimeSpan delay, Exception? exception, object? result, KevlarContext context)
     {
-        Attempt = attempt;
+        RetryNumber = retryNumber;
         Delay = delay;
         Exception = exception;
         Result = result;
@@ -154,7 +154,7 @@ public readonly struct RetryEvent
     }
 
     /// <summary>The 1-based number of the retry about to be made (1 = first retry, i.e. second execution).</summary>
-    public int Attempt { get; }
+    public int RetryNumber { get; }
 
     /// <summary>The delay that will be waited before the retry.</summary>
     public TimeSpan Delay { get; }
@@ -191,7 +191,7 @@ public readonly struct RetryEvent<TResult>
     internal RetryEvent(RetryEvent inner) => _inner = inner;
 
     /// <summary>The 1-based number of the retry about to be made (1 = first retry, i.e. second execution).</summary>
-    public int Attempt => _inner.Attempt;
+    public int RetryNumber => _inner.RetryNumber;
 
     /// <summary>The delay that will be waited before the retry.</summary>
     public TimeSpan Delay => _inner.Delay;

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -47,7 +47,8 @@ public class TelemetryRecorderTests
         var records = recorder.Callbacks;
         await Assert.That(records.Select(record => record.Kind)
             .SequenceEqual([CallbackKind.Retry, CallbackKind.Fallback])).IsTrue();
-        await Assert.That(records[0].Attempt).IsEqualTo(1);
+        await Assert.That(records[0].RetryNumber).IsEqualTo(1);
+        await Assert.That(records[0].AttemptNumber).IsNull();
         await Assert.That(records[0].Result).IsEqualTo(-1);
         await Assert.That(records[0].ShieldName).IsEqualTo("typed");
         await Assert.That(records[1].Result).IsEqualTo(-2);
@@ -130,7 +131,8 @@ public class TelemetryRecorderTests
         await Assert.That(records[0].ShieldName).IsEqualTo("timeout");
         await Assert.That(records[0].Timeout).IsEqualTo(TimeSpan.FromMilliseconds(1));
         await Assert.That(records[1].ShieldName).IsEqualTo("hedge");
-        await Assert.That(records[1].Attempt).IsEqualTo(2);
+        await Assert.That(records[1].AttemptNumber).IsEqualTo(2);
+        await Assert.That(records[1].RetryNumber).IsNull();
         await Assert.That(records[2].From).IsEqualTo(CircuitState.Closed);
         await Assert.That(records[2].To).IsEqualTo(CircuitState.Open);
         await Assert.That(records[2].Exception).IsTypeOf<ApplicationException>();

--- a/tests/Kevlar.Tests/AsyncRetryDelayGeneratorTests.cs
+++ b/tests/Kevlar.Tests/AsyncRetryDelayGeneratorTests.cs
@@ -13,13 +13,13 @@ public class AsyncRetryDelayGeneratorTests
             options.Backoff = Backoff.Constant(TimeSpan.FromHours(1));
             options.DelayGeneratorAsync = retry =>
             {
-                order.Add($"generator:{retry.Delay.TotalHours}");
+                order.Add($"generator:{retry.RetryNumber}:{retry.Delay.TotalHours}");
                 return new ValueTask<TimeSpan?>(TimeSpan.Zero);
             };
-            options.OnRetry = retry => order.Add($"sync:{retry.Delay.TotalSeconds}");
+            options.OnRetry = retry => order.Add($"sync:{retry.RetryNumber}:{retry.Delay.TotalSeconds}");
             options.OnRetryAsync = retry =>
             {
-                order.Add($"async:{retry.Delay.TotalSeconds}");
+                order.Add($"async:{retry.RetryNumber}:{retry.Delay.TotalSeconds}");
                 return default;
             };
         });
@@ -34,7 +34,7 @@ public class AsyncRetryDelayGeneratorTests
 
         await Assert.That(result).IsEqualTo(42);
         await Assert.That(order).IsEquivalentTo(
-            ["attempt:1", "generator:1", "sync:0", "async:0", "attempt:2"],
+            ["attempt:1", "generator:1:1", "sync:1:0", "async:1:0", "attempt:2"],
             TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
@@ -215,7 +215,7 @@ public class AsyncRetryDelayGeneratorTests
                 {
                     lock (events)
                     {
-                        events.Add((retry.Attempt, retry.Outcome.Result));
+                        events.Add((retry.RetryNumber, retry.Outcome.Result));
                     }
 
                     return new ValueTask<TimeSpan?>(TimeSpan.Zero);

--- a/tests/Kevlar.Tests/ConcurrencyTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyTests.cs
@@ -74,7 +74,7 @@ public class ConcurrencyTests
                 options.Backoff = Backoff.None;
                 options.OnRetry = retry =>
                 {
-                    if (retry.Attempt == 1)
+                    if (retry.RetryNumber == 1)
                     {
                         retry.Context.Properties.Set(key, retry.Outcome.Result);
                     }

--- a/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
@@ -15,8 +15,8 @@ public class HedgingActionGeneratorTests
             options.Delay = Timeout.InfiniteTimeSpan;
             options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
             {
-                generatedAttempts.Add(hedge.Attempt);
-                return _ => new ValueTask<int>(hedge.Attempt * 10);
+                generatedAttempts.Add(hedge.AttemptNumber);
+                return _ => new ValueTask<int>(hedge.AttemptNumber * 10);
             });
         });
 
@@ -43,7 +43,7 @@ public class HedgingActionGeneratorTests
                 options.Delay = Timeout.InfiniteTimeSpan;
                 options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
                 {
-                    hedge.Context.Properties.Set(key, hedge.Attempt);
+                    hedge.Context.Properties.Set(key, hedge.AttemptNumber);
                     return null;
                 });
             })
@@ -74,7 +74,7 @@ public class HedgingActionGeneratorTests
             {
                 return _ =>
                 {
-                    generatedCalls += hedge.Attempt;
+                    generatedCalls += hedge.AttemptNumber;
                     return ValueTask.CompletedTask;
                 };
             });
@@ -220,7 +220,7 @@ public class HedgingActionGeneratorTests
             options.MaxAttempts = 3;
             options.Delay = Timeout.InfiniteTimeSpan;
             options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
-                hedge.Attempt == 2
+                hedge.AttemptNumber == 2
                     ? _ => ValueTask.FromException<int>(expected)
                     : _ => new ValueTask<int>(42));
         });
@@ -289,10 +289,10 @@ public class HedgingActionGeneratorTests
             options.Delay = TimeSpan.Zero;
             options.ActionGenerator = HedgeActionGenerator.Create<int>(hedge =>
             {
-                contexts[hedge.Attempt] = hedge.Context;
+                contexts[hedge.AttemptNumber] = hedge.Context;
                 return async token =>
                 {
-                    if (hedge.Attempt == 2)
+                    if (hedge.AttemptNumber == 2)
                     {
                         attemptTwoStarted.TrySetResult();
                         try
@@ -404,7 +404,7 @@ public class HedgingActionGeneratorTests
             options.Delay = Timeout.InfiniteTimeSpan;
             options.ActionGenerator = HedgeActionGenerator.Create(hedge =>
             {
-                generatedAttempts.Add(hedge.Attempt);
+                generatedAttempts.Add(hedge.AttemptNumber);
                 return null;
             });
         });

--- a/tests/Kevlar.Tests/HedgingEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/HedgingEdgeCaseTests.cs
@@ -3,14 +3,14 @@ namespace Kevlar.Tests;
 public class HedgingEdgeCaseTests
 {
     [Test]
-    public async Task OnHedge_Fires_For_Each_Extra_Attempt()
+    public async Task Hedge_Event_Numbers_Are_One_Based_Execution_Counts()
     {
         var hedges = new List<int>();
         var shield = Shield.Hedge(options =>
         {
             options.MaxAttempts = 3;
             options.Delay = System.Threading.Timeout.InfiniteTimeSpan;
-            options.OnHedge = hedge => hedges.Add(hedge.Attempt);
+            options.OnHedge = hedge => hedges.Add(hedge.AttemptNumber);
         });
 
         await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))

--- a/tests/Kevlar.Tests/HedgingTests.cs
+++ b/tests/Kevlar.Tests/HedgingTests.cs
@@ -88,7 +88,7 @@ public class HedgingTests
             {
                 options.MaxAttempts = 2;
                 options.Delay = TimeSpan.FromSeconds(1);
-                options.OnHedge = hedge => hedges.Add(hedge.Attempt);
+                options.OnHedge = hedge => hedges.Add(hedge.AttemptNumber);
             })
             .WithTimeProvider(fakeTime);
 

--- a/tests/Kevlar.Tests/RetryHedgeTimeoutCompositionTests.cs
+++ b/tests/Kevlar.Tests/RetryHedgeTimeoutCompositionTests.cs
@@ -19,7 +19,7 @@ public class RetryHedgeTimeoutCompositionTests
             {
                 options.MaxAttempts = 3;
                 options.Delay = System.Threading.Timeout.InfiniteTimeSpan;
-                options.OnHedge = hedge => events.Add($"hedge-{hedge.Attempt}");
+                options.OnHedge = hedge => events.Add($"hedge-{hedge.AttemptNumber}");
             });
 
         await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
@@ -48,7 +48,7 @@ public class RetryHedgeTimeoutCompositionTests
             {
                 options.MaxAttempts = 3;
                 options.Delay = System.Threading.Timeout.InfiniteTimeSpan;
-                options.OnHedge = hedge => events.Add($"hedge-{hedge.Attempt}");
+                options.OnHedge = hedge => events.Add($"hedge-{hedge.AttemptNumber}");
             })
             .Retry(options =>
             {

--- a/tests/Kevlar.Tests/RetryHookCancellationTests.cs
+++ b/tests/Kevlar.Tests/RetryHookCancellationTests.cs
@@ -245,7 +245,7 @@ public class RetryHookCancellationTests
         using var cancellation = new CancellationTokenSource();
         var failure = new InvalidOperationException("retry me");
         var order = new List<string>();
-        var events = new List<(int Attempt, TimeSpan Delay, Exception? Exception, object? Result, CancellationToken Token)>();
+        var events = new List<(int RetryNumber, TimeSpan Delay, Exception? Exception, object? Result, CancellationToken Token)>();
         var attempts = 0;
         var shield = Shield.Retry(options =>
         {
@@ -254,18 +254,18 @@ public class RetryHookCancellationTests
             options.DelayGenerator = retry =>
             {
                 order.Add("delay");
-                events.Add((retry.Attempt, retry.Delay, retry.Exception, retry.Result, retry.Context.CancellationToken));
+                events.Add((retry.RetryNumber, retry.Delay, retry.Exception, retry.Result, retry.Context.CancellationToken));
                 return TimeSpan.Zero;
             };
             options.OnRetry = retry =>
             {
                 order.Add("sync");
-                events.Add((retry.Attempt, retry.Delay, retry.Exception, retry.Result, retry.Context.CancellationToken));
+                events.Add((retry.RetryNumber, retry.Delay, retry.Exception, retry.Result, retry.Context.CancellationToken));
             };
             options.OnRetryAsync = retry =>
             {
                 order.Add("async");
-                events.Add((retry.Attempt, retry.Delay, retry.Exception, retry.Result, retry.Context.CancellationToken));
+                events.Add((retry.RetryNumber, retry.Delay, retry.Exception, retry.Result, retry.Context.CancellationToken));
                 return default;
             };
         });
@@ -284,7 +284,7 @@ public class RetryHookCancellationTests
         await Assert.That(events.Count).IsEqualTo(3);
         foreach (var retryEvent in events)
         {
-            await Assert.That(retryEvent.Attempt).IsEqualTo(1);
+            await Assert.That(retryEvent.RetryNumber).IsEqualTo(1);
             await Assert.That(retryEvent.Delay).IsEqualTo(TimeSpan.Zero);
             await Assert.That(ReferenceEquals(retryEvent.Exception, failure)).IsTrue();
             await Assert.That(retryEvent.Result).IsNull();

--- a/tests/Kevlar.Tests/RetryTests.cs
+++ b/tests/Kevlar.Tests/RetryTests.cs
@@ -128,24 +128,46 @@ public class RetryTests
     }
 
     [Test]
-    public async Task OnRetry_Receives_Event_Data()
+    public async Task Retry_Event_Numbers_Are_One_Based_Retry_Counts()
     {
-        var events = new List<(int Attempt, TimeSpan Delay, Exception? Exception)>();
+        var events = new List<(int RetryNumber, TimeSpan Delay, Exception? Exception)>();
         var shield = Shield.Retry(options =>
         {
-            options.MaxRetries = 2;
+            options.MaxRetries = 3;
             options.Backoff = Backoff.None;
-            options.OnRetry = retry => events.Add((retry.Attempt, retry.Delay, retry.Exception));
+            options.OnRetry = retry => events.Add((retry.RetryNumber, retry.Delay, retry.Exception));
         });
 
         await Assert.That(async () => await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
             .Throws<InvalidOperationException>();
 
-        await Assert.That(events.Count).IsEqualTo(2);
-        await Assert.That(events[0].Attempt).IsEqualTo(1);
-        await Assert.That(events[1].Attempt).IsEqualTo(2);
+        await Assert.That(events.Select(retry => retry.RetryNumber).SequenceEqual([1, 2, 3])).IsTrue();
         await Assert.That(events[0].Delay).IsEqualTo(TimeSpan.Zero);
         await Assert.That(events[0].Exception).IsTypeOf<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task DelayGenerator_And_OnRetry_Receive_The_Same_Retry_Number_During_Sync_Execution()
+    {
+        var generated = new List<int>();
+        var notified = new List<int>();
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 3;
+            options.Backoff = Backoff.None;
+            options.DelayGenerator = retry =>
+            {
+                generated.Add(retry.RetryNumber);
+                return TimeSpan.Zero;
+            };
+            options.OnRetry = retry => notified.Add(retry.RetryNumber);
+        });
+
+        await Assert.That(() => shield.Execute<int>(static _ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(generated.SequenceEqual([1, 2, 3])).IsTrue();
+        await Assert.That(notified.SequenceEqual(generated)).IsTrue();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- rename retry callback counters to \RetryNumber\ (1 = first retry after initial execution)
- rename hedge callback/generator counters to \AttemptNumber\ (2 = first hedge execution)
- expose distinct nullable counters in \Kevlar.Testing.CallbackRecord\`n- pin sync, async, typed, telemetry, and executable documentation behavior

The counters intentionally keep their existing units; explicit names remove the ambiguous shared \Attempt\ surface without introducing a context-wide number whose meaning changes under nested strategies.

Closes #197

## Validation
- \dotnet build Kevlar.slnx -c Release\`n- \dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict\ (850 passed)
- \dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict\ (51 passed)
- \./scripts/Verify-Docs.ps1\`n- \./scripts/Verify-DocSnippets.ps1 -PackagesPath ./artifacts/issue197-doc-pack -Version 1.0.0-eventnumbers\ (119 snippets)