### PR TITLE
refactor(naming)!: standardize queue limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 | `Shield.For<T>().WhenDefault()` | `Shield.For<T>().WhenResultIsDefault()` |
 | `builder.OrDefault()` | `builder.OrResultIsDefault()` |
 | `Shield.For<T>().Fallback(value)` | `Shield.For<T>().FallbackTo(value)` |
+| `ConcurrencyLimit(..., maxQueue: n)` / `options.MaxQueue` | `ConcurrencyLimit(..., queueLimit: n)` / `options.QueueLimit` |
 
 `OrWhen` is gone: `Or(Func<Exception, bool>)` now mirrors `When(Func<Exception, bool>)`, so the
 untyped predicate has the same spelling in both clause positions. `WhenDefault`/`OrDefault` were

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -41,7 +41,7 @@ services.AddHttpClient("api")
         options.ConcurrencyLimit = new ConcurrencyLimitOptions
         {
             MaxConcurrency = 100,
-            MaxQueue = 20,
+            QueueLimit = 20,
         };
         options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(5);
         options.Handler.ContentReplayPolicy = HttpContentReplayPolicy.Buffer;
@@ -60,7 +60,7 @@ For dependency-aware setup, use the service-provider overload:
 services.AddSingleton(new ConcurrencyLimitOptions
 {
     MaxConcurrency = 100,
-    MaxQueue = 20,
+    QueueLimit = 20,
 });
 services.AddHttpClient("api")
     .AddStandardShield((serviceProvider, options) =>
@@ -260,7 +260,7 @@ services.AddHttpClient("routed")
 `AddStandardHedgingShield` installs a 30s total timeout and up to two hedged attempts. Each endpoint
 gets its own 10-concurrent/zero-queue limiter, 50%-over-30s circuit breaker (minimum 10 attempts,
 15s break), and 10s attempt timeout. Configure those defaults through `TotalTimeout`, `MaxAttempts`,
-`HedgeDelay`, `MaxConcurrency`, `MaxQueue`, `FailureRatio` or `ConsecutiveFailures`,
+`HedgeDelay`, `MaxConcurrency`, `QueueLimit`, `FailureRatio` or `ConsecutiveFailures`,
 `MinimumThroughput`, `SamplingWindow`, `BreakDuration`, and `AttemptTimeout`.
 
 The registration also exposes `ContentReplayPolicy`, `MaximumBufferSize`,

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -16,10 +16,11 @@ var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))
     .Retry(3)
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30))
+    .ConcurrencyLimit(10, queueLimit: 5)
     .WithName("github");
 
 Console.WriteLine(shield);
-// github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s)
+// github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)
 ```
 
 Log it once at startup and every incident review starts from the actual configuration, not the configuration someone remembers. Custom strategies participate by overriding `Strategy.Describe()`.

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -17,7 +17,7 @@ Kevlar's pipeline model translates 1:1 from Polly v8 — the "first strategy add
 | `BrokenCircuitException` | `CircuitOpenException` (with `RetryAfter`) |
 | `TimeoutRejectedException` | `TimeoutExceededException` |
 | `CircuitBreakerManualControl` + `StateProvider` | one `CircuitBreakerMonitor` |
-| `AddConcurrencyLimiter(10, 20)` | `Shield.ConcurrencyLimit(10, maxQueue: 20)` |
+| `AddConcurrencyLimiter(10, 20)` | `Shield.ConcurrencyLimit(10, queueLimit: 20)` |
 | Delegates must return `ValueTask` | `Task`-returning methods flow straight in: `shield.ExecuteAsync(ct => client.GetAsync(url, ct))` |
 | Retry default: constant 2s, no jitter | exponential + jitter, 30s cap |
 | First strategy added is outermost | same rule — pipelines translate 1:1 |

--- a/docs/docs/strategies/concurrency-limit.md
+++ b/docs/docs/strategies/concurrency-limit.md
@@ -7,12 +7,12 @@ sidebar_position: 5
 Concurrency isolation: cap how many executions run at once, so one misbehaving dependency can't drain your whole thread pool or connection pool.
 
 ```csharp
-Shield.ConcurrencyLimit(maxConcurrency: 10, maxQueue: 20);
+Shield.ConcurrencyLimit(maxConcurrency: 10, queueLimit: 20);
 
 Shield.ConcurrencyLimit(o =>
 {
     o.MaxConcurrency = 10;   // default 10
-    o.MaxQueue = 20;         // default 0 — reject immediately when full
+    o.QueueLimit = 20;         // default 0 — reject immediately when full
     o.OnRejected = rejection =>
         logger.LogWarning("Concurrency limit {Limit} rejected work", rejection.MaxConcurrency);
     o.OnRejectedAsync = static _ => ValueTask.CompletedTask;
@@ -24,11 +24,11 @@ Shield.ConcurrencyLimit(o =>
 | Option | Default | What it does |
 |---|---|---|
 | `MaxConcurrency` | `10` | Executions allowed to run simultaneously |
-| `MaxQueue` | `0` | Executions allowed to wait for a slot; `0` = reject immediately when all slots are busy |
+| `QueueLimit` | `0` | Executions allowed to wait for a slot; `0` = reject immediately when all slots are busy |
 | `OnRejected` | — | Synchronous notification for an actual rejection |
 | `OnRejectedAsync` | — | Awaited notification after `OnRejected` |
 
-Total capacity is `MaxConcurrency + MaxQueue`. Anything beyond that fails **immediately** with `ConcurrencyLimitExceededException` — the overflow check happens before any waiting, so rejection is instant and allocation-light.
+Total capacity is `MaxConcurrency + QueueLimit`. Anything beyond that fails **immediately** with `ConcurrencyLimitExceededException` — the overflow check happens before any waiting, so rejection is instant and allocation-light.
 
 For an actual rejection, Kevlar publishes current limiter state and rejection metrics, invokes
 `OnRejected`, awaits `OnRejectedAsync`, then surfaces `ConcurrencyLimitExceededException`. The
@@ -51,7 +51,7 @@ This is the classic *bulkhead* pattern, named after ship compartments: a breach 
 
 ```csharp
 // Each dependency gets its own compartment:
-var searchShield  = Shield.ConcurrencyLimit(10, maxQueue: 20).Timeout(TimeSpan.FromSeconds(2));
+var searchShield  = Shield.ConcurrencyLimit(10, queueLimit: 20).Timeout(TimeSpan.FromSeconds(2));
 var paymentShield = Shield.ConcurrencyLimit(5).Timeout(TimeSpan.FromSeconds(10));
 ```
 
@@ -71,5 +71,5 @@ Shield.Retry(3).ConcurrencyLimit(10);   // retry wraps the concurrency limit:
 Retry-outside is usually what you want: slots are freed during backoff delays instead of being held while sleeping.
 
 :::warning Sync callers block while queueing
-With `MaxQueue > 0`, synchronous `Execute` waits on the semaphore with a blocking wait. Prefer async execution when queueing is enabled.
+With `QueueLimit > 0`, synchronous `Execute` waits on the semaphore with a blocking wait. Prefer async execution when queueing is enabled.
 :::

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -84,7 +84,7 @@ Stateless strategies are omitted.
 
 <!-- doc-test-ignore: The executable documentation harness owns Main; this TUnit example is compiled by Kevlar.Testing.Tests. -->
 ```csharp
-var shield = Shield.ConcurrencyLimit(1, maxQueue: 1);
+var shield = Shield.ConcurrencyLimit(1, queueLimit: 1);
 var probe = new ExecutionProbe();
 
 await shield.ExecuteAsync(probe.Wrap(static _ => ValueTask.CompletedTask));

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -347,7 +347,7 @@ if ($observableSnippetIndex -lt 0 `
 [void]$builder.AppendLine('            Console.SetOut(original);')
 [void]$builder.AppendLine('        }')
 [void]$builder.AppendLine('        var actual = output.ToString().Trim();')
-[void]$builder.AppendLine('        const string expected = "github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s)";')
+[void]$builder.AppendLine('        const string expected = "github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)";')
 [void]$builder.AppendLine('        if (!string.Equals(actual, expected, StringComparison.Ordinal))')
 [void]$builder.AppendLine('        {')
 [void]$builder.AppendLine('            throw new InvalidOperationException($"Documented pipeline output changed. Expected: {expected}; actual: {actual}");')

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -299,14 +299,15 @@ public static class KevlarServiceCollectionExtensions
         var concurrency = configuration.GetSection(nameof(ShieldDefinition.ConcurrencyLimit));
         if (HasChildren(concurrency))
         {
+            RejectLegacyQueueKey(concurrency);
             var concurrencyDefinition = new ConcurrencyLimitDefinition();
             if (ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxConcurrency)) is { } maxConcurrency)
             {
                 concurrencyDefinition.MaxConcurrency = maxConcurrency;
             }
-            if (ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.MaxQueue)) is { } maxQueue)
+            if (ReadInt(concurrency, nameof(ConcurrencyLimitDefinition.QueueLimit)) is { } queueLimit)
             {
-                concurrencyDefinition.MaxQueue = maxQueue;
+                concurrencyDefinition.QueueLimit = queueLimit;
             }
 
             definition.ConcurrencyLimit = concurrencyDefinition;
