### PR TITLE
feat(builders): complete shield overload parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
 
 ### Changed
 
+- Handling-clause builders now match their shield counterparts for configured timeouts, direct
+  custom strategies, and void fallbacks that do not need the handled exception.
 - Every NuGet package now embeds the canonical Kevlar icon, links release notes, and carries a
   NuGet-safe README with status badges. `Kevlar.Analyzers` is marked as a development dependency
   so it does not flow from a packed consumer library.

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -69,7 +69,9 @@ builder held in a variable can be branched into independent chains:
 ```csharp
 var transient = Shield.When<HttpRequestException>();
 
-var reads = transient.Or<TimeoutExceededException>().Retry(3);
+var reads = transient.Or<TimeoutExceededException>()
+    .Timeout(options => options.Timeout = TimeSpan.FromSeconds(10))
+    .Retry(3);
 var writes = transient.Or<IOException>().Retry(1);   // no TimeoutExceededException here
 ```
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -586,7 +586,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     /// <summary>Whether a reactive strategy reads the ambient clause this method seals.</summary>
     private static bool ConsumesHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
         IsClauseConsumingStrategy(method, knownTypes)
-        || (method.Name == "Use" && IsKevlarFluentMethod(method, knownTypes));
+        || (IsKevlarFluentMethod(method, knownTypes, "Use")
+            && method.Parameters.Length == 1
+            && method.Parameters[0].Type.TypeKind == TypeKind.Delegate);
 
     private static bool IsDiscardedClauseBuilder(
         IInvocationOperation invocation,

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -30,7 +30,13 @@ static Kevlar.Shield.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! f
 static Kevlar.ShieldExtensions.Use(this Kevlar.Shield! shield, System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield!
 Kevlar.Shield<TResult>.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield<TResult>!
 Kevlar.ShieldBuilder.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield!
+Kevlar.ShieldBuilder.Use(Kevlar.Strategy! strategy) -> Kevlar.Shield!
 Kevlar.ShieldBuilder<TResult>.Use(System.Func<Kevlar.HandlingClause, Kevlar.Strategy!>! factory) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder<TResult>.Use(Kevlar.Strategy! strategy) -> Kevlar.Shield<TResult>!
+Kevlar.ShieldBuilder.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback) -> Kevlar.Shield!
+Kevlar.ShieldBuilder.Fallback(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>! fallback, System.Action<Kevlar.FallbackOptions!>! configure) -> Kevlar.Shield!
+Kevlar.ShieldBuilder.Timeout(System.Action<Kevlar.TimeoutOptions!>! configure) -> Kevlar.Shield!
+Kevlar.ShieldBuilder<TResult>.Timeout(System.Action<Kevlar.TimeoutOptions!>! configure) -> Kevlar.Shield<TResult>!
 virtual Kevlar.Strategy.Handling.get -> Kevlar.HandlingClause?
 virtual Kevlar.Strategy.InvokesContinuationAtMostOnce.get -> bool
 Kevlar.Shield<TResult>.InvokesContinuationAtMostOnce.get -> bool

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -126,6 +126,25 @@ public sealed class ShieldBuilder
     public Shield Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);
 
     /// <summary>
+    /// Appends a custom strategy. The accumulated handling clause remains ambient for later strategies.
+    /// </summary>
+    public Shield Use(Strategy strategy) => Seal().Use(strategy);
+
+    /// <summary>
+    /// Runs <paramref name="fallback"/> in place of handled failures. Applies to void executions
+    /// only; result-producing recovery needs a typed shield.
+    /// </summary>
+    public Shield Fallback(Func<CancellationToken, ValueTask> fallback) => Seal().Fallback(fallback);
+
+    /// <summary>
+    /// Runs <paramref name="fallback"/> in place of handled failures and configures notifications.
+    /// Applies to void executions only.
+    /// </summary>
+    public Shield Fallback(
+        Func<CancellationToken, ValueTask> fallback,
+        Action<FallbackOptions> configure) => Seal().Fallback(fallback, configure);
+
+    /// <summary>
     /// Runs <paramref name="fallback"/> in place of handled failures. Applies to void executions
     /// only; result-producing recovery needs <c>Shield.For&lt;T&gt;().FallbackTo(…)</c> for a constant
     /// value or a typed <c>Fallback(…)</c> factory.
@@ -142,6 +161,11 @@ public sealed class ShieldBuilder
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>. The handling clauses remain ambient for later strategies.</summary>
     public Shield Timeout(TimeSpan timeout) => Seal().Timeout(timeout);
+
+    /// <summary>
+    /// Adds a configured timeout. The handling clause remains ambient for later strategies.
+    /// </summary>
+    public Shield Timeout(Action<TimeoutOptions> configure) => Seal().Timeout(configure);
 
     /// <summary>Limits throughput. The handling clauses remain ambient for later strategies.</summary>
     public Shield RateLimit(int permits, TimeSpan perWindow) => Seal().RateLimit(permits, perWindow);

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -141,6 +141,11 @@ public sealed class ShieldBuilder<TResult>
     /// <summary>Creates and appends a custom strategy using the accumulated handling clause.</summary>
     public Shield<TResult> Use(Func<HandlingClause, Strategy> factory) => Seal().Use(factory);
 
