### PR TITLE
refactor(naming)!: finish Hedge rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Handling clauses now use one spelling per position. `When…` starts a clause on
 | `builder.OrDefault()` | `builder.OrResultIsDefault()` |
 | `Shield.For<T>().Fallback(value)` | `Shield.For<T>().FallbackTo(value)` |
 | `ConcurrencyLimit(..., maxQueue: n)` / `options.MaxQueue` | `ConcurrencyLimit(..., queueLimit: n)` / `options.QueueLimit` |
+| `HedgingOptions` | `HedgeOptions` |
+| `HedgingStrategyDescriptor` | `HedgeStrategyDescriptor` |
+| `StrategyKind.Hedging` | `StrategyKind.Hedge` |
+| `StandardHedgingShieldOptions` | `StandardHedgeShieldOptions` |
+| `AddStandardHedgingShield(...)` | `AddStandardHedgeShield(...)` |
 
 `OrWhen` is gone: `Or(Func<Exception, bool>)` now mirrors `When(Func<Exception, bool>)`, so the
 untyped predicate has the same spelling in both clause positions. `WhenDefault`/`OrDefault` were
@@ -40,10 +45,8 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
   pair retains the same shared property names and scalar defaults, but helpers that accept an
   untyped options type must configure typed options separately. Typed callbacks and result
   predicates keep their exact compile-time types.
-- `HedgingOptions`/`HedgingOptions<TResult>` were renamed to `HedgeOptions`/`HedgeOptions<TResult>`
-  so the strategy method and its options type share a stem, like `Retry`/`RetryOptions` and
-  `Timeout`/`TimeoutOptions`. `Kevlar.Extensions.Http`'s `StandardHedgingShieldOptions` and
-  `AddStandardHedgingShield` are unchanged.
+- The `Hedge` method, options, testing descriptors, strategy kind, and standard HTTP registration
+  now share one `Hedge` stem, like `Retry`/`RetryOptions` and `Timeout`/`TimeoutOptions`.
 ### Changed
 
 - Every NuGet package now embeds the canonical Kevlar icon, links release notes, and carries a

--- a/benchmarks/Kevlar.Benchmarks/HttpStandardHedgeBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HttpStandardHedgeBenchmarks.cs
@@ -10,7 +10,7 @@ namespace Kevlar.Benchmarks;
 [MemoryDiagnoser]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
 [CategoriesColumn]