@@ -316,6 +317,16 @@ public static class KevlarServiceCollectionExtensions
     }
 
     private static bool HasChildren(IConfigurationSection section) => section.GetChildren().Any();
+
+    private static void RejectLegacyQueueKey(IConfigurationSection section)
+    {
+        const string legacyKey = "MaxQueue";
+        if (section[legacyKey] is not null)
+        {
+            throw new InvalidOperationException(
+                $"Configuration key '{ConfigurationPath.Combine(section.Path, legacyKey)}' is not supported; use 'QueueLimit'.");
+        }
+    }
 
     private static string? Read(IConfiguration configuration, string key) =>
         configuration[key];

--- a/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Shipped.txt
+++ b/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Shipped.txt
@@ -20,8 +20,8 @@ Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition
 Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.ConcurrencyLimitDefinition() -> void
 Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxConcurrency.get -> int
 Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxConcurrency.set -> void
-Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxQueue.get -> int
-Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxQueue.set -> void
+Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.QueueLimit.get -> int
+Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.QueueLimit.set -> void
 Kevlar.Extensions.DependencyInjection.IKevlarRegistry
 Kevlar.Extensions.DependencyInjection.IKevlarRegistry.GetShield(string! name) -> Kevlar.Shield!
 Kevlar.Extensions.DependencyInjection.IKevlarRegistry.GetShield<TResult>(string! name) -> Kevlar.Shield<TResult>!

--- a/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Shipped.txt
+++ b/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Shipped.txt
@@ -20,8 +20,8 @@ Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition
 Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.ConcurrencyLimitDefinition() -> void
 Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxConcurrency.get -> int
 Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxConcurrency.set -> void
-Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.QueueLimit.get -> int
-Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.QueueLimit.set -> void
+Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxQueue.get -> int
+Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxQueue.set -> void
 Kevlar.Extensions.DependencyInjection.IKevlarRegistry
 Kevlar.Extensions.DependencyInjection.IKevlarRegistry.GetShield(string! name) -> Kevlar.Shield!
 Kevlar.Extensions.DependencyInjection.IKevlarRegistry.GetShield<TResult>(string! name) -> Kevlar.Shield<TResult>!

--- a/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
@@ -15,3 +15,7 @@ Kevlar.Extensions.DependencyInjection.IKevlarRegistry.TryGetVoidShield(string! n
 static Kevlar.Extensions.DependencyInjection.KevlarServiceCollectionExtensions.AddPartitionedVoidShield<TKey>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! name, System.Func<System.IServiceProvider!, TKey, Kevlar.VoidShield!>! factory, System.Action<Kevlar.PartitionedShieldOptions!>? configure = null, System.Collections.Generic.IEqualityComparer<TKey>? comparer = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Kevlar.Extensions.DependencyInjection.KevlarServiceCollectionExtensions.AddShield(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! name, Kevlar.VoidShield! shield) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Kevlar.Extensions.DependencyInjection.KevlarServiceCollectionExtensions.AddVoidShield(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! name, System.Func<System.IServiceProvider!, Kevlar.VoidShield!>! factory) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+*REMOVED*Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxQueue.get -> int
+*REMOVED*Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.MaxQueue.set -> void
+Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.QueueLimit.get -> int
+Kevlar.Extensions.DependencyInjection.ConcurrencyLimitDefinition.QueueLimit.set -> void

--- a/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
@@ -92,7 +92,7 @@ public sealed class ShieldDefinition
 
         if (ConcurrencyLimit is { } concurrency)
         {
-            shield = shield.ConcurrencyLimit(concurrency.MaxConcurrency, concurrency.MaxQueue);
+            shield = shield.ConcurrencyLimit(concurrency.MaxConcurrency, concurrency.QueueLimit);
         }
 
         if (AttemptTimeout is { } attempt)
@@ -189,5 +189,5 @@ public sealed class ConcurrencyLimitDefinition
     public int MaxConcurrency { get; set; } = 10;
 
     /// <summary>Executions allowed to wait for a slot. Default 0.</summary>
-    public int MaxQueue { get; set; }
+    public int QueueLimit { get; set; }
 }

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -231,6 +231,6 @@ public static class HttpShield
     private static void Copy(ConcurrencyLimitOptions source, ConcurrencyLimitOptions target)
     {
         target.MaxConcurrency = source.MaxConcurrency;
-        target.MaxQueue = source.MaxQueue;
+        target.QueueLimit = source.QueueLimit;
     }
 }

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -55,8 +55,8 @@ Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxConcurrency.get -> int
 Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxConcurrency.set -> void
 Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaximumBufferSize.get -> long
 Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaximumBufferSize.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxQueue.get -> int
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxQueue.set -> void
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.QueueLimit.get -> int
+Kevlar.Extensions.Http.StandardHedgingShieldOptions.QueueLimit.set -> void
 Kevlar.Extensions.Http.StandardHedgingShieldOptions.MinimumThroughput.get -> int
 Kevlar.Extensions.Http.StandardHedgingShieldOptions.MinimumThroughput.set -> void
 Kevlar.Extensions.Http.StandardHedgingShieldOptions.RequestFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, int, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.Http.HttpRequestMessage!>>?

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -402,7 +402,7 @@ public static class ShieldHttpClientBuilderExtensions
         StandardHedgingShieldOptions options)
     {
         var maxConcurrency = options.MaxConcurrency;
-        var maxQueue = options.MaxQueue;
+        var queueLimit = options.QueueLimit;
         var consecutiveFailures = options.ConsecutiveFailures;
         var failureRatio = options.FailureRatio;
         var minimumThroughput = options.MinimumThroughput;
@@ -412,7 +412,7 @@ public static class ShieldHttpClientBuilderExtensions
 
         Shield<HttpResponseMessage> CreateEndpointShield(Uri _) =>
             HttpShield.WhenTransient()
-                .ConcurrencyLimit(maxConcurrency, maxQueue)
+                .ConcurrencyLimit(maxConcurrency, queueLimit)
                 .CircuitBreaker(circuitBreaker =>
                 {
                     circuitBreaker.ConsecutiveFailures = consecutiveFailures;

--- a/src/Kevlar.Extensions.Http/StandardHedgingShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHedgingShieldOptions.cs
@@ -19,7 +19,7 @@ public sealed class StandardHedgingShieldOptions
     public int MaxConcurrency { get; set; } = 10;
 
     /// <summary>Maximum attempts queued per endpoint. Default 0.</summary>
-    public int MaxQueue { get; set; }
+    public int QueueLimit { get; set; }
 
     /// <summary>Trips each endpoint circuit after this many consecutive transient failures.</summary>
     public int? ConsecutiveFailures { get; set; }

--- a/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
@@ -24,12 +24,13 @@ internal static class StandardHttpConfigurationBinder
     {
         var options = new StandardHedgingShieldOptions();
 
+        RejectLegacyQueueKey(configuration);
         SetTimeSpan(configuration, nameof(options.TotalTimeout), value => options.TotalTimeout = value);
         SetInt(configuration, nameof(options.MaxAttempts), value => options.MaxAttempts = value);
         SetTimeSpan(configuration, nameof(options.HedgeDelay), value => options.HedgeDelay = value);
         SetTimeSpan(configuration, nameof(options.AttemptTimeout), value => options.AttemptTimeout = value);
         SetInt(configuration, nameof(options.MaxConcurrency), value => options.MaxConcurrency = value);
-        SetInt(configuration, nameof(options.MaxQueue), value => options.MaxQueue = value);
+        SetInt(configuration, nameof(options.QueueLimit), value => options.QueueLimit = value);
         SetNullableInt(configuration, nameof(options.ConsecutiveFailures), value => options.ConsecutiveFailures = value);
         SetNullableDouble(configuration, nameof(options.FailureRatio), value => options.FailureRatio = value);
         if (configuration[nameof(options.ConsecutiveFailures)] is not null
@@ -149,9 +150,10 @@ internal static class StandardHttpConfigurationBinder
             return;
         }
 
+        RejectLegacyQueueKey(section);
         var options = standard.ConcurrencyLimit ?? new ConcurrencyLimitOptions();
         SetInt(section, nameof(options.MaxConcurrency), value => options.MaxConcurrency = value);
-        SetInt(section, nameof(options.MaxQueue), value => options.MaxQueue = value);
+        SetInt(section, nameof(options.QueueLimit), value => options.QueueLimit = value);
         standard.ConcurrencyLimit = options;
     }
 
@@ -206,6 +208,19 @@ internal static class StandardHttpConfigurationBinder
         }
     }
 
+    private static void RejectLegacyQueueKey(IConfiguration configuration)
+    {
+        const string legacyKey = "MaxQueue";
+        if (configuration[legacyKey] is not null)
+        {
+            var path = configuration is IConfigurationSection { Path.Length: > 0 } section
+                ? ConfigurationPath.Combine(section.Path, legacyKey)
+                : legacyKey;
+            throw new InvalidOperationException(
+                $"Configuration key '{path}' is not supported; use 'QueueLimit'.");
+        }
+    }
+
     private static void ValidateStandard(
         IConfiguration configuration,
         StandardHttpShieldOptions options)
@@ -217,7 +232,7 @@ internal static class StandardHttpConfigurationBinder
         if (options.ConcurrencyLimit is { } concurrency)
         {
             Ensure(concurrency.MaxConcurrency > 0, configuration.GetSection("ConcurrencyLimit:MaxConcurrency"), "must be positive");
-            Ensure(concurrency.MaxQueue >= 0, configuration.GetSection("ConcurrencyLimit:MaxQueue"), "must not be negative");
+            Ensure(concurrency.QueueLimit >= 0, configuration.GetSection("ConcurrencyLimit:QueueLimit"), "must not be negative");
         }
 
         Ensure(options.AttemptTimeout.Timeout > TimeSpan.Zero, TimeoutSection(configuration, nameof(options.AttemptTimeout)), "must be positive");
@@ -243,7 +258,7 @@ internal static class StandardHttpConfigurationBinder
             "must be non-negative or Timeout.InfiniteTimeSpan");
         Ensure(options.AttemptTimeout > TimeSpan.Zero, configuration.GetSection(nameof(options.AttemptTimeout)), "must be positive");
         Ensure(options.MaxConcurrency > 0, configuration.GetSection(nameof(options.MaxConcurrency)), "must be positive");
