### PR TITLE
refactor(exceptions)!: unify rejection hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
   predicates keep their exact compile-time types.
 - The `Hedge` method, options, testing descriptors, strategy kind, and standard HTTP registration
   now share one `Hedge` stem, like `Retry`/`RetryOptions` and `Timeout`/`TimeoutOptions`.
+- Circuit-open, rate-limit, concurrency-limit, and timeout rejections now derive from
+  `ExecutionRejectedException`, which provides their common `RetryAfter` property. Concrete public
+  exception types expose the conventional `()`, `(string)`, and `(string, Exception)` constructors;
+  the metadata-specific constructors remain available.
+
 ### Changed
 
 - Every NuGet package now embeds the canonical Kevlar icon, links release notes, and carries a

--- a/docs/docs/exceptions.md
+++ b/docs/docs/exceptions.md
@@ -18,41 +18,47 @@ errors handled by a retry, breaker, hedge, or fallback.
 
 | Exception | Thrown by | Properties | Base class | Catch pattern | Default clause |
 |---|---|---|---|---|---|
-| `KevlarException` | Abstract base for core strategy rejections | Inherited `InnerException` carries a cause when the concrete rejection has one. | `Exception` | `catch (KevlarException)` | N/A |
+| `KevlarException` | Abstract base for exceptions raised by core strategies | Inherited `InnerException` carries a cause when the concrete exception has one. | `Exception` | `catch (KevlarException)` | N/A |
+| `ExecutionRejectedException` | Abstract base for execution rejections | `RetryAfter` estimates when execution may be attempted again; inherited `InnerException` carries a cause when known. | `KevlarException` | `catch (ExecutionRejectedException e)` | N/A |
 | `KevlarProxyException` | Internal bookkeeping for adapter-owned exception proxies | `OriginalException` is the failure exposed to handling clauses, public outcomes, and adapter callers; inherited `InnerException` preserves the same cause. | `Exception` | Catch `OriginalException`'s concrete type, such as `RpcException`. | N/A |
-| `TimeoutExceededException` | Timeout | `Timeout` is the winning budget; a strategy-produced timeout carries the delegate's cancellation exception in inherited `InnerException`. The public one-argument constructor leaves it `null`. | `KevlarException` | `catch (TimeoutExceededException e) when (e.Timeout == budget)` | Yes |
-| `CircuitOpenException` | Circuit breaker | `RetryAfter` is the remaining break duration; `IsIsolated` distinguishes manual isolation; inherited `InnerException` is the last failure when known. | `KevlarException` | `catch (CircuitOpenException e) when (e.RetryAfter is { } delay)` | No |
-| `RateLimitExceededException` | Rate limit | `RetryAfter` estimates when a permit may become available. | `KevlarException` | `catch (RateLimitExceededException e) when (e.RetryAfter is { } delay)` | No |
-| `ConcurrencyLimitExceededException` | Concurrency limit | Inherited `InnerException` is `null`; the rejection means both execution and queue capacity are full. | `KevlarException` | `catch (ConcurrencyLimitExceededException)` | No |
+| `TimeoutExceededException` | Timeout | `Timeout` is the winning budget; a strategy-produced timeout carries the delegate's cancellation exception in inherited `InnerException`. `RetryAfter` is `null`. | `ExecutionRejectedException` | `catch (TimeoutExceededException e) when (e.Timeout == budget)` | Yes |
+| `CircuitOpenException` | Circuit breaker | Inherited `RetryAfter` is the remaining break duration; `IsIsolated` distinguishes manual isolation; inherited `InnerException` is the last failure when known. | `ExecutionRejectedException` | `catch (CircuitOpenException e) when (e.RetryAfter is { } delay)` | No |
+| `RateLimitExceededException` | Rate limit | Inherited `RetryAfter` estimates when a permit may become available. | `ExecutionRejectedException` | `catch (RateLimitExceededException e) when (e.RetryAfter is { } delay)` | No |
+| `ConcurrencyLimitExceededException` | Concurrency limit | Inherited `RetryAfter` and `InnerException` are `null`; the rejection means both execution and queue capacity are full. | `ExecutionRejectedException` | `catch (ConcurrencyLimitExceededException)` | No |
 | `HttpRequestReplayException` | HTTP request replay and endpoint routing | Inherited `InnerException` is the content failure when serialization or buffering caused the replay failure. | `InvalidOperationException` | `catch (HttpRequestReplayException e)` | Yes |
 | `ChaosInjectedException` | Chaos fault injection | Inherited `InnerException` is populated only when the configured injected fault wraps a cause. | `Exception` | `catch (ChaosInjectedException e)` | Yes |
 | `ShieldAssertionException` | Kevlar.Testing assertions and bounded waits | Inherited `InnerException` is `null`; `Message` explains the failed assertion or unmet condition. | `Exception` | `catch (ShieldAssertionException e)` | Yes |
 