-public class HttpStandardHedgingBenchmarks
+public class HttpStandardHedgeBenchmarks
 {
     private ServiceProvider _services = null!;
     private HttpClient _manual = null!;
@@ -25,7 +25,7 @@ public class HttpStandardHedgingBenchmarks
             .AddShield(CreateOuterShield(), CreateHandlerOptions());
         services.AddHttpClient("standard")
             .ConfigurePrimaryHttpMessageHandler(static () => new SuccessHandler())
-            .AddStandardHedgingShield(static options =>
+            .AddStandardHedgeShield(static options =>
             {
                 options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.invalid")));
                 options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.invalid")));
@@ -44,13 +44,13 @@ public class HttpStandardHedgingBenchmarks
         _services.Dispose();
     }
 
-    [BenchmarkCategory("HttpStandardHedgingHappy"), Benchmark(Baseline = true)]
+    [BenchmarkCategory("HttpStandardHedgeHappy"), Benchmark(Baseline = true)]
     public async Task ManualComposition()
     {
         using var response = await _manual.GetAsync("https://origin.invalid/");
     }
 
-    [BenchmarkCategory("HttpStandardHedgingHappy"), Benchmark]
+    [BenchmarkCategory("HttpStandardHedgeHappy"), Benchmark]
     public async Task StandardRegistration()
     {
         using var response = await _standard.GetAsync("https://origin.invalid/");

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -136,7 +136,7 @@ full configuration path. A successful reload starts fresh breaker, limiter, and 
 state. `HttpClientFactory` handler rotation also creates fresh state and reruns the
 service-provider callback; disposed handlers unsubscribe from configuration changes.
 
-Hedging uses the same reload contract. Its scalar keys match `StandardHedgingShieldOptions`, and
+Hedging uses the same reload contract. Its scalar keys match `StandardHedgeShieldOptions`, and
 `Endpoints` is required:
 
 ```csharp
@@ -153,7 +153,7 @@ var configuration = new ConfigurationBuilder()
     .Build();
 
 services.AddHttpClient("routed")
-    .AddStandardHedgingShield(configuration);
+    .AddStandardHedgeShield(configuration);
 ```
 
 ## Bring your own pipeline
@@ -247,7 +247,7 @@ path and query:
 
 ```csharp
 services.AddHttpClient("routed")
-    .AddStandardHedgingShield(options =>
+    .AddStandardHedgeShield(options =>
     {
         options.Endpoints.Add(new HttpEndpoint(new Uri("https://api-a.example"), weight: 3));
         options.Endpoints.Add(new HttpEndpoint(new Uri("https://api-b.example"), weight: 1));
@@ -257,7 +257,7 @@ services.AddHttpClient("routed")
     });
 ```
 
-`AddStandardHedgingShield` installs a 30s total timeout and up to two hedged attempts. Each endpoint
+`AddStandardHedgeShield` installs a 30s total timeout and up to two hedged attempts. Each endpoint
 gets its own 10-concurrent/zero-queue limiter, 50%-over-30s circuit breaker (minimum 10 attempts,
 15s break), and 10s attempt timeout. Configure those defaults through `TotalTimeout`, `MaxAttempts`,
 `HedgeDelay`, `MaxConcurrency`, `QueueLimit`, `FailureRatio` or `ConsecutiveFailures`,
@@ -298,7 +298,7 @@ shield so every additional send goes through safe replay and routing.
 - **Redirects remain transport-owned.** Each Kevlar attempt begins with the original absolute URI (or its routed authority). Normal `HttpClientHandler` redirect policy runs inside that attempt.
 - **State sharing depends on registration form.** Parameterless `AddStandardShield()`, its one-argument options callback, and `AddShield(shield)` build/capture one shield for that named client, so state survives handler rotation. Service-provider callbacks run once per `HttpClientFactory` handler lifetime and create fresh state unless they resolve and return shared state from DI.
 - **Configuration-backed state is replaced, not mutated.** Reload and handler rotation publish fresh complete pipelines. Requests already executing retain the snapshot they captured at send start.
-- **Standard hedging state is endpoint-local.** `AddStandardHedgingShield` creates one limiter and breaker per authority in each `HttpClientFactory` handler pipeline and reuses them across requests for that handler's lifetime.
+- **Standard hedging state is endpoint-local.** `AddStandardHedgeShield` creates one limiter and breaker per authority in each `HttpClientFactory` handler pipeline and reuses them across requests for that handler's lifetime.
 - **Compose with other handlers normally.** The Kevlar handler is a regular `DelegatingHandler`; ordering relative to your own handlers follows the usual `AddHttpMessageHandler` rules.
 
 :::tip Handling clause already done

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Kevlar.Analyzers;
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 {
     /// <summary>The KEV002 rule.</summary>
-    public static readonly DiagnosticDescriptor SynchronousHedgingRule = new(
+    public static readonly DiagnosticDescriptor SynchronousHedgeRule = new(
         id: "KEV002",
         title: "Multi-attempt hedging requires asynchronous execution",
         messageFormat: "This shield contains multi-attempt hedging, which cannot run through synchronous 'Execute'. Use 'ExecuteAsync' or remove hedging.",
@@ -51,7 +51,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         description: "Circuit breakers, rate limiters, concurrency limiters, and partition providers must outlive individual executions so their resilience state is retained and shared.");
 
     /// <summary>The KEV006 rule.</summary>
-    public static readonly DiagnosticDescriptor UntypedHedgingRule = new(
+    public static readonly DiagnosticDescriptor UntypedHedgeRule = new(
         id: "KEV006",
         title: "Hedging on an untyped Shield requires an idempotent action",
         messageFormat: "Hedging on an untyped Shield runs the execution delegate more than once, concurrently. Build a result-aware shield with Shield.For<T>() so result clauses can select the winning attempt, or confirm the action is idempotent.",
@@ -113,10 +113,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
-            SynchronousHedgingRule,
+            SynchronousHedgeRule,
             UnreachableReactiveStrategyRule,
             EphemeralStatefulShieldRule,
-            UntypedHedgingRule,
+            UntypedHedgeRule,
             DeadHandlingClauseRule,
             DiscardedChainResultRule,
             InheritedHandlingClauseRule,
@@ -152,7 +152,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 out _))
         {
             context.ReportDiagnostic(Diagnostic.Create(
-                SynchronousHedgingRule,
+                SynchronousHedgeRule,
                 invocation.Syntax.GetLocation()));
         }
 
@@ -202,7 +202,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         if (IsUntypedHedge(invocation.TargetMethod, knownTypes))
         {
             context.ReportDiagnostic(Diagnostic.Create(
-                UntypedHedgingRule,
+                UntypedHedgeRule,
                 invocation.Syntax.GetLocation()));
         }
 

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -8,6 +8,6 @@ static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.InheritedHandlingClauseR
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.ImplicitDefaultHandlingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
-static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgeRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.UnreachableReactiveStrategyRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
-static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.UntypedHedgingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.UntypedHedgeRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -33,44 +33,44 @@ Kevlar.Extensions.Http.ShieldHttpHandlerOptions.RequestFactory.set -> void
 Kevlar.Extensions.Http.ShieldHttpHandlerOptions.Routing.get -> Kevlar.Extensions.Http.HttpEndpointRoutingOptions?
 Kevlar.Extensions.Http.ShieldHttpHandlerOptions.Routing.set -> void
 Kevlar.Extensions.Http.ShieldHttpHandlerOptions.ShieldHttpHandlerOptions() -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.AllowUnsafeMethodReplay.get -> bool
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.AllowUnsafeMethodReplay.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.AttemptTimeout.get -> System.TimeSpan
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.AttemptTimeout.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.BreakDuration.get -> System.TimeSpan
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.BreakDuration.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.ConsecutiveFailures.get -> int?
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.ConsecutiveFailures.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.ContentReplayPolicy.get -> Kevlar.Extensions.Http.HttpContentReplayPolicy
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.ContentReplayPolicy.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.Endpoints.get -> System.Collections.Generic.IList<Kevlar.Extensions.Http.HttpEndpoint!>!
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.FailureRatio.get -> double?
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.FailureRatio.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.HedgeDelay.get -> System.TimeSpan
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.HedgeDelay.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxAttempts.get -> int
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxAttempts.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxConcurrency.get -> int
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaxConcurrency.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaximumBufferSize.get -> long
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MaximumBufferSize.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.QueueLimit.get -> int
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.QueueLimit.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MinimumThroughput.get -> int
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.MinimumThroughput.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.RequestFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, int, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.Http.HttpRequestMessage!>>?
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.RequestFactory.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.SamplingWindow.get -> System.TimeSpan
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.SamplingWindow.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.Seed.get -> int
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.Seed.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.SelectionMode.get -> Kevlar.Extensions.Http.HttpEndpointSelectionMode
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.SelectionMode.set -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.StandardHedgingShieldOptions() -> void
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.TotalTimeout.get -> System.TimeSpan
-Kevlar.Extensions.Http.StandardHedgingShieldOptions.TotalTimeout.set -> void
-static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardHedgingShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<Kevlar.Extensions.Http.StandardHedgingShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+Kevlar.Extensions.Http.StandardHedgeShieldOptions
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.AllowUnsafeMethodReplay.get -> bool
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.AllowUnsafeMethodReplay.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.AttemptTimeout.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.AttemptTimeout.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.BreakDuration.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.BreakDuration.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.ConsecutiveFailures.get -> int?
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.ConsecutiveFailures.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.ContentReplayPolicy.get -> Kevlar.Extensions.Http.HttpContentReplayPolicy
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.ContentReplayPolicy.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.Endpoints.get -> System.Collections.Generic.IList<Kevlar.Extensions.Http.HttpEndpoint!>!
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.FailureRatio.get -> double?
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.FailureRatio.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelay.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelay.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaxAttempts.get -> int
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaxAttempts.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaxConcurrency.get -> int
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaxConcurrency.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaximumBufferSize.get -> long
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaximumBufferSize.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.QueueLimit.get -> int
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.QueueLimit.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MinimumThroughput.get -> int
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.MinimumThroughput.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.RequestFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, int, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.Http.HttpRequestMessage!>>?
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.RequestFactory.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.SamplingWindow.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.SamplingWindow.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.Seed.get -> int
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.Seed.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.SelectionMode.get -> Kevlar.Extensions.Http.HttpEndpointSelectionMode
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.SelectionMode.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.StandardHedgeShieldOptions() -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.TotalTimeout.get -> System.TimeSpan
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.TotalTimeout.set -> void
+static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardHedgeShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<Kevlar.Extensions.Http.StandardHedgeShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Kevlar.Shield<System.Net.Http.HttpResponseMessage!>! shield, Kevlar.Extensions.Http.ShieldHttpHandlerOptions! options) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, Kevlar.Shield<System.Net.Http.HttpResponseMessage!>!>! shieldFactory, System.Func<System.IServiceProvider!, Kevlar.Extensions.Http.ShieldHttpHandlerOptions!>! optionsFactory) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Kevlar.Extensions.Http.StandardHttpShieldOptions
@@ -94,5 +94,5 @@ static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShiel
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Action<System.IServiceProvider!, Kevlar.Extensions.Http.StandardHttpShieldOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.IServiceProvider!, Kevlar.Extensions.Http.StandardHttpShieldOptions!>! configure, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
-static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardHedgingShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
-static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardHedgingShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.IServiceProvider!, Kevlar.Extensions.Http.StandardHedgingShieldOptions!>! configure, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardHedgeShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
+static Kevlar.Extensions.Http.ShieldHttpClientBuilderExtensions.AddStandardHedgeShield(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.IServiceProvider!, Kevlar.Extensions.Http.StandardHedgeShieldOptions!>! configure, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -248,9 +248,9 @@ public static class ShieldHttpClientBuilderExtensions
     /// Adds a standard endpoint-aware pipeline: total timeout, hedging, per-endpoint concurrency
     /// limit and circuit breaker, then per-attempt timeout.
     /// </summary>
-    public static IHttpClientBuilder AddStandardHedgingShield(
+    public static IHttpClientBuilder AddStandardHedgeShield(
         this IHttpClientBuilder builder,
-        Action<StandardHedgingShieldOptions> configure)
+        Action<StandardHedgeShieldOptions> configure)
     {
         if (builder is null)
         {
@@ -262,9 +262,9 @@ public static class ShieldHttpClientBuilderExtensions
             throw new ArgumentNullException(nameof(configure));
         }
 
-        var options = new StandardHedgingShieldOptions();
+        var options = new StandardHedgeShieldOptions();
         configure(options);
-        var shield = CreateHedgingShield(options);
+        var shield = CreateHedgeShield(options);
         var handlerOptions = CreateHandlerOptions(options);
 
         return UseStandardTimeout(builder).AddHttpMessageHandler(() =>
@@ -275,11 +275,11 @@ public static class ShieldHttpClientBuilderExtensions
     /// Adds a reload-aware standard hedging shield bound from a configuration section.
     /// A valid change replaces the complete pipeline and all endpoint-local state.
     /// </summary>
-    public static IHttpClientBuilder AddStandardHedgingShield(
+    public static IHttpClientBuilder AddStandardHedgeShield(
         this IHttpClientBuilder builder,
         IConfiguration configuration,
         Action<Exception>? onReloadFailure = null) =>
-        AddStandardHedgingShield(
+        AddStandardHedgeShield(
             builder,
             configuration,
             static (_, _) => { },
@@ -290,10 +290,10 @@ public static class ShieldHttpClientBuilderExtensions
     /// using the handler pipeline's service provider. The callback runs for every snapshot after
     /// configuration values have been applied.
     /// </summary>
-    public static IHttpClientBuilder AddStandardHedgingShield(
+    public static IHttpClientBuilder AddStandardHedgeShield(
         this IHttpClientBuilder builder,
         IConfiguration configuration,
-        Action<IServiceProvider, StandardHedgingShieldOptions> configure,
+        Action<IServiceProvider, StandardHedgeShieldOptions> configure,
         Action<Exception>? onReloadFailure = null)
     {
         if (builder is null)
@@ -311,15 +311,15 @@ public static class ShieldHttpClientBuilderExtensions
             throw new ArgumentNullException(nameof(configure));
         }
 
-        ValidateHedgingConfiguration(configuration);
+        ValidateHedgeConfiguration(configuration);
         return UseStandardTimeout(builder).AddHttpMessageHandler(services =>
         {
             HttpShieldPipeline CreatePipeline()
             {
-                var options = StandardHttpConfigurationBinder.BindHedging(configuration);
+                var options = StandardHttpConfigurationBinder.BindHedge(configuration);
                 configure(services, options);
                 return new HttpShieldPipeline(
-                    CreateHedgingShield(options),
+                    CreateHedgeShield(options),
                     CreateHandlerOptions(options));
             }
 
@@ -336,13 +336,13 @@ public static class ShieldHttpClientBuilderExtensions
         _ = new HttpShieldPipeline(HttpShield.Standard(options), Snapshot(options.Handler));
     }
 
-    private static void ValidateHedgingConfiguration(IConfiguration configuration)
+    private static void ValidateHedgeConfiguration(IConfiguration configuration)
     {
-        var options = StandardHttpConfigurationBinder.BindHedging(configuration);
-        _ = new HttpShieldPipeline(CreateHedgingShield(options), CreateHandlerOptions(options));
+        var options = StandardHttpConfigurationBinder.BindHedge(configuration);
+        _ = new HttpShieldPipeline(CreateHedgeShield(options), CreateHandlerOptions(options));
     }
 
-    private static Shield<HttpResponseMessage> CreateHedgingShield(StandardHedgingShieldOptions options) =>
+    private static Shield<HttpResponseMessage> CreateHedgeShield(StandardHedgeShieldOptions options) =>
         HttpShield.WhenTransient(
                 Shield.Timeout(options.TotalTimeout)
                     .For<HttpResponseMessage>())
@@ -350,7 +350,7 @@ public static class ShieldHttpClientBuilderExtensions
             .Or<CircuitOpenException>()
             .Hedge(options.MaxAttempts, options.HedgeDelay);
 
-    private static ShieldHttpHandlerOptions CreateHandlerOptions(StandardHedgingShieldOptions options)
+    private static ShieldHttpHandlerOptions CreateHandlerOptions(StandardHedgeShieldOptions options)
     {
         if (!Enum.IsDefined(typeof(HttpEndpointSelectionMode), options.SelectionMode))
         {
@@ -399,7 +399,7 @@ public static class ShieldHttpClientBuilderExtensions
     }
 
     private static Func<Uri, Shield<HttpResponseMessage>> CreateEndpointShieldFactory(
-        StandardHedgingShieldOptions options)
+        StandardHedgeShieldOptions options)
     {
         var maxConcurrency = options.MaxConcurrency;
         var queueLimit = options.QueueLimit;

--- a/src/Kevlar.Extensions.Http/StandardHedgeShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHedgeShieldOptions.cs
@@ -1,7 +1,7 @@
 namespace Kevlar.Extensions.Http;
 
 /// <summary>Configures the standard endpoint-aware HTTP hedging pipeline.</summary>
-public sealed class StandardHedgingShieldOptions
+public sealed class StandardHedgeShieldOptions
 {
     /// <summary>The maximum duration of the complete request. Default 30 seconds.</summary>
     public TimeSpan TotalTimeout { get; set; } = TimeSpan.FromSeconds(30);

--- a/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
@@ -20,9 +20,9 @@ internal static class StandardHttpConfigurationBinder
         return options;
     }
 
-    public static StandardHedgingShieldOptions BindHedging(IConfiguration configuration)
+    public static StandardHedgeShieldOptions BindHedge(IConfiguration configuration)
     {
-        var options = new StandardHedgingShieldOptions();
+        var options = new StandardHedgeShieldOptions();
 
         RejectLegacyQueueKey(configuration);
         SetTimeSpan(configuration, nameof(options.TotalTimeout), value => options.TotalTimeout = value);
@@ -48,7 +48,7 @@ internal static class StandardHttpConfigurationBinder
         SetBool(configuration, nameof(options.AllowUnsafeMethodReplay), value => options.AllowUnsafeMethodReplay = value);
         BindEndpoints(configuration.GetSection(nameof(options.Endpoints)), options.Endpoints);
 
-        ValidateHedging(configuration, options);
+        ValidateHedge(configuration, options);
         return options;
     }
 
@@ -246,9 +246,9 @@ internal static class StandardHttpConfigurationBinder
         }
     }
 
-    private static void ValidateHedging(
+    private static void ValidateHedge(
         IConfiguration configuration,
-        StandardHedgingShieldOptions options)
+        StandardHedgeShieldOptions options)
     {
         Ensure(options.TotalTimeout > TimeSpan.Zero, configuration.GetSection(nameof(options.TotalTimeout)), "must be positive");
         Ensure(options.MaxAttempts >= 1, configuration.GetSection(nameof(options.MaxAttempts)), "must be at least 1");

--- a/src/Kevlar.Testing/HedgeStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/HedgeStrategyDescriptor.cs
@@ -1,15 +1,15 @@
 namespace Kevlar.Testing;
 
 /// <summary>Read-only hedging configuration.</summary>
-public sealed class HedgingStrategyDescriptor : StrategyDescriptor
+public sealed class HedgeStrategyDescriptor : StrategyDescriptor
 {
-    internal HedgingStrategyDescriptor(
+    internal HedgeStrategyDescriptor(
         string description,
         int maxAttempts,
         TimeSpan delay,
         bool hasNotification,
         bool hasHandlingOverride)
-        : base(StrategyKind.Hedging, description)
+        : base(StrategyKind.Hedge, description)
     {
         MaxAttempts = maxAttempts;
         Delay = delay;

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -22,10 +22,10 @@ Kevlar.Testing.FallbackStrategyDescriptor
 Kevlar.Testing.FallbackStrategyDescriptor.HasNotification.get -> bool
 Kevlar.Testing.FallbackStrategyDescriptor.IsVoid.get -> bool
 Kevlar.Testing.FallbackStrategyDescriptor.ResultType.get -> System.Type?
-Kevlar.Testing.HedgingStrategyDescriptor
-Kevlar.Testing.HedgingStrategyDescriptor.Delay.get -> System.TimeSpan
-Kevlar.Testing.HedgingStrategyDescriptor.HasNotification.get -> bool
-Kevlar.Testing.HedgingStrategyDescriptor.MaxAttempts.get -> int
+Kevlar.Testing.HedgeStrategyDescriptor
+Kevlar.Testing.HedgeStrategyDescriptor.Delay.get -> System.TimeSpan
+Kevlar.Testing.HedgeStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.HedgeStrategyDescriptor.MaxAttempts.get -> int
 Kevlar.Testing.RateLimitStrategyDescriptor
 Kevlar.Testing.RateLimitStrategyDescriptor.Burst.get -> int
 Kevlar.Testing.RateLimitStrategyDescriptor.Permits.get -> int
@@ -55,7 +55,7 @@ Kevlar.Testing.StrategyKind.CircuitBreaker = 3 -> Kevlar.Testing.StrategyKind
 Kevlar.Testing.StrategyKind.ConcurrencyLimit = 5 -> Kevlar.Testing.StrategyKind
 Kevlar.Testing.StrategyKind.Custom = 0 -> Kevlar.Testing.StrategyKind
 Kevlar.Testing.StrategyKind.Fallback = 7 -> Kevlar.Testing.StrategyKind
-Kevlar.Testing.StrategyKind.Hedging = 6 -> Kevlar.Testing.StrategyKind
+Kevlar.Testing.StrategyKind.Hedge = 6 -> Kevlar.Testing.StrategyKind
 Kevlar.Testing.StrategyKind.RateLimit = 4 -> Kevlar.Testing.StrategyKind
 Kevlar.Testing.StrategyKind.Retry = 1 -> Kevlar.Testing.StrategyKind
 Kevlar.Testing.StrategyKind.Timeout = 2 -> Kevlar.Testing.StrategyKind
@@ -71,7 +71,7 @@ static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor(this Kevlar.Shiel
 static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor<TResult>(this Kevlar.Shield<TResult>! shield) -> Kevlar.Testing.ShieldDescriptor!
 Kevlar.Testing.CircuitBreakerStrategyDescriptor.HasHandlingOverride.get -> bool
 Kevlar.Testing.FallbackStrategyDescriptor.HasHandlingOverride.get -> bool
-Kevlar.Testing.HedgingStrategyDescriptor.HasHandlingOverride.get -> bool
+Kevlar.Testing.HedgeStrategyDescriptor.HasHandlingOverride.get -> bool
 Kevlar.Testing.RetryStrategyDescriptor.HasHandlingOverride.get -> bool
 Kevlar.Testing.CircuitBreakerStateSnapshot
 Kevlar.Testing.CircuitBreakerStateSnapshot.State.get -> Kevlar.CircuitState

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -89,7 +89,7 @@ public static class ShieldDescriptorExtensions
                 concurrency.MaxConcurrency,
                 concurrency.QueueLimit,
                 concurrency.HasNotification),
-            HedgingStrategy hedging => new HedgingStrategyDescriptor(
+            HedgingStrategy hedging => new HedgeStrategyDescriptor(
                 description,
                 hedging.MaxAttempts,
                 hedging.Delay,

--- a/src/Kevlar.Testing/StrategyKind.cs
+++ b/src/Kevlar.Testing/StrategyKind.cs
@@ -22,7 +22,7 @@ public enum StrategyKind
     ConcurrencyLimit,
 
     /// <summary>A hedging strategy.</summary>
-    Hedging,
+    Hedge,
 
     /// <summary>A fallback strategy.</summary>
     Fallback,

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -3,11 +3,28 @@ using Kevlar.Analyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System.Reflection;
 
 namespace Kevlar.Analyzers.Tests;
 
 public class PipelineHazardAnalyzerTests
 {
+    [Test]
+    public async Task Public_Surface_Uses_One_Hedge_Stem()
+    {
+        var legacyNames = typeof(PipelineHazardAnalyzer).Assembly.ExportedTypes
+            .SelectMany(static type => type
+                .GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Select(static member => member.Name)
+                .Append(type.Name))
+            .Where(static name => name.Contains("Hedging", StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .Order()
+            .ToArray();
+
+        await Assert.That(legacyNames).IsEmpty();
+    }
+
     [Test]
     public async Task Custom_Strategy_Can_Declare_Single_Invocation_Without_Diagnostics()
     {

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -442,7 +442,7 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Routes_And_Isolates_Endpoint_Breakers()
+    public async Task Standard_Hedge_Routes_And_Isolates_Endpoint_Breakers()
     {
         var calls = new System.Collections.Concurrent.ConcurrentDictionary<string, int>(
             StringComparer.Ordinal);
@@ -453,7 +453,7 @@ public class HttpReplayTests
             return Task.FromResult(new HttpResponseMessage(
                 host == "first.example" ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
         });
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
@@ -461,7 +461,7 @@ public class HttpReplayTests
             options.ConsecutiveFailures = 1;
             options.FailureRatio = null;
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
 
         using var first = await client.GetAsync("https://origin.example/api");
         using var second = await client.GetAsync("https://origin.example/api");
@@ -473,7 +473,7 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Attempt_Timeout_Advances_To_Next_Endpoint()
+    public async Task Standard_Hedge_Attempt_Timeout_Advances_To_Next_Endpoint()
     {
         var timedOut = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var transport = new RecordingHandler(async (_, request, cancellationToken) =>
@@ -493,14 +493,14 @@ public class HttpReplayTests
 
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.HedgeDelay = Timeout.InfiniteTimeSpan;
             options.AttemptTimeout = TimeSpan.FromMilliseconds(20);
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
 
         using var response = await client.GetAsync("https://origin.example/api")
             .WaitAsync(TimeSpan.FromSeconds(5));
@@ -511,14 +511,14 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Propagates_Caller_Cancellation()
+    public async Task Standard_Hedge_Propagates_Caller_Cancellation()
     {
         var transport = new RecordingHandler(async (_, _, cancellationToken) =>
         {
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
@@ -526,7 +526,7 @@ public class HttpReplayTests
             options.TotalTimeout = TimeSpan.FromMinutes(1);
             options.AttemptTimeout = TimeSpan.FromMinutes(1);
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
         using var cancellation = new CancellationTokenSource();
 
         var send = client.GetAsync("https://origin.example/api", cancellation.Token);
@@ -538,14 +538,14 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Total_Timeout_Covers_All_Attempts()
+    public async Task Standard_Hedge_Total_Timeout_Covers_All_Attempts()
     {
         var transport = new RecordingHandler(async (_, _, cancellationToken) =>
         {
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
@@ -553,7 +553,7 @@ public class HttpReplayTests
             options.TotalTimeout = TimeSpan.FromSeconds(1);
             options.AttemptTimeout = TimeSpan.FromMinutes(1);
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
 
         _ = await Assert.That(async () => await client.GetAsync("https://origin.example/api"))
             .Throws<TimeoutExceededException>();
@@ -562,7 +562,7 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Explicitly_Replays_Unsafe_Content_And_Disposes_Failure()
+    public async Task Standard_Hedge_Explicitly_Replays_Unsafe_Content_And_Disposes_Failure()
     {
         var failedContent = new TrackingContent("failed");
         var bodies = new List<string>();
@@ -573,7 +573,7 @@ public class HttpReplayTests
                 ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = failedContent }
                 : new HttpResponseMessage(HttpStatusCode.OK);
         });
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
@@ -581,7 +581,7 @@ public class HttpReplayTests
             options.ContentReplayPolicy = HttpContentReplayPolicy.Buffer;
             options.AllowUnsafeMethodReplay = true;
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
         {
             Content = new StringContent("payload"),
@@ -595,18 +595,18 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Rejects_Unsafe_Replay_Without_Explicit_Opt_In()
+    public async Task Standard_Hedge_Rejects_Unsafe_Replay_Without_Explicit_Opt_In()
     {
         var failedContent = new TrackingContent("failed");
         var transport = new RecordingHandler((_, _, _) => Task.FromResult(
             new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = failedContent }));
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.HedgeDelay = Timeout.InfiniteTimeSpan;
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://origin.example/upload")
         {
             Content = new StringContent("payload"),
@@ -620,7 +620,7 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Uses_Second_Endpoint_When_First_Is_Concurrency_Limited()
+    public async Task Standard_Hedge_Uses_Second_Endpoint_When_First_Is_Concurrency_Limited()
     {
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -636,7 +636,7 @@ public class HttpReplayTests
 
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
@@ -646,7 +646,7 @@ public class HttpReplayTests
             options.TotalTimeout = TimeSpan.FromMinutes(1);
             options.AttemptTimeout = TimeSpan.FromMinutes(1);
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
 
         var holding = client.GetAsync("https://origin.example/holding");
         await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -662,7 +662,7 @@ public class HttpReplayTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Uses_Weighted_Endpoint_Selection()
+    public async Task Standard_Hedge_Uses_Weighted_Endpoint_Selection()
     {
         var hosts = new List<string>();
         var transport = new RecordingHandler((_, request, _) =>
@@ -670,7 +670,7 @@ public class HttpReplayTests
             hosts.Add(request.RequestUri!.Host);
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        using var services = CreateStandardHedgingServices(transport, options =>
+        using var services = CreateStandardHedgeServices(transport, options =>
         {
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example"), 5));
             options.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example"), 1));
@@ -678,7 +678,7 @@ public class HttpReplayTests
             options.Seed = 1729;
             options.MaxAttempts = 1;
         });
-        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedging");
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
 
         for (var index = 0; index < 32; index++)
         {
@@ -896,14 +896,14 @@ public class HttpReplayTests
         return new ShieldHttpHandlerOptions { Routing = routing };
     }
 
-    private static ServiceProvider CreateStandardHedgingServices(
+    private static ServiceProvider CreateStandardHedgeServices(
         HttpMessageHandler transport,
-        Action<StandardHedgingShieldOptions> configure)
+        Action<StandardHedgeShieldOptions> configure)
     {
         var services = new ServiceCollection();
-        services.AddHttpClient("standard-hedging")
+        services.AddHttpClient("standard-hedge")
             .ConfigurePrimaryHttpMessageHandler(() => transport)
-            .AddStandardHedgingShield(configure);
+            .AddStandardHedgeShield(configure);
         return services.BuildServiceProvider();
     }
 

--- a/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
@@ -201,7 +201,7 @@ public class HttpResilienceTests
     }
 
     [Test]
-    public async Task HttpClientFactory_Standard_Hedging_Routes_Across_Loopback_Endpoints()
+    public async Task HttpClientFactory_Standard_Hedge_Routes_Across_Loopback_Endpoints()
     {
         await using var failing = FlakyHttpServer.Start((_, context) =>
             FlakyHttpServer.Respond(context, 503));
@@ -209,7 +209,7 @@ public class HttpResilienceTests
             FlakyHttpServer.Respond(context, 200, "hedged ok"));
         using var services = new ServiceCollection()
             .AddHttpClient("hedged-backend")
-            .AddStandardHedgingShield(options =>
+            .AddStandardHedgeShield(options =>
             {
                 options.Endpoints.Add(new HttpEndpoint(new Uri(failing.Url)));
                 options.Endpoints.Add(new HttpEndpoint(new Uri(healthy.Url)));

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -65,7 +65,7 @@ public class PipelineDescriptorTests
             StrategyKind.CircuitBreaker,
             StrategyKind.RateLimit,
             StrategyKind.ConcurrencyLimit,
-            StrategyKind.Hedging);
+            StrategyKind.Hedge);
 
         var timeout = descriptor.AssertContainsSingle<TimeoutStrategyDescriptor>();
         await Assert.That(timeout.Timeout).IsEqualTo(TimeSpan.FromSeconds(2));
@@ -100,7 +100,7 @@ public class PipelineDescriptorTests
         await Assert.That(concurrency.QueueLimit).IsEqualTo(2);
         await Assert.That(concurrency.HasNotification).IsTrue();
 
-        var hedge = descriptor.AssertContainsSingle<HedgingStrategyDescriptor>();
+        var hedge = descriptor.AssertContainsSingle<HedgeStrategyDescriptor>();
         await Assert.That(hedge.MaxAttempts).IsEqualTo(3);
         await Assert.That(hedge.Delay).IsEqualTo(TimeSpan.FromMilliseconds(25));
         await Assert.That(hedge.HasNotification).IsTrue();
@@ -159,7 +159,7 @@ public class PipelineDescriptorTests
 
         await Assert.That(descriptor.AssertContainsSingle<RetryStrategyDescriptor>().HasHandlingOverride).IsTrue();
         await Assert.That(descriptor.AssertContainsSingle<CircuitBreakerStrategyDescriptor>().HasHandlingOverride).IsTrue();
-        await Assert.That(descriptor.AssertContainsSingle<HedgingStrategyDescriptor>().HasHandlingOverride).IsTrue();
+        await Assert.That(descriptor.AssertContainsSingle<HedgeStrategyDescriptor>().HasHandlingOverride).IsTrue();
         await Assert.That(descriptor.AssertContainsSingle<FallbackStrategyDescriptor>().HasHandlingOverride).IsTrue();
 
         var ambient = Shield.Retry(1).GetDescriptor().AssertContainsSingle<RetryStrategyDescriptor>();

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -1,12 +1,38 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Kevlar.Extensions.DependencyInjection;
+using Kevlar.Extensions.Http;
 using Kevlar.Testing;
+using System.Reflection;
 
 namespace Kevlar.Tests;
 
 public class ApiShapeTests
 {
+    [Test]
+    public async Task Public_Surface_Uses_One_Hedge_Stem()
+    {
+        var assemblies = new[]
+        {
+            typeof(Shield).Assembly,
+            typeof(ShieldDefinition).Assembly,
+            typeof(StandardHedgeShieldOptions).Assembly,
+            typeof(ShieldDescriptor).Assembly,
+        };
+        var legacyNames = assemblies
+            .SelectMany(static assembly => assembly.ExportedTypes)
+            .SelectMany(static type => type
+                .GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Select(static member => member.Name)
+                .Append(type.Name))
+            .Where(static name => name.Contains("Hedging", StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .Order()
+            .ToArray();
+
+        await Assert.That(legacyNames).IsEmpty();
+    }
+
     [Test]
     public async Task Exactly_One_Public_Type_Named_BackoffKind_Across_All_Assemblies()
     {
@@ -54,7 +80,7 @@ public class ApiShapeTests
         {
             typeof(Shield).Assembly,
             typeof(Extensions.DependencyInjection.ShieldDefinition).Assembly,
-            typeof(Extensions.Http.StandardHedgingShieldOptions).Assembly,
+            typeof(Extensions.Http.StandardHedgeShieldOptions).Assembly,
         };
         var legacyMembers = assemblies
             .SelectMany(static assembly => assembly.GetExportedTypes())

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -23,13 +23,13 @@ public class HttpConfigurationReloadTests
                 configuration,
                 (Action<IServiceProvider, StandardHttpShieldOptions>)null!))
             .Throws<ArgumentNullException>();
-        var hedgingConfigurationError = await Assert.That(() => builder.AddStandardHedgingShield((IConfiguration)null!))
+        var hedgeConfigurationError = await Assert.That(() => builder.AddStandardHedgeShield((IConfiguration)null!))
             .Throws<ArgumentNullException>();
 
         await Assert.That(builderError!.ParamName).IsEqualTo("builder");
         await Assert.That(configurationError!.ParamName).IsEqualTo("configuration");
         await Assert.That(configureError!.ParamName).IsEqualTo("configure");
-        await Assert.That(hedgingConfigurationError!.ParamName).IsEqualTo("configuration");
+        await Assert.That(hedgeConfigurationError!.ParamName).IsEqualTo("configuration");
     }
 
     [Test]
@@ -147,7 +147,7 @@ public class HttpConfigurationReloadTests
     }
 
     [Test]
-    public async Task Hedging_Section_Binds_All_Supported_Values()
+    public async Task Hedge_Section_Binds_All_Supported_Values()
     {
         var configuration = BuildConfiguration(
             ("TotalTimeout", "00:00:20"),
@@ -167,10 +167,10 @@ public class HttpConfigurationReloadTests
             ("MaximumBufferSize", "8192"),
             ("AllowUnsafeMethodReplay", "true"),
             ("Endpoints:0", "https://one.example"));
-        StandardHedgingShieldOptions? bound = null;
+        StandardHedgeShieldOptions? bound = null;
         var services = new ServiceCollection();
         services.AddHttpClient("client")
-            .AddStandardHedgingShield(configuration, (_, options) => bound = options);
+            .AddStandardHedgeShield(configuration, (_, options) => bound = options);
         using var provider = services.BuildServiceProvider();
 
         _ = provider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
@@ -295,7 +295,7 @@ public class HttpConfigurationReloadTests
             .Throws<InvalidOperationException>()
             .WithMessage(
                 "Configuration key 'Clients:GitHub:ConcurrencyLimit:MaxQueue' is not supported; use 'QueueLimit'.");
-        await Assert.That(() => builder.AddStandardHedgingShield(hedging))
+        await Assert.That(() => builder.AddStandardHedgeShield(hedging))
             .Throws<InvalidOperationException>()
             .WithMessage(
                 "Configuration key 'Clients:GitHub:MaxQueue' is not supported; use 'QueueLimit'.");
@@ -599,7 +599,7 @@ public class HttpConfigurationReloadTests
     }
 
     [Test]
-    public async Task Hedging_Section_Binds_Endpoints_And_Routes_Attempts()
+    public async Task Hedge_Section_Binds_Endpoints_And_Routes_Attempts()
     {
         var configuration = BuildConfiguration(
             ("MaxAttempts", "2"),
@@ -619,7 +619,7 @@ public class HttpConfigurationReloadTests
         serviceCollection.AddHttpClient("hedged", client =>
                 client.Timeout = TimeSpan.FromMilliseconds(10))
             .ConfigurePrimaryHttpMessageHandler(() => transport)
-            .AddStandardHedgingShield(configuration);
+            .AddStandardHedgeShield(configuration);
         using var services = serviceCollection.BuildServiceProvider();
         var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("hedged");
 

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -246,17 +246,17 @@ public class HttpContractTests
     }
 
     [Test]
-    public async Task Standard_Hedging_Uses_Shield_Timeout_Instead_Of_HttpClient_Timeout()
+    public async Task Standard_Hedge_Uses_Shield_Timeout_Instead_Of_HttpClient_Timeout()
     {
         using var services = new ServiceCollection()
-            .AddHttpClient("standard-hedging-timeout", client =>
+            .AddHttpClient("standard-hedge-timeout", client =>
                 client.Timeout = TimeSpan.FromMilliseconds(10))
-            .AddStandardHedgingShield(options =>
+            .AddStandardHedgeShield(options =>
                 options.Endpoints.Add(new HttpEndpoint(new Uri("https://example.test"))))
             .Services
             .BuildServiceProvider();
         using var client = services.GetRequiredService<IHttpClientFactory>()
-            .CreateClient("standard-hedging-timeout");
+            .CreateClient("standard-hedge-timeout");
 
         await Assert.That(client.Timeout).IsEqualTo(Timeout.InfiniteTimeSpan);
     }
@@ -946,12 +946,12 @@ public class HttpContractTests
         await Assert.That(() => builder.AddStandardShield(
                 (Action<IServiceProvider, StandardHttpShieldOptions>)null!))
             .Throws<ArgumentNullException>();
-        await Assert.That(() => ShieldHttpClientBuilderExtensions.AddStandardHedgingShield(
+        await Assert.That(() => ShieldHttpClientBuilderExtensions.AddStandardHedgeShield(
                 nullBuilder!, _ => { }))
             .Throws<ArgumentNullException>();
-        await Assert.That(() => builder.AddStandardHedgingShield(null!))
+        await Assert.That(() => builder.AddStandardHedgeShield(null!))
             .Throws<ArgumentNullException>();
-        await Assert.That(() => builder.AddStandardHedgingShield(_ => { }))
+        await Assert.That(() => builder.AddStandardHedgeShield(_ => { }))
             .Throws<ArgumentException>();
     }
 


### PR DESCRIPTION
Closes #199

Standardizes public Hedge naming across Kevlar.Testing, Kevlar.Extensions.Http, and analyzer descriptor fields. Updates API baselines, docs, migration notes, reflection guards, tests, and benchmarks.

Validation:
- dotnet build Kevlar.slnx -c Release
- Kevlar.Tests: 894 passed
- Kevlar.Testing.Tests: 52 passed
- Kevlar.Analyzers.Tests: 82 passed
- Kevlar.IntegrationTests: 132 passed
- scripts/Verify-Docs.ps1
- scripts/Verify-DocSnippets.ps1: 125 snippets