-        Ensure(options.MaxQueue >= 0, configuration.GetSection(nameof(options.MaxQueue)), "must not be negative");
+        Ensure(options.QueueLimit >= 0, configuration.GetSection(nameof(options.QueueLimit)), "must not be negative");
         ValidateCircuitBreaker(configuration, options.ConsecutiveFailures, options.FailureRatio, options.MinimumThroughput, options.SamplingWindow, options.BreakDuration);
         Ensure(options.MaximumBufferSize > 0, configuration.GetSection(nameof(options.MaximumBufferSize)), "must be positive");
         Ensure(

--- a/src/Kevlar.Testing/ConcurrencyLimitStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/ConcurrencyLimitStrategyDescriptor.cs
@@ -6,12 +6,12 @@ public sealed class ConcurrencyLimitStrategyDescriptor : StrategyDescriptor
     internal ConcurrencyLimitStrategyDescriptor(
         string description,
         int maxConcurrency,
-        int maxQueue,
+        int queueLimit,
         bool hasNotification)
         : base(StrategyKind.ConcurrencyLimit, description)
     {
         MaxConcurrency = maxConcurrency;
-        MaxQueue = maxQueue;
+        QueueLimit = queueLimit;
         HasNotification = hasNotification;
     }
 
@@ -19,7 +19,7 @@ public sealed class ConcurrencyLimitStrategyDescriptor : StrategyDescriptor
     public int MaxConcurrency { get; }
 
     /// <summary>The maximum wait queue size.</summary>
-    public int MaxQueue { get; }
+    public int QueueLimit { get; }
 
     /// <summary>Whether synchronous or asynchronous rejection notifications are configured.</summary>
     public bool HasNotification { get; }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -14,7 +14,7 @@ Kevlar.Testing.CircuitBreakerStrategyDescriptor.MinimumThroughput.get -> int
 Kevlar.Testing.CircuitBreakerStrategyDescriptor.SamplingWindow.get -> System.TimeSpan
 Kevlar.Testing.ConcurrencyLimitStrategyDescriptor
 Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.MaxConcurrency.get -> int
-Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.MaxQueue.get -> int
+Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.QueueLimit.get -> int
 Kevlar.Testing.CustomStrategyDescriptor
 Kevlar.Testing.CustomStrategyDescriptor.Handling.get -> Kevlar.HandlingClause?
 Kevlar.Testing.CustomStrategyDescriptor.StrategyType.get -> System.Type!

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -87,7 +87,7 @@ public static class ShieldDescriptorExtensions
             ConcurrencyLimitStrategy concurrency => new ConcurrencyLimitStrategyDescriptor(
                 description,
                 concurrency.MaxConcurrency,
-                concurrency.MaxQueue,
+                concurrency.QueueLimit,
                 concurrency.HasNotification),
             HedgingStrategy hedging => new HedgingStrategyDescriptor(
                 description,

--- a/src/Kevlar/PublicAPI.Shipped.txt
+++ b/src/Kevlar/PublicAPI.Shipped.txt
@@ -45,8 +45,8 @@ Kevlar.ConcurrencyLimitOptions
 Kevlar.ConcurrencyLimitOptions.ConcurrencyLimitOptions() -> void
 Kevlar.ConcurrencyLimitOptions.MaxConcurrency.get -> int
 Kevlar.ConcurrencyLimitOptions.MaxConcurrency.set -> void
-Kevlar.ConcurrencyLimitOptions.QueueLimit.get -> int
-Kevlar.ConcurrencyLimitOptions.QueueLimit.set -> void
+Kevlar.ConcurrencyLimitOptions.MaxQueue.get -> int
+Kevlar.ConcurrencyLimitOptions.MaxQueue.set -> void
 Kevlar.Continuation<T, TState>
 Kevlar.Continuation<T, TState>.Continuation() -> void
 Kevlar.Continuation<T, TState>.InvokeAsync(Kevlar.KevlarContext! context) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
@@ -152,7 +152,7 @@ Kevlar.Shield.Name.get -> string?
 Kevlar.Shield<TResult>
 Kevlar.Shield<TResult>.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Execute(System.Func<System.Threading.CancellationToken, TResult>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
 Kevlar.Shield<TResult>.Execute<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, TResult>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
@@ -187,7 +187,7 @@ Kevlar.Shield<TResult>.Wrap(Kevlar.Shield<TResult>! inner) -> Kevlar.Shield<TRes
 Kevlar.ShieldBuilder
 Kevlar.ShieldBuilder.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield!
-Kevlar.ShieldBuilder.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
+Kevlar.ShieldBuilder.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.Hedge(int maxAttempts, System.TimeSpan delay) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield!
@@ -206,7 +206,7 @@ Kevlar.ShieldBuilder.When<TException>(System.Func<TException!, bool>! predicate)
 Kevlar.ShieldBuilder<TResult>
 Kevlar.ShieldBuilder<TResult>.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
@@ -263,7 +263,7 @@ static Kevlar.Outcome<T>.FromResult(T result) -> Kevlar.Outcome<T>
 static Kevlar.Shield.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield!
 static Kevlar.Shield.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.Shield.Compose(params Kevlar.Shield![]! shields) -> Kevlar.Shield!
-static Kevlar.Shield.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
+static Kevlar.Shield.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
 static Kevlar.Shield.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.Shield.Empty.get -> Kevlar.Shield!
 static Kevlar.Shield.For<TResult>() -> Kevlar.ShieldBuilder<TResult>!
@@ -284,7 +284,7 @@ static Kevlar.Shield.When<TException>(System.Func<TException!, bool>! predicate)
 static Kevlar.Shield<TResult>.Empty.get -> Kevlar.Shield<TResult>!
 static Kevlar.ShieldExtensions.CircuitBreaker(this Kevlar.Shield! shield, int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.CircuitBreaker(this Kevlar.Shield! shield, System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield!
-static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!

--- a/src/Kevlar/PublicAPI.Shipped.txt
+++ b/src/Kevlar/PublicAPI.Shipped.txt
@@ -45,8 +45,8 @@ Kevlar.ConcurrencyLimitOptions
 Kevlar.ConcurrencyLimitOptions.ConcurrencyLimitOptions() -> void
 Kevlar.ConcurrencyLimitOptions.MaxConcurrency.get -> int
 Kevlar.ConcurrencyLimitOptions.MaxConcurrency.set -> void
-Kevlar.ConcurrencyLimitOptions.MaxQueue.get -> int
-Kevlar.ConcurrencyLimitOptions.MaxQueue.set -> void
+Kevlar.ConcurrencyLimitOptions.QueueLimit.get -> int
+Kevlar.ConcurrencyLimitOptions.QueueLimit.set -> void
 Kevlar.Continuation<T, TState>
 Kevlar.Continuation<T, TState>.Continuation() -> void
 Kevlar.Continuation<T, TState>.InvokeAsync(Kevlar.KevlarContext! context) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
@@ -152,7 +152,7 @@ Kevlar.Shield.Name.get -> string?
 Kevlar.Shield<TResult>
 Kevlar.Shield<TResult>.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.Shield<TResult>.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield<TResult>!
+Kevlar.Shield<TResult>.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield<TResult>!
 Kevlar.Shield<TResult>.Execute(System.Func<System.Threading.CancellationToken, TResult>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
 Kevlar.Shield<TResult>.Execute<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, TResult>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> TResult
@@ -187,7 +187,7 @@ Kevlar.Shield<TResult>.Wrap(Kevlar.Shield<TResult>! inner) -> Kevlar.Shield<TRes
 Kevlar.ShieldBuilder
 Kevlar.ShieldBuilder.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield!
-Kevlar.ShieldBuilder.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
+Kevlar.ShieldBuilder.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.Hedge(int maxAttempts, System.TimeSpan delay) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.Hedge(System.Action<Kevlar.HedgingOptions!>! configure) -> Kevlar.Shield!
@@ -206,7 +206,7 @@ Kevlar.ShieldBuilder.When<TException>(System.Func<TException!, bool>! predicate)
 Kevlar.ShieldBuilder<TResult>
 Kevlar.ShieldBuilder<TResult>.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield<TResult>!
-Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<Kevlar.Outcome<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! fallback, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder<TResult>.Fallback(TResult fallbackValue, System.Action<Kevlar.FallbackEvent<TResult>>? onFallback = null) -> Kevlar.Shield<TResult>!
@@ -263,7 +263,7 @@ static Kevlar.Outcome<T>.FromResult(T result) -> Kevlar.Outcome<T>
 static Kevlar.Shield.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield!
 static Kevlar.Shield.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.Shield.Compose(params Kevlar.Shield![]! shields) -> Kevlar.Shield!
-static Kevlar.Shield.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
+static Kevlar.Shield.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
 static Kevlar.Shield.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.Shield.Empty.get -> Kevlar.Shield!
 static Kevlar.Shield.For<TResult>() -> Kevlar.ShieldBuilder<TResult>!
@@ -284,7 +284,7 @@ static Kevlar.Shield.When<TException>(System.Func<TException!, bool>! predicate)
 static Kevlar.Shield<TResult>.Empty.get -> Kevlar.Shield<TResult>!
 static Kevlar.ShieldExtensions.CircuitBreaker(this Kevlar.Shield! shield, int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.CircuitBreaker(this Kevlar.Shield! shield, System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.Shield!
-static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
 static Kevlar.ShieldExtensions.Fallback(this Kevlar.Shield! shield, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -157,7 +157,7 @@ Kevlar.ConcurrencyLimitRejectedEvent
 Kevlar.ConcurrencyLimitRejectedEvent.ConcurrencyLimitRejectedEvent() -> void
 Kevlar.ConcurrencyLimitRejectedEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.ConcurrencyLimitRejectedEvent.MaxConcurrency.get -> int
-Kevlar.ConcurrencyLimitRejectedEvent.MaxQueue.get -> int
+Kevlar.ConcurrencyLimitRejectedEvent.QueueLimit.get -> int
 Kevlar.ConcurrencyLimitRejectedEvent.StrategyIndex.get -> int
 Kevlar.RateLimitOptions.OnRejected.get -> System.Action<Kevlar.RateLimitRejectedEvent>?
 Kevlar.RateLimitOptions.OnRejected.set -> void
@@ -299,7 +299,7 @@ Kevlar.ShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.Ca
 Kevlar.VoidShield
 Kevlar.VoidShield.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.VoidShield!
 Kevlar.VoidShield.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.VoidShield!
-Kevlar.VoidShield.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.VoidShield!
+Kevlar.VoidShield.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.VoidShield!
 Kevlar.VoidShield.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.VoidShield!
 Kevlar.VoidShield.Execute(System.Action<System.Threading.CancellationToken>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Kevlar.VoidShield.Execute<TState>(TState state, System.Action<TState, System.Threading.CancellationToken>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
@@ -340,7 +340,7 @@ Kevlar.VoidShield.Wrap(Kevlar.VoidShield! inner) -> Kevlar.VoidShield!
 Kevlar.VoidShieldBuilder
 Kevlar.VoidShieldBuilder.CircuitBreaker(int consecutiveFailures, System.TimeSpan breakDuration) -> Kevlar.VoidShield!
 Kevlar.VoidShieldBuilder.CircuitBreaker(System.Action<Kevlar.CircuitBreakerOptions!>! configure) -> Kevlar.VoidShield!
-Kevlar.VoidShieldBuilder.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.VoidShield!
+Kevlar.VoidShieldBuilder.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.VoidShield!
 Kevlar.VoidShieldBuilder.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.VoidShield!
 Kevlar.VoidShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.VoidShield!
 Kevlar.VoidShieldBuilder.Fallback(System.Func<System.Exception!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.VoidShield!

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -407,3 +407,17 @@ Kevlar.HedgeOptions<TResult>.OnHedge.get -> System.Action<Kevlar.HedgeEvent>?
 Kevlar.HedgeOptions<TResult>.OnHedge.set -> void
 Kevlar.HedgeOptions<TResult>.OnHedgeAsync.get -> System.Func<Kevlar.HedgeEvent, System.Threading.Tasks.ValueTask>?
 Kevlar.HedgeOptions<TResult>.OnHedgeAsync.set -> void
+*REMOVED*Kevlar.ConcurrencyLimitOptions.MaxQueue.get -> int
+*REMOVED*Kevlar.ConcurrencyLimitOptions.MaxQueue.set -> void
+*REMOVED*Kevlar.Shield<TResult>.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield<TResult>!
+*REMOVED*Kevlar.ShieldBuilder.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
+*REMOVED*Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield<TResult>!
+*REMOVED*static Kevlar.Shield.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
+*REMOVED*static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield!
+Kevlar.ConcurrencyLimitOptions.QueueLimit.get -> int
+Kevlar.ConcurrencyLimitOptions.QueueLimit.set -> void
+Kevlar.Shield<TResult>.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
+Kevlar.ShieldBuilder<TResult>.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield<TResult>!
+static Kevlar.Shield.ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!
+static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int maxConcurrency, int queueLimit = 0) -> Kevlar.Shield!

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -101,7 +101,7 @@ public sealed class Shield
     public static Shield RateLimit(Action<RateLimitOptions> configure) => ShieldExtensions.RateLimit(Empty, configure);
 
     /// <summary>Caps concurrent executions at <paramref name="maxConcurrency"/> with an optional wait queue.</summary>
-    public static Shield ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) => ShieldExtensions.ConcurrencyLimit(Empty, maxConcurrency, maxQueue);
+    public static Shield ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) => ShieldExtensions.ConcurrencyLimit(Empty, maxConcurrency, queueLimit);
 
     /// <summary>Adds a concurrency limit strategy configured via <paramref name="configure"/>.</summary>
     public static Shield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => ShieldExtensions.ConcurrencyLimit(Empty, configure);

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -150,7 +150,7 @@ public sealed class ShieldBuilder
     public Shield RateLimit(Action<RateLimitOptions> configure) => Seal().RateLimit(configure);
 
     /// <summary>Caps concurrency. The handling clauses remain ambient for later strategies.</summary>
-    public Shield ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) => Seal().ConcurrencyLimit(maxConcurrency, maxQueue);
+    public Shield ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) => Seal().ConcurrencyLimit(maxConcurrency, queueLimit);
 
     /// <summary>Adds a configured concurrency limit. The handling clauses remain ambient for later strategies.</summary>
     public Shield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -177,7 +177,7 @@ public sealed class ShieldBuilder<TResult>
     public Shield<TResult> RateLimit(Action<RateLimitOptions> configure) => Seal().RateLimit(configure);
 
     /// <summary>Caps concurrency. The handling clauses remain ambient for later strategies.</summary>
-    public Shield<TResult> ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) => Seal().ConcurrencyLimit(maxConcurrency, maxQueue);
+    public Shield<TResult> ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) => Seal().ConcurrencyLimit(maxConcurrency, queueLimit);
 
     /// <summary>Adds a configured concurrency limit. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) => Seal().ConcurrencyLimit(configure);

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -111,10 +111,10 @@ public static class ShieldExtensions
     }
 
     /// <summary>Appends a concurrency limit capping concurrency at <paramref name="maxConcurrency"/> with an optional wait queue.</summary>
-    public static Shield ConcurrencyLimit(this Shield shield, int maxConcurrency, int maxQueue = 0) => shield.ConcurrencyLimit(options =>
+    public static Shield ConcurrencyLimit(this Shield shield, int maxConcurrency, int queueLimit = 0) => shield.ConcurrencyLimit(options =>
     {
         options.MaxConcurrency = maxConcurrency;
-        options.MaxQueue = maxQueue;
+        options.QueueLimit = queueLimit;
     });
 
     /// <summary>Appends a concurrency limit strategy configured via <paramref name="configure"/>.</summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -184,10 +184,10 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Caps concurrent executions at <paramref name="maxConcurrency"/> with an optional wait queue.</summary>
-    public Shield<TResult> ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) => ConcurrencyLimit(options =>
+    public Shield<TResult> ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) => ConcurrencyLimit(options =>
     {
         options.MaxConcurrency = maxConcurrency;
-        options.MaxQueue = maxQueue;
+        options.QueueLimit = queueLimit;
     });
 
     /// <summary>Adds a concurrency limit strategy configured via <paramref name="configure"/>.</summary>

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitOptions.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitOptions.cs
@@ -2,7 +2,7 @@ namespace Kevlar;
 
 /// <summary>
 /// Configuration for a concurrency limit (concurrency limiter) strategy: at most
-/// <see cref="MaxConcurrency"/> executions run at once, with up to <see cref="MaxQueue"/>
+/// <see cref="MaxConcurrency"/> executions run at once, with up to <see cref="QueueLimit"/>
 /// more waiting; anything beyond that is rejected immediately.
 /// </summary>
 /// <remarks>
@@ -16,7 +16,7 @@ public sealed class ConcurrencyLimitOptions
     public int MaxConcurrency { get; set; } = 10;
 
     /// <summary>Maximum executions allowed to wait for a slot. Default 0 (reject immediately when full).</summary>
-    public int MaxQueue { get; set; }
+    public int QueueLimit { get; set; }
 
     /// <summary>Invoked synchronously when an execution is rejected.</summary>
     public Action<ConcurrencyLimitRejectedEvent>? OnRejected { get; set; }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitRejectedEvent.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitRejectedEvent.cs
@@ -5,12 +5,12 @@ public readonly struct ConcurrencyLimitRejectedEvent
 {
     internal ConcurrencyLimitRejectedEvent(
         int maxConcurrency,
-        int maxQueue,
+        int queueLimit,
         int strategyIndex,
         KevlarContext context)
     {
         MaxConcurrency = maxConcurrency;
-        MaxQueue = maxQueue;
+        QueueLimit = queueLimit;
         StrategyIndex = strategyIndex;
         Context = context;
     }
@@ -19,7 +19,7 @@ public readonly struct ConcurrencyLimitRejectedEvent
     public int MaxConcurrency { get; }
 
     /// <summary>The configured maximum wait queue size.</summary>
-    public int MaxQueue { get; }
+    public int QueueLimit { get; }
 
     /// <summary>The zero-based position of this strategy in the executing shield.</summary>
     public int StrategyIndex { get; }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -10,7 +10,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     // Atomic permits serve the uncontended path; the semaphore carries permits only to registered waiters.
     private readonly SemaphoreSlim _semaphore;
     private readonly int _maxConcurrency;
-    private readonly int _maxQueue;
+    private readonly int _queueLimit;
     private readonly long _capacity;
     private readonly Action<ConcurrencyLimitRejectedEvent>? _onRejected;
     private readonly Func<ConcurrencyLimitRejectedEvent, ValueTask>? _onRejectedAsync;
@@ -26,7 +26,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     internal int MaxConcurrency => _maxConcurrency;
 
-    internal int MaxQueue => _maxQueue;
+    internal int QueueLimit => _queueLimit;
 
     internal bool HasNotification => _onRejected is not null || _onRejectedAsync is not null;
 
@@ -41,18 +41,18 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
     {
         Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");
-        Throw.IfOutOfRange(options.MaxQueue < 0, nameof(options), "MaxQueue must not be negative.");
+        Throw.IfOutOfRange(options.QueueLimit < 0, nameof(options), "QueueLimit must not be negative.");
         _semaphore = new SemaphoreSlim(0, options.MaxConcurrency);
         _maxConcurrency = options.MaxConcurrency;
-        _maxQueue = options.MaxQueue;
-        _capacity = options.MaxConcurrency + (long)options.MaxQueue;
+        _queueLimit = options.QueueLimit;
+        _capacity = options.MaxConcurrency + (long)options.QueueLimit;
         _available = options.MaxConcurrency;
         _onRejected = options.OnRejected;
         _onRejectedAsync = options.OnRejectedAsync;
     }
 
     public override string Describe() =>
-        _maxQueue > 0 ? $"ConcurrencyLimit({_maxConcurrency}, queue {_maxQueue})" : $"ConcurrencyLimit({_maxConcurrency})";
+        _queueLimit > 0 ? $"ConcurrencyLimit({_maxConcurrency}, queue {_queueLimit})" : $"ConcurrencyLimit({_maxConcurrency})";
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
@@ -93,7 +93,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
         var rejectedEvent = new ConcurrencyLimitRejectedEvent(
             _maxConcurrency,
-            _maxQueue,
+            _queueLimit,
             context.StrategyIndex,
             context);
         try

--- a/src/Kevlar/VoidShield.cs
+++ b/src/Kevlar/VoidShield.cs
@@ -89,8 +89,8 @@ public sealed class VoidShield
     public VoidShield RateLimit(Action<RateLimitOptions> configure) => new(_pipeline.RateLimit(configure));
 
     /// <summary>Adds a concurrency limit.</summary>
-    public VoidShield ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) =>
-        new(_pipeline.ConcurrencyLimit(maxConcurrency, maxQueue));
+    public VoidShield ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) =>
+        new(_pipeline.ConcurrencyLimit(maxConcurrency, queueLimit));
 
     /// <summary>Adds a configured concurrency limit.</summary>
     public VoidShield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) =>

--- a/src/Kevlar/VoidShieldBuilder.cs
+++ b/src/Kevlar/VoidShieldBuilder.cs
@@ -81,8 +81,8 @@ public sealed class VoidShieldBuilder
     public VoidShield RateLimit(Action<RateLimitOptions> configure) => new(_builder.RateLimit(configure));
 
     /// <summary>Adds a concurrency limit while preserving the clause.</summary>
-    public VoidShield ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) =>
-        new(_builder.ConcurrencyLimit(maxConcurrency, maxQueue));
+    public VoidShield ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) =>
+        new(_builder.ConcurrencyLimit(maxConcurrency, queueLimit));
 
     /// <summary>Adds a configured concurrency limit while preserving the clause.</summary>
     public VoidShield ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure) =>