-`RetryAfter` can be `null`: callers must treat it as advisory. A manually isolated circuit has
-`IsIsolated == true` and no automatic retry time. `CircuitOpenException.InnerException` is diagnostic
-history, not a new failure from the rejected call.
+Every concrete exception exposes `()`, `(string)`, and `(string, Exception)` constructors. Metadata-
+specific constructors remain the preferred way to represent a real strategy rejection.
+
+`ExecutionRejectedException.RetryAfter` can be `null`: callers must treat it as advisory. A manually
+isolated circuit has `IsIsolated == true` and no automatic retry time.
+`CircuitOpenException.InnerException` is diagnostic history, not a new failure from the rejected
+call.
 
 ## Catching core rejections
 
-Catch a concrete type when its metadata changes recovery behavior. Catch `KevlarException` only when
-all core rejections share one response.
+Catch a concrete type when its metadata changes recovery behavior. Catch
+`ExecutionRejectedException` when every execution rejection shares one response; catch
+`KevlarException` only when other future core exception families should share it too.
 
 <!-- doc-test-run: catch-kevlar-exception -->
 ```csharp
-var caughtKevlarException = false;
+var caughtExecutionRejection = false;
 try
 {
     await Shield.Empty.ExecuteAsync<int>(
         _ => throw new TimeoutExceededException(TimeSpan.FromSeconds(1)));
 }
-catch (KevlarException)
+catch (ExecutionRejectedException exception) when (exception.RetryAfter is null)
 {
-    caughtKevlarException = true;
+    caughtExecutionRejection = true;
 }
 
-if (!caughtKevlarException)
+if (!caughtExecutionRejection)
 {
-    throw new InvalidOperationException("The KevlarException catch did not match.");
+    throw new InvalidOperationException("The ExecutionRejectedException catch did not match.");
 }
 ```
 
@@ -196,7 +202,8 @@ if (!caughtAssertion)
 
 ## Timeout is not `System.TimeoutException`
 
-`TimeoutExceededException` deliberately derives from `KevlarException`, not
+`TimeoutExceededException` deliberately derives from `ExecutionRejectedException` (and therefore
+`KevlarException`), not
 `System.TimeoutException`. A `catch (TimeoutException)` compiles but does not match a Kevlar timeout. <!-- doc-lint: allow-TimeoutException -->
 This mirrors Polly's `TimeoutRejectedException` behavior. Catch `TimeoutExceededException` and inspect
 its `Timeout` property.

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -24,13 +24,15 @@ Kevlar's pipeline model translates 1:1 from Polly v8 — the "first strategy add
 
 :::warning `TimeoutExceededException` is **not** a `System.TimeoutException`
 
-`Kevlar.TimeoutExceededException` derives from `KevlarException`, not from `System.TimeoutException`.
-Polly set the same trap — `TimeoutRejectedException` derived from `ExecutionRejectedException`, never
+`Kevlar.TimeoutExceededException` derives from `ExecutionRejectedException`, not from
+`System.TimeoutException`. Polly set the same trap — `TimeoutRejectedException` derived from its own
+`ExecutionRejectedException`, never
 from `System.TimeoutException` — and the reflex is the same in both libraries: a `catch (TimeoutException)` <!-- doc-lint: allow-TimeoutException -->
 carried over from application code still compiles, never matches, and lets the timeout escape as an
 unhandled exception.
 
-Catch the exception the strategy actually throws, or `KevlarException` for any Kevlar rejection:
+Catch the exception the strategy actually throws, or `ExecutionRejectedException` for any Kevlar
+execution rejection:
 
 ```csharp
 var saveShield = Shield.Timeout(TimeSpan.FromSeconds(30));
@@ -43,14 +45,15 @@ catch (TimeoutExceededException exception)      // not System.TimeoutException
 {
     logger.LogWarning("Timed out after {Timeout}", exception.Timeout);
 }
-catch (KevlarException exception)               // CircuitOpenException, RateLimitExceededException, …
+catch (ExecutionRejectedException exception)    // CircuitOpenException, RateLimitExceededException, …
 {
     logger.LogWarning(exception, "Shielded call was rejected");
 }
 ```
 
 The same applies to `CircuitOpenException`, `RateLimitExceededException` and
