### PR TITLE
feat(backoff)!: add configurable jitter modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var user = await shield.ExecuteAsync(
 ```
 
 That reads in execution order: the 30-second timeout wraps the retries, which wrap the circuit
-breaker. `Retry(3)` uses exponential backoff with jitter by default. The cancellation token passed
+breaker. `Retry(3)` uses exponential backoff with equal jitter by default. The cancellation token passed
 to your delegate is important—it is how timeouts and abandoned attempts stop the underlying work.
 
 Build shields once and reuse them. They are immutable and thread-safe. Reuse also matters for

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -165,7 +165,7 @@ var shield = Shield
     .WithName("github");
 
 logger.LogInformation("using {Shield}", shield);
-// github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s)
+// github: Timeout(30s) → Retry(3, exponential 250ms ×2, equal jitter, cap 30s) → CircuitBreaker(5 consecutive, break 30s)
 ```
 
 Log it at startup and code review becomes "read the log line".

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -29,7 +29,7 @@ using Kevlar;
 
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))   // total budget for the whole operation
-    .Retry(3)                            // exponential backoff + jitter, out of the box
+    .Retry(3)                            // exponential backoff + equal jitter, out of the box
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 
 var user = await shield.ExecuteAsync(ct => LoadUserAsync(id, ct), cancellationToken);
@@ -38,7 +38,7 @@ var user = await shield.ExecuteAsync(ct => LoadUserAsync(id, ct), cancellationTo
 Three things to notice:
 
 1. **Reading order is execution order.** The first strategy in the chain is the outermost — the timeout wraps the retries, which wrap the circuit breaker. Same rule as ASP.NET middleware.
-2. **The defaults are the ones you'd have picked.** `Retry(3)` means exponential backoff with jitter, starting at 250ms and capped at 30s.
+2. **The defaults are the ones you'd have picked.** `Retry(3)` means exponential backoff with equal jitter, starting at 250ms and capped at 30s.
 3. **Your delegate gets a cancellation token.** Always use the token you're handed — it's how timeouts and hedging cancel abandoned work.
 
 ## Reuse it everywhere

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -87,7 +87,7 @@ var configuration = new ConfigurationBuilder()
         ["Http:Api:Retry:MaxRetries"] = "2",
         ["Http:Api:Retry:Backoff"] = "Exponential",
         ["Http:Api:Retry:BaseDelay"] = "00:00:00.100",
-        ["Http:Api:Retry:Jitter"] = "true",
+        ["Http:Api:Retry:Jitter"] = "Equal",
         ["Http:Api:AttemptTimeout"] = "00:00:05",
         ["Http:Api:Handler:MaximumBufferSize"] = "262144",
     })
@@ -102,7 +102,8 @@ services.AddHttpClient("api")
 
 Timeouts accept either a scalar (`TotalTimeout`) or the options-shaped
 `TotalTimeout:Timeout` key. Retry keys are `MaxRetries`, `Backoff` (`None`, `Constant`, `Linear`,
-or `Exponential`), `BaseDelay`, `Factor`, `Jitter`, `BackoffMaxDelay`, and `MaxDelay`. Circuit
+or `Exponential`), `BaseDelay`, `Factor`, `Jitter` (`None`, `Equal`, `Full`, or `Decorrelated`),
+`BackoffMaxDelay`, and `MaxDelay`. Circuit
 breaker, concurrency-limit, handler, routing, and endpoint keys match their public option-property
 names. Endpoint entries accept either a URI scalar or `Uri` plus optional `Weight` children.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -12,7 +12,7 @@ using Kevlar;
 
 var shield = Shield
     .Timeout(TimeSpan.FromSeconds(30))                    // total budget for the whole operation
-    .Retry(3)                                             // exponential backoff + jitter, out of the box
+    .Retry(3)                                             // exponential backoff + equal jitter, out of the box
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 
 var user = await shield.ExecuteAsync(ct => LoadUserAsync(id, ct), cancellationToken);
@@ -24,7 +24,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 
 - **Intuitive first.** `Shield.When<TimeoutExceededException>().Retry(3)` reads like what it does. No context pooling ceremony, no predicate-builder classes, no options objects for the simple cases — and full options objects when you want them.
 - **Fast.** Outcomes flow between pipeline layers as structs instead of thrown exceptions; contexts are pooled internally; state-passing overloads eliminate closures; `ValueTask` end to end.
-- **Production defaults.** `Shield.Retry(3)` gives you exponential backoff *with jitter* capped at 30s — the thing you'd have configured anyway.
+- **Production defaults.** `Shield.Retry(3)` gives you exponential backoff *with equal jitter* capped at 30s — the thing you'd have configured anyway.
 - **Hard to hold wrong.** `Task` and `ValueTask` delegates both flow straight in; impossible chain orders throw at build time with a fix in the message; the `Kevlar.Analyzers` package flags cancellation and pipeline hazards at compile time.
 - **Observable out of the box.** Every shield describes itself (`shield.ToString()` prints the whole pipeline) and publishes metrics through a built-in `Meter` — no telemetry package, no setup.
 - **Composable.** Shields merge with `Wrap` and `Compose`, chain fluently, and stateful strategies (breakers, limiters) intentionally share their state wherever the same shield instance is reused.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -20,7 +20,7 @@ var shield = Shield
     .WithName("github");
 
 Console.WriteLine(shield);
-// github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)
+// github: Timeout(30s) → Retry(3, exponential 250ms ×2, equal jitter, cap 30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)
 ```
 
 Log it once at startup and every incident review starts from the actual configuration, not the configuration someone remembers. Custom strategies participate by overriding `Strategy.Describe()`.

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -19,7 +19,7 @@ Kevlar's pipeline model translates 1:1 from Polly v8 — the "first strategy add
 | `CircuitBreakerManualControl` + `StateProvider` | one `CircuitBreakerMonitor` |
 | `AddConcurrencyLimiter(10, 20)` | `Shield.ConcurrencyLimit(10, queueLimit: 20)` |
 | Delegates must return `ValueTask` | `Task`-returning methods flow straight in: `shield.ExecuteAsync(ct => client.GetAsync(url, ct))` |
-| Retry default: constant 2s, no jitter | exponential + jitter, 30s cap |
+| Retry default: constant 2s, no jitter | exponential + equal jitter, 30s cap |
 | First strategy added is outermost | same rule — pipelines translate 1:1 |
 
 :::warning `TimeoutExceededException` is **not** a `System.TimeoutException`
@@ -103,7 +103,7 @@ Note the handling clause: written once, it covers the retry *and* the breaker. I
 
 ## Semantic differences worth knowing
 
-- **Retry defaults differ.** Polly's default is constant 2s delays with no jitter; Kevlar's is exponential-with-jitter from 250ms capped at 30s. If you relied on Polly's default timing, say so explicitly: `Shield.Retry(3, Backoff.Constant(TimeSpan.FromSeconds(2)))`.
+- **Retry defaults differ.** Polly's default is constant 2s delays with no jitter; Kevlar's is exponential with equal jitter from 250ms capped at 30s. If you relied on Polly's default timing, say so explicitly: `Shield.Retry(3, Backoff.Constant(TimeSpan.FromSeconds(2)))`.
 - **Standard HTTP retry delays are bounded.** `HttpShield.Standard()` honours `Retry-After` but caps every retry delay at 10 seconds by default. Set `StandardHttpShieldOptions.Retry.MaxDelay` to choose another bound.
 - **Handling clauses are ambient within one fluent chain.** A clause applies to every reactive strategy after it until replaced; call `WhenAnyError()` to return subsequent strategies to Kevlar's default. `Wrap` and `Compose` seal clauses at the composition boundary: strategies already inside keep their handling, while strategies appended afterwards use the default unless you declare a new local clause. For a Polly strategy with a distinct `ShouldHandle`, set that strategy's `HandlesException` / `HandlesResult` options; a local override fully replaces the ambient clause.
 - **Default handling is narrower.** Polly's default predicate handles every exception except

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -40,9 +40,10 @@ _ = Backoff.None;                                // no delay between attempts
 _ = Backoff.Default;                             // what bare Retry(n) uses
 ```
 
-- `Jitter.None` uses the exact curve; `Equal` scales it by [0.5, 1.5); `Full` selects [0, curve); `Decorrelated` selects [initial delay, previous delay × 3]. Decorrelated state is isolated per execution.
+- `Jitter.None` uses the exact curve; `Equal` scales it by [0.5, 1.5); `Full` selects [0, curve); `Decorrelated` selects [initial delay, previous delay × 3]. Decorrelated state is isolated per retry execution. Direct backoff consumers can carry the effective preceding delay through `GetDelay(attempt, previousDelay)`; pass zero for the first draw.
 - `Exponential(initialDelay, factor = 2.0, maxDelay = null, jitter = Jitter.Equal)` is the default curve. `Backoff.Default` = `Exponential(250ms, maxDelay: 30s)`.
 - `Constant(delay, jitter = Jitter.None)` and `Linear(step, maxDelay = null, jitter = Jitter.None)` also accept jitter explicitly.