--- a/tests/Kevlar.IntegrationTests/DatabaseResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/DatabaseResilienceTests.cs
@@ -31,7 +31,7 @@ public class DatabaseResilienceTests
 
         // Same load through a concurrency limit sized to the pool: everything succeeds.
         var guarded = new FlakyDatabase { MaxConnections = 5, Latency = TimeSpan.FromMilliseconds(50) };
-        var shield = Shield.ConcurrencyLimit(maxConcurrency: 5, maxQueue: 15);
+        var shield = Shield.ConcurrencyLimit(maxConcurrency: 5, queueLimit: 15);
 
         var results = await Task.WhenAll(Enumerable.Range(0, 20)
             .Select(_ => shield.ExecuteAsync(ct => new ValueTask<string>(guarded.QueryAsync("select 1", ct))).AsTask()));
@@ -101,7 +101,7 @@ public class DatabaseResilienceTests
             .When<TransientDatabaseException>()
             .Retry(3, Backoff.Constant(TimeSpan.FromMilliseconds(5)))
             .CircuitBreaker(10, TimeSpan.FromSeconds(30))
-            .ConcurrencyLimit(maxConcurrency: 5, maxQueue: 20);
+            .ConcurrencyLimit(maxConcurrency: 5, queueLimit: 20);
 
         var result = await shield.ExecuteAsync(ct => new ValueTask<string>(database.QueryAsync("insert order", ct)));
 

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -642,7 +642,7 @@ public class HttpReplayTests
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.HedgeDelay = Timeout.InfiniteTimeSpan;
             options.MaxConcurrency = 1;