-`ConcurrencyLimitExceededException`: every rejection Kevlar raises derives from `KevlarException`.
+`ConcurrencyLimitExceededException`: every execution rejection Kevlar raises derives from
+`ExecutionRejectedException`, which itself derives from `KevlarException`.
 The [exceptions reference](exceptions.md) covers every core and satellite exception in one place.
 
 :::

--- a/src/Kevlar.Extensions.Http/HttpRequestReplayException.cs
+++ b/src/Kevlar.Extensions.Http/HttpRequestReplayException.cs
@@ -3,6 +3,12 @@ namespace Kevlar.Extensions.Http;
 /// <summary>Thrown when another HTTP attempt cannot be created safely.</summary>
 public sealed class HttpRequestReplayException : InvalidOperationException
 {
+    /// <summary>Creates a replay error with a default message.</summary>
+    public HttpRequestReplayException()
+        : base("The HTTP request could not be replayed safely.")
+    {
+    }
+
     /// <summary>Creates a replay error with actionable details.</summary>
     public HttpRequestReplayException(string message)
         : base(message)

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -18,6 +18,7 @@ Kevlar.Extensions.Http.HttpEndpointSelectionMode
 Kevlar.Extensions.Http.HttpEndpointSelectionMode.Ordered = 0 -> Kevlar.Extensions.Http.HttpEndpointSelectionMode
 Kevlar.Extensions.Http.HttpEndpointSelectionMode.Weighted = 1 -> Kevlar.Extensions.Http.HttpEndpointSelectionMode
 Kevlar.Extensions.Http.HttpRequestReplayException
+Kevlar.Extensions.Http.HttpRequestReplayException.HttpRequestReplayException() -> void
 Kevlar.Extensions.Http.HttpRequestReplayException.HttpRequestReplayException(string! message) -> void
 Kevlar.Extensions.Http.HttpRequestReplayException.HttpRequestReplayException(string! message, System.Exception! innerException) -> void
 Kevlar.Extensions.Http.ShieldDelegatingHandler.ShieldDelegatingHandler(Kevlar.Shield<System.Net.Http.HttpResponseMessage!>! shield, Kevlar.Extensions.Http.ShieldHttpHandlerOptions! options) -> void

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -38,6 +38,8 @@ Kevlar.Testing.RetryStrategyDescriptor.HasNotification.get -> bool
 Kevlar.Testing.RetryStrategyDescriptor.MaxDelay.get -> System.TimeSpan?
 Kevlar.Testing.RetryStrategyDescriptor.MaxRetries.get -> int
 Kevlar.Testing.ShieldAssertionException
+Kevlar.Testing.ShieldAssertionException.ShieldAssertionException() -> void
+Kevlar.Testing.ShieldAssertionException.ShieldAssertionException(string! message, System.Exception! innerException) -> void
 Kevlar.Testing.ShieldAssertionException.ShieldAssertionException(string! message) -> void
 Kevlar.Testing.ShieldDescriptor
 Kevlar.Testing.ShieldExecutionExtensions

--- a/src/Kevlar.Testing/ShieldAssertionException.cs
+++ b/src/Kevlar.Testing/ShieldAssertionException.cs
@@ -3,9 +3,21 @@ namespace Kevlar.Testing;
 /// <summary>Thrown when a structured shield assertion fails.</summary>
 public sealed class ShieldAssertionException : Exception
 {
+    /// <summary>Creates an assertion failure with a default message.</summary>
+    public ShieldAssertionException()
+        : base("A shield assertion failed.")
+    {
+    }
+
     /// <summary>Creates an assertion failure with an actionable message.</summary>
     public ShieldAssertionException(string message)
         : base(message)
+    {
+    }
+
+    /// <summary>Creates an assertion failure with an actionable message and cause.</summary>
+    public ShieldAssertionException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Kevlar/Exceptions/CircuitOpenException.cs
+++ b/src/Kevlar/Exceptions/CircuitOpenException.cs
@@ -1,20 +1,36 @@
 namespace Kevlar;
 
 /// <summary>Thrown when a circuit breaker rejects an execution because the circuit is open.</summary>
-public sealed class CircuitOpenException : KevlarException
+public sealed class CircuitOpenException : ExecutionRejectedException
 {
-    /// <summary>Initializes the exception.</summary>
-    public CircuitOpenException(TimeSpan? retryAfter, bool isIsolated, Exception? lastException)
-        : base(isIsolated
-            ? "The circuit is manually isolated and is rejecting executions until it is reset."
-            : "The circuit is open and is rejecting executions.", lastException!)
+    private const string OpenMessage = "The circuit is open and is rejecting executions.";
+    private const string IsolatedMessage =
+        "The circuit is manually isolated and is rejecting executions until it is reset.";
+
+    /// <summary>Initializes an open-circuit rejection.</summary>
+    public CircuitOpenException()
+        : base(OpenMessage)
     {
-        RetryAfter = retryAfter;
-        IsIsolated = isIsolated;
     }
 
-    /// <summary>Time remaining until the circuit will allow a probe execution, when known.</summary>
-    public TimeSpan? RetryAfter { get; }
+    /// <summary>Initializes an open-circuit rejection with a custom message.</summary>
+    public CircuitOpenException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes an open-circuit rejection with a custom message and last failure.</summary>
+    public CircuitOpenException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>Initializes the exception.</summary>
+    public CircuitOpenException(TimeSpan? retryAfter, bool isIsolated, Exception? lastException)
+        : base(isIsolated ? IsolatedMessage : OpenMessage, retryAfter, lastException)
+    {
+        IsIsolated = isIsolated;
+    }
 
     /// <summary><see langword="true"/> when the circuit was manually isolated rather than tripped by failures.</summary>
     public bool IsIsolated { get; }

--- a/src/Kevlar/Exceptions/ConcurrencyLimitExceededException.cs
+++ b/src/Kevlar/Exceptions/ConcurrencyLimitExceededException.cs
@@ -1,11 +1,26 @@
 namespace Kevlar;
 
 /// <summary>Thrown when a concurrency limit strategy rejects an execution because both the concurrency and queue limits are full.</summary>
-public sealed class ConcurrencyLimitExceededException : KevlarException
+public sealed class ConcurrencyLimitExceededException : ExecutionRejectedException
 {
+    private const string DefaultMessage =
+        "The concurrency limit's concurrency and queue limits are both full.";
+
     /// <summary>Initializes the exception.</summary>
     public ConcurrencyLimitExceededException()
-        : base("The concurrency limit's concurrency and queue limits are both full.")
+        : base(DefaultMessage)
+    {
+    }
+
+    /// <summary>Initializes a concurrency-limit rejection with a custom message.</summary>
+    public ConcurrencyLimitExceededException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a concurrency-limit rejection with a custom message and cause.</summary>
+    public ConcurrencyLimitExceededException(string message, Exception innerException)
+        : base(message, innerException)
     {
     }
 }

--- a/src/Kevlar/Exceptions/ExecutionRejectedException.cs
+++ b/src/Kevlar/Exceptions/ExecutionRejectedException.cs
@@ -1,0 +1,35 @@
+namespace Kevlar;
+
+/// <summary>Base class for executions rejected by a Kevlar strategy.</summary>
+public abstract class ExecutionRejectedException : KevlarException
+{
+    /// <summary>Initializes a rejection with no retry estimate.</summary>
+    protected ExecutionRejectedException()
+    {
+    }
+
+    /// <summary>Initializes a rejection with no retry estimate.</summary>
+    protected ExecutionRejectedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a rejection with no retry estimate and a cause.</summary>
+    protected ExecutionRejectedException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>Initializes a rejection with an optional retry estimate and cause.</summary>
+    protected ExecutionRejectedException(
+        string message,
+        TimeSpan? retryAfter,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        RetryAfter = retryAfter;
+    }
+
+    /// <summary>Estimated time until execution may be attempted again, when known.</summary>
+    public TimeSpan? RetryAfter { get; }
+}

--- a/src/Kevlar/Exceptions/KevlarException.cs
+++ b/src/Kevlar/Exceptions/KevlarException.cs
@@ -3,6 +3,11 @@ namespace Kevlar;
 /// <summary>Base class for exceptions raised by Kevlar strategies themselves.</summary>
 public abstract class KevlarException : Exception
 {
+    /// <summary>Initializes the exception.</summary>
+    protected KevlarException()
+    {
+    }
+
     /// <summary>Initializes the exception with a message.</summary>
     protected KevlarException(string message)
         : base(message)
@@ -10,7 +15,7 @@ public abstract class KevlarException : Exception
     }
 
     /// <summary>Initializes the exception with a message and inner exception.</summary>
-    protected KevlarException(string message, Exception innerException)
+    protected KevlarException(string message, Exception? innerException)
         : base(message, innerException)
     {
     }

--- a/src/Kevlar/Exceptions/RateLimitExceededException.cs
+++ b/src/Kevlar/Exceptions/RateLimitExceededException.cs
@@ -1,13 +1,31 @@
 namespace Kevlar;
 
 /// <summary>Thrown when a rate limit strategy rejects an execution.</summary>
-public sealed class RateLimitExceededException : KevlarException
+public sealed class RateLimitExceededException : ExecutionRejectedException
 {
+    private const string DefaultMessage = "The rate limit has been exceeded.";
+
+    /// <summary>Initializes a rate-limit rejection without a retry estimate.</summary>
+    public RateLimitExceededException()
+        : base(DefaultMessage)
+    {
+    }
+
+    /// <summary>Initializes a rate-limit rejection with a custom message.</summary>
+    public RateLimitExceededException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a rate-limit rejection with a custom message and cause.</summary>
+    public RateLimitExceededException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
     /// <summary>Initializes the exception.</summary>
     public RateLimitExceededException(TimeSpan? retryAfter)
-        : base("The rate limit has been exceeded.")
-        => RetryAfter = retryAfter;
-
-    /// <summary>Estimated time until a permit becomes available, when known.</summary>
-    public TimeSpan? RetryAfter { get; }
+        : base(DefaultMessage, retryAfter)
+    {
+    }
 }

--- a/src/Kevlar/Exceptions/TimeoutExceededException.cs
+++ b/src/Kevlar/Exceptions/TimeoutExceededException.cs
@@ -1,14 +1,35 @@
 namespace Kevlar;
 
 /// <summary>Thrown when a timeout strategy cancels an execution that exceeded its allotted time.</summary>
-public sealed class TimeoutExceededException : KevlarException
+public sealed class TimeoutExceededException : ExecutionRejectedException
 {
+    private const string DefaultMessage = "The execution exceeded its allotted timeout.";
+
+    /// <summary>Initializes a timeout rejection without a recorded timeout.</summary>
+    public TimeoutExceededException()
+        : base(DefaultMessage)
+    {
+    }
+
+    /// <summary>Initializes a timeout rejection with a custom message.</summary>
+    public TimeoutExceededException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a timeout rejection with a custom message and cause.</summary>
+    public TimeoutExceededException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
     /// <summary>Initializes the exception for the given timeout.</summary>
     public TimeoutExceededException(TimeSpan timeout)
         : base(FormatMessage(timeout))
         => Timeout = timeout;
 
-    internal TimeoutExceededException(TimeSpan timeout, OperationCanceledException innerException)
+    /// <summary>Initializes the exception for the given timeout and triggering cancellation.</summary>
+    public TimeoutExceededException(TimeSpan timeout, OperationCanceledException innerException)
         : base(FormatMessage(timeout), innerException)
         => Timeout = timeout;
 

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -23,16 +23,17 @@ internal abstract class OutcomeJudge
         public override bool ShouldHandle<T>(in Outcome<T> outcome) =>
             outcome.Exception is { } exception && IsOrdinaryError(exception);
 
-        private static bool IsOrdinaryError(Exception exception) => exception is not (
-            OperationCanceledException
-            or CircuitOpenException
-            or RateLimitExceededException
-            or ConcurrencyLimitExceededException
-            or OutOfMemoryException
-            or InsufficientExecutionStackException
-            or StackOverflowException
-            or ThreadAbortException
-            or AccessViolationException);
+        private static bool IsOrdinaryError(Exception exception) =>
+            // A timeout is a recoverable attempt outcome; other execution rejections are fail-fast.
+            exception is TimeoutExceededException
+            || exception is not (
+                OperationCanceledException
+                or ExecutionRejectedException
+                or OutOfMemoryException
+                or InsufficientExecutionStackException
+                or StackOverflowException
+                or ThreadAbortException
+                or AccessViolationException);
     }
 }
 

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -430,3 +430,26 @@ static Kevlar.ShieldExtensions.ConcurrencyLimit(this Kevlar.Shield! shield, int 
 Kevlar.HedgeEvent.AttemptNumber.get -> int
 Kevlar.RetryEvent.RetryNumber.get -> int
 Kevlar.RetryEvent<TResult>.RetryNumber.get -> int
+*REMOVED*Kevlar.CircuitOpenException.RetryAfter.get -> System.TimeSpan?
+*REMOVED*Kevlar.KevlarException.KevlarException(string! message, System.Exception! innerException) -> void
+*REMOVED*Kevlar.RateLimitExceededException.RetryAfter.get -> System.TimeSpan?
+Kevlar.CircuitOpenException.CircuitOpenException() -> void
+Kevlar.CircuitOpenException.CircuitOpenException(string! message) -> void
+Kevlar.CircuitOpenException.CircuitOpenException(string! message, System.Exception! innerException) -> void
+Kevlar.ConcurrencyLimitExceededException.ConcurrencyLimitExceededException(string! message) -> void
+Kevlar.ConcurrencyLimitExceededException.ConcurrencyLimitExceededException(string! message, System.Exception! innerException) -> void
+Kevlar.ExecutionRejectedException
+Kevlar.ExecutionRejectedException.ExecutionRejectedException() -> void
+Kevlar.ExecutionRejectedException.ExecutionRejectedException(string! message) -> void
+Kevlar.ExecutionRejectedException.ExecutionRejectedException(string! message, System.Exception? innerException) -> void
+Kevlar.ExecutionRejectedException.ExecutionRejectedException(string! message, System.TimeSpan? retryAfter, System.Exception? innerException = null) -> void
+Kevlar.ExecutionRejectedException.RetryAfter.get -> System.TimeSpan?
+Kevlar.KevlarException.KevlarException(string! message, System.Exception? innerException) -> void
+Kevlar.KevlarException.KevlarException() -> void
+Kevlar.RateLimitExceededException.RateLimitExceededException() -> void
+Kevlar.RateLimitExceededException.RateLimitExceededException(string! message) -> void
+Kevlar.RateLimitExceededException.RateLimitExceededException(string! message, System.Exception! innerException) -> void
+Kevlar.TimeoutExceededException.TimeoutExceededException() -> void
+Kevlar.TimeoutExceededException.TimeoutExceededException(string! message) -> void
+Kevlar.TimeoutExceededException.TimeoutExceededException(string! message, System.Exception! innerException) -> void
+Kevlar.TimeoutExceededException.TimeoutExceededException(System.TimeSpan timeout, System.OperationCanceledException! innerException) -> void

--- a/tests/Kevlar.Tests/DefaultHandlingTests.cs
+++ b/tests/Kevlar.Tests/DefaultHandlingTests.cs
@@ -105,9 +105,9 @@ public class DefaultHandlingTests
             .FallbackTo(42);
 
         var unhandled = await defaultFallback.ExecuteOutcomeAsync(_ =>
-            throw new RateLimitExceededException(null));
+            throw new RateLimitExceededException(retryAfter: null));
         var handled = await explicitFallback.ExecuteAsync(_ =>
-            throw new RateLimitExceededException(null));
+            throw new RateLimitExceededException(retryAfter: null));
 
         await Assert.That(unhandled.Exception).IsTypeOf<RateLimitExceededException>();
         await Assert.That(handled).IsEqualTo(42);

--- a/tests/Kevlar.Tests/ExceptionContractTests.cs
+++ b/tests/Kevlar.Tests/ExceptionContractTests.cs
@@ -1,0 +1,224 @@
+using System.Reflection;
+using Kevlar.Chaos;
+using Kevlar.Extensions.DependencyInjection;
+using Kevlar.Extensions.Grpc;
+using Kevlar.Extensions.Http;
+using Kevlar.Extensions.RateLimiting;
+using Kevlar.Internal;
+using Kevlar.Testing;
+
+namespace Kevlar.Tests;
+
+public class ExceptionContractTests
+{
+    private static readonly Assembly[] ShippedAssemblies =
+    [
+        typeof(Shield).Assembly,
+        typeof(Kevlar.Analyzers.PipelineHazardAnalyzer).Assembly,
+        typeof(ChaosShield).Assembly,
+        typeof(KevlarServiceCollectionExtensions).Assembly,
+        typeof(GrpcShield).Assembly,
+        typeof(HttpShield).Assembly,
+        typeof(ShieldRateLimiterExtensions).Assembly,
+        typeof(TelemetryRecorder).Assembly,
+    ];
+
+    [Test]
+    public async Task Every_Core_Rejection_Derives_From_ExecutionRejectedException()
+    {
+        Type[] rejectionTypes =
+        [
+            typeof(CircuitOpenException),
+            typeof(RateLimitExceededException),
+            typeof(ConcurrencyLimitExceededException),
+            typeof(TimeoutExceededException),
+        ];
+
+        foreach (var rejectionType in rejectionTypes)
+        {
+            await Assert.That(rejectionType.IsSubclassOf(typeof(ExecutionRejectedException))).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Catching_ExecutionRejectedException_Exposes_Common_RetryAfter()
+    {
+        var retryAfter = TimeSpan.FromSeconds(5);
+        ExecutionRejectedException[] rejections =
+        [
+            new CircuitOpenException(retryAfter, isIsolated: false, lastException: null),
+            new RateLimitExceededException(retryAfter),
+            new ConcurrencyLimitExceededException(),
+            new TimeoutExceededException(TimeSpan.FromSeconds(1)),
+        ];
+
+        foreach (var rejection in rejections)
+        {
+            var caught = CatchRejection(rejection);
+            await Assert.That(ReferenceEquals(caught, rejection)).IsTrue();
+        }
+
+        await Assert.That(rejections[0].RetryAfter).IsEqualTo(retryAfter);
+        await Assert.That(rejections[1].RetryAfter).IsEqualTo(retryAfter);
+        await Assert.That(rejections[2].RetryAfter).IsNull();
+        await Assert.That(rejections[3].RetryAfter).IsNull();
+    }
+
+    [Test]
+    public async Task Default_Handling_Excludes_Rejections_But_Allows_Timeouts()
+    {
+        var customRejection = Outcome<int>.FromException(new TestExecutionRejectedException());
+        var timeout = Outcome<int>.FromException(
+            new TimeoutExceededException(TimeSpan.FromSeconds(1)));
+
+        await Assert.That(OutcomeJudge.Default.ShouldHandle(in customRejection)).IsFalse();
+        await Assert.That(OutcomeJudge.Default.ShouldHandle(in timeout)).IsTrue();
+    }
+
+    [Test]
+    public async Task Every_Concrete_Public_Exception_Has_Standard_Constructors()
+    {
+        foreach (var exceptionType in GetPublicExceptionTypes().Where(static type => !type.IsAbstract))
+        {
+            await Assert.That(exceptionType.GetConstructor(Type.EmptyTypes)).IsNotNull();
+            await Assert.That(exceptionType.GetConstructor([typeof(string)])).IsNotNull();
+            await Assert.That(exceptionType.GetConstructor([typeof(string), typeof(Exception)])).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task Core_Exception_Bases_Have_Protected_Standard_Constructors()
+    {
+        Type[] baseTypes = [typeof(KevlarException), typeof(ExecutionRejectedException)];
+        Type[][] signatures =
+        [
+            Type.EmptyTypes,
+            [typeof(string)],
+            [typeof(string), typeof(Exception)],
+        ];
+
+        foreach (var baseType in baseTypes)
+        {
+            foreach (var signature in signatures)
+            {
+                var constructor = baseType.GetConstructor(
+                    BindingFlags.Instance | BindingFlags.NonPublic,
+                    binder: null,
+                    signature,
+                    modifiers: null);
+                await Assert.That(constructor).IsNotNull();
+            }
+        }
+    }
+
+    [Test]
+    public async Task Standard_Constructors_Preserve_Message_And_Inner_Exception()
+    {
+        var innerException = new InvalidOperationException("cause");
+        foreach (var exceptionType in GetPublicExceptionTypes().Where(static type => !type.IsAbstract))
+        {
+            var withMessage = (Exception)Activator.CreateInstance(exceptionType, "custom")!;
+            var withCause = (Exception)Activator.CreateInstance(exceptionType, "custom", innerException)!;
+
+            await Assert.That(withMessage.Message).IsEqualTo("custom");
+            await Assert.That(ReferenceEquals(withCause.InnerException, innerException)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Satellite_Exceptions_Keep_Their_Domain_Base_Classes()
+    {
+        var expectedNonCoreExceptions = new Dictionary<Type, Type>
+        {
+            [typeof(KevlarProxyException)] = typeof(Exception),
+            [typeof(ChaosInjectedException)] = typeof(Exception),
+            [typeof(HttpRequestReplayException)] = typeof(InvalidOperationException),
+            [typeof(ShieldAssertionException)] = typeof(Exception),
+        };
+        var actualNonCoreExceptions = GetPublicExceptionTypes()
+            .Where(static type => !typeof(KevlarException).IsAssignableFrom(type))
+            .ToDictionary(static type => type, static type => type.BaseType!);
+
+        await Assert.That(actualNonCoreExceptions).IsEquivalentTo(expectedNonCoreExceptions);
+    }
+
+    [Test]
+    public async Task Exceptions_Are_Sealed_Or_Abstract()
+    {
+        foreach (var exceptionType in GetPublicExceptionTypes())
+        {
+            await Assert.That(exceptionType.IsSealed || exceptionType.IsAbstract).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task CircuitOpenException_Preserves_Isolation_And_Last_Failure()
+    {
+        var lastException = new InvalidOperationException("last failure");
+        var open = new CircuitOpenException(
+            TimeSpan.FromSeconds(2),
+            isIsolated: false,
+            lastException: null);
+        var isolated = new CircuitOpenException(
+            retryAfter: null,
+            isIsolated: true,
+            lastException);
+
+        await Assert.That(open.InnerException).IsNull();
+        await Assert.That(open.IsIsolated).IsFalse();
+        await Assert.That(isolated.IsIsolated).IsTrue();
+        await Assert.That(ReferenceEquals(isolated.InnerException, lastException)).IsTrue();
+    }
+
+    [Test]
+    public async Task TimeoutExceededException_Preserves_Triggering_Cancellation()
+    {
+        var cancellation = new OperationCanceledException("timed out");
+        var exception = new TimeoutExceededException(TimeSpan.FromSeconds(3), cancellation);
+
+        await Assert.That(ReferenceEquals(exception.InnerException, cancellation)).IsTrue();
+        await Assert.That(exception).IsNotTypeOf<TimeoutException>();
+    }
+
+    [Test]
+    public async Task Default_Exception_Messages_Are_Stable()
+    {
+        var expectedMessages = new Dictionary<Exception, string>
+        {
+            [new CircuitOpenException()] = "The circuit is open and is rejecting executions.",
+            [new RateLimitExceededException()] = "The rate limit has been exceeded.",
+            [new ConcurrencyLimitExceededException()] =
+                "The concurrency limit's concurrency and queue limits are both full.",
+            [new TimeoutExceededException()] = "The execution exceeded its allotted timeout.",
+            [new ChaosInjectedException()] = "A fault was injected by Kevlar.Chaos.",
+            [new HttpRequestReplayException()] = "The HTTP request could not be replayed safely.",
+            [new ShieldAssertionException()] = "A shield assertion failed.",
+        };
+
+        foreach (var (exception, expectedMessage) in expectedMessages)
+        {
+            await Assert.That(exception.Message).IsEqualTo(expectedMessage);
+        }
+    }
+
+    private static ExecutionRejectedException CatchRejection(Exception exception)
+    {
+        try
+        {
+            throw exception;
+        }
+        catch (ExecutionRejectedException rejection)
+        {
+            return rejection;
+        }
+    }
+
+    private static Type[] GetPublicExceptionTypes() => ShippedAssemblies
+        .SelectMany(static assembly => assembly.ExportedTypes)
+        .Where(static type => typeof(Exception).IsAssignableFrom(type))
+        .OrderBy(static type => type.FullName, StringComparer.Ordinal)
+        .ToArray();
+
+    private sealed class TestExecutionRejectedException()
+        : ExecutionRejectedException("Test rejection.");
+}


### PR DESCRIPTION
## Summary
- add `ExecutionRejectedException` as the common base for circuit-open, rate-limit, concurrency-limit, and timeout rejections
- expose shared `RetryAfter` metadata and conventional exception constructors while preserving timeout/default-handling behavior
- keep satellite exception base classes domain-specific, update public API baselines/docs, and add reflection/behavior contracts

Closes #202

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m` (892 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (918 passed)
- `dotnet run --project tests/Kevlar.Chaos.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (35 passed)
- `dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (52 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (133 passed)
- `dotnet run --project tests/Kevlar.NetStandard.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (11 passed)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0-exceptions` (135 snippets, both targets)
- `dnx dotnet-inspect` confirmed the emitted hierarchy and constructor counts
- `Verify-Packages.ps1`: all SourceLink checks passed; Windows-local deterministic repeat hashing diverged for `Kevlar.Extensions.Grpc.dll` (the package gate runs on Ubuntu CI)