+- Configuration accepts the enum names; legacy Boolean jitter values remain aliases for `Equal` and `None`.
 - Without `maxDelay`, built-in and custom backoffs clamp only at the runtime timer limit (`uint.MaxValue - 1` milliseconds, roughly 49.7 days). Use `maxDelay` for an application-specific cap.
 
 ## Full options

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -11,7 +11,7 @@ See the [exceptions reference](../exceptions.md) for failures the default retry 
 ## Quick forms
 
 ```csharp
-Shield.Retry(3);                                          // exponential + jitter (250ms base, 30s cap)
+Shield.Retry(3);                                          // exponential + equal jitter (250ms base, 30s cap)
 Shield.Retry(3, Backoff.Constant(TimeSpan.FromSeconds(1)));
 Shield.Retry(3, Backoff.Linear(TimeSpan.FromMilliseconds(500)));
 Shield.RetryForever(Backoff.Exponential(TimeSpan.FromSeconds(1), maxDelay: TimeSpan.FromMinutes(1)));
@@ -22,7 +22,7 @@ plus 3 retries. The same reading applies to `MaxRetries` in the options form, an
 overload on `Shield`, `Shield<T>`, and the `When…` builders.
 
 :::tip The default is the good one
-Bare `Shield.Retry(3)` gives exponential backoff **with jitter**, 250ms base, capped at 30s. Jitter prevents retry storms where every failed caller retries in lockstep; you'd have configured this anyway.
+Bare `Shield.Retry(3)` gives exponential backoff **with equal jitter**, 250ms base, capped at 30s. Jitter prevents retry storms where every failed caller retries in lockstep; you'd have configured this anyway.
 :::
 
 ## Backoff
@@ -33,14 +33,17 @@ Bare `Shield.Retry(3)` gives exponential backoff **with jitter**, 250ms base, ca
 Backoff.Constant(TimeSpan.FromSeconds(1));       // 1s, 1s, 1s, ...
 Backoff.Linear(TimeSpan.FromMilliseconds(500));  // 500ms, 1s, 1.5s, ...
 Backoff.Exponential(TimeSpan.FromSeconds(1));    // ~1s, ~2s, ~4s, ... (jittered)
+Backoff.Exponential(TimeSpan.FromSeconds(1), jitter: Jitter.Full);
+Backoff.Exponential(TimeSpan.FromSeconds(1), jitter: Jitter.Decorrelated);
 Backoff.Custom(attempt => TimeSpan.FromMilliseconds(100 * attempt));   // attempt is 1-based
 _ = Backoff.None;                                // no delay between attempts
 _ = Backoff.Default;                             // what bare Retry(n) uses
 ```
 