-            options.MaxQueue = 0;
+            options.QueueLimit = 0;
             options.TotalTimeout = TimeSpan.FromMinutes(1);
             options.AttemptTimeout = TimeSpan.FromMinutes(1);
         });

--- a/tests/Kevlar.IntegrationTests/MessagingResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/MessagingResilienceTests.cs
@@ -110,7 +110,7 @@ public class MessagingResilienceTests
         var maxObserved = 0;
         var handled = 0;
 
-        var consumer = Shield.ConcurrencyLimit(maxConcurrency: 4, maxQueue: 16);
+        var consumer = Shield.ConcurrencyLimit(maxConcurrency: 4, queueLimit: 16);
 
         var workers = new List<Task>();
         while (broker.TryConsume(out _))

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -42,7 +42,7 @@ public class PipelineDescriptorTests
             .ConcurrencyLimit(options =>
             {
                 options.MaxConcurrency = 6;
-                options.MaxQueue = 2;
+                options.QueueLimit = 2;
                 options.OnRejected = _ => { };
             })
             .Hedge(options =>
@@ -97,7 +97,7 @@ public class PipelineDescriptorTests
 
         var concurrency = descriptor.AssertContainsSingle<ConcurrencyLimitStrategyDescriptor>();
         await Assert.That(concurrency.MaxConcurrency).IsEqualTo(6);
-        await Assert.That(concurrency.MaxQueue).IsEqualTo(2);
+        await Assert.That(concurrency.QueueLimit).IsEqualTo(2);
         await Assert.That(concurrency.HasNotification).IsTrue();
 
         var hedge = descriptor.AssertContainsSingle<HedgingStrategyDescriptor>();

--- a/tests/Kevlar.Testing.Tests/StateProbeTests.cs
+++ b/tests/Kevlar.Testing.Tests/StateProbeTests.cs
@@ -23,7 +23,7 @@ public class StateProbeTests
                 options.Window = TimeSpan.FromSeconds(1);
                 options.QueueLimit = 1;
             })