+    /// <summary>
+    /// Appends a custom strategy. The accumulated handling clause remains ambient for later strategies.
+    /// </summary>
+    public Shield<TResult> Use(Strategy strategy) => Seal().Use(strategy);
+
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/>.</summary>
     public Shield<TResult> FallbackTo(TResult fallbackValue) => Seal().FallbackTo(fallbackValue);
 
@@ -169,6 +174,11 @@ public sealed class ShieldBuilder<TResult>
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> Timeout(TimeSpan timeout) => Seal().Timeout(timeout);
+
+    /// <summary>
+    /// Adds a configured timeout. The handling clause remains ambient for later strategies.
+    /// </summary>
+    public Shield<TResult> Timeout(Action<TimeoutOptions> configure) => Seal().Timeout(configure);
 
     /// <summary>Limits throughput. The handling clauses remain ambient for later strategies.</summary>
     public Shield<TResult> RateLimit(int permits, TimeSpan perWindow) => Seal().RateLimit(permits, perWindow);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -654,6 +654,7 @@ public class PipelineHazardAnalyzerTests
         var cases = new[]
         {
             "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).WhenAnyError().Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Timeout(static options => options.Timeout = TimeSpan.FromSeconds(1)).WhenAnyError().Retry(1);",
             "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).When<TimeoutException>().Retry(1);",
             "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().RateLimit(1, TimeSpan.FromSeconds(1)).When<TimeoutException>().Retry(1);",
             "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).WhenResult(static value => value < 0).Retry(1);",
@@ -671,6 +672,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
             "_ = Shield.When<InvalidOperationException>().Fallback(static (_, _) => default);",
+            "_ = Shield.When<InvalidOperationException>().Fallback(static _ => default);",
             "_ = Shield.For<int>().WhenResult(static value => value < 0).FallbackTo(0);",
             "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
             "var clause = Shield.When<InvalidOperationException>(); _ = clause.Retry(1);",
@@ -733,6 +735,7 @@ public class PipelineHazardAnalyzerTests
             "Shield.For<int>().Retry(3);",
             "Shield.When<InvalidOperationException>().Retry(3);",
             "Shield.For<int>().WhenResult(static value => value < 0).FallbackTo(0);",
+            "Shield.When<InvalidOperationException>().Fallback(static _ => default);",
             "Shield.Compose(Shield.Empty, Shield.Empty);",
             "var shield = Shield.Empty; shield.Timeout(TimeSpan.FromSeconds(1));",
         };

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -657,7 +657,9 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.When<InvalidOperationException>().Timeout(static options => options.Timeout = TimeSpan.FromSeconds(1)).WhenAnyError().Retry(1);",
             "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).When<TimeoutException>().Retry(1);",
             "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().RateLimit(1, TimeSpan.FromSeconds(1)).When<TimeoutException>().Retry(1);",
+            "_ = Shield.When<InvalidOperationException>().Use((Strategy)null!).When<TimeoutException>().Retry(1);",
             "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).WhenResult(static value => value < 0).Retry(1);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Use((Strategy)null!).WhenResult(static value => value < 0).Retry(1);",
         };
 
         await AssertEachAsync(cases, "KEV007", "KEV004");
@@ -673,7 +675,9 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
             "_ = Shield.When<InvalidOperationException>().Fallback(static (_, _) => default);",
             "_ = Shield.When<InvalidOperationException>().Fallback(static _ => default);",
+            "_ = Shield.When<InvalidOperationException>().Use(static clause => (Strategy)null!).When<TimeoutException>().Retry(1);",
             "_ = Shield.For<int>().WhenResult(static value => value < 0).FallbackTo(0);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Use(static clause => (Strategy)null!).WhenResult(static value => value < 0).Retry(1);",
             "_ = Shield.For<int>().When<InvalidOperationException>().Timeout(TimeSpan.FromSeconds(1)).Retry(1);",
             "var clause = Shield.When<InvalidOperationException>(); _ = clause.Retry(1);",
             "var clause = Shield.When<InvalidOperationException>(); _ = clause.Or<TimeoutException>().Retry(1);",