-- `Exponential(initialDelay, factor = 2.0, maxDelay = null, jitter = true)` — jitter scales each delay by a random factor in [0.5, 1.5) to avoid synchronized retry storms. `Backoff.Default` = `Exponential(250ms, maxDelay: 30s)`.
-- `Linear(step, maxDelay = null)` — step × attempt, no jitter.
-- When you don't pass a `maxDelay`, built-in backoffs still clamp at 1 day.
+- `Jitter.None` uses the exact curve; `Equal` scales it by [0.5, 1.5); `Full` selects [0, curve); `Decorrelated` selects [initial delay, previous delay × 3]. Decorrelated state is isolated per execution.
+- `Exponential(initialDelay, factor = 2.0, maxDelay = null, jitter = Jitter.Equal)` is the default curve. `Backoff.Default` = `Exponential(250ms, maxDelay: 30s)`.
+- `Constant(delay, jitter = Jitter.None)` and `Linear(step, maxDelay = null, jitter = Jitter.None)` also accept jitter explicitly.
+- Without `maxDelay`, built-in and custom backoffs clamp only at the runtime timer limit (`uint.MaxValue - 1` milliseconds, roughly 49.7 days). Use `maxDelay` for an application-specific cap.
 
 ## Full options
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -93,7 +93,7 @@ const features: FeatureItem[] = [
     accent: 'SAFE',
     description: (
       <>
-        <code>Shield.Retry(3)</code> includes exponential backoff with jitter,
+        <code>Shield.Retry(3)</code> includes exponential backoff with equal jitter,
         capped at 30 seconds—the production setting you wanted anyway.
       </>
     ),

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -355,7 +355,7 @@ if ($observableSnippetIndex -lt 0 `
 [void]$builder.AppendLine('            Console.SetOut(original);')
 [void]$builder.AppendLine('        }')
 [void]$builder.AppendLine('        var actual = output.ToString().Trim();')
-[void]$builder.AppendLine('        var expected = "github: Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)" + Environment.NewLine + "1,2,3";')
+[void]$builder.AppendLine('        var expected = "github: Timeout(30s) → Retry(3, exponential 250ms ×2, equal jitter, cap 30s) → CircuitBreaker(5 consecutive, break 30s) → ConcurrencyLimit(10, queue 5)" + Environment.NewLine + "1,2,3";')
 [void]$builder.AppendLine('        if (!string.Equals(actual, expected, StringComparison.Ordinal))')
 [void]$builder.AppendLine('        {')
 [void]$builder.AppendLine('            throw new InvalidOperationException($"Documented executable output changed. Expected: {expected}; actual: {actual}");')

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -241,7 +241,7 @@ public static class KevlarServiceCollectionExtensions
             {
                 retryDefinition.Factor = factor;
             }
-            if (ReadBool(retry, nameof(RetryDefinition.Jitter)) is { } jitter)
+            if (ReadEnum<Jitter>(retry, nameof(RetryDefinition.Jitter)) is { } jitter)
             {
                 retryDefinition.Jitter = jitter;
             }
@@ -351,9 +351,6 @@ public static class KevlarServiceCollectionExtensions
             ? ParseDouble(configuration, key, value)
             : null;
 
-    private static bool? ReadBool(IConfiguration configuration, string key) =>
-        Read(configuration, key) is { } value ? ParseBool(configuration, key, value) : null;
-
     private static TimeSpan? ReadTimeSpan(IConfiguration configuration, string key) =>
         Read(configuration, key) is { } value
             ? ParseTimeSpan(configuration, key, value)
@@ -403,11 +400,6 @@ public static class KevlarServiceCollectionExtensions
             ? parsed
             : throw InvalidValue(configuration, key, value, "a number");
 
-    private static bool ParseBool(IConfiguration configuration, string key, string value) =>
-        bool.TryParse(value, out var parsed)
-            ? parsed
-            : throw InvalidValue(configuration, key, value, "a Boolean");
-
     private static TimeSpan ParseTimeSpan(IConfiguration configuration, string key, string value) =>
         TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var parsed)
             ? parsed
@@ -416,6 +408,7 @@ public static class KevlarServiceCollectionExtensions
     private static TEnum ParseEnum<TEnum>(IConfiguration configuration, string key, string value)
         where TEnum : struct, Enum =>
         Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed)
+        && Enum.IsDefined(typeof(TEnum), parsed)
             ? parsed
             : throw InvalidValue(configuration, key, value, $"a {typeof(TEnum).Name}");
 

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -241,7 +241,7 @@ public static class KevlarServiceCollectionExtensions
             {
                 retryDefinition.Factor = factor;
             }
-            if (ReadEnum<Jitter>(retry, nameof(RetryDefinition.Jitter)) is { } jitter)
+            if (ReadJitter(retry, nameof(RetryDefinition.Jitter)) is { } jitter)
             {
                 retryDefinition.Jitter = jitter;
             }
@@ -367,6 +367,11 @@ public static class KevlarServiceCollectionExtensions
             ? ParseEnum<TEnum>(configuration, key, value)
             : null;
 
+    private static Jitter? ReadJitter(IConfiguration configuration, string key) =>
+        Read(configuration, key) is { } value
+            ? ParseJitter(configuration, key, value)
+            : null;
+
     private static BackoffKind? ReadBackoffKind(IConfiguration configuration, string key)
     {
         if (Read(configuration, key) is not { } value)
@@ -411,6 +416,11 @@ public static class KevlarServiceCollectionExtensions
         && Enum.IsDefined(typeof(TEnum), parsed)
             ? parsed
             : throw InvalidValue(configuration, key, value, $"a {typeof(TEnum).Name}");
+
+    private static Jitter ParseJitter(IConfiguration configuration, string key, string value) =>
+        bool.TryParse(value, out var enabled)
+            ? enabled ? Jitter.Equal : Jitter.None
+            : ParseEnum<Jitter>(configuration, key, value);
 
     private static InvalidOperationException InvalidValue(
         IConfiguration configuration,

--- a/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.DependencyInjection/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@
 *REMOVED*Kevlar.Extensions.DependencyInjection.BackoffKind.None = 0 -> Kevlar.Extensions.DependencyInjection.BackoffKind
 *REMOVED*Kevlar.Extensions.DependencyInjection.RetryDefinition.Backoff.get -> Kevlar.Extensions.DependencyInjection.BackoffKind
 Kevlar.Extensions.DependencyInjection.RetryDefinition.Backoff.get -> Kevlar.BackoffKind
+*REMOVED*Kevlar.Extensions.DependencyInjection.RetryDefinition.Jitter.get -> bool
+Kevlar.Extensions.DependencyInjection.RetryDefinition.Jitter.get -> Kevlar.Jitter
 Kevlar.Extensions.DependencyInjection.IShieldProvider
 Kevlar.Extensions.DependencyInjection.IShieldProvider.Current.get -> Kevlar.Shield!
 static Kevlar.Extensions.DependencyInjection.KevlarServiceCollectionExtensions.AddReloadingShield(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! name, Microsoft.Extensions.Configuration.IConfiguration! configuration, System.Action<System.Exception!>? onReloadFailure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/ShieldDefinition.cs
@@ -125,8 +125,8 @@ public sealed class RetryDefinition
     /// <summary>Exponential growth factor. Default 2.</summary>
     public double Factor { get; set; } = 2.0;
 
-    /// <summary>Whether exponential delays are jittered. Default true.</summary>
-    public bool Jitter { get; set; } = true;
+    /// <summary>The jitter mode applied to built-in backoff delays. Default equal jitter.</summary>
+    public Jitter Jitter { get; set; } = Jitter.Equal;
 
     /// <summary>An absolute upper bound applied to every delay. Default 30s for exponential.</summary>
     public TimeSpan? MaxDelay { get; set; }
@@ -134,8 +134,8 @@ public sealed class RetryDefinition
     internal Backoff BuildBackoff() => Backoff switch
     {
         BackoffKind.None => Kevlar.Backoff.None,
-        BackoffKind.Constant => Kevlar.Backoff.Constant(BaseDelay ?? TimeSpan.FromSeconds(1)),
-        BackoffKind.Linear => Kevlar.Backoff.Linear(BaseDelay ?? TimeSpan.FromMilliseconds(500), MaxDelay),
+        BackoffKind.Constant => Kevlar.Backoff.Constant(BaseDelay ?? TimeSpan.FromSeconds(1), Jitter),
+        BackoffKind.Linear => Kevlar.Backoff.Linear(BaseDelay ?? TimeSpan.FromMilliseconds(500), MaxDelay, Jitter),
         BackoffKind.Exponential => Kevlar.Backoff.Exponential(
             BaseDelay ?? TimeSpan.FromMilliseconds(250),
             Factor,

--- a/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
@@ -100,7 +100,7 @@ internal static class StandardHttpConfigurationBinder
             : ParseDouble(section.GetSection("Factor"), factorValue);
         var jitter = jitterValue is null
             ? Jitter.Equal
-            : ParseEnum<Jitter>(section, "Jitter", jitterValue);
+            : ParseJitter(section, "Jitter", jitterValue);
         var backoffMaxDelay = backoffMaxDelayValue is null
             ? TimeSpan.FromSeconds(30)
             : ParseNullableTimeSpan(section.GetSection("BackoffMaxDelay"), backoffMaxDelayValue);
@@ -430,6 +430,11 @@ internal static class StandardHttpConfigurationBinder
 
         throw InvalidValue(section.GetSection(key), value, $"a {typeof(TEnum).Name}");
     }
+
+    private static Jitter ParseJitter(IConfiguration section, string key, string value) =>
+        bool.TryParse(value, out var enabled)
+            ? enabled ? Jitter.Equal : Jitter.None
+            : ParseEnum<Jitter>(section, key, value);
 
     private static InvalidOperationException InvalidValue(
         IConfigurationSection section,

--- a/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
@@ -99,8 +99,8 @@ internal static class StandardHttpConfigurationBinder
             ? 2d
             : ParseDouble(section.GetSection("Factor"), factorValue);
         var jitter = jitterValue is null
-            ? true
-            : ParseBool(section.GetSection("Jitter"), jitterValue);
+            ? Jitter.Equal
+            : ParseEnum<Jitter>(section, "Jitter", jitterValue);
         var backoffMaxDelay = backoffMaxDelayValue is null
             ? TimeSpan.FromSeconds(30)
             : ParseNullableTimeSpan(section.GetSection("BackoffMaxDelay"), backoffMaxDelayValue);
@@ -118,8 +118,8 @@ internal static class StandardHttpConfigurationBinder
         options.Backoff = kind switch
         {
             RetryBackoffKind.None => Backoff.None,
-            RetryBackoffKind.Constant => Backoff.Constant(baseDelay),
-            RetryBackoffKind.Linear => Backoff.Linear(baseDelay, backoffMaxDelay),
+            RetryBackoffKind.Constant => Backoff.Constant(baseDelay, jitter),
+            RetryBackoffKind.Linear => Backoff.Linear(baseDelay, backoffMaxDelay, jitter),
             RetryBackoffKind.Exponential => Backoff.Exponential(baseDelay, factor, backoffMaxDelay, jitter),
             _ => throw new InvalidOperationException("Unsupported retry backoff."),
         };

--- a/src/Kevlar.Testing/BackoffDescriptor.cs
+++ b/src/Kevlar.Testing/BackoffDescriptor.cs
@@ -8,7 +8,7 @@ public sealed class BackoffDescriptor
         TimeSpan? baseDelay,
         double? factor,
         TimeSpan? maxDelay,
-        bool? jitter)
+        Jitter? jitter)
     {
         Kind = kind;
         BaseDelay = baseDelay;
@@ -29,6 +29,6 @@ public sealed class BackoffDescriptor
     /// <summary>The linear or exponential delay cap, when configured.</summary>
     public TimeSpan? MaxDelay { get; }
 
-    /// <summary>Whether exponential jitter is enabled, when applicable.</summary>
-    public bool? Jitter { get; }
+    /// <summary>The jitter mode for built-in backoffs, when applicable.</summary>
+    public Jitter? Jitter { get; }
 }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 Kevlar.Testing.BackoffDescriptor
 Kevlar.Testing.BackoffDescriptor.BaseDelay.get -> System.TimeSpan?
 Kevlar.Testing.BackoffDescriptor.Factor.get -> double?
-Kevlar.Testing.BackoffDescriptor.Jitter.get -> bool?
+Kevlar.Testing.BackoffDescriptor.Jitter.get -> Kevlar.Jitter?
 Kevlar.Testing.BackoffDescriptor.Kind.get -> Kevlar.BackoffKind
 Kevlar.Testing.BackoffDescriptor.MaxDelay.get -> System.TimeSpan?
 Kevlar.Testing.CircuitBreakerStrategyDescriptor

--- a/src/Kevlar/Backoff.cs
+++ b/src/Kevlar/Backoff.cs
@@ -12,37 +12,46 @@ public abstract class Backoff
     }
 
     /// <summary>No delay between attempts.</summary>
-    public static Backoff None { get; } = new ConstantBackoff(TimeSpan.Zero);
+    public static Backoff None { get; } = new ConstantBackoff(TimeSpan.Zero, global::Kevlar.Jitter.None);
 
     /// <summary>
-    /// Kevlar's default: exponential backoff starting at 250ms with a factor of 2, ±50% jitter,
+    /// Kevlar's default: exponential backoff starting at 250ms with a factor of 2, equal jitter,
     /// capped at 30 seconds.
     /// </summary>
     public static Backoff Default { get; } = Exponential(TimeSpan.FromMilliseconds(250), maxDelay: TimeSpan.FromSeconds(30));
 
-    /// <summary>The same delay before every attempt.</summary>
-    public static Backoff Constant(TimeSpan delay)
+    /// <summary>The same base delay before every attempt, with optional jitter.</summary>
+    public static Backoff Constant(TimeSpan delay, Jitter jitter = global::Kevlar.Jitter.None)
     {
         Throw.IfOutOfRange(delay < TimeSpan.Zero, nameof(delay), "Delay must not be negative.");
         Throw.IfOutOfRange(delay > DelayHelper.MaximumDelay, nameof(delay), "Delay exceeds the runtime timer limit.");
-        return new ConstantBackoff(delay);
+        ValidateJitter(jitter);
+        return new ConstantBackoff(delay, jitter);
     }
 
-    /// <summary>Linearly increasing delay: <paramref name="step"/>, 2×step, 3×step…</summary>
-    public static Backoff Linear(TimeSpan step, TimeSpan? maxDelay = null)
+    /// <summary>Linearly increasing base delay: <paramref name="step"/>, 2×step, 3×step…, with optional jitter.</summary>
+    public static Backoff Linear(
+        TimeSpan step,
+        TimeSpan? maxDelay = null,
+        Jitter jitter = global::Kevlar.Jitter.None)
     {
         Throw.IfOutOfRange(step < TimeSpan.Zero, nameof(step), "Step must not be negative.");
         ValidateMaxDelay(maxDelay);
-        return new LinearBackoff(step, maxDelay);
+        ValidateJitter(jitter);
+        return new LinearBackoff(step, maxDelay, jitter);
     }
 
     /// <summary>
     /// Exponentially increasing delay: <paramref name="initialDelay"/>, then multiplied by
-    /// <paramref name="factor"/> after each attempt. With <paramref name="jitter"/> enabled
-    /// (the default) each delay is scaled by a random factor in [0.5, 1.5) to avoid
-    /// synchronized retry storms.
+    /// <paramref name="factor"/> after each attempt. The default equal jitter scales each delay
+    /// by a random factor in [0.5, 1.5) to avoid synchronized retry storms. Decorrelated jitter
+    /// instead selects each delay between the initial delay and three times the preceding delay.
     /// </summary>
-    public static Backoff Exponential(TimeSpan initialDelay, double factor = 2.0, TimeSpan? maxDelay = null, bool jitter = true)
+    public static Backoff Exponential(
+        TimeSpan initialDelay,
+        double factor = 2.0,
+        TimeSpan? maxDelay = null,
+        Jitter jitter = global::Kevlar.Jitter.Equal)
     {
         Throw.IfOutOfRange(initialDelay < TimeSpan.Zero, nameof(initialDelay), "Initial delay must not be negative.");
         Throw.IfOutOfRange(
@@ -50,6 +59,7 @@ public abstract class Backoff
             nameof(factor),
             "Factor must be finite and at least 1.");
         ValidateMaxDelay(maxDelay);
+        ValidateJitter(jitter);
         return new ExponentialBackoff(initialDelay, factor, maxDelay, jitter);
     }
 
@@ -82,8 +92,10 @@ public abstract class Backoff
     /// <summary>The linear or exponential delay cap, when configured.</summary>
     public virtual TimeSpan? MaxDelay => null;
 
-    /// <summary>Whether exponential jitter is enabled, when applicable.</summary>
-    public virtual bool? Jitter => null;
+    /// <summary>The jitter mode for built-in backoffs, when applicable.</summary>
+    public virtual Jitter? Jitter => null;
+
+    internal virtual TimeSpan GetDelay(int attempt, TimeSpan previousDelay) => GetDelay(attempt);
 
     private protected static void ValidateAttempt(int attempt) =>
         Throw.IfOutOfRange(attempt < 1, nameof(attempt), "Attempt must be at least 1.");
@@ -94,6 +106,12 @@ public abstract class Backoff
         Throw.IfOutOfRange(maxDelay > DelayHelper.MaximumDelay, nameof(maxDelay), "Maximum delay exceeds the runtime timer limit.");
     }
 
+    private static void ValidateJitter(Jitter jitter) =>
+        Throw.IfOutOfRange(
+            !Enum.IsDefined(typeof(Jitter), jitter),
+            nameof(jitter),
+            "Unknown jitter mode.");
+
     private static TimeSpan FromTicksClamped(double ticks, TimeSpan? maxDelay)
     {
         if (double.IsNaN(ticks))
@@ -101,7 +119,7 @@ public abstract class Backoff
             return TimeSpan.Zero;
         }
 
-        var max = maxDelay ?? TimeSpan.FromDays(1);
+        var max = maxDelay ?? DelayHelper.MaximumDelay;
         if (ticks >= max.Ticks)
         {
             return max;
@@ -110,16 +128,79 @@ public abstract class Backoff
         return ticks <= 0 ? TimeSpan.Zero : TimeSpan.FromTicks((long)ticks);
     }
 
+    private protected static double ApplyJitter(double ticks, Jitter jitter) => jitter switch
+    {
+        global::Kevlar.Jitter.None => ticks,
+        global::Kevlar.Jitter.Equal => ticks * (0.5 + SharedRandom.NextDouble()),
+        global::Kevlar.Jitter.Full => ticks * SharedRandom.NextDouble(),
+        _ => ticks,
+    };
+
+    private protected static TimeSpan GetDecorrelatedDelay(
+        int attempt,
+        TimeSpan initialDelay,
+        TimeSpan? maxDelay)
+    {
+        ValidateAttempt(attempt);
+        var previousDelay = initialDelay;
+        for (var currentAttempt = 0; currentAttempt < attempt; currentAttempt++)
+        {
+            previousDelay = GetDecorrelatedDelay(initialDelay, previousDelay, maxDelay);
+        }
+
+        return previousDelay;
+    }
+
+    private protected static TimeSpan GetDecorrelatedDelay(
+        TimeSpan initialDelay,
+        TimeSpan previousDelay,
+        TimeSpan? maxDelay)
+    {
+        var lowerTicks = (double)initialDelay.Ticks;
+        var previousTicks = previousDelay > TimeSpan.Zero ? previousDelay.Ticks : initialDelay.Ticks;
+        var upperTicks = Math.Max(lowerTicks, previousTicks * 3d);
+        return FromTicksClamped(
+            lowerTicks + (SharedRandom.NextDouble() * (upperTicks - lowerTicks)),
+            maxDelay);
+    }
+
+    private protected static string DescribeJitter(Jitter jitter) => jitter switch
+    {
+        global::Kevlar.Jitter.None => string.Empty,
+        global::Kevlar.Jitter.Equal => ", equal jitter",
+        global::Kevlar.Jitter.Full => ", full jitter",
+        global::Kevlar.Jitter.Decorrelated => ", decorrelated jitter",
+        _ => string.Empty,
+    };
+
+    private protected static string DescribeCap(TimeSpan? maxDelay) =>
+        maxDelay is { } max ? $", cap {DescribeHelper.Time(max)}" : string.Empty;
+
     private sealed class ConstantBackoff : Backoff
     {
         private readonly TimeSpan _delay;
+        private readonly Jitter _jitter;
 
-        public ConstantBackoff(TimeSpan delay) => _delay = delay;
+        public ConstantBackoff(TimeSpan delay, Jitter jitter)
+        {
+            _delay = delay;
+            _jitter = jitter;
+        }
 
         public override TimeSpan GetDelay(int attempt)
         {
             ValidateAttempt(attempt);
-            return _delay;
+            return _jitter == global::Kevlar.Jitter.Decorrelated
+                ? GetDecorrelatedDelay(attempt, _delay, maxDelay: null)
+                : FromTicksClamped(ApplyJitter(_delay.Ticks, _jitter), maxDelay: null);
+        }
+
+        internal override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
+        {
+            ValidateAttempt(attempt);
+            return _jitter == global::Kevlar.Jitter.Decorrelated
+                ? GetDecorrelatedDelay(_delay, previousDelay, maxDelay: null)
+                : GetDelay(attempt);
         }
 
         public override BackoffKind Kind =>
@@ -127,25 +208,41 @@ public abstract class Backoff
 
         public override TimeSpan? InitialDelay => _delay;
 
+        public override Jitter? Jitter => _jitter;
+
         public override string ToString() =>
-            _delay == TimeSpan.Zero ? "no delay" : $"constant {DescribeHelper.Time(_delay)}";
+            _delay == TimeSpan.Zero
+                ? "no delay"
+                : $"constant {DescribeHelper.Time(_delay)}{DescribeJitter(_jitter)}";
     }
 
     private sealed class LinearBackoff : Backoff
     {
         private readonly TimeSpan _step;
         private readonly TimeSpan? _maxDelay;
+        private readonly Jitter _jitter;
 
-        public LinearBackoff(TimeSpan step, TimeSpan? maxDelay)
+        public LinearBackoff(TimeSpan step, TimeSpan? maxDelay, Jitter jitter)
         {
             _step = step;
             _maxDelay = maxDelay;
+            _jitter = jitter;
         }
 
         public override TimeSpan GetDelay(int attempt)
         {
             ValidateAttempt(attempt);
-            return FromTicksClamped((double)_step.Ticks * attempt, _maxDelay);
+            return _jitter == global::Kevlar.Jitter.Decorrelated
+                ? GetDecorrelatedDelay(attempt, _step, _maxDelay)
+                : FromTicksClamped(ApplyJitter((double)_step.Ticks * attempt, _jitter), _maxDelay);
+        }
+
+        internal override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
+        {
+            ValidateAttempt(attempt);
+            return _jitter == global::Kevlar.Jitter.Decorrelated
+                ? GetDecorrelatedDelay(_step, previousDelay, _maxDelay)
+                : GetDelay(attempt);
         }
 
         public override BackoffKind Kind => BackoffKind.Linear;
@@ -154,11 +251,10 @@ public abstract class Backoff
 
         public override TimeSpan? MaxDelay => _maxDelay;
 
-        public override string ToString()
-        {
-            var cap = _maxDelay is { } max ? $" ≤{DescribeHelper.Time(max)}" : string.Empty;
-            return $"linear {DescribeHelper.Time(_step)} steps{cap}";
-        }
+        public override Jitter? Jitter => _jitter;
+
+        public override string ToString() =>
+            $"linear {DescribeHelper.Time(_step)} steps{DescribeJitter(_jitter)}{DescribeCap(_maxDelay)}";
     }
 
     private sealed class ExponentialBackoff : Backoff
@@ -166,9 +262,9 @@ public abstract class Backoff
         private readonly TimeSpan _initialDelay;
         private readonly double _factor;
         private readonly TimeSpan? _maxDelay;
-        private readonly bool _jitter;
+        private readonly Jitter _jitter;
 
-        public ExponentialBackoff(TimeSpan initialDelay, double factor, TimeSpan? maxDelay, bool jitter)
+        public ExponentialBackoff(TimeSpan initialDelay, double factor, TimeSpan? maxDelay, Jitter jitter)
         {
             _initialDelay = initialDelay;
             _factor = factor;
@@ -179,14 +275,21 @@ public abstract class Backoff
         public override TimeSpan GetDelay(int attempt)
         {
             ValidateAttempt(attempt);
-            var ticks = _initialDelay.Ticks * Math.Pow(_factor, attempt - 1);
-
-            if (_jitter)
+            if (_jitter == global::Kevlar.Jitter.Decorrelated)
             {
-                ticks *= 0.5 + SharedRandom.NextDouble();
+                return GetDecorrelatedDelay(attempt, _initialDelay, _maxDelay);
             }
 
-            return FromTicksClamped(ticks, _maxDelay);
+            var ticks = _initialDelay.Ticks * Math.Pow(_factor, attempt - 1);
+            return FromTicksClamped(ApplyJitter(ticks, _jitter), _maxDelay);
+        }
+
+        internal override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
+        {
+            ValidateAttempt(attempt);
+            return _jitter == global::Kevlar.Jitter.Decorrelated
+                ? GetDecorrelatedDelay(_initialDelay, previousDelay, _maxDelay)
+                : GetDelay(attempt);
         }
 
         public override BackoffKind Kind => BackoffKind.Exponential;
@@ -197,14 +300,10 @@ public abstract class Backoff
 
         public override TimeSpan? MaxDelay => _maxDelay;
 
-        public override bool? Jitter => _jitter;
+        public override Jitter? Jitter => _jitter;
 
-        public override string ToString()
-        {
-            var jitter = _jitter ? " +jitter" : string.Empty;
-            var cap = _maxDelay is { } max ? $" ≤{DescribeHelper.Time(max)}" : string.Empty;
-            return FormattableString.Invariant($"exponential {DescribeHelper.Time(_initialDelay)} ×{_factor:0.#}{jitter}{cap}");
-        }
+        public override string ToString() => FormattableString.Invariant(
+            $"exponential {DescribeHelper.Time(_initialDelay)} ×{_factor:0.#}{DescribeJitter(_jitter)}{DescribeCap(_maxDelay)}");
     }
 
     private sealed class CustomBackoff : Backoff

--- a/src/Kevlar/Backoff.cs
+++ b/src/Kevlar/Backoff.cs
@@ -95,7 +95,11 @@ public abstract class Backoff
     /// <summary>The jitter mode for built-in backoffs, when applicable.</summary>
     public virtual Jitter? Jitter => null;
 
-    internal virtual TimeSpan GetDelay(int attempt, TimeSpan previousDelay) => GetDelay(attempt);
+    /// <summary>
+    /// Returns the delay before the given retry attempt, using the preceding effective delay for
+    /// stateful jitter modes. Pass <see cref="TimeSpan.Zero"/> for the first decorrelated draw.
+    /// </summary>
+    public virtual TimeSpan GetDelay(int attempt, TimeSpan previousDelay) => GetDelay(attempt);
 
     private protected static void ValidateAttempt(int attempt) =>
         Throw.IfOutOfRange(attempt < 1, nameof(attempt), "Attempt must be at least 1.");
@@ -195,7 +199,7 @@ public abstract class Backoff
                 : FromTicksClamped(ApplyJitter(_delay.Ticks, _jitter), maxDelay: null);
         }
 
-        internal override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
+        public override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
         {
             ValidateAttempt(attempt);
             return _jitter == global::Kevlar.Jitter.Decorrelated
@@ -237,7 +241,7 @@ public abstract class Backoff
                 : FromTicksClamped(ApplyJitter((double)_step.Ticks * attempt, _jitter), _maxDelay);
         }
 
-        internal override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
+        public override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
         {
             ValidateAttempt(attempt);
             return _jitter == global::Kevlar.Jitter.Decorrelated
@@ -284,7 +288,7 @@ public abstract class Backoff
             return FromTicksClamped(ApplyJitter(ticks, _jitter), _maxDelay);
         }
 
-        internal override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
+        public override TimeSpan GetDelay(int attempt, TimeSpan previousDelay)
         {
             ValidateAttempt(attempt);
             return _jitter == global::Kevlar.Jitter.Decorrelated

--- a/src/Kevlar/Jitter.cs
+++ b/src/Kevlar/Jitter.cs
@@ -1,0 +1,20 @@
+namespace Kevlar;
+
+/// <summary>Controls randomization applied to built-in retry backoff delays.</summary>
+public enum Jitter
+{
+    /// <summary>Uses the exact delay produced by the backoff curve.</summary>
+    None,
+
+    /// <summary>Scales each delay by a uniformly random factor in [0.5, 1.5).</summary>
+    Equal,
+
+    /// <summary>Selects a uniformly random delay in [0, the backoff curve's delay).</summary>
+    Full,
+
+    /// <summary>
+    /// Selects each delay uniformly between the initial delay and three times the preceding
+    /// delay, capped by the configured maximum.
+    /// </summary>
+    Decorrelated,
+}

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -7,8 +7,19 @@ Kevlar.BackoffKind.None = 0 -> Kevlar.BackoffKind
 abstract Kevlar.Backoff.Kind.get -> Kevlar.BackoffKind
 virtual Kevlar.Backoff.Factor.get -> double?
 virtual Kevlar.Backoff.InitialDelay.get -> System.TimeSpan?
-virtual Kevlar.Backoff.Jitter.get -> bool?
+virtual Kevlar.Backoff.Jitter.get -> Kevlar.Jitter?
 virtual Kevlar.Backoff.MaxDelay.get -> System.TimeSpan?
+Kevlar.Jitter
+Kevlar.Jitter.Decorrelated = 3 -> Kevlar.Jitter
+Kevlar.Jitter.Equal = 1 -> Kevlar.Jitter
+Kevlar.Jitter.Full = 2 -> Kevlar.Jitter
+Kevlar.Jitter.None = 0 -> Kevlar.Jitter
+*REMOVED*static Kevlar.Backoff.Constant(System.TimeSpan delay) -> Kevlar.Backoff!
+*REMOVED*static Kevlar.Backoff.Exponential(System.TimeSpan initialDelay, double factor = 2, System.TimeSpan? maxDelay = null, bool jitter = true) -> Kevlar.Backoff!
+*REMOVED*static Kevlar.Backoff.Linear(System.TimeSpan step, System.TimeSpan? maxDelay = null) -> Kevlar.Backoff!
+static Kevlar.Backoff.Constant(System.TimeSpan delay, Kevlar.Jitter jitter = Kevlar.Jitter.None) -> Kevlar.Backoff!
+static Kevlar.Backoff.Exponential(System.TimeSpan initialDelay, double factor = 2, System.TimeSpan? maxDelay = null, Kevlar.Jitter jitter = Kevlar.Jitter.Equal) -> Kevlar.Backoff!
+static Kevlar.Backoff.Linear(System.TimeSpan step, System.TimeSpan? maxDelay = null, Kevlar.Jitter jitter = Kevlar.Jitter.None) -> Kevlar.Backoff!
 Kevlar.HandlingClause
 *REMOVED*Kevlar.StrategyNode
 Kevlar.KevlarProxyException

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Kevlar.BackoffKind.Linear = 2 -> Kevlar.BackoffKind
 Kevlar.BackoffKind.None = 0 -> Kevlar.BackoffKind
 abstract Kevlar.Backoff.Kind.get -> Kevlar.BackoffKind
 virtual Kevlar.Backoff.Factor.get -> double?
+virtual Kevlar.Backoff.GetDelay(int attempt, System.TimeSpan previousDelay) -> System.TimeSpan
 virtual Kevlar.Backoff.InitialDelay.get -> System.TimeSpan?
 virtual Kevlar.Backoff.Jitter.get -> Kevlar.Jitter?
 virtual Kevlar.Backoff.MaxDelay.get -> System.TimeSpan?

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -485,7 +485,7 @@ public sealed class Shield
 
     /// <summary>
     /// Describes the pipeline, outermost strategy first, e.g.
-    /// <c>Timeout(30s) → Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(5 consecutive, break 30s)</c>.
+    /// <c>Timeout(30s) → Retry(3, exponential 250ms ×2, equal jitter, cap 30s) → CircuitBreaker(5 consecutive, break 30s)</c>.
     /// </summary>
     public override string ToString() => Describe(Name, Strategies);
 

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -124,6 +124,7 @@ internal sealed class RetryStrategy : Strategy
         ValueTask<Outcome<T>> execution,
         bool firstOutcomeShouldRetry)
     {
+        var previousBackoffDelay = TimeSpan.Zero;
         for (var retriesUsed = 0; ; retriesUsed++)
         {
             var outcome = await execution.ConfigureAwait(false);
@@ -137,7 +138,8 @@ internal sealed class RetryStrategy : Strategy
 
             var attempt = retriesUsed + 1;
             KevlarMetrics.Retry(context.ShieldName);
-            var delay = _backoff.GetDelay(attempt);
+            var delay = _backoff.GetDelay(attempt, previousBackoffDelay);
+            previousBackoffDelay = delay;
 
             if (_maxDelay is { } cap && delay > cap)
             {

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -139,12 +139,13 @@ internal sealed class RetryStrategy : Strategy
             var attempt = retriesUsed + 1;
             KevlarMetrics.Retry(context.ShieldName);
             var delay = _backoff.GetDelay(attempt, previousBackoffDelay);
-            previousBackoffDelay = delay;
 
             if (_maxDelay is { } cap && delay > cap)
             {
                 delay = cap;
             }
+
+            previousBackoffDelay = delay;
 
             if (_delayGenerator is not null
                 || _delayGeneratorAsync is not null

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -18,6 +18,10 @@ public class AllocationBudgetTests
         Outcome<int>.FromException(RecoverableFailure);
 
     private readonly Shield _empty = Shield.Empty;
+    private readonly Backoff _equalJitter = Backoff.Exponential(
+        TimeSpan.FromMilliseconds(1),
+        factor: 1,
+        jitter: Jitter.Equal);
     private readonly Shield _retry = Shield.Retry(3, Backoff.None);
     private readonly Shield _asyncDelayRetry = Shield.Retry(options =>
     {
@@ -122,6 +126,7 @@ public class AllocationBudgetTests
     public void Documented_Hot_Paths_Allocate_Zero_Bytes_Per_Operation()
     {
         AssertZero("empty sync", this, static test => test._empty.Execute(static _ => 42));
+        AssertZero("equal jitter", this, static test => _ = test._equalJitter.GetDelay(1));
         AssertZero("empty async", this, static test =>
             test._empty.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("empty async state", this, static test =>

--- a/tests/Kevlar.NetStandard.Tests/BackoffTests.cs
+++ b/tests/Kevlar.NetStandard.Tests/BackoffTests.cs
@@ -1,0 +1,28 @@
+namespace Kevlar.NetStandard.Tests;
+
+public class BackoffTests
+{
+    [Test]
+    public async Task Jitter_Is_Thread_Safe_On_NetStandard_Build()
+    {
+        var backoff = Backoff.Exponential(
+            TimeSpan.FromMilliseconds(1),
+            factor: 1,
+            jitter: Jitter.Equal);
+        var invalidDelays = 0;
+
+        Parallel.For(0, 32, _ =>
+        {
+            for (var draw = 0; draw < 10_000; draw++)
+            {
+                var delay = backoff.GetDelay(1);
+                if (delay < TimeSpan.FromTicks(5_000) || delay >= TimeSpan.FromTicks(15_000))
+                {
+                    Interlocked.Increment(ref invalidDelays);
+                }
+            }
+        });
+
+        await Assert.That(invalidDelays).IsEqualTo(0);
+    }
+}

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -249,7 +249,7 @@ public class PipelineDescriptorTests
             TimeSpan.FromMilliseconds(30),
             factor: 3,
             maxDelay: TimeSpan.FromSeconds(4),
-            jitter: false));
+            jitter: Jitter.None));
 
         await Assert.That(none.Kind).IsEqualTo(BackoffKind.None);
         await Assert.That(none.BaseDelay).IsEqualTo(TimeSpan.Zero);
@@ -260,7 +260,7 @@ public class PipelineDescriptorTests
         await Assert.That(exponential.BaseDelay).IsEqualTo(TimeSpan.FromMilliseconds(30));
         await Assert.That(exponential.Factor).IsEqualTo(3);
         await Assert.That(exponential.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(4));
-        await Assert.That(exponential.Jitter).IsFalse();
+        await Assert.That(exponential.Jitter).IsEqualTo(Jitter.None);
     }
 
     [Test]
@@ -274,7 +274,7 @@ public class PipelineDescriptorTests
             Backoff.None,
             Backoff.Constant(TimeSpan.FromMilliseconds(10)),
             Backoff.Linear(TimeSpan.FromMilliseconds(10)),
-            Backoff.Exponential(TimeSpan.FromMilliseconds(10), jitter: false),
+            Backoff.Exponential(TimeSpan.FromMilliseconds(10), jitter: Jitter.None),
             Backoff.Custom(_ => TimeSpan.Zero),
         };
 

--- a/tests/Kevlar.Tests/BackoffConfigurationTests.cs
+++ b/tests/Kevlar.Tests/BackoffConfigurationTests.cs
@@ -7,32 +7,32 @@ public class BackoffConfigurationTests
     {
         var cases = new[]
         {
-            new ExpectedConfiguration(Backoff.None, BackoffKind.None, TimeSpan.Zero, null, null, null),
+            new ExpectedConfiguration(Backoff.None, BackoffKind.None, TimeSpan.Zero, null, null, Jitter.None),
             new ExpectedConfiguration(
                 Backoff.Constant(TimeSpan.FromMilliseconds(100)),
                 BackoffKind.Constant,
                 TimeSpan.FromMilliseconds(100),
                 null,
                 null,
-                null),
+                Jitter.None),
             new ExpectedConfiguration(
                 Backoff.Linear(TimeSpan.FromMilliseconds(200), TimeSpan.FromSeconds(2)),
                 BackoffKind.Linear,
                 TimeSpan.FromMilliseconds(200),
                 null,
                 TimeSpan.FromSeconds(2),
-                null),
+                Jitter.None),
             new ExpectedConfiguration(
                 Backoff.Exponential(
                     TimeSpan.FromMilliseconds(250),
                     factor: 3,
                     maxDelay: TimeSpan.FromSeconds(30),
-                    jitter: false),
+                    jitter: Jitter.None),
                 BackoffKind.Exponential,
                 TimeSpan.FromMilliseconds(250),
                 3,
                 TimeSpan.FromSeconds(30),
-                false),
+                Jitter.None),
             new ExpectedConfiguration(Backoff.Custom(_ => TimeSpan.Zero), BackoffKind.Custom, null, null, null, null),
         };
 
@@ -52,5 +52,5 @@ public class BackoffConfigurationTests
         TimeSpan? InitialDelay,
         double? Factor,
         TimeSpan? MaxDelay,
-        bool? Jitter);
+        Jitter? Jitter);
 }

--- a/tests/Kevlar.Tests/BackoffTests.cs
+++ b/tests/Kevlar.Tests/BackoffTests.cs
@@ -2,6 +2,9 @@ namespace Kevlar.Tests;
 
 public class BackoffTests
 {
+    private static readonly TimeSpan MaximumRuntimeDelay =
+        TimeSpan.FromMilliseconds(uint.MaxValue - 1d);
+
     [Test]
     public async Task None_Returns_Zero_For_Every_Attempt()
     {
@@ -39,20 +42,32 @@ public class BackoffTests
     }
 
     [Test]
-    public async Task Exponential_Without_Jitter_Doubles_Each_Attempt()
+    public async Task Exponential_Jitter_None_Is_Deterministic()
     {
-        var backoff = Backoff.Exponential(TimeSpan.FromSeconds(1), factor: 2.0, jitter: false);
+        var backoff = Backoff.Exponential(
+            TimeSpan.FromMilliseconds(250),
+            factor: 2,
+            jitter: Jitter.None);
 
-        await Assert.That(backoff.GetDelay(1)).IsEqualTo(TimeSpan.FromSeconds(1));
-        await Assert.That(backoff.GetDelay(2)).IsEqualTo(TimeSpan.FromSeconds(2));
-        await Assert.That(backoff.GetDelay(3)).IsEqualTo(TimeSpan.FromSeconds(4));
-        await Assert.That(backoff.GetDelay(4)).IsEqualTo(TimeSpan.FromSeconds(8));
+        var delays = Enumerable.Range(1, 4).Select(backoff.GetDelay).ToArray();
+
+        await Assert.That(delays).IsEquivalentTo(
+            [
+                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromMilliseconds(500),
+                TimeSpan.FromMilliseconds(1000),
+                TimeSpan.FromMilliseconds(2000),
+            ]);
     }
 
     [Test]
     public async Task Exponential_Respects_MaxDelay()
     {
-        var backoff = Backoff.Exponential(TimeSpan.FromSeconds(1), factor: 2.0, maxDelay: TimeSpan.FromSeconds(5), jitter: false);
+        var backoff = Backoff.Exponential(
+            TimeSpan.FromSeconds(1),
+            factor: 2,
+            maxDelay: TimeSpan.FromSeconds(5),
+            jitter: Jitter.None);
 
         await Assert.That(backoff.GetDelay(3)).IsEqualTo(TimeSpan.FromSeconds(4));
         await Assert.That(backoff.GetDelay(4)).IsEqualTo(TimeSpan.FromSeconds(5));
@@ -60,24 +75,149 @@ public class BackoffTests
     }
 
     [Test]
-    public async Task Exponential_Defaults_To_A_One_Day_Ceiling()
+    public async Task Default_Cap_Is_The_Runtime_Timer_Limit_For_BuiltIn_And_Custom_Backoff()
     {
-        var backoff = Backoff.Exponential(TimeSpan.FromDays(1), factor: 2.0, jitter: false);
+        var exponential = Backoff.Exponential(
+            TimeSpan.FromSeconds(1),
+            factor: 2,
+            jitter: Jitter.None);
+        var custom = Backoff.Custom(_ => TimeSpan.MaxValue);
 
-        await Assert.That(backoff.GetDelay(10)).IsEqualTo(TimeSpan.FromDays(1));
+        await Assert.That(exponential.GetDelay(60)).IsEqualTo(MaximumRuntimeDelay);
+        await Assert.That(custom.GetDelay(60)).IsEqualTo(MaximumRuntimeDelay);
     }
 
     [Test]
-    public async Task Exponential_Jitter_Stays_Within_Half_To_OneAndAHalf_Times_The_Base()
+    public async Task Exponential_Jitter_Equal_Stays_Within_Half_To_OneAndHalf_With_Base_Mean()
     {
-        var backoff = Backoff.Exponential(TimeSpan.FromSeconds(1), factor: 1.0, jitter: true);
+        var baseDelay = TimeSpan.FromSeconds(1);
+        var backoff = Backoff.Exponential(baseDelay, factor: 1, jitter: Jitter.Equal);
+        var totalTicks = 0d;
+        var inRange = true;
 
-        for (var i = 0; i < 200; i++)
+        for (var sample = 0; sample < 10_000; sample++)
         {
             var delay = backoff.GetDelay(1);
-            await Assert.That(delay >= TimeSpan.FromSeconds(0.5)).IsTrue();
-            await Assert.That(delay < TimeSpan.FromSeconds(1.5)).IsTrue();
+            inRange &= delay >= baseDelay * 0.5 && delay < baseDelay * 1.5;
+            totalTicks += delay.Ticks;
         }
+
+        var meanRatio = totalTicks / 10_000 / baseDelay.Ticks;
+        await Assert.That(inRange).IsTrue();
+        await Assert.That(meanRatio).IsBetween(0.95, 1.05);
+    }
+
+    [Test]
+    public async Task Exponential_Jitter_Full_Stays_Within_Zero_To_Base()
+    {
+        var baseDelay = TimeSpan.FromSeconds(1);
+        var backoff = Backoff.Exponential(baseDelay, factor: 1, jitter: Jitter.Full);
+        var inRange = true;
+
+        for (var sample = 0; sample < 10_000; sample++)
+        {
+            var delay = backoff.GetDelay(1);
+            inRange &= delay >= TimeSpan.Zero && delay < baseDelay;
+        }
+
+        await Assert.That(inRange).IsTrue();
+    }
+
+    [Test]
+    public async Task Exponential_Jitter_Decorrelated_Depends_On_Previous_Delay()
+    {
+        var initialDelay = TimeSpan.FromMilliseconds(100);
+        var maxDelay = TimeSpan.FromSeconds(5);
+        var backoff = Backoff.Exponential(
+            initialDelay,
+            maxDelay: maxDelay,
+            jitter: Jitter.Decorrelated);
+        var previousDelay = initialDelay;
+        var inRange = true;
+
+        for (var attempt = 1; attempt <= 10_000; attempt++)
+        {
+            var delay = backoff.GetDelay(attempt, previousDelay);
+            var upperBound = previousDelay * 3 > maxDelay ? maxDelay : previousDelay * 3;
+            inRange &= delay >= initialDelay && delay <= upperBound;
+            previousDelay = delay;
+        }
+
+        await Assert.That(inRange).IsTrue();
+    }
+
+    [Test]
+    public async Task Constant_And_Linear_Accept_Equal_And_Full_Jitter()
+    {
+        var equalConstant = Backoff.Constant(TimeSpan.FromSeconds(1), Jitter.Equal);
+        var fullConstant = Backoff.Constant(TimeSpan.FromSeconds(1), Jitter.Full);
+        var equalLinear = Backoff.Linear(TimeSpan.FromSeconds(1), jitter: Jitter.Equal);
+        var fullLinear = Backoff.Linear(TimeSpan.FromSeconds(1), jitter: Jitter.Full);
+        var inRange = true;
+
+        for (var sample = 0; sample < 10_000; sample++)
+        {
+            var equalConstantDelay = equalConstant.GetDelay(1);
+            var fullConstantDelay = fullConstant.GetDelay(1);
+            var equalLinearDelay = equalLinear.GetDelay(2);
+            var fullLinearDelay = fullLinear.GetDelay(2);
+            inRange &= equalConstantDelay >= TimeSpan.FromMilliseconds(500)
+                && equalConstantDelay < TimeSpan.FromMilliseconds(1500)
+                && fullConstantDelay >= TimeSpan.Zero
+                && fullConstantDelay < TimeSpan.FromSeconds(1)
+                && equalLinearDelay >= TimeSpan.FromSeconds(1)
+                && equalLinearDelay < TimeSpan.FromSeconds(3)
+                && fullLinearDelay >= TimeSpan.Zero
+                && fullLinearDelay < TimeSpan.FromSeconds(2);
+        }
+
+        await Assert.That(inRange).IsTrue();
+    }
+
+    [Test]
+    public async Task Jitter_Uses_SharedRandom_And_Is_Thread_Safe()
+    {
+        var backoff = Backoff.Exponential(TimeSpan.FromSeconds(1), factor: 1, jitter: Jitter.Equal);
+        var invalidDelays = 0;
+
+        Parallel.For(0, 32, _ =>
+        {
+            for (var sample = 0; sample < 10_000; sample++)
+            {
+                var delay = backoff.GetDelay(1);
+                if (delay < TimeSpan.FromMilliseconds(500) || delay >= TimeSpan.FromMilliseconds(1500))
+                {
+                    Interlocked.Increment(ref invalidDelays);
+                }
+            }
+        });
+
+        await Assert.That(invalidDelays).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task MaxDelay_Caps_Every_Jitter_Mode_Including_Decorrelated()
+    {
+        var maxDelay = TimeSpan.FromMilliseconds(10);
+        var inRange = true;
+
+        foreach (var jitter in Enum.GetValues<Jitter>())
+        {
+            var backoff = Backoff.Exponential(
+                TimeSpan.FromMilliseconds(5),
+                factor: 4,
+                maxDelay: maxDelay,
+                jitter: jitter);
+            var previousDelay = TimeSpan.FromMilliseconds(5);
+            for (var attempt = 1; attempt <= 100; attempt++)
+            {
+                var delay = backoff.GetDelay(attempt, previousDelay);
+                inRange &= delay >= TimeSpan.Zero && delay <= maxDelay;
+                previousDelay = delay;
+            }
+        }
+
+        await Assert.That(inRange).IsTrue();
     }
 
     [Test]
@@ -121,6 +261,7 @@ public class BackoffTests
         await Assert.That(() => Backoff.Linear(TimeSpan.FromSeconds(-1))).Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => Backoff.Exponential(TimeSpan.FromSeconds(-1))).Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => Backoff.Exponential(TimeSpan.FromSeconds(1), factor: 0.5)).Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => Backoff.Constant(TimeSpan.Zero, (Jitter)int.MaxValue)).Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => Backoff.Custom(null!)).Throws<ArgumentNullException>();
     }
 }

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -89,21 +89,21 @@ public class ConfigurationBindingTests
         var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("tuned");
 
         await Assert.That(shield.ToString())
-            .IsEqualTo("tuned: Timeout(30s) → Retry(5, constant 1s) → CircuitBreaker(50% over 30s, min 20, break 15s)");
+            .IsEqualTo("tuned: Timeout(30s) → Retry(5, constant 1s, equal jitter) → CircuitBreaker(50% over 30s, min 20, break 15s)");
     }
 
     [Test]
     [Arguments("none", "no delay")]
     [Arguments("CONSTANT", "constant 1s")]
     [Arguments("Linear", "linear 1s steps")]
-    [Arguments("eXpOnEnTiAl", "exponential 1s ×2 ≤30s")]
+    [Arguments("eXpOnEnTiAl", "exponential 1s ×2, cap 30s")]
     public async Task RetryDefinition_Binds_BackoffKind_From_Configuration(string value, string expected)
     {
         var configuration = BuildConfiguration(
             ("Retry:MaxRetries", "1"),
             ("Retry:Backoff", value),
             ("Retry:BaseDelay", "00:00:01"),
-            ("Retry:Jitter", "false"),
+            ("Retry:Jitter", "None"),
             ("Retry:MaxDelay", ""));
         var services = new ServiceCollection();
         services.AddShield("backoff", configuration);
@@ -128,6 +128,39 @@ public class ConfigurationBindingTests
     }
 
     [Test]
+    [Arguments("None", "exponential 1s ×2, cap 30s")]
+    [Arguments("equal", "exponential 1s ×2, equal jitter, cap 30s")]
+    [Arguments("FULL", "exponential 1s ×2, full jitter, cap 30s")]
+    [Arguments("Decorrelated", "exponential 1s ×2, decorrelated jitter, cap 30s")]
+    public async Task RetryDefinition_Binds_Jitter_From_Configuration(string value, string expected)
+    {
+        var configuration = BuildConfiguration(
+            ("Retry:MaxRetries", "1"),
+            ("Retry:BaseDelay", "00:00:01"),
+            ("Retry:Jitter", value));
+        var services = new ServiceCollection();
+        services.AddShield("jitter", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("jitter");
+
+        await Assert.That(shield.ToString()).IsEqualTo($"jitter: Retry(1, {expected})");
+    }
+
+    [Test]
+    public async Task Invalid_Jitter_Throws_With_Path()
+    {
+        var configuration = BuildConfiguration(("Retry:Jitter", "randomish"));
+        var services = new ServiceCollection();
+        services.AddShield("invalid", configuration);
+        using var provider = services.BuildServiceProvider();
+
+        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<InvalidOperationException>()
+            .WithMessage("Configuration value 'randomish' for 'Retry:Jitter' is not a Jitter.");
+    }
+
+    [Test]
     public async Task Custom_BackoffKind_Throws_With_Path()
     {
         var configuration = BuildConfiguration(("Retry:Backoff", "Custom"));
@@ -148,7 +181,7 @@ public class ConfigurationBindingTests
         var definition = new ShieldDefinition { Retry = new RetryDefinition() };
 
         await Assert.That(definition.Build().ToString())
-            .IsEqualTo("Retry(3, exponential 250ms ×2 +jitter ≤30s)");
+            .IsEqualTo("Retry(3, exponential 250ms ×2, equal jitter, cap 30s)");
     }
 
     [Test]
@@ -160,7 +193,7 @@ public class ConfigurationBindingTests
             ("Retry:Backoff", "exponential"),
             ("Retry:BaseDelay", "00:00:00.100"),
             ("Retry:Factor", "3"),
-            ("Retry:Jitter", "false"),
+            ("Retry:Jitter", "None"),
             ("Retry:MaxDelay", "00:00:02"),
             ("CircuitBreaker:FailureRatio", "0.25"),
             ("CircuitBreaker:MinimumThroughput", "4"),
@@ -180,7 +213,7 @@ public class ConfigurationBindingTests
         var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("complete");
 
         await Assert.That(shield.ToString()).IsEqualTo(
-            "complete: Timeout(20s) → Retry(2, exponential 100ms ×3 ≤2s) → CircuitBreaker(25% over 8s, min 4, break 5s) → RateLimit(5/10s, burst 7, queue 2) → ConcurrencyLimit(3, queue 4) → Timeout(1s)");
+            "complete: Timeout(20s) → Retry(2, exponential 100ms ×3, cap 2s) → CircuitBreaker(25% over 8s, min 4, break 5s) → RateLimit(5/10s, burst 7, queue 2) → ConcurrencyLimit(3, queue 4) → Timeout(1s)");
     }
 
     [Test]
@@ -229,7 +262,7 @@ public class ConfigurationBindingTests
         var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("defaults");
 
         await Assert.That(shield.ToString()).IsEqualTo(
-            "defaults: Retry(3, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → RateLimit(100/1s) → ConcurrencyLimit(10)");
+            "defaults: Retry(3, exponential 250ms ×2, equal jitter, cap 30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → RateLimit(100/1s) → ConcurrencyLimit(10)");
     }
 
     [Test]
@@ -302,7 +335,7 @@ public class ConfigurationBindingTests
         var shield = provider.GetRequiredService<IKevlarRegistry>().GetShield("nullable");
 
         await Assert.That(shield.ToString()).IsEqualTo(
-            "nullable: Retry(0, exponential 250ms ×2 +jitter ≤30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → RateLimit(5/1s)");
+            "nullable: Retry(0, exponential 250ms ×2, equal jitter, cap 30s) → CircuitBreaker(50% over 30s, min 10, break 15s) → RateLimit(5/1s)");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -132,6 +132,8 @@ public class ConfigurationBindingTests
     [Arguments("equal", "exponential 1s ×2, equal jitter, cap 30s")]
     [Arguments("FULL", "exponential 1s ×2, full jitter, cap 30s")]
     [Arguments("Decorrelated", "exponential 1s ×2, decorrelated jitter, cap 30s")]
+    [Arguments("false", "exponential 1s ×2, cap 30s")]
+    [Arguments("true", "exponential 1s ×2, equal jitter, cap 30s")]
     public async Task RetryDefinition_Binds_Jitter_From_Configuration(string value, string expected)
     {
         var configuration = BuildConfiguration(

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -332,8 +332,8 @@ public class DependencyInjectionContractTests
     [Test]
     [Arguments(BackoffKind.None, "no delay, ≤4s")]
     [Arguments(BackoffKind.Constant, "constant 2s, ≤4s")]
-    [Arguments(BackoffKind.Linear, "linear 2s steps ≤4s")]
-    [Arguments(BackoffKind.Exponential, "exponential 2s ×3 ≤4s")]
+    [Arguments(BackoffKind.Linear, "linear 2s steps, cap 4s")]
+    [Arguments(BackoffKind.Exponential, "exponential 2s ×3, cap 4s")]
     public async Task Every_BackoffKind_Binds_All_Applicable_Knobs(BackoffKind kind, string expected)
     {
         var definition = new ShieldDefinition
@@ -344,7 +344,7 @@ public class DependencyInjectionContractTests
                 Backoff = kind,
                 BaseDelay = TimeSpan.FromSeconds(2),
                 Factor = 3,
-                Jitter = false,
+                Jitter = Jitter.None,
                 MaxDelay = TimeSpan.FromSeconds(4),
             },
         };

--- a/tests/Kevlar.Tests/DescribeTests.cs
+++ b/tests/Kevlar.Tests/DescribeTests.cs
@@ -12,7 +12,7 @@ public class DescribeTests
     public async Task Default_Retry_Describes_Its_Backoff()
     {
         await Assert.That(Shield.Retry(3).ToString())
-            .IsEqualTo("Retry(3, exponential 250ms ×2 +jitter ≤30s)");
+            .IsEqualTo("Retry(3, exponential 250ms ×2, equal jitter, cap 30s)");
     }
 
     [Test]
@@ -30,7 +30,7 @@ public class DescribeTests
     public async Task RetryForever_Is_Named_As_Such()
     {
         await Assert.That(Shield.RetryForever().ToString())
-            .IsEqualTo("RetryForever(exponential 250ms ×2 +jitter ≤30s)");
+            .IsEqualTo("RetryForever(exponential 250ms ×2, equal jitter, cap 30s)");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -147,6 +147,27 @@ public class HttpConfigurationReloadTests
     }
 
     [Test]
+    [Arguments("false", "exponential 100ms ×2, cap 30s")]
+    [Arguments("true", "exponential 100ms ×2, equal jitter, cap 30s")]
+    public async Task Standard_Section_Accepts_Legacy_Boolean_Jitter(
+        string value,
+        string expected)
+    {
+        var configuration = BuildConfiguration(
+            ("Retry:BaseDelay", "00:00:00.100"),
+            ("Retry:Jitter", value));
+        StandardHttpShieldOptions? bound = null;
+        var services = new ServiceCollection();
+        services.AddHttpClient("client")
+            .AddStandardShield(configuration, (_, options) => bound = options);
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+
+        await Assert.That(bound!.Retry.Backoff.ToString()).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task Hedge_Section_Binds_All_Supported_Values()
     {
         var configuration = BuildConfiguration(

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -101,7 +101,7 @@ public class HttpConfigurationReloadTests
         await Assert.That(bound).IsNotNull();
         await Assert.That(bound!.TotalTimeout.Timeout).IsEqualTo(TimeSpan.FromSeconds(20));
         await Assert.That(bound.Retry.MaxRetries).IsEqualTo(4);
-        await Assert.That(bound.Retry.Backoff.ToString()).IsEqualTo("linear 100ms steps ≤2s");
+        await Assert.That(bound.Retry.Backoff.ToString()).IsEqualTo("linear 100ms steps, equal jitter, cap 2s");
         await Assert.That(bound.Retry.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(1));
         await Assert.That(bound.CircuitBreaker.ConsecutiveFailures).IsEqualTo(2);
         await Assert.That(bound.CircuitBreaker.FailureRatio).IsNull();
@@ -123,8 +123,8 @@ public class HttpConfigurationReloadTests
     [Test]
     [Arguments("None", "no delay")]
     [Arguments("Constant", "constant 100ms")]
-    [Arguments("Linear", "linear 100ms steps ≤2s")]
-    [Arguments("Exponential", "exponential 100ms ×3 ≤2s")]
+    [Arguments("Linear", "linear 100ms steps, cap 2s")]
+    [Arguments("Exponential", "exponential 100ms ×3, cap 2s")]
     public async Task Standard_Section_Binds_Each_Backoff(
         string kind,
         string expected)
@@ -133,7 +133,7 @@ public class HttpConfigurationReloadTests
             ("Retry:Backoff", kind),
             ("Retry:BaseDelay", "00:00:00.100"),
             ("Retry:Factor", "3"),
-            ("Retry:Jitter", "false"),
+            ("Retry:Jitter", "None"),
             ("Retry:BackoffMaxDelay", "00:00:02"));
         StandardHttpShieldOptions? bound = null;
         var services = new ServiceCollection();

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -374,7 +374,7 @@ public class HttpContractTests
     public async Task Standard_Has_The_Documented_Pipeline() =>
         await Assert.That(HttpShield.Standard().ToString()).IsEqualTo(
             "Timeout(30s) → [when HttpRequestException | TaskCanceledException matching predicate | TimeoutExceededException | result predicate] "
-            + "Retry(3, exponential 250ms ×2 +jitter ≤30s, ≤10s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
+            + "Retry(3, exponential 250ms ×2, equal jitter, cap 30s, ≤10s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
 
     [Test]
     public async Task Configured_Standard_Has_Custom_Stages()

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -46,7 +46,7 @@ public class NumericBoundaryTests
             BackoffKind.None => Backoff.None,
             BackoffKind.Constant => Backoff.Constant(TimeSpan.Zero),
             BackoffKind.Linear => Backoff.Linear(TimeSpan.FromTicks(1)),
-            BackoffKind.Exponential => Backoff.Exponential(TimeSpan.FromTicks(1), jitter: false),
+            BackoffKind.Exponential => Backoff.Exponential(TimeSpan.FromTicks(1), jitter: Jitter.None),
             BackoffKind.Custom => Backoff.Custom(_ => TimeSpan.Zero),
             _ => throw new ArgumentOutOfRangeException(nameof(kind)),
         };
@@ -60,7 +60,7 @@ public class NumericBoundaryTests
     {
         var cap = TimeSpan.FromSeconds(2);
         var linear = Backoff.Linear(TimeSpan.MaxValue, cap);
-        var exponential = Backoff.Exponential(TimeSpan.MaxValue, double.MaxValue, cap, jitter: false);
+        var exponential = Backoff.Exponential(TimeSpan.MaxValue, double.MaxValue, cap, jitter: Jitter.None);
         var custom = Backoff.Custom(_ => TimeSpan.MaxValue);
 
         await Assert.That(linear.GetDelay(int.MaxValue)).IsEqualTo(cap);
@@ -71,7 +71,7 @@ public class NumericBoundaryTests
     [Test]
     public async Task Zero_Exponential_Backoff_Remains_Zero_When_The_Power_Overflows()
     {
-        var backoff = Backoff.Exponential(TimeSpan.Zero, double.MaxValue, jitter: false);
+        var backoff = Backoff.Exponential(TimeSpan.Zero, double.MaxValue, jitter: Jitter.None);
 
         await Assert.That(backoff.GetDelay(3)).IsEqualTo(TimeSpan.Zero);
     }

--- a/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/RetryEdgeCaseTests.cs
@@ -185,6 +185,42 @@ public class RetryEdgeCaseTests
     }
 
     [Test]
+    public async Task MaxDelay_Bounds_Decorrelated_Jitter_State()
+    {
+        var cap = TimeSpan.FromTicks(2);
+        var attempts = 0;
+        var seenDelays = new List<TimeSpan>();
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1_000;
+            options.Backoff = Backoff.Exponential(
+                TimeSpan.FromTicks(1),
+                jitter: Jitter.Decorrelated);
+            options.MaxDelay = cap;
+            options.DelayGenerator = retry =>
+            {
+                seenDelays.Add(retry.Delay);
+                return TimeSpan.Zero;
+            };
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return attempts <= 1_000
+                ? throw new InvalidOperationException()
+                : new ValueTask<int>(attempts);
+        });
+
+        var uncappedTailDelays = seenDelays
+            .Skip(500)
+            .Count(delay => delay < cap);
+
+        await Assert.That(result).IsEqualTo(1_001);
+        await Assert.That(uncappedTailDelays).IsGreaterThan(50);
+    }
+
+    [Test]
     public async Task Negative_DelayGenerator_Values_Are_Ignored()
     {
         var seenDelays = new List<TimeSpan>();

--- a/tests/Kevlar.Tests/StrategyModelTests.cs
+++ b/tests/Kevlar.Tests/StrategyModelTests.cs
@@ -475,7 +475,7 @@ public class StrategyModelTests
         foreach (var command in commands)
         {
             var initial = TimeSpan.FromTicks(command.DelaySelector);
-            var delay = Backoff.Exponential(initial, factor: 2, maxDelay: TimeSpan.FromTicks(20), jitter: false)
+            var delay = Backoff.Exponential(initial, factor: 2, maxDelay: TimeSpan.FromTicks(20), jitter: Jitter.None)
                 .GetDelay(command.DelaySelector + 1);
             Ensure(delay >= TimeSpan.Zero && delay <= TimeSpan.FromTicks(20), 0, command, "backoff escaped its domain");
         }


### PR DESCRIPTION
Summary: replaces Boolean exponential jitter with explicit None, Equal, Full, and Decorrelated modes; adds jitter to constant and linear backoff; keeps decorrelated state execution-local and exposes a previous-delay overload for direct consumers; removes the hidden one-day cap; updates DI, HTTP configuration, Testing descriptors, docs, tests, and API ledgers. Legacy Boolean configuration values remain accepted. Breaking change for 1.0: the public Backoff factory signatures and Jitter metadata now use the Jitter enum. Closes #203. Validation: Release solution build; core, Testing, .NET Standard fallback, and allocation tests on supported frameworks; docs structure, compiled snippets, and production site build.