-            .ConcurrencyLimit(2, maxQueue: 1)
+            .ConcurrencyLimit(2, queueLimit: 1)
             .WithTimeProvider(timeProvider);
 
         monitor.Isolate();
@@ -81,7 +81,7 @@ public class StateProbeTests
     {
         var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var shared = Shield.ConcurrencyLimit(1, maxQueue: 1);
+        var shared = Shield.ConcurrencyLimit(1, queueLimit: 1);
         var firstAlias = Shield.Compose(shared).WithName("first");
         var secondAlias = Shield.Compose(shared).WithName("second");
 
@@ -160,7 +160,7 @@ public class StateProbeTests
     [Test]
     public async Task StateSnapshot_Supports_Typed_Shields_And_Immutable_Collections()
     {
-        var shield = Shield.For<int>().ConcurrencyLimit(3, maxQueue: 2);
+        var shield = Shield.For<int>().ConcurrencyLimit(3, queueLimit: 2);
 
         var snapshot = shield.GetStateSnapshot();
         var concurrency = snapshot.Strategies.OfType<ConcurrencyLimitStateSnapshot>().Single();

--- a/tests/Kevlar.Testing.Tests/TimeControlTests.cs
+++ b/tests/Kevlar.Testing.Tests/TimeControlTests.cs
@@ -134,7 +134,7 @@ public class TimeControlTests
         using var admission = new QueueAdmissionSignal("kevlar.concurrency_limit.queued", ShieldName);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var shield = Shield.ConcurrencyLimit(1, maxQueue: 1).WithName(ShieldName);
+        var shield = Shield.ConcurrencyLimit(1, queueLimit: 1).WithName(ShieldName);
         var first = shield.ExecuteAsync<int>(async _ =>
         {
             started.TrySetResult();

--- a/tests/Kevlar.Tests/AmbientContextContractTests.cs
+++ b/tests/Kevlar.Tests/AmbientContextContractTests.cs
@@ -120,7 +120,7 @@ public class AmbientContextContractTests
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var runningStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var observations = new List<Observation>();
-        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, maxQueue: 1);
+        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, queueLimit: 1);
 
         var running = shield.ExecuteAsync(async _ =>
         {

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -48,6 +48,25 @@ public class ApiShapeTests
     }
 
     [Test]
+    public async Task No_Public_Member_Named_MaxQueue_Remains()
+    {
+        var assemblies = new[]
+        {
+            typeof(Shield).Assembly,
+            typeof(Extensions.DependencyInjection.ShieldDefinition).Assembly,
+            typeof(Extensions.Http.StandardHedgingShieldOptions).Assembly,
+        };
+        var legacyMembers = assemblies
+            .SelectMany(static assembly => assembly.GetExportedTypes())
+            .SelectMany(static type => type.GetMembers())
+            .Where(static member => member.Name == "MaxQueue")
+            .Select(static member => $"{member.DeclaringType}.{member.Name}")
+            .ToArray();
+
+        await Assert.That(legacyMembers).IsEmpty();
+    }
+
+    [Test]
     public async Task Typed_CircuitBreaker_Requires_Typed_Options_Configurator()
     {
         var compilation = CreateCompilation(

--- a/tests/Kevlar.Tests/ConcurrencyLimitEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyLimitEdgeCaseTests.cs
@@ -36,7 +36,7 @@ public class BulkheadEdgeCaseTests
     [Test]
     public async Task Cancelling_A_Queued_Execution_Frees_Its_Queue_Slot()
     {
-        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, maxQueue: 1);
+        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, queueLimit: 1);
         var gate = new TaskCompletionSource();
         var started = new TaskCompletionSource();
         using var cancellation = new CancellationTokenSource();
@@ -73,7 +73,7 @@ public class BulkheadEdgeCaseTests
     public async Task Concurrency_Is_Never_Exceeded_Under_Parallel_Load()
     {
         const int MaxConcurrency = 3;
-        var shield = Shield.ConcurrencyLimit(MaxConcurrency, maxQueue: 50);
+        var shield = Shield.ConcurrencyLimit(MaxConcurrency, queueLimit: 50);
         var current = 0;
         var peak = 0;
         var barrier = new AsyncBarrier("maximum concurrent executions", MaxConcurrency);
@@ -98,7 +98,7 @@ public class BulkheadEdgeCaseTests
     [Test]
     public async Task Overload_Beyond_Capacity_Rejects_Exactly_The_Overflow()
     {
-        var shield = Shield.ConcurrencyLimit(maxConcurrency: 2, maxQueue: 3);
+        var shield = Shield.ConcurrencyLimit(maxConcurrency: 2, queueLimit: 3);
         var barrier = new AsyncBarrier("both concurrency slots", 2);
 
         // Fill both concurrency slots.

--- a/tests/Kevlar.Tests/ConcurrencyLimitRaceTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyLimitRaceTests.cs
@@ -6,9 +6,9 @@ public class ConcurrencyLimitRaceTests
     public async Task Exact_Capacity_Is_Admitted_And_Overflow_Is_Rejected()
     {
         const int MaxConcurrency = 3;
-        const int MaxQueue = 5;
+        const int QueueLimit = 5;
         const int Overflow = 7;
-        var shield = Shield.ConcurrencyLimit(MaxConcurrency, MaxQueue);
+        var shield = Shield.ConcurrencyLimit(MaxConcurrency, QueueLimit);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var runningStarted = new AsyncCounter("running concurrency-limit calls");
         var queuedStarted = new AsyncCounter("queued concurrency-limit calls");
@@ -34,7 +34,7 @@ public class ConcurrencyLimitRaceTests
 
         await runningStarted.WaitForAsync(MaxConcurrency);
 
-        var queued = Enumerable.Range(0, MaxQueue)
+        var queued = Enumerable.Range(0, QueueLimit)
             .Select(index => shield.ExecuteAsync(_ =>
             {
                 Enter(ref inFlight, ref peak, MaxConcurrency);
@@ -54,7 +54,7 @@ public class ConcurrencyLimitRaceTests
         release.SetResult();
         await Task.WhenAll(running);
         await Task.WhenAll(queued);
-        await queuedStarted.WaitForAsync(MaxQueue);
+        await queuedStarted.WaitForAsync(QueueLimit);
 
         await Assert.That(Volatile.Read(ref peak)).IsEqualTo(MaxConcurrency);
         await Assert.That(Volatile.Read(ref inFlight)).IsEqualTo(0);
@@ -66,7 +66,7 @@ public class ConcurrencyLimitRaceTests
     [Arguments(GrantCancellationOrder.Concurrent)]
     public async Task Grant_And_Queued_Cancellation_Decrement_Accounting_Once(GrantCancellationOrder order)
     {
-        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, maxQueue: 1);
+        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, queueLimit: 1);
         var releaseRunning = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var runningStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var queuedStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -163,7 +163,7 @@ public class ConcurrencyLimitRaceTests
     {
         const int MaxConcurrency = 2;
         const int Rounds = 32;
-        var shield = Shield.ConcurrencyLimit(MaxConcurrency, maxQueue: 3);
+        var shield = Shield.ConcurrencyLimit(MaxConcurrency, queueLimit: 3);
         var inFlight = 0;
         var peak = 0;
 
@@ -228,7 +228,7 @@ public class ConcurrencyLimitRaceTests
     [Test]
     public async Task Derived_And_Composed_Copies_Share_Running_And_Queue_Accounting()
     {
-        var limiter = Shield.ConcurrencyLimit(maxConcurrency: 1, maxQueue: 1);
+        var limiter = Shield.ConcurrencyLimit(maxConcurrency: 1, queueLimit: 1);
         var named = limiter.WithName("named");
         var composed = Shield.Retry(0, Backoff.None).Wrap(limiter);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -258,9 +258,9 @@ public class ConcurrencyLimitRaceTests
     [Arguments(int.MaxValue, 1)]
     public async Task Accepted_Capacity_Arithmetic_Near_Int_MaxValue_Remains_Usable(
         int maxConcurrency,
-        int maxQueue)
+        int queueLimit)
     {
-        var shield = Shield.ConcurrencyLimit(maxConcurrency, maxQueue);
+        var shield = Shield.ConcurrencyLimit(maxConcurrency, queueLimit);
 
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
 

--- a/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
@@ -26,13 +26,13 @@ public class BulkheadTests
             .Throws<ArgumentOutOfRangeException>()
             .WithMessage("MaxConcurrency must be positive. (Parameter 'options')");
 
-        await Assert.That(() => Shield.ConcurrencyLimit(maxConcurrency: 1, maxQueue: -1))
+        await Assert.That(() => Shield.ConcurrencyLimit(maxConcurrency: 1, queueLimit: -1))
             .Throws<ArgumentOutOfRangeException>()
-            .WithMessage("MaxQueue must not be negative. (Parameter 'options')");
+            .WithMessage("QueueLimit must not be negative. (Parameter 'options')");
     }
 
     [Test]
-    public async Task Rejects_When_Concurrency_And_Queue_Are_Full()
+    public async Task ConcurrencyLimit_Zero_QueueLimit_Rejects_Immediately()
     {
         var shield = Shield.ConcurrencyLimit(maxConcurrency: 1);
         var gate = new TaskCompletionSource();
@@ -58,9 +58,9 @@ public class BulkheadTests
     }
 
     [Test]
-    public async Task Queued_Executions_Run_When_A_Slot_Frees()
+    public async Task ConcurrencyLimit_QueueLimit_Admits_Exactly_N_Waiters()
     {
-        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, maxQueue: 1);
+        var shield = Shield.ConcurrencyLimit(maxConcurrency: 1, queueLimit: 1);
         var gate = new TaskCompletionSource();
         var started = new TaskCompletionSource();
 

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -171,7 +171,7 @@ public class ConfigurationBindingTests
             ("RateLimit:Burst", "7"),
             ("RateLimit:QueueLimit", "2"),
             ("ConcurrencyLimit:MaxConcurrency", "3"),
-            ("ConcurrencyLimit:MaxQueue", "4"),
+            ("ConcurrencyLimit:QueueLimit", "4"),
             ("AttemptTimeout", "00:00:01"));
         var services = new ServiceCollection();
         services.AddShield("complete", configuration);
@@ -184,13 +184,44 @@ public class ConfigurationBindingTests
     }
 
     [Test]
+    public async Task ConcurrencyLimit_Definition_Binds_QueueLimit_From_Configuration()
+    {
+        var configuration = BuildConfiguration(
+            ("ConcurrencyLimit:MaxConcurrency", "3"),
+            ("ConcurrencyLimit:QueueLimit", "5"));
+        var services = new ServiceCollection();
+        services.AddShield("queue", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("queue");
+
+        await Assert.That(shield.ToString()).IsEqualTo("queue: ConcurrencyLimit(3, queue 5)");
+    }
+
+    [Test]
+    public async Task Unknown_Key_MaxQueue_Is_Rejected_With_Configuration_Path()
+    {
+        var configuration = BuildConfiguration(("ConcurrencyLimit:MaxQueue", "5"));
+        var services = new ServiceCollection();
+        services.AddShield("legacy", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var exception = await Assert.That(
+                () => provider.GetRequiredService<IKevlarRegistry>().GetShield("legacy"))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).Contains("ConcurrencyLimit:MaxQueue");
+        await Assert.That(exception.Message).Contains("QueueLimit");
+    }
+
+    [Test]
     public async Task Configuration_Preserves_Definition_Defaults_For_Absent_Keys()
     {
         var configuration = BuildConfiguration(
             ("Retry:MaxRetries", "3"),
             ("CircuitBreaker:FailureRatio", "0.5"),
             ("RateLimit:Burst", "100"),
-            ("ConcurrencyLimit:MaxQueue", "0"));
+            ("ConcurrencyLimit:QueueLimit", "0"));
         var services = new ServiceCollection();
         services.AddShield("defaults", configuration);
         using var provider = services.BuildServiceProvider();

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -320,7 +320,7 @@ public class DependencyInjectionContractTests
                 Burst = 7,
                 QueueLimit = 2,
             },
-            ConcurrencyLimit = new ConcurrencyLimitDefinition { MaxConcurrency = 3, MaxQueue = 4 },
+            ConcurrencyLimit = new ConcurrencyLimitDefinition { MaxConcurrency = 3, QueueLimit = 4 },
             AttemptTimeout = TimeSpan.FromSeconds(1),
         };
 

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -76,7 +76,7 @@ public class HttpConfigurationReloadTests
             ("CircuitBreaker:SamplingWindow", "00:00:08"),
             ("CircuitBreaker:BreakDuration", "00:00:04"),
             ("ConcurrencyLimit:MaxConcurrency", "3"),
-            ("ConcurrencyLimit:MaxQueue", "4"),
+            ("ConcurrencyLimit:QueueLimit", "4"),
             ("AttemptTimeout", "00:00:02"),
             ("Handler:ContentReplayPolicy", "Buffer"),
             ("Handler:MaximumBufferSize", "4096"),
@@ -109,7 +109,7 @@ public class HttpConfigurationReloadTests
         await Assert.That(bound.CircuitBreaker.SamplingWindow).IsEqualTo(TimeSpan.FromSeconds(8));
         await Assert.That(bound.CircuitBreaker.BreakDuration).IsEqualTo(TimeSpan.FromSeconds(4));
         await Assert.That(bound.ConcurrencyLimit!.MaxConcurrency).IsEqualTo(3);
-        await Assert.That(bound.ConcurrencyLimit.MaxQueue).IsEqualTo(4);
+        await Assert.That(bound.ConcurrencyLimit.QueueLimit).IsEqualTo(4);
         await Assert.That(bound.AttemptTimeout.Timeout).IsEqualTo(TimeSpan.FromSeconds(2));
         await Assert.That(bound.Handler.ContentReplayPolicy).IsEqualTo(HttpContentReplayPolicy.Buffer);
         await Assert.That(bound.Handler.MaximumBufferSize).IsEqualTo(4096);
@@ -155,7 +155,7 @@ public class HttpConfigurationReloadTests
             ("HedgeDelay", "00:00:00.250"),
             ("AttemptTimeout", "00:00:02"),
             ("MaxConcurrency", "4"),
-            ("MaxQueue", "5"),
+            ("QueueLimit", "5"),
             ("ConsecutiveFailures", "2"),
             ("FailureRatio", ""),
             ("MinimumThroughput", "6"),
@@ -181,7 +181,7 @@ public class HttpConfigurationReloadTests
         await Assert.That(bound.HedgeDelay).IsEqualTo(TimeSpan.FromMilliseconds(250));
         await Assert.That(bound.AttemptTimeout).IsEqualTo(TimeSpan.FromSeconds(2));
         await Assert.That(bound.MaxConcurrency).IsEqualTo(4);
-        await Assert.That(bound.MaxQueue).IsEqualTo(5);
+        await Assert.That(bound.QueueLimit).IsEqualTo(5);
         await Assert.That(bound.ConsecutiveFailures).IsEqualTo(2);
         await Assert.That(bound.FailureRatio).IsNull();
         await Assert.That(bound.MinimumThroughput).IsEqualTo(6);
@@ -232,7 +232,7 @@ public class HttpConfigurationReloadTests
     [Arguments("CircuitBreaker:SamplingWindow", "00:00:00", "must be positive")]
     [Arguments("CircuitBreaker:BreakDuration", "00:00:00", "must be positive")]
     [Arguments("ConcurrencyLimit:MaxConcurrency", "0", "must be positive")]
-    [Arguments("ConcurrencyLimit:MaxQueue", "-1", "must not be negative")]
+    [Arguments("ConcurrencyLimit:QueueLimit", "-1", "must not be negative")]
     [Arguments("AttemptTimeout", "00:00:00", "must be positive")]
     [Arguments("Handler:MaximumBufferSize", "0", "must be positive")]
     [Arguments("Handler:Routing:Endpoints:0:Weight", "0", "must be positive")]
@@ -280,6 +280,25 @@ public class HttpConfigurationReloadTests
             .Throws<InvalidOperationException>()
             .WithMessage(
                 "Configuration value 'many' for 'Clients:GitHub:Retry:MaxRetries' is not an integer.");
+    }
+
+    [Test]
+    public async Task Legacy_MaxQueue_Keys_Are_Rejected_With_Their_Full_Path()
+    {
+        var builder = new ServiceCollection().AddHttpClient("legacy");
+        var standard = BuildConfiguration(("Clients:GitHub:ConcurrencyLimit:MaxQueue", "5"))
+            .GetSection("Clients:GitHub");
+        var hedging = BuildConfiguration(("Clients:GitHub:MaxQueue", "5"))
+            .GetSection("Clients:GitHub");
+
+        await Assert.That(() => builder.AddStandardShield(standard))
+            .Throws<InvalidOperationException>()
+            .WithMessage(
+                "Configuration key 'Clients:GitHub:ConcurrencyLimit:MaxQueue' is not supported; use 'QueueLimit'.");
+        await Assert.That(() => builder.AddStandardHedgingShield(hedging))
+            .Throws<InvalidOperationException>()
+            .WithMessage(
+                "Configuration key 'Clients:GitHub:MaxQueue' is not supported; use 'QueueLimit'.");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -396,7 +396,7 @@ public class HttpContractTests
             ConcurrencyLimit = new ConcurrencyLimitOptions
             {
                 MaxConcurrency = 12,
-                MaxQueue = 4,
+                QueueLimit = 4,
             },
             AttemptTimeout = new TimeoutOptions { Timeout = TimeSpan.FromSeconds(3) },
         };
@@ -533,7 +533,7 @@ public class HttpContractTests
                 options.ConcurrencyLimit = new ConcurrencyLimitOptions
                 {
                     MaxConcurrency = 1,
-                    MaxQueue = 0,
+                    QueueLimit = 0,
                 };
             })
             .Services

--- a/tests/Kevlar.Tests/LimiterRejectionHookTests.cs
+++ b/tests/Kevlar.Tests/LimiterRejectionHookTests.cs
@@ -61,7 +61,7 @@ public class LimiterRejectionHookTests
             .ConcurrencyLimit(options =>
             {
                 options.MaxConcurrency = 1;
-                options.MaxQueue = 0;
+                options.QueueLimit = 0;
                 options.OnRejected = rejection =>
                 {
                     observed = rejection;
@@ -90,7 +90,7 @@ public class LimiterRejectionHookTests
 
         await Assert.That(order.SequenceEqual(["sync", "async"])).IsTrue();
         await Assert.That(observed.MaxConcurrency).IsEqualTo(1);
-        await Assert.That(observed.MaxQueue).IsEqualTo(0);
+        await Assert.That(observed.QueueLimit).IsEqualTo(0);
         await Assert.That(observed.StrategyIndex).IsEqualTo(0);
         await Assert.That(observedShieldName).IsEqualTo("bulkhead");
 
@@ -185,7 +185,7 @@ public class LimiterRejectionHookTests
         var shield = Shield.ConcurrencyLimit(options =>
         {
             options.MaxConcurrency = 1;
-            options.MaxQueue = 1;
+            options.QueueLimit = 1;
             options.OnRejected = _ => rejections++;
         });
         using var cancellation = new CancellationTokenSource();

--- a/tests/Kevlar.Tests/TypedBuilderForwardingTests.cs
+++ b/tests/Kevlar.Tests/TypedBuilderForwardingTests.cs
@@ -65,7 +65,7 @@ public class TypedBuilderForwardingTests
             {
                 concurrencyConfigured = true;
                 options.MaxConcurrency = 2;
-                options.MaxQueue = 3;
+                options.QueueLimit = 3;
             }), typeof(ConcurrencyLimitStrategy)),
         };
 

--- a/tests/Kevlar.Tests/VoidShieldFluentContractTests.cs
+++ b/tests/Kevlar.Tests/VoidShieldFluentContractTests.cs
@@ -54,7 +54,7 @@ public class VoidShieldFluentContractTests
             {
                 concurrencyConfigured = true;
                 options.MaxConcurrency = 2;
-                options.MaxQueue = 3;
+                options.QueueLimit = 3;
             }), typeof(ConcurrencyLimitStrategy)),
             (baseline.Hedge(2, TimeSpan.Zero), typeof(HedgingStrategy)),
             (baseline.Hedge(options =>
@@ -217,7 +217,7 @@ public class VoidShieldFluentContractTests
             {
                 concurrencyConfigured = true;
                 options.MaxConcurrency = 2;
-                options.MaxQueue = 3;
+                options.QueueLimit = 3;
             }), typeof(ConcurrencyLimitStrategy)),
         };
 


### PR DESCRIPTION
## Summary
- rename every concurrency-limit \MaxQueue\/\maxQueue\ surface to \QueueLimit\/\queueLimit\`n- propagate the name through DI definitions, HTTP hedging, testing descriptors, config keys, docs, and public API baselines
- reject legacy configuration keys with their full path and migration guidance
- pin admission counts, reflection shape, binding, per-authority HTTP behavior, descriptors, and executable description output

Closes #198

## Validation
- \dotnet build Kevlar.slnx -c Release\`n- \dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 750 --zero-tests-policy strict\ (864 passed)
- \dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build -- --timeout 5m --minimum-expected-tests 45 --zero-tests-policy strict\ (51 passed)
- \dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m --minimum-expected-tests 100 --zero-tests-policy strict\ (131 passed before final main rebase; affected named arguments compiled after rebase)
- \./scripts/Verify-Docs.ps1\`n- \./scripts/Verify-DocSnippets.ps1 -PackagesPath ./artifacts/issue198-doc-pack2 -Version 1.0.0-queue2\ (125 snippets)