--- a/tests/Kevlar.Tests/BuilderParityTests.cs
+++ b/tests/Kevlar.Tests/BuilderParityTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+
+namespace Kevlar.Tests;
+
+public class BuilderParityTests
+{
+    [Test]
+    public void Builders_Expose_The_Missing_Shield_Overload_Signatures()
+    {
+        AssertSignature(typeof(ShieldBuilder), nameof(ShieldBuilder.Timeout), typeof(Action<TimeoutOptions>));
+        AssertSignature(typeof(ShieldBuilder<int>), nameof(ShieldBuilder<int>.Timeout), typeof(Action<TimeoutOptions>));
+        AssertSignature(typeof(ShieldBuilder), nameof(ShieldBuilder.Use), typeof(Strategy));
+        AssertSignature(typeof(ShieldBuilder<int>), nameof(ShieldBuilder<int>.Use), typeof(Strategy));
+        AssertSignature(
+            typeof(ShieldBuilder),
+            nameof(ShieldBuilder.Fallback),
+            typeof(Func<CancellationToken, ValueTask>));
+        AssertSignature(
+            typeof(ShieldBuilder),
+            nameof(ShieldBuilder.Fallback),
+            typeof(Func<CancellationToken, ValueTask>),
+            typeof(Action<FallbackOptions>));
+
+    }
+
+    [Test]
+    public async Task Builder_Timeout_Configure_Applies_TimeoutGenerator()
+    {
+        var generatorCalls = 0;
+        var shield = Shield.When<InvalidOperationException>()
+            .Timeout(options => options.TimeoutGenerator = _ =>
+            {
+                generatorCalls++;
+                return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+            })
+            .Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(generatorCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Builder_Use_Strategy_Preserves_The_Ambient_Clause()
+    {
+        var attempts = 0;
+        var shield = Shield.When<InvalidOperationException>()
+            .Use(new PassThroughStrategy())
+            .Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            attempts++;
+            return attempts == 1
+                ? ValueTask.FromException<int>(new InvalidOperationException())
+                : new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Typed_Builder_Timeout_And_Use_Preserve_The_Result_Clause()
+    {
+        var generatorCalls = 0;
+        var attempts = 0;
+        var shield = Shield.For<int>()
+            .WhenResult(0)
+            .Timeout(options => options.TimeoutGenerator = _ =>
+            {
+                generatorCalls++;
+                return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+            })
+            .Use(new PassThroughStrategy())
+            .Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(attempts++ == 0 ? 0 : 42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(generatorCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Builder_Fallback_Without_Exception_Argument_Runs()
+    {
+        var fallbackCalls = 0;
+        var notificationCalls = 0;
+        var bare = Shield.When<InvalidOperationException>()
+            .Fallback(_ =>
+            {
+                fallbackCalls++;
+                return ValueTask.CompletedTask;
+            });
+        var configured = Shield.When<InvalidOperationException>()
+            .Fallback(
+                _ =>
+                {
+                    fallbackCalls++;
+                    return ValueTask.CompletedTask;
+                },
+                options => options.OnFallback = _ => notificationCalls++);
+
+        await bare.ExecuteAsync(static _ => ValueTask.FromException(new InvalidOperationException()));
+        await configured.ExecuteAsync(static _ => ValueTask.FromException(new InvalidOperationException()));
+
+        await Assert.That(fallbackCalls).IsEqualTo(2);
+        await Assert.That(notificationCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Builder_Timeout_Configure_Has_The_Same_Description_As_Shield_Timeout()
+    {
+        var fromBuilder = Shield.When<InvalidOperationException>()
+            .Timeout(static options => options.TimeoutGenerator =
+                static _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1)))
+            .Retry(3);
+        var fromShield = Shield.Timeout(static options => options.TimeoutGenerator =
+                static _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1)))
+            .When<InvalidOperationException>()
+            .Retry(3);
+
+        const string expected =
+            "Timeout(dynamic) → [when InvalidOperationException] " +
+            "Retry(3, exponential 250ms ×2, equal jitter, cap 30s)";
+        await Assert.That(fromBuilder.ToString()).IsEqualTo(expected);
+        await Assert.That(fromShield.ToString()).IsEqualTo(expected);
+    }
+
+    private static void AssertSignature(Type type, string methodName, params Type[] parameterTypes)
+    {
+        var method = type.GetMethod(
+            methodName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly,
+            binder: null,
+            parameterTypes,
+            modifiers: null);
+        if (method is null)
+        {
+            throw new InvalidOperationException(
+                $"{type.Name}.{methodName}({string.Join(", ", parameterTypes.Select(static parameter => parameter.Name))}) was not found.");
+        }
+    }
+
+    private sealed class PassThroughStrategy : Strategy
+    {
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
+    }
+}


### PR DESCRIPTION
Closes #209.

## What changed
- add `Timeout(Action<TimeoutOptions>)` and `Use(Strategy)` to typed and untyped handling-clause builders
- add exception-independent void fallback overloads to `ShieldBuilder`
- guard exact signatures and behavior, including clause preservation and configured notifications
- extend KEV007/KEV008 analyzer cases and the executable builder documentation

`VoidShield` parity items became obsolete when #261 removed that pre-release type family. Outcome execution overloads remain tracked by #235.

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build --framework net8.0 -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build --framework net10.0 -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m`
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/packages-loop209 -Version 1.0.0-loop209`