### PR TITLE
refactor(events): unify callback context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Breaking changes
 
+- Strategy callback events now expose their position through public
+  `KevlarContext.StrategyIndex`; the duplicate properties on limiter rejection events were removed.
+  Circuit transitions use `CircuitBreakerStateChangedEvent` and carry execution context, while
+  manual monitor transitions carry a detached context at index `-1`. Typed circuit-breaker
+  duration generators receive `CircuitBreakerBreakDurationEvent<TResult>` with a directly stored
+  outcome and failure statistics. Typed retry events likewise store their outcome without boxing.
 - `HedgeOptions<TResult>.ActionGenerator` is now a strongly typed delegate. Assign the generator
   directly instead of wrapping it with `HedgeActionGenerator.Create<TResult>(...)`; the erased
   wrapper remains available on untyped `HedgeOptions`. Typed generator events now expose the latest

--- a/docs/docs/custom-strategies.md
+++ b/docs/docs/custom-strategies.md
@@ -140,6 +140,7 @@ The context flows through the whole pipeline:
 - `context.TimeProvider` — **always use this instead of `DateTime`/`Stopwatch`/`Task.Delay`**, so your strategy stays [testable with `FakeTimeProvider`](testing.md) like the built-ins.
 - `context.CancellationToken` — the current token. Strategies such as timeouts *replace* this for the layers beneath them — which is why delegates must use the token they're handed rather than a captured one.
 - `context.IsSynchronous` — `true` under `Execute`; branch on it if your strategy would otherwise block or break a sync caller (hedging throws for sync callers this way).
+- `context.StrategyIndex` — the current strategy's zero-based pipeline position. Nested execution restores the outer index before its strategy resumes, and hedge forks preserve the inner position.
 - `context.Properties` — a typed property bag: `Set(key, value)`, `TryGet(key, out value)`, `GetOrDefault(key)`, keyed by `KevlarKey<T>`:
 
 <!-- doc-test-declaration: split-before=context.Properties -->

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -35,9 +35,9 @@ Configure either `ConsecutiveFailures` *or* `FailureRatio` — not both. When ne
 | `MinimumThroughput` | `10` | Sampling mode: don't judge until at least this many calls landed in the window |
 | `SamplingWindow` | `30s` | Rolling window over which the ratio is measured (tracked in 10 buckets) |
 | `BreakDuration` | `15s` | How long the circuit stays open before allowing a probe |
-| `BreakDurationGenerator` | — | Awaited outcome/context-aware duration; overrides `BreakDuration` for each trip |
+| `BreakDurationGenerator` | — | Awaited outcome, failure-statistics, and context-aware duration; overrides `BreakDuration` for each trip |
 | `Monitor` | — | A `CircuitBreakerMonitor` for observing + manual control |
-| `OnStateChanged` | — | Callback on every transition: `e.From`, `e.To`, `e.LastException` |
+| `OnStateChanged` | — | Callback on every transition: `e.From`, `e.To`, `e.LastException`, `e.Context` |
 | `OnStateChangedAsync` | — | Awaited callback on every transition, after `OnStateChanged` |
 | `HandlesException` | — | Local exception predicate; replaces the ambient clause for this breaker |
 | `HandlesResult` (`CircuitBreakerOptions<T>`) | — | Local result predicate on `Shield<T>`; replaces the ambient clause together with `HandlesException` |
@@ -54,6 +54,7 @@ var breaker = Shield.CircuitBreaker(o =>
     {
         await Task.Yield(); // for example, fetch a dependency recovery hint
         trip.Context.CancellationToken.ThrowIfCancellationRequested();
+        Console.WriteLine($"Opening at {trip.FailureRate:P0} failures");
         return trip.Exception is TimeoutExceededException
             ? TimeSpan.FromMinutes(1)
             : TimeSpan.FromSeconds(30);
@@ -61,7 +62,14 @@ var breaker = Shield.CircuitBreaker(o =>
 });
 ```
 
-The generator runs after the handled outcome crosses the threshold and before the circuit changes to `Open`. It is awaited outside the circuit lock. Its duration must be positive; its exception or cancellation propagates unchanged and leaves the circuit available for a later trip. `Result` carries a boxed handled result when a typed shield trips without an exception. `Context` is pooled and must not be retained after the callback completes. A dynamic breaker describes itself as `break dynamic` without running the generator.
+The generator runs after the handled outcome crosses the threshold and before the circuit changes
+to `Open`. It receives `FailureRate`, `FailureCount`, and `ConsecutiveFailures` at that moment and
+is awaited outside the circuit lock. Its duration must be positive; its exception or cancellation
+propagates unchanged and leaves the circuit available for a later trip. Untyped shields expose
+`Exception` and boxed `Result`; `CircuitBreakerOptions<T>` instead receives
+`CircuitBreakerBreakDurationEvent<T>` with a directly stored `Outcome<T>`. `Context` is pooled and
+must not be retained after the callback completes. A dynamic breaker describes itself as
+`break dynamic` without running the generator.
 
 ## The state machine
 
@@ -109,7 +117,17 @@ await monitor.ResetAsync();
 
 A monitor binds to exactly **one** breaker: assign it to `CircuitBreakerOptions.Monitor` when building the shield, and keep your reference. Binding it twice throws, as does using it before binding.
 
-Transitions are delivered serially in state-change order: `OnStateChanged`, awaited `OnStateChangedAsync`, then `monitor.StateChanged`. Callbacks run outside the circuit lock, so they can read `State` or call the synchronous or asynchronous monitor controls; a reentrant transition is queued behind the transition currently being delivered. Use `ResetAsync()` and `IsolateAsync()` when asynchronous transition callbacks are configured so the calling thread is not blocked. If an observer throws, later observers still run and the circuit keeps its new, usable state. One callback failure is rethrown unchanged after delivery; multiple failures are combined in an `AggregateException`.
+Transitions are delivered serially in state-change order: `OnStateChanged`, awaited
+`OnStateChangedAsync`, then `monitor.StateChanged`. The monitor intentionally retains an
+`Action<CircuitBreakerStateChangedEvent>` event so the three observers share one event shape and
+delivery model. Execution-driven transitions carry the triggering pooled context. Manual
+`Isolate`/`Reset` transitions carry a detached context with `StrategyIndex == -1`, no shield name,
+and an empty property bag. Callbacks run outside the circuit lock, so they can read `State` or call
+the synchronous or asynchronous monitor controls; a reentrant transition is queued behind the
+transition currently being delivered. Use `ResetAsync()` and `IsolateAsync()` when asynchronous
+transition callbacks are configured so the calling thread is not blocked. If an observer throws,
+later observers still run and the circuit keeps its new, usable state. One callback failure is
+rethrown unchanged after delivery; multiple failures are combined in an `AggregateException`.
 
 ## Share the circuit deliberately
 

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -86,7 +86,7 @@ next attempt is suppressed and caller cancellation surfaces. A generator excepti
 its original identity and skips later hooks. `RetryEvent.Context` is pooled execution state: use it
 only before the returned `ValueTask` completes; never retain it or its property bag.
 
-On an untyped `Shield`, the `RetryEvent` callbacks receive: `RetryNumber` (1-based, so `1` is the first retry after the initial execution), `Delay`, `Exception` (null when a handled *result* triggered the retry), `Result` (the handled result, boxed as `object?`) and `Context`. On a typed `Shield<T>`, the events are `RetryEvent<T>` instead: same `RetryNumber`/`Delay`/`Context`, plus the handled failure as a typed `Outcome<T>` — `e.Outcome.Result` is your `T`, no casting.
+On an untyped `Shield`, the `RetryEvent` callbacks receive: `RetryNumber` (1-based, so `1` is the first retry after the initial execution), `Delay`, `Exception` (null when a handled *result* triggered the retry), `Result` (the handled result, boxed as `object?`) and `Context`. On a typed `Shield<T>`, the events are `RetryEvent<T>` instead: same `RetryNumber`/`Delay`/`Context`, plus the handled failure as a directly stored typed `Outcome<T>` — `e.Outcome.Result` is your `T`, with no boxing, reconstruction, or cast.
 
 <!-- doc-test-run: retry-numbers -->
 ```csharp

--- a/src/Kevlar.Chaos/ChaosEvent.cs
+++ b/src/Kevlar.Chaos/ChaosEvent.cs
@@ -7,6 +7,8 @@ namespace Kevlar.Chaos;
 /// </remarks>
 public readonly struct ChaosEvent
 {
+    private readonly KevlarContext? _context;
+
     internal ChaosEvent(
         ChaosInjectionKind kind,
         KevlarContext context,
@@ -16,7 +18,7 @@ public readonly struct ChaosEvent
         double sample)
     {
         Kind = kind;
-        Context = context;
+        _context = context;
         Operation = operation;
         Environment = environment;
         InjectionRate = injectionRate;
@@ -27,7 +29,9 @@ public readonly struct ChaosEvent
     public ChaosInjectionKind Kind { get; }
 
     /// <summary>Gets the current Kevlar execution context.</summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => _context
+        ?? throw new InvalidOperationException(
+            "A default strategy event has no execution context.");
 
     /// <summary>Gets the operation from the active <see cref="ChaosScope"/>, if any.</summary>
     public string? Operation { get; }

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -216,21 +216,12 @@ public static class HttpShield
         CircuitBreakerOptions<HttpResponseMessage> source,
         CircuitBreakerOptions<HttpResponseMessage> target)
     {
-        var breakDurationGenerator = source.BreakDurationGenerator;
         target.ConsecutiveFailures = source.ConsecutiveFailures;
         target.FailureRatio = source.FailureRatio;
         target.MinimumThroughput = source.MinimumThroughput;
         target.SamplingWindow = source.SamplingWindow;
         target.BreakDuration = source.BreakDuration;
-        target.BreakDurationGenerator = breakDurationGenerator is null
-            ? null
-            : item => breakDurationGenerator(new CircuitBreakerBreakDurationEvent(
-                item.Outcome.Exception,
-                item.Outcome.Exception is null ? item.Outcome.Result : null,
-                item.FailureRate,
-                item.FailureCount,
-                item.ConsecutiveFailures,
-                item.Context));
+        target.BreakDurationGenerator = source.BreakDurationGenerator;
         target.HandlesException = source.HandlesException;
         target.HandlesResult = source.HandlesResult;
         target.Monitor = source.Monitor;

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -216,12 +216,21 @@ public static class HttpShield
         CircuitBreakerOptions<HttpResponseMessage> source,
         CircuitBreakerOptions<HttpResponseMessage> target)
     {
+        var breakDurationGenerator = source.BreakDurationGenerator;
         target.ConsecutiveFailures = source.ConsecutiveFailures;
         target.FailureRatio = source.FailureRatio;
         target.MinimumThroughput = source.MinimumThroughput;
         target.SamplingWindow = source.SamplingWindow;
         target.BreakDuration = source.BreakDuration;
-        target.BreakDurationGenerator = source.BreakDurationGenerator;
+        target.BreakDurationGenerator = breakDurationGenerator is null
+            ? null
+            : item => breakDurationGenerator(new CircuitBreakerBreakDurationEvent(
+                item.Outcome.Exception,
+                item.Outcome.Exception is null ? item.Outcome.Result : null,
+                item.FailureRate,
+                item.FailureCount,
+                item.ConsecutiveFailures,
+                item.Context));
         target.HandlesException = source.HandlesException;
         target.HandlesResult = source.HandlesResult;
         target.Monitor = source.Monitor;

--- a/src/Kevlar.Extensions.RateLimiting/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.RateLimiting/PublicAPI.Unshipped.txt
@@ -20,7 +20,7 @@ Kevlar.Extensions.RateLimiting.RateLimiterAdapterRejectedEvent.Context.get -> Ke
 Kevlar.Extensions.RateLimiting.RateLimiterAdapterRejectedEvent.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!
 Kevlar.Extensions.RateLimiting.RateLimiterAdapterRejectedEvent.PermitCount.get -> int
 Kevlar.Extensions.RateLimiting.RateLimiterAdapterRejectedEvent.RetryAfter.get -> System.TimeSpan?
-Kevlar.Extensions.RateLimiting.RateLimiterAdapterRejectedEvent.StrategyIndex.get -> int
+*REMOVED*Kevlar.Extensions.RateLimiting.RateLimiterAdapterRejectedEvent.StrategyIndex.get -> int
 Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions
 static Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions.UseRateLimiter(this Kevlar.Shield! shield, Kevlar.Extensions.RateLimiting.RateLimitLeaseAcquirer! acquireLease, System.Action<Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions!>? configure = null) -> Kevlar.Shield!
 static Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions.UseRateLimiter(this Kevlar.Shield! shield, System.Threading.RateLimiting.RateLimiter! limiter, System.Action<Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions!>? configure = null) -> Kevlar.Shield!

--- a/src/Kevlar.Extensions.RateLimiting/RateLimiterAdapterRejectedEvent.cs
+++ b/src/Kevlar.Extensions.RateLimiting/RateLimiterAdapterRejectedEvent.cs
@@ -3,18 +3,18 @@ namespace Kevlar.Extensions.RateLimiting;
 /// <summary>Describes an execution rejected by an adapted rate limiter.</summary>
 public readonly struct RateLimiterAdapterRejectedEvent
 {
+    private readonly KevlarContext? _context;
+
     internal RateLimiterAdapterRejectedEvent(
         TimeSpan? retryAfter,
         IReadOnlyDictionary<string, object?> metadata,
         int permitCount,
-        int strategyIndex,
         KevlarContext context)
     {
         RetryAfter = retryAfter;
         Metadata = metadata;
         PermitCount = permitCount;
-        StrategyIndex = strategyIndex;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The lease-provided delay before another acquisition should be attempted.</summary>
@@ -26,12 +26,11 @@ public readonly struct RateLimiterAdapterRejectedEvent
     /// <summary>The number of permits requested for the execution.</summary>
     public int PermitCount { get; }
 
-    /// <summary>The zero-based position of this strategy in the executing shield.</summary>
-    public int StrategyIndex { get; }
-
     /// <summary>
     /// The ambient execution context. It is pooled; do not retain it after synchronous and
     /// asynchronous rejection callbacks complete.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => _context
+        ?? throw new InvalidOperationException(
+            "A default strategy event has no execution context.");
 }

--- a/src/Kevlar.Extensions.RateLimiting/RateLimiterStrategy.cs
+++ b/src/Kevlar.Extensions.RateLimiting/RateLimiterStrategy.cs
@@ -169,7 +169,6 @@ internal sealed class RateLimiterStrategy : Strategy
             retryAfter,
             metadata,
             _permitCount,
-            context.StrategyIndex,
             context);
         try
         {

--- a/src/Kevlar.Testing/CallbackKind.cs
+++ b/src/Kevlar.Testing/CallbackKind.cs
@@ -17,4 +17,7 @@ public enum CallbackKind
 
     /// <summary>A circuit-breaker transition callback.</summary>
     CircuitTransition,
+
+    /// <summary>A circuit-breaker break-duration callback.</summary>
+    CircuitBreakDuration,
 }

--- a/src/Kevlar.Testing/CallbackRecord.cs
+++ b/src/Kevlar.Testing/CallbackRecord.cs
@@ -7,6 +7,7 @@ public sealed class CallbackRecord
         long sequence,
         CallbackKind kind,
         string? shieldName = null,
+        int? strategyIndex = null,
         int? retryNumber = null,
         int? attemptNumber = null,
         TimeSpan? delay = null,
@@ -14,11 +15,15 @@ public sealed class CallbackRecord
         Exception? exception = null,
         object? result = null,
         CircuitState? from = null,
-        CircuitState? to = null)
+        CircuitState? to = null,
+        double? failureRate = null,
+        long? failureCount = null,
+        int? consecutiveFailures = null)
     {
         Sequence = sequence;
         Kind = kind;
         ShieldName = shieldName;
+        StrategyIndex = strategyIndex;
         RetryNumber = retryNumber;
         AttemptNumber = attemptNumber;
         Delay = delay;
@@ -27,6 +32,9 @@ public sealed class CallbackRecord
         Result = result;
         From = from;
         To = to;
+        FailureRate = failureRate;
+        FailureCount = failureCount;
+        ConsecutiveFailures = consecutiveFailures;
     }
 
     /// <summary>The recorder-wide sequence number.</summary>
@@ -37,6 +45,9 @@ public sealed class CallbackRecord
 
     /// <summary>The shield name copied from the callback context, when available.</summary>
     public string? ShieldName { get; }
+
+    /// <summary>The zero-based strategy position copied from the callback context.</summary>
+    public int? StrategyIndex { get; }
 
     /// <summary>The 1-based retry number, when this is a retry callback.</summary>
     public int? RetryNumber { get; }
@@ -62,10 +73,20 @@ public sealed class CallbackRecord
     /// <summary>The circuit state entered, when applicable.</summary>
     public CircuitState? To { get; }
 
+    /// <summary>The circuit failure ratio, when this is a break-duration callback.</summary>
+    public double? FailureRate { get; }
+
+    /// <summary>The circuit failure count, when this is a break-duration callback.</summary>
+    public long? FailureCount { get; }
+
+    /// <summary>The consecutive circuit failure count, when this is a break-duration callback.</summary>
+    public int? ConsecutiveFailures { get; }
+
     internal CallbackRecord WithSequence(long sequence) => new(
         sequence,
         Kind,
         ShieldName,
+        strategyIndex: StrategyIndex,
         retryNumber: RetryNumber,
         attemptNumber: AttemptNumber,
         delay: Delay,
@@ -73,5 +94,8 @@ public sealed class CallbackRecord
         exception: Exception,
         result: Result,
         from: From,
-        to: To);
+        to: To,
+        failureRate: FailureRate,
+        failureCount: FailureCount,
+        consecutiveFailures: ConsecutiveFailures);
 }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -111,6 +111,7 @@ static Kevlar.Testing.ShieldStateSnapshotExtensions.GetStateSnapshot(this Kevlar
 static Kevlar.Testing.ShieldStateSnapshotExtensions.GetStateSnapshot<TResult>(this Kevlar.Shield<TResult>! shield) -> Kevlar.Testing.ShieldStateSnapshot!
 Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.CircuitTransition = 4 -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackKind.CircuitBreakDuration = 5 -> Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.Fallback = 3 -> Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.Hedge = 2 -> Kevlar.Testing.CallbackKind
 Kevlar.Testing.CallbackKind.Retry = 0 -> Kevlar.Testing.CallbackKind
@@ -121,6 +122,10 @@ Kevlar.Testing.CallbackRecord.Delay.get -> System.TimeSpan?
 Kevlar.Testing.CallbackRecord.Exception.get -> System.Exception?
 Kevlar.Testing.CallbackRecord.From.get -> Kevlar.CircuitState?
 Kevlar.Testing.CallbackRecord.Kind.get -> Kevlar.Testing.CallbackKind
+Kevlar.Testing.CallbackRecord.ConsecutiveFailures.get -> int?
+Kevlar.Testing.CallbackRecord.FailureCount.get -> long?
+Kevlar.Testing.CallbackRecord.FailureRate.get -> double?
+Kevlar.Testing.CallbackRecord.StrategyIndex.get -> int?
 Kevlar.Testing.CallbackRecord.RetryNumber.get -> int?
 Kevlar.Testing.CallbackRecord.Result.get -> object?
 Kevlar.Testing.CallbackRecord.Sequence.get -> long
@@ -136,12 +141,14 @@ Kevlar.Testing.TelemetryRecorder
 Kevlar.Testing.TelemetryRecorder.Callbacks.get -> System.Collections.Generic.IReadOnlyList<Kevlar.Testing.CallbackRecord!>!
 Kevlar.Testing.TelemetryRecorder.Dispose() -> void
 Kevlar.Testing.TelemetryRecorder.Metrics.get -> System.Collections.Generic.IReadOnlyList<Kevlar.Testing.MetricRecord!>!
-Kevlar.Testing.TelemetryRecorder.Record(Kevlar.CircuitStateChangedEvent item) -> void
+Kevlar.Testing.TelemetryRecorder.Record(Kevlar.CircuitBreakerStateChangedEvent item) -> void
+Kevlar.Testing.TelemetryRecorder.Record(Kevlar.CircuitBreakerBreakDurationEvent item, System.TimeSpan breakDuration) -> System.Threading.Tasks.ValueTask<System.TimeSpan>
 Kevlar.Testing.TelemetryRecorder.Record(Kevlar.FallbackEvent item) -> void
 Kevlar.Testing.TelemetryRecorder.Record(Kevlar.HedgeEvent item) -> void
 Kevlar.Testing.TelemetryRecorder.Record(Kevlar.RetryEvent item) -> void
 Kevlar.Testing.TelemetryRecorder.Record(Kevlar.TimeoutEvent item) -> void
 Kevlar.Testing.TelemetryRecorder.Record<TResult>(Kevlar.FallbackEvent<TResult> item) -> void
+Kevlar.Testing.TelemetryRecorder.Record<TResult>(Kevlar.CircuitBreakerBreakDurationEvent<TResult> item, System.TimeSpan breakDuration) -> System.Threading.Tasks.ValueTask<System.TimeSpan>
 Kevlar.Testing.TelemetryRecorder.Record<TResult>(Kevlar.RetryEvent<TResult> item) -> void
 Kevlar.Testing.TelemetryRecorder.TelemetryRecorder(bool captureMetrics = true) -> void
 Kevlar.Testing.TelemetryRecorder.WaitForCallbackCountAsync(int count, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Kevlar.Testing/TelemetryRecorder.cs
+++ b/src/Kevlar.Testing/TelemetryRecorder.cs
@@ -74,35 +74,69 @@ public sealed class TelemetryRecorder : IDisposable
 
     /// <summary>Records an untyped retry callback.</summary>
     public void Record(RetryEvent item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Retry, item.Context.ShieldName, retryNumber: item.RetryNumber,
+        0, CallbackKind.Retry, item.Context.ShieldName,
+        strategyIndex: item.Context.StrategyIndex, retryNumber: item.RetryNumber,
         delay: item.Delay, exception: item.Exception, result: item.Result));
 
     /// <summary>Records a typed retry callback.</summary>
     public void Record<TResult>(RetryEvent<TResult> item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Retry, item.Context.ShieldName, retryNumber: item.RetryNumber,
+        0, CallbackKind.Retry, item.Context.ShieldName,
+        strategyIndex: item.Context.StrategyIndex, retryNumber: item.RetryNumber,
         delay: item.Delay, exception: item.Outcome.Exception, result: item.Outcome.Result));
 
     /// <summary>Records a timeout callback.</summary>
     public void Record(TimeoutEvent item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Timeout, item.Context.ShieldName, timeout: item.Timeout));
+        0, CallbackKind.Timeout, item.Context.ShieldName,
+        strategyIndex: item.Context.StrategyIndex, timeout: item.Timeout));
 
     /// <summary>Records a hedge callback.</summary>
     public void Record(HedgeEvent item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Hedge, item.Context.ShieldName, attemptNumber: item.AttemptNumber));
+        0, CallbackKind.Hedge, item.Context.ShieldName,
+        strategyIndex: item.Context.StrategyIndex, attemptNumber: item.AttemptNumber));
 
     /// <summary>Records an untyped fallback callback.</summary>
     public void Record(FallbackEvent item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.Fallback, item.Context.ShieldName, exception: item.Exception));
+        0, CallbackKind.Fallback, item.Context.ShieldName,
+        strategyIndex: item.Context.StrategyIndex, exception: item.Exception));
 
     /// <summary>Records a typed fallback callback.</summary>
     public void Record<TResult>(FallbackEvent<TResult> item) => AddCallback(new CallbackRecord(
         0, CallbackKind.Fallback, item.Context.ShieldName,
+        strategyIndex: item.Context.StrategyIndex,
         exception: item.Outcome.Exception, result: item.Outcome.Result));
 
     /// <summary>Records a circuit-breaker transition callback.</summary>
-    public void Record(CircuitStateChangedEvent item) => AddCallback(new CallbackRecord(
-        0, CallbackKind.CircuitTransition, exception: item.LastException,
+    public void Record(CircuitBreakerStateChangedEvent item) => AddCallback(new CallbackRecord(
+        0, CallbackKind.CircuitTransition, shieldName: item.Context.ShieldName,
+        strategyIndex: item.Context.StrategyIndex,
+        exception: item.LastException,
         from: item.From, to: item.To));
+
+    /// <summary>Records an untyped circuit-breaker break-duration callback.</summary>
+    public ValueTask<TimeSpan> Record(
+        CircuitBreakerBreakDurationEvent item,
+        TimeSpan breakDuration) =>
+        RecordBreakDuration(
+            item.Context,
+            item.Exception,
+            item.Result,
+            item.FailureRate,
+            item.FailureCount,
+            item.ConsecutiveFailures,
+            breakDuration);
+
+    /// <summary>Records a typed circuit-breaker break-duration callback.</summary>
+    public ValueTask<TimeSpan> Record<TResult>(
+        CircuitBreakerBreakDurationEvent<TResult> item,
+        TimeSpan breakDuration) =>
+        RecordBreakDuration(
+            item.Context,
+            item.Outcome.Exception,
+            item.Outcome.Result,
+            item.FailureRate,
+            item.FailureCount,
+            item.ConsecutiveFailures,
+            breakDuration);
 
     /// <summary>Waits until at least <paramref name="count"/> metrics have been captured.</summary>
     public Task WaitForMetricCountAsync(int count, CancellationToken cancellationToken = default) =>
@@ -185,6 +219,28 @@ public sealed class TelemetryRecorder : IDisposable
         }
 
         signal.TrySetResult(true);
+    }
+
+    private ValueTask<TimeSpan> RecordBreakDuration(
+        KevlarContext context,
+        Exception? exception,
+        object? result,
+        double failureRate,
+        long failureCount,
+        int consecutiveFailures,
+        TimeSpan breakDuration)
+    {
+        AddCallback(new CallbackRecord(
+            0,
+            CallbackKind.CircuitBreakDuration,
+            context.ShieldName,
+            strategyIndex: context.StrategyIndex,
+            exception: exception,
+            result: result,
+            failureRate: failureRate,
+            failureCount: failureCount,
+            consecutiveFailures: consecutiveFailures));
+        return new ValueTask<TimeSpan>(breakDuration);
     }
 
     private async Task WaitForCountAsync(

--- a/src/Kevlar/Internal/EventContext.cs
+++ b/src/Kevlar/Internal/EventContext.cs
@@ -1,0 +1,8 @@
+namespace Kevlar.Internal;
+
+internal static class EventContext
+{
+    internal static KevlarContext Required(KevlarContext? context) =>
+        context ?? throw new InvalidOperationException(
+            "A default strategy event has no execution context.");
+}

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -27,6 +27,7 @@ public sealed class KevlarContext
     private CancellationToken _cancellationToken;
     private bool _isSynchronous;
     private string? _shieldName;
+    private int _strategyIndex = -1;
     private TimeProvider _timeProvider = TimeProvider.System;
 
 #if DEBUG
@@ -77,7 +78,20 @@ public sealed class KevlarContext
         internal set => _shieldName = value;
     }
 
-    internal int StrategyIndex { get; set; }
+    /// <summary>
+    /// The zero-based position of the strategy currently executing, or <c>-1</c> outside a
+    /// strategy. Nested strategies temporarily replace this value and restore it on return.
+    /// </summary>
+    public int StrategyIndex
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _strategyIndex;
+        }
+
+        internal set => _strategyIndex = value;
+    }
 
     /// <summary>The time provider used for delays, timeouts and time-window calculations.</summary>
     public TimeProvider TimeProvider
@@ -122,6 +136,9 @@ public sealed class KevlarContext
         MarkReturned(context);
         Pool.Return(context);
     }
+
+    /// <summary>Creates the detached context used by manual circuit-breaker transitions.</summary>
+    internal static KevlarContext CreateManual() => new();
 
     /// <summary>
     /// Creates a detached copy of this context for a concurrent attempt (used by hedging).

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -140,6 +140,21 @@ public sealed class KevlarContext
     /// <summary>Creates the detached context used by manual circuit-breaker transitions.</summary>
     internal static KevlarContext CreateManual() => new();
 
+    /// <summary>Creates a detached snapshot for an event that may outlive this pooled context.</summary>
+    internal KevlarContext CreateDetachedSnapshot()
+    {
+        var snapshot = new KevlarContext
+        {
+            CancellationToken = CancellationToken,
+            IsSynchronous = IsSynchronous,
+            TimeProvider = TimeProvider,
+            ShieldName = ShieldName,
+            StrategyIndex = StrategyIndex,
+        };
+        Properties.CopyTo(snapshot.Properties);
+        return snapshot;
+    }
+
     /// <summary>
     /// Creates a detached copy of this context for a concurrent attempt (used by hedging).
     /// The copy shares no mutable state with the original.

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -25,6 +25,7 @@ public sealed class KevlarContext
     private readonly KevlarProperties _properties = new();
 
     private CancellationToken _cancellationToken;
+    private long _activeStrategyMask;
     private bool _isSynchronous;
     private string? _shieldName;
     private int _strategyIndex = -1;
@@ -168,6 +169,37 @@ public sealed class KevlarContext
         return fork;
     }
 
+    internal bool TryEnterStrategy(int strategyIndex)
+    {
+        var bit = 1L << (strategyIndex & 63);
+        while (true)
+        {
+            var current = Volatile.Read(ref _activeStrategyMask);
+            if ((current & bit) != 0)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _activeStrategyMask, current | bit, current) == current)
+            {
+                return true;
+            }
+        }
+    }
+
+    internal void ExitStrategy(int strategyIndex)
+    {
+        var bit = ~(1L << (strategyIndex & 63));
+        while (true)
+        {
+            var current = Volatile.Read(ref _activeStrategyMask);
+            if (Interlocked.CompareExchange(ref _activeStrategyMask, current & bit, current) == current)
+            {
+                return;
+            }
+        }
+    }
+
     /// <summary>
     /// Clears the debug pooling guard on a context that Kevlar's own pool tests inspect after it
     /// went back to the pool. A no-op in release builds, where the guard does not exist.
@@ -216,6 +248,7 @@ public sealed class KevlarContext
             context.IsSynchronous = false;
             context.ShieldName = null;
             context.StrategyIndex = -1;
+            context._activeStrategyMask = 0;
             context.TimeProvider = TimeProvider.System;
             context._properties.Clear();
             return true;

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -43,14 +43,40 @@ Kevlar.Shield<TResult>.InvokesContinuationAtMostOnce.get -> bool
 Kevlar.CircuitBreakerBreakDurationEvent
 Kevlar.CircuitBreakerBreakDurationEvent.CircuitBreakerBreakDurationEvent() -> void
 Kevlar.CircuitBreakerBreakDurationEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.CircuitBreakerBreakDurationEvent.ConsecutiveFailures.get -> int
 Kevlar.CircuitBreakerBreakDurationEvent.Exception.get -> System.Exception?
+Kevlar.CircuitBreakerBreakDurationEvent.FailureCount.get -> long
+Kevlar.CircuitBreakerBreakDurationEvent.FailureRate.get -> double
 Kevlar.CircuitBreakerBreakDurationEvent.Result.get -> object?
+Kevlar.CircuitBreakerBreakDurationEvent<TResult>
+Kevlar.CircuitBreakerBreakDurationEvent<TResult>.CircuitBreakerBreakDurationEvent() -> void
+Kevlar.CircuitBreakerBreakDurationEvent<TResult>.ConsecutiveFailures.get -> int
+Kevlar.CircuitBreakerBreakDurationEvent<TResult>.Context.get -> Kevlar.KevlarContext!
+Kevlar.CircuitBreakerBreakDurationEvent<TResult>.FailureCount.get -> long
+Kevlar.CircuitBreakerBreakDurationEvent<TResult>.FailureRate.get -> double
+Kevlar.CircuitBreakerBreakDurationEvent<TResult>.Outcome.get -> Kevlar.Outcome<TResult>
+Kevlar.CircuitBreakerMonitor.StateChanged -> System.Action<Kevlar.CircuitBreakerStateChangedEvent>?
 Kevlar.CircuitBreakerMonitor.IsolateAsync() -> System.Threading.Tasks.ValueTask
 Kevlar.CircuitBreakerMonitor.ResetAsync() -> System.Threading.Tasks.ValueTask
 Kevlar.CircuitBreakerOptions.BreakDurationGenerator.get -> System.Func<Kevlar.CircuitBreakerBreakDurationEvent, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
 Kevlar.CircuitBreakerOptions.BreakDurationGenerator.set -> void
-Kevlar.CircuitBreakerOptions.OnStateChangedAsync.get -> System.Func<Kevlar.CircuitStateChangedEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.CircuitBreakerOptions.OnStateChanged.get -> System.Action<Kevlar.CircuitBreakerStateChangedEvent>?
+Kevlar.CircuitBreakerOptions.OnStateChangedAsync.get -> System.Func<Kevlar.CircuitBreakerStateChangedEvent, System.Threading.Tasks.ValueTask>?
 Kevlar.CircuitBreakerOptions.OnStateChangedAsync.set -> void
+Kevlar.CircuitBreakerStateChangedEvent
+Kevlar.CircuitBreakerStateChangedEvent.CircuitBreakerStateChangedEvent() -> void
+Kevlar.CircuitBreakerStateChangedEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.CircuitBreakerStateChangedEvent.From.get -> Kevlar.CircuitState
+Kevlar.CircuitBreakerStateChangedEvent.LastException.get -> System.Exception?
+Kevlar.CircuitBreakerStateChangedEvent.To.get -> Kevlar.CircuitState
+Kevlar.KevlarContext.StrategyIndex.get -> int
+*REMOVED*Kevlar.CircuitBreakerMonitor.StateChanged -> System.Action<Kevlar.CircuitStateChangedEvent>?
+*REMOVED*Kevlar.CircuitBreakerOptions.OnStateChanged.get -> System.Action<Kevlar.CircuitStateChangedEvent>?
+*REMOVED*Kevlar.CircuitStateChangedEvent
+*REMOVED*Kevlar.CircuitStateChangedEvent.CircuitStateChangedEvent() -> void
+*REMOVED*Kevlar.CircuitStateChangedEvent.From.get -> Kevlar.CircuitState
+*REMOVED*Kevlar.CircuitStateChangedEvent.LastException.get -> System.Exception?
+*REMOVED*Kevlar.CircuitStateChangedEvent.To.get -> Kevlar.CircuitState
 Kevlar.Outcome<T>.TryGetResult(out T result) -> bool
 Kevlar.Shield.ExecuteOutcomeAsync<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<T>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<T>>
 Kevlar.Shield<TResult>.ExecuteOutcomeAsync<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>! action, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<Kevlar.Outcome<TResult>>
@@ -177,7 +203,7 @@ Kevlar.ConcurrencyLimitRejectedEvent.ConcurrencyLimitRejectedEvent() -> void
 Kevlar.ConcurrencyLimitRejectedEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.ConcurrencyLimitRejectedEvent.MaxConcurrency.get -> int
 Kevlar.ConcurrencyLimitRejectedEvent.QueueLimit.get -> int
-Kevlar.ConcurrencyLimitRejectedEvent.StrategyIndex.get -> int
+*REMOVED*Kevlar.ConcurrencyLimitRejectedEvent.StrategyIndex.get -> int
 Kevlar.RateLimitOptions.OnRejected.get -> System.Action<Kevlar.RateLimitRejectedEvent>?
 Kevlar.RateLimitOptions.OnRejected.set -> void
 Kevlar.RateLimitOptions.OnRejectedAsync.get -> System.Func<Kevlar.RateLimitRejectedEvent, System.Threading.Tasks.ValueTask>?
@@ -189,7 +215,7 @@ Kevlar.RateLimitRejectedEvent.Context.get -> Kevlar.KevlarContext!
 Kevlar.RateLimitRejectedEvent.Permits.get -> int
 Kevlar.RateLimitRejectedEvent.QueueLimit.get -> int
 Kevlar.RateLimitRejectedEvent.RetryAfter.get -> System.TimeSpan?
-Kevlar.RateLimitRejectedEvent.StrategyIndex.get -> int
+*REMOVED*Kevlar.RateLimitRejectedEvent.StrategyIndex.get -> int
 Kevlar.RateLimitRejectedEvent.Window.get -> System.TimeSpan
 Kevlar.ShieldBuilder.ConcurrencyLimit(System.Action<Kevlar.ConcurrencyLimitOptions!>! configure) -> Kevlar.Shield!
 Kevlar.ShieldBuilder.RateLimit(System.Action<Kevlar.RateLimitOptions!>! configure) -> Kevlar.Shield!
@@ -310,7 +336,7 @@ static Kevlar.KevlarKey<T>.operator !=(Kevlar.KevlarKey<T> left, Kevlar.KevlarKe
 static Kevlar.KevlarKey<T>.operator ==(Kevlar.KevlarKey<T> left, Kevlar.KevlarKey<T> right) -> bool
 Kevlar.CircuitBreakerOptions<TResult>.BreakDuration.get -> System.TimeSpan
 Kevlar.CircuitBreakerOptions<TResult>.BreakDuration.set -> void
-Kevlar.CircuitBreakerOptions<TResult>.BreakDurationGenerator.get -> System.Func<Kevlar.CircuitBreakerBreakDurationEvent, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Kevlar.CircuitBreakerOptions<TResult>.BreakDurationGenerator.get -> System.Func<Kevlar.CircuitBreakerBreakDurationEvent<TResult>, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
 Kevlar.CircuitBreakerOptions<TResult>.BreakDurationGenerator.set -> void
 Kevlar.CircuitBreakerOptions<TResult>.ConsecutiveFailures.get -> int?
 Kevlar.CircuitBreakerOptions<TResult>.ConsecutiveFailures.set -> void
@@ -322,9 +348,9 @@ Kevlar.CircuitBreakerOptions<TResult>.MinimumThroughput.get -> int
 Kevlar.CircuitBreakerOptions<TResult>.MinimumThroughput.set -> void
 Kevlar.CircuitBreakerOptions<TResult>.Monitor.get -> Kevlar.CircuitBreakerMonitor?
 Kevlar.CircuitBreakerOptions<TResult>.Monitor.set -> void
-Kevlar.CircuitBreakerOptions<TResult>.OnStateChanged.get -> System.Action<Kevlar.CircuitStateChangedEvent>?
+Kevlar.CircuitBreakerOptions<TResult>.OnStateChanged.get -> System.Action<Kevlar.CircuitBreakerStateChangedEvent>?
 Kevlar.CircuitBreakerOptions<TResult>.OnStateChanged.set -> void
-Kevlar.CircuitBreakerOptions<TResult>.OnStateChangedAsync.get -> System.Func<Kevlar.CircuitStateChangedEvent, System.Threading.Tasks.ValueTask>?
+Kevlar.CircuitBreakerOptions<TResult>.OnStateChangedAsync.get -> System.Func<Kevlar.CircuitBreakerStateChangedEvent, System.Threading.Tasks.ValueTask>?
 Kevlar.CircuitBreakerOptions<TResult>.OnStateChangedAsync.set -> void
 Kevlar.CircuitBreakerOptions<TResult>.SamplingWindow.get -> System.TimeSpan
 Kevlar.CircuitBreakerOptions<TResult>.SamplingWindow.set -> void

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -630,7 +630,11 @@ public sealed class Shield
         StrategyNode? next = null;
         for (var i = strategies.Length - 1; i >= 0; i--)
         {
-            next = new StrategyNode(strategies[i], next, i);
+            next = new StrategyNode(
+                strategies[i],
+                next,
+                i,
+                i > 0 && strategies[i - 1].RequiresContinuationOverlapIsolation);
         }
 
         return next;

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationEvent.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationEvent.cs
@@ -8,10 +8,16 @@ public readonly struct CircuitBreakerBreakDurationEvent
     internal CircuitBreakerBreakDurationEvent(
         Exception? exception,
         object? result,
+        double failureRate,
+        long failureCount,
+        int consecutiveFailures,
         KevlarContext context)
     {
         Exception = exception;
         Result = result;
+        FailureRate = failureRate;
+        FailureCount = failureCount;
+        ConsecutiveFailures = consecutiveFailures;
         _context = context;
     }
 
@@ -21,10 +27,59 @@ public readonly struct CircuitBreakerBreakDurationEvent
     /// <summary>The handled result (boxed), or <see langword="null"/> when an exception occurred.</summary>
     public object? Result { get; }
 
+    /// <summary>The handled-failure ratio when the circuit opened.</summary>
+    public double FailureRate { get; }
+
+    /// <summary>The handled-failure count when the circuit opened.</summary>
+    public long FailureCount { get; }
+
+    /// <summary>The consecutive handled-failure count when the circuit opened.</summary>
+    public int ConsecutiveFailures { get; }
+
     /// <summary>
     /// The ambient execution context. It is pooled; do not retain it or its property bag after
     /// the callback completes.
     /// </summary>
-    public KevlarContext Context => _context
-        ?? throw new InvalidOperationException("A default break-duration event has no execution context.");
+    public KevlarContext Context => Internal.EventContext.Required(_context);
+}
+
+/// <summary>
+/// Describes the typed handled outcome that is about to open a circuit.
+/// </summary>
+/// <typeparam name="TResult">The shield result type.</typeparam>
+public readonly struct CircuitBreakerBreakDurationEvent<TResult>
+{
+    private readonly KevlarContext? _context;
+
+    internal CircuitBreakerBreakDurationEvent(
+        Outcome<TResult> outcome,
+        double failureRate,
+        long failureCount,
+        int consecutiveFailures,
+        KevlarContext context)
+    {
+        Outcome = outcome;
+        FailureRate = failureRate;
+        FailureCount = failureCount;
+        ConsecutiveFailures = consecutiveFailures;
+        _context = context;
+    }
+
+    /// <summary>The handled outcome that opened the circuit.</summary>
+    public Outcome<TResult> Outcome { get; }
+
+    /// <summary>The handled-failure ratio when the circuit opened.</summary>
+    public double FailureRate { get; }
+
+    /// <summary>The handled-failure count when the circuit opened.</summary>
+    public long FailureCount { get; }
+
+    /// <summary>The consecutive handled-failure count when the circuit opened.</summary>
+    public int ConsecutiveFailures { get; }
+
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it or its property bag after
+    /// the callback completes.
+    /// </summary>
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationGenerator.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerBreakDurationGenerator.cs
@@ -1,0 +1,59 @@
+namespace Kevlar.Strategies;
+
+internal sealed class CircuitBreakerBreakDurationGenerator
+{
+    private readonly Delegate _generator;
+    private readonly Type? _resultType;
+
+    private CircuitBreakerBreakDurationGenerator(Delegate generator, Type? resultType)
+    {
+        _generator = generator;
+        _resultType = resultType;
+    }
+
+    internal static CircuitBreakerBreakDurationGenerator Create(
+        Func<CircuitBreakerBreakDurationEvent, ValueTask<TimeSpan>> generator) =>
+        new(generator, resultType: null);
+
+    internal static CircuitBreakerBreakDurationGenerator Create<TResult>(
+        Func<CircuitBreakerBreakDurationEvent<TResult>, ValueTask<TimeSpan>> generator) =>
+        new(generator, typeof(TResult));
+
+    internal ValueTask<TimeSpan> Invoke<TResult>(
+        in Outcome<TResult> outcome,
+        in CircuitBreakerFailureStatistics statistics,
+        KevlarContext context)
+    {
+        if (_resultType is null)
+        {
+            var item = new CircuitBreakerBreakDurationEvent(
+                outcome.Exception,
+                outcome.Exception is null ? outcome.Result : null,
+                statistics.FailureRate,
+                statistics.FailureCount,
+                statistics.ConsecutiveFailures,
+                context);
+            return ((Func<CircuitBreakerBreakDurationEvent, ValueTask<TimeSpan>>)_generator)(item);
+        }
+
+        if (_resultType != typeof(TResult))
+        {
+            throw new InvalidOperationException(
+                $"The circuit-breaker break-duration generator was created for '{_resultType}', " +
+                $"but this execution returns '{typeof(TResult)}'.");
+        }
+
+        var typedItem = new CircuitBreakerBreakDurationEvent<TResult>(
+            outcome,
+            statistics.FailureRate,
+            statistics.FailureCount,
+            statistics.ConsecutiveFailures,
+            context);
+        return ((Func<CircuitBreakerBreakDurationEvent<TResult>, ValueTask<TimeSpan>>)_generator)(typedItem);
+    }
+}
+
+internal readonly record struct CircuitBreakerFailureStatistics(
+    double FailureRate,
+    long FailureCount,
+    int ConsecutiveFailures);

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -782,6 +782,7 @@ internal sealed class CircuitBreakerCore
             {
                 if (!parent.ObserversCompleted)
                 {
+                    publication.DetachContext();
                     publication.Parent = parent;
                     parent.PendingChildren++;
                     return default;
@@ -806,6 +807,7 @@ internal sealed class CircuitBreakerCore
         }
         else if (Volatile.Read(ref _publishingThreadId) == Environment.CurrentManagedThreadId)
         {
+            publication.DetachContext();
             publication.Parent = _activePublication;
             _activePublication!.PendingChildren++;
         }
@@ -1103,7 +1105,7 @@ internal sealed class CircuitBreakerCore
 
     private sealed class TransitionPublication(CircuitBreakerStateChangedEvent stateChange)
     {
-        public CircuitBreakerStateChangedEvent StateChange { get; } = stateChange;
+        public CircuitBreakerStateChangedEvent StateChange { get; private set; } = stateChange;
 
         public TaskCompletionSource<bool> Completion { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1117,6 +1119,8 @@ internal sealed class CircuitBreakerCore
         public bool ObserversCompleted { get; set; }
 
         public Exception? Failure { get; set; }
+
+        public void DetachContext() => StateChange = StateChange.WithDetachedContext();
 
         public void ThrowIfFailed()
         {

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -24,9 +24,9 @@ internal sealed class CircuitBreakerCore
     private readonly TimeSpan _breakDuration;
     private readonly double _breakDurationTimestampUnits;
     private readonly Action<CircuitState> _recordState;
-    private readonly Func<CircuitBreakerBreakDurationEvent, ValueTask<TimeSpan>>? _breakDurationGenerator;
-    private readonly Action<CircuitStateChangedEvent>? _onStateChanged;
-    private readonly Func<CircuitStateChangedEvent, ValueTask>? _onStateChangedAsync;
+    private readonly CircuitBreakerBreakDurationGenerator? _breakDurationGenerator;
+    private readonly Action<CircuitBreakerStateChangedEvent>? _onStateChanged;
+    private readonly Func<CircuitBreakerStateChangedEvent, ValueTask>? _onStateChangedAsync;
     private readonly CircuitBreakerMonitor? _monitor;
     private readonly Queue<TransitionPublication> _pendingTransitions = new();
     private readonly AsyncLocal<TransitionPublication?>? _ambientPublication;
@@ -50,7 +50,10 @@ internal sealed class CircuitBreakerCore
     private int _publishingThreadId;
     private TransitionPublication? _activePublication;
 
-    public CircuitBreakerCore(CircuitBreakerOptions options, Action<CircuitState> recordState)
+    public CircuitBreakerCore(
+        CircuitBreakerOptions options,
+        CircuitBreakerBreakDurationGenerator? breakDurationGenerator,
+        Action<CircuitState> recordState)
     {
         Throw.IfOutOfRange(options.ConsecutiveFailures is <= 0, nameof(options.ConsecutiveFailures), "ConsecutiveFailures must be positive.");
         Throw.IfOutOfRange(
@@ -76,7 +79,7 @@ internal sealed class CircuitBreakerCore
         _breakDuration = options.BreakDuration;
         _breakDurationTimestampUnits = options.BreakDuration.TotalSeconds * Stopwatch.Frequency;
         _recordState = recordState;
-        _breakDurationGenerator = options.BreakDurationGenerator;
+        _breakDurationGenerator = breakDurationGenerator;
         _onStateChanged = options.OnStateChanged;
         _onStateChangedAsync = options.OnStateChangedAsync;
         _ambientPublication = options.OnStateChangedAsync is null
@@ -130,10 +133,16 @@ internal sealed class CircuitBreakerCore
     /// </summary>
     public bool TryEnter(
         TimeProvider timeProvider,
+        KevlarContext context,
         out CircuitOpenException? rejection,
         out long admittedProbeGeneration)
     {
-        var allowed = TryEnterCore(timeProvider, out rejection, out var transition, out admittedProbeGeneration);
+        var allowed = TryEnterCore(
+            timeProvider,
+            context,
+            out rejection,
+            out var transition,
+            out admittedProbeGeneration);
 
         try
         {
@@ -152,10 +161,11 @@ internal sealed class CircuitBreakerCore
         return allowed;
     }
 
-    public ValueTask<EntryResult> TryEnterAsync(TimeProvider timeProvider)
+    public ValueTask<EntryResult> TryEnterAsync(TimeProvider timeProvider, KevlarContext context)
     {
         var allowed = TryEnterCore(
             timeProvider,
+            context,
             out var rejection,
             out var transition,
             out var admittedProbeGeneration);
@@ -190,6 +200,7 @@ internal sealed class CircuitBreakerCore
 
     private bool TryEnterCore(
         TimeProvider timeProvider,
+        KevlarContext context,
         out CircuitOpenException? rejection,
         out TransitionPublication? transition,
         out long admittedProbeGeneration)
@@ -220,7 +231,7 @@ internal sealed class CircuitBreakerCore
                         return false;
                     }
 
-                    transition = ChangeState(CircuitState.HalfOpen);
+                    transition = ChangeState(CircuitState.HalfOpen, context);
                     _probeInFlight = true;
                     admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
                     return true;
@@ -267,15 +278,17 @@ internal sealed class CircuitBreakerCore
         CircuitOpenException? Rejection,
         long AdmittedProbeGeneration);
 
-    public void RecordSuccess(TimeProvider timeProvider)
+    public void RecordSuccess(TimeProvider timeProvider, KevlarContext context)
     {
-        Publish(RecordSuccessCore(timeProvider));
+        Publish(RecordSuccessCore(timeProvider, context));
     }
 
-    public ValueTask RecordSuccessAsync(TimeProvider timeProvider) =>
-        PublishAsync(RecordSuccessCore(timeProvider));
+    public ValueTask RecordSuccessAsync(TimeProvider timeProvider, KevlarContext context) =>
+        PublishAsync(RecordSuccessCore(timeProvider, context));
 
-    private TransitionPublication? RecordSuccessCore(TimeProvider timeProvider)
+    private TransitionPublication? RecordSuccessCore(
+        TimeProvider timeProvider,
+        KevlarContext context)
     {
         lock (_gate)
         {
@@ -284,7 +297,7 @@ internal sealed class CircuitBreakerCore
                 _probeInFlight = false;
                 CancelPendingOpening();
                 ResetMetrics();
-                return ChangeState(CircuitState.Closed);
+                return ChangeState(CircuitState.Closed, context);
             }
 
             if (_state == CircuitState.Closed)
@@ -300,9 +313,12 @@ internal sealed class CircuitBreakerCore
         }
     }
 
-    public void RecordFailure(TimeProvider timeProvider, Exception? exception)
+    public void RecordFailure(
+        TimeProvider timeProvider,
+        Exception? exception,
+        KevlarContext context)
     {
-        Publish(RecordFailureCore(timeProvider, exception));
+        Publish(RecordFailureCore(timeProvider, exception, context));
     }
 
     public ValueTask RecordFailureAsync<T>(
@@ -312,10 +328,14 @@ internal sealed class CircuitBreakerCore
     {
         if (_breakDurationGenerator is null)
         {
-            return PublishAsync(RecordFailureCore(timeProvider, outcome.Exception));
+            return PublishAsync(RecordFailureCore(timeProvider, outcome.Exception, context));
         }
 
-        if (!TryReserveDynamicOpening(timeProvider, outcome.Exception, out var reservation))
+        if (!TryReserveDynamicOpening(
+                timeProvider,
+                outcome.Exception,
+                context,
+                out var reservation))
         {
             return default;
         }
@@ -323,11 +343,11 @@ internal sealed class CircuitBreakerCore
         ValueTask<TimeSpan> generation;
         try
         {
-            var item = new CircuitBreakerBreakDurationEvent(
-                outcome.Exception,
-                outcome.Exception is null ? outcome.Result : null,
+            var statistics = reservation.Statistics;
+            generation = _breakDurationGenerator.Invoke(
+                in outcome,
+                in statistics,
                 context);
-            generation = _breakDurationGenerator(item);
         }
         catch
         {
@@ -355,7 +375,10 @@ internal sealed class CircuitBreakerCore
         return PublishAsync(CommitDynamicOpening(reservation, timeProvider, duration));
     }
 
-    private TransitionPublication? RecordFailureCore(TimeProvider timeProvider, Exception? exception)
+    private TransitionPublication? RecordFailureCore(
+        TimeProvider timeProvider,
+        Exception? exception,
+        KevlarContext context)
     {
         lock (_gate)
         {
@@ -365,7 +388,7 @@ internal sealed class CircuitBreakerCore
             {
                 _probeInFlight = false;
                 _openUntilTimestamp = GetCurrentTimestamp(timeProvider) + _breakDurationTimestampUnits;
-                return ChangeState(CircuitState.Open);
+                return ChangeState(CircuitState.Open, context);
             }
 
             if (_state == CircuitState.Closed)
@@ -374,7 +397,7 @@ internal sealed class CircuitBreakerCore
                     ? 0
                     : GetCurrentTimestamp(timeProvider);
 
-                if (IsTripped(timestamp))
+                if (RecordFailureAndCheckThreshold(timestamp, out _))
                 {
                     if (_failureRatio is null)
                     {
@@ -382,7 +405,7 @@ internal sealed class CircuitBreakerCore
                     }
 
                     _openUntilTimestamp = timestamp + _breakDurationTimestampUnits;
-                    return ChangeState(CircuitState.Open);
+                    return ChangeState(CircuitState.Open, context);
                 }
             }
 
@@ -393,6 +416,7 @@ internal sealed class CircuitBreakerCore
     private bool TryReserveDynamicOpening(
         TimeProvider timeProvider,
         Exception? exception,
+        KevlarContext context,
         out OpeningReservation reservation)
     {
         lock (_gate)
@@ -403,26 +427,48 @@ internal sealed class CircuitBreakerCore
             {
                 if (_state == CircuitState.Closed)
                 {
-                    _ = IsTripped(_failureRatio is null ? 0 : GetCurrentTimestamp(timeProvider));
+                    _ = RecordFailureAndCheckThreshold(
+                        _failureRatio is null ? 0 : GetCurrentTimestamp(timeProvider),
+                        out _);
                 }
 
                 return false;
             }
 
-            var shouldOpen = _state switch
+            CircuitBreakerFailureStatistics statistics;
+            bool shouldOpen;
+            if (_state == CircuitState.HalfOpen)
             {
-                CircuitState.HalfOpen => true,
-                CircuitState.Closed => IsTripped(
-                    _failureRatio is null ? 0 : GetCurrentTimestamp(timeProvider)),
-                _ => false,
-            };
+                statistics = new CircuitBreakerFailureStatistics(
+                    FailureRate: 1,
+                    FailureCount: 1,
+                    ConsecutiveFailures: 1);
+                shouldOpen = true;
+            }
+            else if (_state == CircuitState.Closed)
+            {
+                shouldOpen = RecordFailureAndCheckThreshold(
+                    _failureRatio is null ? 0 : GetCurrentTimestamp(timeProvider),
+                    out statistics);
+            }
+            else
+            {
+                statistics = default;
+                shouldOpen = false;
+            }
+
             if (!shouldOpen)
             {
                 return false;
             }
 
             _openingPending = true;
-            reservation = new OpeningReservation(++_openingGeneration, _state, exception);
+            reservation = new OpeningReservation(
+                ++_openingGeneration,
+                _state,
+                exception,
+                context,
+                statistics);
             return true;
         }
     }
@@ -466,7 +512,7 @@ internal sealed class CircuitBreakerCore
             _lastException = reservation.Exception;
             _openUntilTimestamp = GetCurrentTimestamp(timeProvider)
                 + (duration.TotalSeconds * Stopwatch.Frequency);
-            return ChangeState(CircuitState.Open);
+            return ChangeState(CircuitState.Open, reservation.Context);
         }
     }
 
@@ -500,7 +546,9 @@ internal sealed class CircuitBreakerCore
     private readonly record struct OpeningReservation(
         long Generation,
         CircuitState ExpectedState,
-        Exception? Exception);
+        Exception? Exception,
+        KevlarContext Context,
+        CircuitBreakerFailureStatistics Statistics);
 
     /// <summary>Releases a half-open probe slot without recording an outcome (e.g. the probe was cancelled).</summary>
     public void AbandonProbe(long probeGeneration)
@@ -529,7 +577,7 @@ internal sealed class CircuitBreakerCore
             _probeInFlight = false;
             return _state == CircuitState.Isolated
                 ? null
-                : ChangeState(CircuitState.Isolated);
+                : ChangeState(CircuitState.Isolated, KevlarContext.CreateManual());
         }
     }
 
@@ -549,15 +597,22 @@ internal sealed class CircuitBreakerCore
             _probeInFlight = false;
             return _state == CircuitState.Closed
                 ? null
-                : ChangeState(CircuitState.Closed);
+                : ChangeState(CircuitState.Closed, KevlarContext.CreateManual());
         }
     }
 
-    private bool IsTripped(double timestamp)
+    private bool RecordFailureAndCheckThreshold(
+        double timestamp,
+        out CircuitBreakerFailureStatistics statistics)
     {
+        _consecutiveFailures++;
         if (_consecutiveFailureLimit is { } limit)
         {
-            return ++_consecutiveFailures >= limit;
+            statistics = new CircuitBreakerFailureStatistics(
+                FailureRate: 1,
+                FailureCount: _consecutiveFailures,
+                ConsecutiveFailures: _consecutiveFailures);
+            return _consecutiveFailures >= limit;
         }
 
         var bucket = AdvanceBucket(timestamp);
@@ -570,7 +625,12 @@ internal sealed class CircuitBreakerCore
             total += _bucketFailures[i] + _bucketSuccesses[i];
         }
 
-        return total >= _minimumThroughput && (double)failures / total >= _failureRatio!.Value;
+        var failureRate = (double)failures / total;
+        statistics = new CircuitBreakerFailureStatistics(
+            failureRate,
+            failures,
+            _consecutiveFailures);
+        return total >= _minimumThroughput && failureRate >= _failureRatio!.Value;
     }
 
     private int AdvanceBucket(TimeProvider timeProvider) => AdvanceBucket(GetCurrentTimestamp(timeProvider));
@@ -667,9 +727,13 @@ internal sealed class CircuitBreakerCore
         public double TimestampScale { get; }
     }
 
-    private TransitionPublication ChangeState(CircuitState next)
+    private TransitionPublication ChangeState(CircuitState next, KevlarContext context)
     {
-        var transition = new CircuitStateChangedEvent(_state, next, _lastException);
+        var transition = new CircuitBreakerStateChangedEvent(
+            _state,
+            next,
+            _lastException,
+            context);
         _state = next;
         var publication = new TransitionPublication(transition);
         _pendingTransitions.Enqueue(publication);
@@ -925,7 +989,7 @@ internal sealed class CircuitBreakerCore
         CompletePublication(publication);
     }
 
-    private Exception? PublishObservers(CircuitStateChangedEvent stateChange)
+    private Exception? PublishObservers(CircuitBreakerStateChangedEvent stateChange)
     {
         Exception? failure = null;
         try
@@ -967,7 +1031,8 @@ internal sealed class CircuitBreakerCore
         return failure;
     }
 
-    private async ValueTask<Exception?> PublishObserversAsync(CircuitStateChangedEvent stateChange)
+    private async ValueTask<Exception?> PublishObserversAsync(
+        CircuitBreakerStateChangedEvent stateChange)
     {
         Exception? failure = null;
         try
@@ -1036,9 +1101,9 @@ internal sealed class CircuitBreakerCore
         };
     }
 
-    private sealed class TransitionPublication(CircuitStateChangedEvent stateChange)
+    private sealed class TransitionPublication(CircuitBreakerStateChangedEvent stateChange)
     {
-        public CircuitStateChangedEvent StateChange { get; } = stateChange;
+        public CircuitBreakerStateChangedEvent StateChange { get; } = stateChange;
 
         public TaskCompletionSource<bool> Completion { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -22,7 +22,7 @@ public sealed class CircuitBreakerMonitor
     /// transition publishers, so they should not perform I/O, wait on external work, or otherwise
     /// run for a long time.
     /// </summary>
-    public event Action<CircuitStateChangedEvent>? StateChanged;
+    public event Action<CircuitBreakerStateChangedEvent>? StateChanged;
 
     /// <summary>Forces the circuit open. Executions are rejected until <see cref="Reset"/> is called.</summary>
     public void Isolate() => BoundCore().Isolate();
@@ -55,7 +55,7 @@ public sealed class CircuitBreakerMonitor
         }
     }
 
-    internal void Raise(in CircuitStateChangedEvent stateChangedEvent) => StateChanged?.Invoke(stateChangedEvent);
+    internal void Raise(in CircuitBreakerStateChangedEvent stateChangedEvent) => StateChanged?.Invoke(stateChangedEvent);
 
     private CircuitBreakerCore BoundCore() =>
         _core ?? throw new InvalidOperationException(

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -62,12 +62,12 @@ public sealed class CircuitBreakerOptions
     /// are aggregated. The handler runs synchronously and blocks later transition publishers, so
     /// it should not perform I/O, wait on external work, or otherwise run for a long time.
     /// </summary>
-    public Action<CircuitStateChangedEvent>? OnStateChanged { get; set; }
+    public Action<CircuitBreakerStateChangedEvent>? OnStateChanged { get; set; }
 
     /// <summary>
     /// Invoked and awaited on every state transition, after <see cref="OnStateChanged"/> and
     /// before <see cref="CircuitBreakerMonitor.StateChanged"/>. Transitions are delivered
     /// serially outside the circuit lock.
     /// </summary>
-    public Func<CircuitStateChangedEvent, ValueTask>? OnStateChangedAsync { get; set; }
+    public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChangedAsync { get; set; }
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
@@ -45,16 +45,16 @@ public sealed class CircuitBreakerOptions<TResult>
     public TimeSpan BreakDuration { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <inheritdoc cref="CircuitBreakerOptions.BreakDurationGenerator"/>
-    public Func<CircuitBreakerBreakDurationEvent, ValueTask<TimeSpan>>? BreakDurationGenerator { get; set; }
+    public Func<CircuitBreakerBreakDurationEvent<TResult>, ValueTask<TimeSpan>>? BreakDurationGenerator { get; set; }
 
     /// <inheritdoc cref="CircuitBreakerOptions.Monitor"/>
     public CircuitBreakerMonitor? Monitor { get; set; }
 
     /// <inheritdoc cref="CircuitBreakerOptions.OnStateChanged"/>
-    public Action<CircuitStateChangedEvent>? OnStateChanged { get; set; }
+    public Action<CircuitBreakerStateChangedEvent>? OnStateChanged { get; set; }
 
     /// <inheritdoc cref="CircuitBreakerOptions.OnStateChangedAsync"/>
-    public Func<CircuitStateChangedEvent, ValueTask>? OnStateChangedAsync { get; set; }
+    public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChangedAsync { get; set; }
 
     internal CircuitBreakerOptions ToUntyped() => new()
     {
@@ -64,7 +64,6 @@ public sealed class CircuitBreakerOptions<TResult>
         MinimumThroughput = MinimumThroughput,
         SamplingWindow = SamplingWindow,
         BreakDuration = BreakDuration,
-        BreakDurationGenerator = BreakDurationGenerator,
         Monitor = Monitor,
         OnStateChanged = OnStateChanged,
         OnStateChangedAsync = OnStateChangedAsync,

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerState.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerState.cs
@@ -17,13 +17,20 @@ public enum CircuitState
 }
 
 /// <summary>Describes a circuit breaker state transition.</summary>
-public readonly struct CircuitStateChangedEvent
+public readonly struct CircuitBreakerStateChangedEvent
 {
-    internal CircuitStateChangedEvent(CircuitState from, CircuitState to, Exception? lastException)
+    private readonly KevlarContext? _context;
+
+    internal CircuitBreakerStateChangedEvent(
+        CircuitState from,
+        CircuitState to,
+        Exception? lastException,
+        KevlarContext context)
     {
         From = from;
         To = to;
         LastException = lastException;
+        _context = context;
     }
 
     /// <summary>The state the circuit left.</summary>
@@ -34,4 +41,10 @@ public readonly struct CircuitStateChangedEvent
 
     /// <summary>The exception from the failure that caused the transition, when applicable.</summary>
     public Exception? LastException { get; }
+
+    /// <summary>
+    /// The triggering execution context. Manual monitor transitions receive a detached context
+    /// with <see cref="KevlarContext.StrategyIndex"/> equal to <c>-1</c>.
+    /// </summary>
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerState.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerState.cs
@@ -47,4 +47,10 @@ public readonly struct CircuitBreakerStateChangedEvent
     /// with <see cref="KevlarContext.StrategyIndex"/> equal to <c>-1</c>.
     /// </summary>
     public KevlarContext Context => Internal.EventContext.Required(_context);
+
+    internal CircuitBreakerStateChangedEvent WithDetachedContext() => new(
+        From,
+        To,
+        LastException,
+        Context.CreateDetachedSnapshot());
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -12,16 +12,26 @@ internal sealed class CircuitBreakerStrategy : Strategy
     private readonly OutcomeJudge _judge;
 
     public CircuitBreakerStrategy(CircuitBreakerOptions options, OutcomeJudge judge)
-        : this(options, judge, options.HasHandlingOverride)
+        : this(
+            options,
+            judge,
+            options.HasHandlingOverride,
+            options.BreakDurationGenerator is null
+                ? null
+                : CircuitBreakerBreakDurationGenerator.Create(options.BreakDurationGenerator))
     {
     }
 
     private CircuitBreakerStrategy(
         CircuitBreakerOptions options,
         OutcomeJudge judge,
-        bool hasHandlingOverride)
+        bool hasHandlingOverride,
+        CircuitBreakerBreakDurationGenerator? breakDurationGenerator)
     {
-        _core = new CircuitBreakerCore(options, RecordTransitionState);
+        _core = new CircuitBreakerCore(
+            options,
+            breakDurationGenerator,
+            RecordTransitionState);
         _judge = judge;
         HasHandlingOverride = hasHandlingOverride;
     }
@@ -29,7 +39,13 @@ internal sealed class CircuitBreakerStrategy : Strategy
     internal static CircuitBreakerStrategy Create<TResult>(
         CircuitBreakerOptions<TResult> options,
         OutcomeJudge judge) =>
-        new(options.ToUntyped(), judge, options.HasHandlingOverride);
+        new(
+            options.ToUntyped(),
+            judge,
+            options.HasHandlingOverride,
+            options.BreakDurationGenerator is null
+                ? null
+                : CircuitBreakerBreakDurationGenerator.Create(options.BreakDurationGenerator));
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 
@@ -51,7 +67,11 @@ internal sealed class CircuitBreakerStrategy : Strategy
             return ExecuteConfiguredAsync(next, context, alias, recordState);
         }
 
-        if (!_core.TryEnter(context.TimeProvider, out var rejection, out var admittedProbeGeneration))
+        if (!_core.TryEnter(
+                context.TimeProvider,
+                context,
+                out var rejection,
+                out var admittedProbeGeneration))
         {
             if (recordState)
             {
@@ -103,11 +123,11 @@ internal sealed class CircuitBreakerStrategy : Strategy
     {
         if (_judge.ShouldHandle(in outcome))
         {
-            _core.RecordFailure(context.TimeProvider, outcome.Exception);
+            _core.RecordFailure(context.TimeProvider, outcome.Exception, context);
         }
         else if (outcome.Exception is null)
         {
-            _core.RecordSuccess(context.TimeProvider);
+            _core.RecordSuccess(context.TimeProvider, context);
         }
         else
         {
@@ -211,7 +231,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
         StrategyMetricAlias alias,
         bool recordState)
     {
-        var entry = _core.TryEnterAsync(context.TimeProvider);
+        var entry = _core.TryEnterAsync(context.TimeProvider, context);
         if (!entry.IsCompletedSuccessfully)
         {
             return AwaitConfiguredEntryAsync(entry, next, context, alias, recordState);
@@ -310,7 +330,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
         }
         else if (outcome.Exception is null)
         {
-            recording = _core.RecordSuccessAsync(context.TimeProvider);
+            recording = _core.RecordSuccessAsync(context.TimeProvider, context);
         }
         else
         {

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitRejectedEvent.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitRejectedEvent.cs
@@ -3,16 +3,16 @@ namespace Kevlar;
 /// <summary>Describes an execution rejected by the built-in concurrency limiter.</summary>
 public readonly struct ConcurrencyLimitRejectedEvent
 {
+    private readonly KevlarContext? _context;
+
     internal ConcurrencyLimitRejectedEvent(
         int maxConcurrency,
         int queueLimit,
-        int strategyIndex,
         KevlarContext context)
     {
         MaxConcurrency = maxConcurrency;
         QueueLimit = queueLimit;
-        StrategyIndex = strategyIndex;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The configured maximum concurrent executions.</summary>
@@ -21,12 +21,9 @@ public readonly struct ConcurrencyLimitRejectedEvent
     /// <summary>The configured maximum wait queue size.</summary>
     public int QueueLimit { get; }
 
-    /// <summary>The zero-based position of this strategy in the executing shield.</summary>
-    public int StrategyIndex { get; }
-
     /// <summary>
     /// The ambient execution context. It is pooled; do not retain it after synchronous and
     /// asynchronous rejection callbacks complete.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -94,7 +94,6 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         var rejectedEvent = new ConcurrencyLimitRejectedEvent(
             _maxConcurrency,
             _queueLimit,
-            context.StrategyIndex,
             context);
         try
         {

--- a/src/Kevlar/Strategies/Fallback/FallbackEvent.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackEvent.cs
@@ -3,10 +3,12 @@ namespace Kevlar;
 /// <summary>Describes an exception being replaced by an untyped fallback.</summary>
 public readonly struct FallbackEvent
 {
+    private readonly KevlarContext? _context;
+
     internal FallbackEvent(Exception exception, KevlarContext context)
     {
         Exception = exception;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The handled exception being replaced.</summary>
@@ -16,5 +18,5 @@ public readonly struct FallbackEvent
     /// The ambient execution context. It remains valid until the notification callback completes
     /// and must not be retained afterward.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/Fallback/FallbackEventOfT.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackEventOfT.cs
@@ -3,10 +3,12 @@ namespace Kevlar;
 /// <summary>Describes an outcome being replaced by a fallback.</summary>
 public readonly struct FallbackEvent<TResult>
 {
+    private readonly KevlarContext? _context;
+
     internal FallbackEvent(Outcome<TResult> outcome, KevlarContext context)
     {
         Outcome = outcome;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The handled outcome — the exception or result value being replaced.</summary>
@@ -16,5 +18,5 @@ public readonly struct FallbackEvent<TResult>
     /// The ambient execution context. It remains valid until the notification callback completes
     /// and must not be retained afterward.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEvent.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEvent.cs
@@ -3,13 +3,15 @@ namespace Kevlar;
 /// <summary>Arguments used to select a void-returning operation for a hedged attempt.</summary>
 public readonly struct HedgeActionGeneratorEvent
 {
+    private readonly KevlarContext? _context;
+
     internal HedgeActionGeneratorEvent(
         int attemptNumber,
         KevlarContext context,
         Func<CancellationToken, ValueTask> originalAction)
     {
         AttemptNumber = attemptNumber;
-        Context = context;
+        _context = context;
         OriginalAction = originalAction;
     }
 
@@ -17,7 +19,7 @@ public readonly struct HedgeActionGeneratorEvent
     public int AttemptNumber { get; }
 
     /// <summary>The isolated context that belongs to this attempt.</summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 
     /// <summary>
     /// The original operation, including strategies nested inside the hedge. The supplied token

--- a/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEventOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeActionGeneratorEventOfT.cs
@@ -3,6 +3,8 @@ namespace Kevlar;
 /// <summary>Arguments used to select a result-returning operation for a hedged attempt.</summary>
 public readonly struct HedgeActionGeneratorEvent<TResult>
 {
+    private readonly KevlarContext? _context;
+
     internal HedgeActionGeneratorEvent(
         int attemptNumber,
         KevlarContext context,
@@ -10,7 +12,7 @@ public readonly struct HedgeActionGeneratorEvent<TResult>
         Outcome<TResult>? outcome)
     {
         AttemptNumber = attemptNumber;
-        Context = context;
+        _context = context;
         OriginalAction = originalAction;
         Outcome = outcome;
     }
@@ -19,7 +21,7 @@ public readonly struct HedgeActionGeneratorEvent<TResult>
     public int AttemptNumber { get; }
 
     /// <summary>The isolated context that belongs to this attempt.</summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 
     /// <summary>
     /// The original operation, including strategies nested inside the hedge. The supplied token

--- a/src/Kevlar/Strategies/Hedging/HedgeDelayEvent.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeDelayEvent.cs
@@ -3,10 +3,12 @@ namespace Kevlar;
 /// <summary>Describes an additional hedged attempt whose stagger delay is being selected.</summary>
 public readonly struct HedgeDelayEvent
 {
+    private readonly KevlarContext? _context;
+
     internal HedgeDelayEvent(int attemptNumber, KevlarContext context, TimeSpan elapsed)
     {
         AttemptNumber = attemptNumber;
-        Context = context;
+        _context = context;
         Elapsed = elapsed;
     }
 
@@ -16,7 +18,7 @@ public readonly struct HedgeDelayEvent
     /// <summary>
     /// The ambient execution context. It is pooled; do not retain it after the generator completes.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 
     /// <summary>The elapsed time since the primary attempt started.</summary>
     public TimeSpan Elapsed { get; }

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -71,10 +71,12 @@ public sealed class HedgeOptions
 /// <summary>Describes a hedged attempt being launched.</summary>
 public readonly struct HedgeEvent
 {
+    private readonly KevlarContext? _context;
+
     internal HedgeEvent(int attemptNumber, KevlarContext context)
     {
         AttemptNumber = attemptNumber;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The 1-based number of the attempt being launched (2 = first hedge).</summary>
@@ -84,5 +86,5 @@ public readonly struct HedgeEvent
     /// The ambient execution context. It is pooled; do not retain it after synchronous and
     /// asynchronous hedge callbacks complete.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -63,6 +63,8 @@ internal sealed class HedgingStrategy : Strategy
 
     protected internal override bool InvokesContinuationAtMostOnce => _maxAttempts == 1;
 
+    internal override bool RequiresContinuationOverlapIsolation => false;
+
     public override string Describe() =>
         $"Hedge({_maxAttempts} attempts, delay {(HasDelayGenerator ? "generator" : DescribeHelper.Time(_delay))})";
 

--- a/src/Kevlar/Strategies/RateLimit/RateLimitRejectedEvent.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitRejectedEvent.cs
@@ -3,13 +3,14 @@ namespace Kevlar;
 /// <summary>Describes an execution rejected by the built-in rate limiter.</summary>
 public readonly struct RateLimitRejectedEvent
 {
+    private readonly KevlarContext? _context;
+
     internal RateLimitRejectedEvent(
         TimeSpan? retryAfter,
         int permits,
         TimeSpan window,
         int burst,
         int queueLimit,
-        int strategyIndex,
         KevlarContext context)
     {
         RetryAfter = retryAfter;
@@ -17,8 +18,7 @@ public readonly struct RateLimitRejectedEvent
         Window = window;
         Burst = burst;
         QueueLimit = queueLimit;
-        StrategyIndex = strategyIndex;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The estimated delay before another execution can be admitted, when available.</summary>
@@ -36,12 +36,9 @@ public readonly struct RateLimitRejectedEvent
     /// <summary>The configured maximum wait queue size.</summary>
     public int QueueLimit { get; }
 
-    /// <summary>The zero-based position of this strategy in the executing shield.</summary>
-    public int StrategyIndex { get; }
-
     /// <summary>
     /// The ambient execution context. It is pooled; do not retain it after synchronous and
     /// asynchronous rejection callbacks complete.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -103,7 +103,6 @@ internal sealed class RateLimitStrategy : Strategy
             _window,
             _burst,
             _queueLimit,
-            context.StrategyIndex,
             context);
 
         try

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -144,13 +144,15 @@ public sealed class RetryOptions<TResult>
 /// <summary>Describes a retry that is about to happen.</summary>
 public readonly struct RetryEvent
 {
+    private readonly KevlarContext? _context;
+
     internal RetryEvent(int retryNumber, TimeSpan delay, Exception? exception, object? result, KevlarContext context)
     {
         RetryNumber = retryNumber;
         Delay = delay;
         Exception = exception;
         Result = result;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The 1-based number of the retry about to be made (1 = first retry, i.e. second execution).</summary>
@@ -180,31 +182,38 @@ public readonly struct RetryEvent
     /// The ambient execution context. It is pooled; do not retain it or its property bag after
     /// the callback (including an asynchronous callback) completes.
     /// </summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }
 
 /// <summary>Describes a retry that is about to happen, with the handled outcome typed as <typeparamref name="TResult"/>.</summary>
 public readonly struct RetryEvent<TResult>
 {
-    private readonly RetryEvent _inner;
+    private readonly KevlarContext? _context;
 
-    internal RetryEvent(RetryEvent inner) => _inner = inner;
+    internal RetryEvent(
+        int retryNumber,
+        TimeSpan delay,
+        Outcome<TResult> outcome,
+        KevlarContext context)
+    {
+        RetryNumber = retryNumber;
+        Delay = delay;
+        Outcome = outcome;
+        _context = context;
+    }
 
     /// <summary>The 1-based number of the retry about to be made (1 = first retry, i.e. second execution).</summary>
-    public int RetryNumber => _inner.RetryNumber;
+    public int RetryNumber { get; }
 
     /// <summary>The delay that will be waited before the retry.</summary>
-    public TimeSpan Delay => _inner.Delay;
+    public TimeSpan Delay { get; }
 
     /// <summary>The handled outcome — the exception or result value that triggered this retry.</summary>
-    public Outcome<TResult> Outcome =>
-        _inner.Exception is { } exception
-            ? Outcome<TResult>.FromException(exception)
-            : Outcome<TResult>.FromResult((TResult)_inner.Result!);
+    public Outcome<TResult> Outcome { get; }
 
     /// <summary>
     /// The ambient execution context. It is pooled; do not retain it or its property bag after
     /// the callback (including an asynchronous callback) completes.
     /// </summary>
-    public KevlarContext Context => _inner.Context;
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -8,10 +8,11 @@ internal sealed class RetryStrategy : Strategy
     private readonly int _maxRetries;
     private readonly Backoff _backoff;
     private readonly TimeSpan? _maxDelay;
-    private readonly Action<RetryEvent>? _onRetry;
-    private readonly Func<RetryEvent, ValueTask>? _onRetryAsync;
-    private readonly Func<RetryEvent, TimeSpan?>? _delayGenerator;
-    private readonly Func<RetryEvent, ValueTask<TimeSpan?>>? _delayGeneratorAsync;
+    private readonly Delegate? _onRetry;
+    private readonly Delegate? _onRetryAsync;
+    private readonly Delegate? _delayGenerator;
+    private readonly Delegate? _delayGeneratorAsync;
+    private readonly Type? _callbackResultType;
 
     public RetryStrategy(RetryOptions options, OutcomeJudge judge)
         : this(
@@ -23,7 +24,8 @@ internal sealed class RetryStrategy : Strategy
             options.OnRetryAsync,
             options.DelayGenerator,
             options.DelayGeneratorAsync,
-            options.HasHandlingOverride)
+            options.HasHandlingOverride,
+            callbackResultType: null)
     {
     }
 
@@ -32,11 +34,12 @@ internal sealed class RetryStrategy : Strategy
         Backoff backoff,
         TimeSpan? maxDelay,
         OutcomeJudge judge,
-        Action<RetryEvent>? onRetry,
-        Func<RetryEvent, ValueTask>? onRetryAsync,
-        Func<RetryEvent, TimeSpan?>? delayGenerator,
-        Func<RetryEvent, ValueTask<TimeSpan?>>? delayGeneratorAsync,
-        bool hasHandlingOverride)
+        Delegate? onRetry,
+        Delegate? onRetryAsync,
+        Delegate? delayGenerator,
+        Delegate? delayGeneratorAsync,
+        bool hasHandlingOverride,
+        Type? callbackResultType)
     {
         Throw.IfOutOfRange(maxRetries < 0, "options", "MaxRetries must not be negative.");
         Throw.IfNull(backoff, "options");
@@ -51,28 +54,23 @@ internal sealed class RetryStrategy : Strategy
         _onRetryAsync = onRetryAsync;
         _delayGenerator = delayGenerator;
         _delayGeneratorAsync = delayGeneratorAsync;
+        _callbackResultType = callbackResultType;
         HasHandlingOverride = hasHandlingOverride;
     }
 
     internal static RetryStrategy Create<TResult>(RetryOptions<TResult> options, OutcomeJudge judge)
     {
-        var onRetry = options.OnRetry;
-        var onRetryAsync = options.OnRetryAsync;
-        var delayGenerator = options.DelayGenerator;
-        var delayGeneratorAsync = options.DelayGeneratorAsync;
-
         return new RetryStrategy(
             options.MaxRetries,
             options.Backoff,
             options.MaxDelay,
             judge,
-            onRetry is null ? null : retry => onRetry(new RetryEvent<TResult>(retry)),
-            onRetryAsync is null ? null : retry => onRetryAsync(new RetryEvent<TResult>(retry)),
-            delayGenerator is null ? null : retry => delayGenerator(new RetryEvent<TResult>(retry)),
-            delayGeneratorAsync is null
-                ? null
-                : retry => delayGeneratorAsync(new RetryEvent<TResult>(retry)),
-            options.HasHandlingOverride);
+            options.OnRetry,
+            options.OnRetryAsync,
+            options.DelayGenerator,
+            options.DelayGeneratorAsync,
+            options.HasHandlingOverride,
+            typeof(TResult));
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
@@ -152,31 +150,44 @@ internal sealed class RetryStrategy : Strategy
                 || _onRetry is not null
                 || _onRetryAsync is not null)
             {
-                var result = outcome.Exception is null ? (object?)outcome.Result : null;
-
                 if (_delayGenerator is not null)
                 {
-                    var generated = _delayGenerator(
-                        new RetryEvent(attempt, delay, outcome.Exception, result, context));
+                    var generated = InvokeDelayGenerator(
+                        _delayGenerator,
+                        attempt,
+                        delay,
+                        in outcome,
+                        context);
                     delay = ApplyGeneratedDelay(delay, generated);
                 }
 
                 if (_delayGeneratorAsync is not null)
                 {
-                    var generated = await _delayGeneratorAsync(
-                        new RetryEvent(attempt, delay, outcome.Exception, result, context))
+                    var generated = await InvokeDelayGeneratorAsync(
+                        _delayGeneratorAsync,
+                        attempt,
+                        delay,
+                        outcome,
+                        context)
                         .ConfigureAwait(false);
                     delay = ApplyGeneratedDelay(delay, generated);
                 }
 
                 if (_onRetry is not null || _onRetryAsync is not null)
                 {
-                    var retryEvent = new RetryEvent(attempt, delay, outcome.Exception, result, context);
-                    _onRetry?.Invoke(retryEvent);
+                    if (_onRetry is not null)
+                    {
+                        InvokeOnRetry(_onRetry, attempt, delay, in outcome, context);
+                    }
 
                     if (_onRetryAsync is not null)
                     {
-                        await _onRetryAsync(retryEvent).ConfigureAwait(false);
+                        await InvokeOnRetryAsync(
+                            _onRetryAsync,
+                            attempt,
+                            delay,
+                            outcome,
+                            context).ConfigureAwait(false);
                     }
                 }
             }
@@ -202,6 +213,101 @@ internal sealed class RetryStrategy : Strategy
         && !context.Properties.SuppressAdditionalAttempts
         && _judge.ShouldHandle(in outcome)
         && !context.CancellationToken.IsCancellationRequested;
+
+    private TimeSpan? InvokeDelayGenerator<T>(
+        Delegate generator,
+        int retryNumber,
+        TimeSpan delay,
+        in Outcome<T> outcome,
+        KevlarContext context)
+    {
+        if (_callbackResultType is null)
+        {
+            return ((Func<RetryEvent, TimeSpan?>)generator)(
+                CreateUntypedEvent(retryNumber, delay, in outcome, context));
+        }
+
+        ValidateCallbackResultType<T>();
+        return ((Func<RetryEvent<T>, TimeSpan?>)generator)(
+            new RetryEvent<T>(retryNumber, delay, outcome, context));
+    }
+
+    private ValueTask<TimeSpan?> InvokeDelayGeneratorAsync<T>(
+        Delegate generator,
+        int retryNumber,
+        TimeSpan delay,
+        Outcome<T> outcome,
+        KevlarContext context)
+    {
+        if (_callbackResultType is null)
+        {
+            return ((Func<RetryEvent, ValueTask<TimeSpan?>>)generator)(
+                CreateUntypedEvent(retryNumber, delay, in outcome, context));
+        }
+
+        ValidateCallbackResultType<T>();
+        return ((Func<RetryEvent<T>, ValueTask<TimeSpan?>>)generator)(
+            new RetryEvent<T>(retryNumber, delay, outcome, context));
+    }
+
+    private void InvokeOnRetry<T>(
+        Delegate callback,
+        int retryNumber,
+        TimeSpan delay,
+        in Outcome<T> outcome,
+        KevlarContext context)
+    {
+        if (_callbackResultType is null)
+        {
+            ((Action<RetryEvent>)callback)(
+                CreateUntypedEvent(retryNumber, delay, in outcome, context));
+            return;
+        }
+
+        ValidateCallbackResultType<T>();
+        ((Action<RetryEvent<T>>)callback)(
+            new RetryEvent<T>(retryNumber, delay, outcome, context));
+    }
+
+    private ValueTask InvokeOnRetryAsync<T>(
+        Delegate callback,
+        int retryNumber,
+        TimeSpan delay,
+        Outcome<T> outcome,
+        KevlarContext context)
+    {
+        if (_callbackResultType is null)
+        {
+            return ((Func<RetryEvent, ValueTask>)callback)(
+                CreateUntypedEvent(retryNumber, delay, in outcome, context));
+        }
+
+        ValidateCallbackResultType<T>();
+        return ((Func<RetryEvent<T>, ValueTask>)callback)(
+            new RetryEvent<T>(retryNumber, delay, outcome, context));
+    }
+
+    private static RetryEvent CreateUntypedEvent<T>(
+        int retryNumber,
+        TimeSpan delay,
+        in Outcome<T> outcome,
+        KevlarContext context) =>
+        new(
+            retryNumber,
+            delay,
+            outcome.Exception,
+            outcome.Exception is null ? outcome.Result : null,
+            context);
+
+    private void ValidateCallbackResultType<T>()
+    {
+        if (_callbackResultType != typeof(T))
+        {
+            throw new InvalidOperationException(
+                $"The retry callbacks were created for '{_callbackResultType}', " +
+                $"but this execution returns '{typeof(T)}'.");
+        }
+    }
 
     private TimeSpan ApplyGeneratedDelay(TimeSpan current, TimeSpan? generated)
     {

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -89,6 +89,8 @@ internal sealed class RetryStrategy : Strategy
 
     protected internal override bool InvokesContinuationAtMostOnce => _maxRetries == 0;
 
+    internal override bool RequiresContinuationOverlapIsolation => false;
+
     public override string Describe()
     {
         var cap = _maxDelay is { } max ? $", ≤{DescribeHelper.Time(max)}" : string.Empty;

--- a/src/Kevlar/Strategies/Timeout/TimeoutOptions.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutOptions.cs
@@ -31,15 +31,17 @@ public sealed class TimeoutOptions
 /// <summary>Describes an execution that exceeded its timeout.</summary>
 public readonly struct TimeoutEvent
 {
+    private readonly KevlarContext? _context;
+
     internal TimeoutEvent(TimeSpan timeout, KevlarContext context)
     {
         Timeout = timeout;
-        Context = context;
+        _context = context;
     }
 
     /// <summary>The timeout that was exceeded.</summary>
     public TimeSpan Timeout { get; }
 
     /// <summary>The ambient execution context.</summary>
-    public KevlarContext Context { get; }
+    public KevlarContext Context => Internal.EventContext.Required(_context);
 }

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -31,6 +31,8 @@ public abstract class Strategy
     /// </remarks>
     protected internal virtual bool InvokesContinuationAtMostOnce => false;
 
+    internal virtual bool RequiresContinuationOverlapIsolation => !InvokesContinuationAtMostOnce;
+
     /// <summary>
     /// The handling clause this reactive strategy acts on, or <see langword="null"/> for a
     /// proactive strategy. Override this when the strategy receives a clause through a
@@ -117,6 +119,11 @@ public readonly struct Continuation<T, TState>
 
     private ValueTask<Outcome<T>> InvokeStrategyAsync(StrategyNode node, KevlarContext context)
     {
+        if (node.RequiresOverlapIsolation && !context.TryEnterStrategy(node.Index))
+        {
+            return InvokeStrategyWithForkAsync(node, context);
+        }
+
         ValueTask<Outcome<T>> execution;
         var previousStrategyIndex = node.Index - 1;
 
@@ -130,22 +137,40 @@ public readonly struct Continuation<T, TState>
         catch (Exception exception)
         {
             context.StrategyIndex = previousStrategyIndex;
+            ExitStrategyIfRequired(node, context);
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
         }
 
         if (execution.IsCompletedSuccessfully)
         {
             context.StrategyIndex = previousStrategyIndex;
+            ExitStrategyIfRequired(node, context);
             return execution;
         }
 
-        return AwaitStrategyAsync(execution, context, previousStrategyIndex);
+        return AwaitStrategyAsync(execution, context, previousStrategyIndex, node);
+    }
+
+    private async ValueTask<Outcome<T>> InvokeStrategyWithForkAsync(
+        StrategyNode node,
+        KevlarContext context)
+    {
+        var fork = context.Fork(context.CancellationToken);
+        try
+        {
+            return await InvokeStrategyAsync(node, fork).ConfigureAwait(false);
+        }
+        finally
+        {
+            KevlarContext.Return(fork);
+        }
     }
 
     private static async ValueTask<Outcome<T>> AwaitStrategyAsync(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,
-        int previousStrategyIndex)
+        int previousStrategyIndex,
+        StrategyNode node)
     {
         try
         {
@@ -158,17 +183,31 @@ public readonly struct Continuation<T, TState>
         finally
         {
             context.StrategyIndex = previousStrategyIndex;
+            ExitStrategyIfRequired(node, context);
+        }
+    }
+
+    private static void ExitStrategyIfRequired(StrategyNode node, KevlarContext context)
+    {
+        if (node.RequiresOverlapIsolation)
+        {
+            context.ExitStrategy(node.Index);
         }
     }
 }
 
 internal sealed class StrategyNode
 {
-    internal StrategyNode(Strategy strategy, StrategyNode? next, int index)
+    internal StrategyNode(
+        Strategy strategy,
+        StrategyNode? next,
+        int index,
+        bool requiresOverlapIsolation)
     {
         Strategy = strategy;
         Next = next;
         Index = index;
+        RequiresOverlapIsolation = requiresOverlapIsolation;
     }
 
     internal Strategy Strategy { get; }
@@ -176,4 +215,6 @@ internal sealed class StrategyNode
     internal StrategyNode? Next { get; }
 
     internal int Index { get; }
+
+    internal bool RequiresOverlapIsolation { get; }
 }

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -118,7 +118,7 @@ public readonly struct Continuation<T, TState>
     private ValueTask<Outcome<T>> InvokeStrategyAsync(StrategyNode node, KevlarContext context)
     {
         ValueTask<Outcome<T>> execution;
-        var previousStrategyIndex = context.StrategyIndex;
+        var previousStrategyIndex = node.Index - 1;
 
         try
         {

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -118,6 +118,7 @@ public readonly struct Continuation<T, TState>
     private ValueTask<Outcome<T>> InvokeStrategyAsync(StrategyNode node, KevlarContext context)
     {
         ValueTask<Outcome<T>> execution;
+        var previousStrategyIndex = context.StrategyIndex;
 
         try
         {
@@ -128,15 +129,23 @@ public readonly struct Continuation<T, TState>
         }
         catch (Exception exception)
         {
+            context.StrategyIndex = previousStrategyIndex;
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception));
         }
 
-        return execution.IsCompletedSuccessfully
-            ? execution
-            : AwaitStrategyAsync(execution);
+        if (execution.IsCompletedSuccessfully)
+        {
+            context.StrategyIndex = previousStrategyIndex;
+            return execution;
+        }
+
+        return AwaitStrategyAsync(execution, context, previousStrategyIndex);
     }
 
-    private static async ValueTask<Outcome<T>> AwaitStrategyAsync(ValueTask<Outcome<T>> execution)
+    private static async ValueTask<Outcome<T>> AwaitStrategyAsync(
+        ValueTask<Outcome<T>> execution,
+        KevlarContext context,
+        int previousStrategyIndex)
     {
         try
         {
@@ -145,6 +154,10 @@ public readonly struct Continuation<T, TState>
         catch (Exception exception)
         {
             return Outcome<T>.FromException(exception);
+        }
+        finally
+        {
+            context.StrategyIndex = previousStrategyIndex;
         }
     }
 }

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -77,6 +77,20 @@ public class AllocationBudgetTests
     private readonly Shield<int> _typedJudge = Shield.For<int>()
         .WhenResult(-1)
         .Retry(3, Backoff.None);
+    private readonly Shield<int> _typedRetryNotification = Shield.For<int>()
+        .WhenResult(-1)
+        .Retry(static options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.OnRetry = static item =>
+            {
+                if (item.Outcome.Result == int.MinValue)
+                {
+                    throw new InvalidOperationException();
+                }
+            };
+        });
     private readonly Shield _composed = Shield
         .RateLimit(1_000_000_000, TimeSpan.FromSeconds(1))
         .Timeout(TimeSpan.FromMinutes(1))
@@ -241,6 +255,13 @@ public class AllocationBudgetTests
         AssertZero("concurrency state metrics", this, static test =>
             test._concurrencyLimit.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
     }
+
+    [Test]
+    public void RetryEvent_Typed_Outcome_Round_Trips_Without_Boxing() =>
+        AssertZero("typed retry notification", this, static test =>
+            test._typedRetryNotification.ExecuteAsync(static _ => new ValueTask<int>(-1))
+                .GetAwaiter()
+                .GetResult());
 
     /// <summary>Verifies bounded allocations for failure and parallel execution paths.</summary>
     [Test]

--- a/tests/Kevlar.Extensions.RateLimiting.Tests/RateLimiterAdapterTests.cs
+++ b/tests/Kevlar.Extensions.RateLimiting.Tests/RateLimiterAdapterTests.cs
@@ -129,12 +129,14 @@ public class RateLimiterAdapterTests
         using var listener = new RejectionListener("fixed-window");
         var order = new List<string>();
         RateLimiterAdapterRejectedEvent observed = default;
+        var observedStrategyIndex = -1;
         var shield = Shield.Empty
             .UseRateLimiter(limiter, options =>
             {
                 options.OnRejected = rejection =>
                 {
                     observed = rejection;
+                    observedStrategyIndex = rejection.Context.StrategyIndex;
                     order.Add(listener.Count == 1 ? "metric-sync" : "sync-before-metric");
                 };
                 options.OnRejectedAsync = async rejection =>
@@ -156,7 +158,7 @@ public class RateLimiterAdapterTests
         await Assert.That(observed.RetryAfter).IsEqualTo(exception.RetryAfter);
         await Assert.That(observed.Metadata.ContainsKey(MetadataName.RetryAfter.Name)).IsTrue();
         await Assert.That(observed.PermitCount).IsEqualTo(1);
-        await Assert.That(observed.StrategyIndex).IsEqualTo(0);
+        await Assert.That(observedStrategyIndex).IsEqualTo(0);
         await Assert.That(order.SequenceEqual(["metric-sync", "async"])).IsTrue();
     }
 

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -139,6 +139,32 @@ public class TelemetryRecorderTests
     }
 
     [Test]
+    public async Task Records_Circuit_Break_Duration_Statistics_And_Strategy_Index()
+    {
+        using var recorder = new TelemetryRecorder(captureMetrics: false);
+        var shield = Shield.For<int>()
+            .WhenResult(static result => result < 0)
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.BreakDurationGenerator = item =>
+                    recorder.Record(item, TimeSpan.FromMinutes(1));
+            })
+            .WithName("typed-breaker");
+
+        _ = await shield.ExecuteAsync(static _ => new ValueTask<int>(-1));
+
+        var record = recorder.Callbacks.Single();
+        await Assert.That(record.Kind).IsEqualTo(CallbackKind.CircuitBreakDuration);
+        await Assert.That(record.ShieldName).IsEqualTo("typed-breaker");
+        await Assert.That(record.StrategyIndex).IsEqualTo(0);
+        await Assert.That(record.Result).IsEqualTo(-1);
+        await Assert.That(record.FailureRate).IsEqualTo(1);
+        await Assert.That(record.FailureCount).IsEqualTo(1);
+        await Assert.That(record.ConsecutiveFailures).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Waiters_Honor_Cancellation()
     {
         using var recorder = new TelemetryRecorder(captureMetrics: false);

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -2,6 +2,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Http;
+using Kevlar.Extensions.RateLimiting;
+using Kevlar.Chaos;
 using Kevlar.Testing;
 using System.Reflection;
 
@@ -42,6 +44,63 @@ public class ApiShapeTests
 
         await Assert.That(typedReloadShapes).IsEquivalentTo(untypedReloadShapes);
         await Assert.That(methods.Where(static method => method.Name == "AddVoidShield")).IsEmpty();
+    }
+
+    [Test]
+    public async Task Strategy_Event_Structs_Have_One_Context_Contract()
+    {
+        var eventTypes = GetStrategyEventTypes();
+
+        await Assert.That(eventTypes.Length).IsGreaterThan(0);
+        foreach (var eventType in eventTypes)
+        {
+            await Assert.That(eventType.IsDefined(
+                typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute),
+                inherit: false)).IsTrue();
+            await Assert.That(eventType.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Any(static constructor => constructor.IsAssembly)).IsTrue();
+
+            var contextProperty = eventType.GetProperty(
+                "Context",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+            await Assert.That(contextProperty).IsNotNull();
+            await Assert.That(contextProperty!.PropertyType).IsEqualTo(typeof(KevlarContext));
+
+            var concreteType = eventType.IsGenericTypeDefinition
+                ? eventType.MakeGenericType(
+                    Enumerable.Repeat(typeof(int), eventType.GetGenericArguments().Length).ToArray())
+                : eventType;
+            var defaultEvent = Activator.CreateInstance(concreteType);
+            var concreteContextProperty = concreteType.GetProperty(
+                "Context",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
+            var failure = await Assert.That(() => concreteContextProperty.GetValue(defaultEvent))
+                .Throws<TargetInvocationException>();
+            await Assert.That(failure!.InnerException).IsTypeOf<InvalidOperationException>();
+        }
+    }
+
+    [Test]
+    public async Task Event_Type_Names_Share_Strategy_Prefix()
+    {
+        var prefixes = new[]
+        {
+            "CircuitBreaker",
+            "Chaos",
+            "ConcurrencyLimit",
+            "Fallback",
+            "Hedge",
+            "RateLimit",
+            "RateLimiter",
+            "Retry",
+            "Timeout",
+        };
+        var eventTypes = GetStrategyEventTypes();
+
+        await Assert.That(eventTypes.All(type => prefixes.Any(prefix =>
+            type.Name.StartsWith(prefix, StringComparison.Ordinal)))).IsTrue();
+        await Assert.That(eventTypes.Any(static type =>
+            type.Name.StartsWith("CircuitState", StringComparison.Ordinal))).IsFalse();
     }
 
     [Test]
@@ -286,4 +345,17 @@ public class ApiShapeTests
             references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
     }
+
+    private static Type[] GetStrategyEventTypes() =>
+        new[]
+        {
+            typeof(Shield).Assembly,
+            typeof(ChaosEvent).Assembly,
+            typeof(RateLimiterRejectedEvent).Assembly,
+        }
+            .Distinct()
+            .SelectMany(static assembly => assembly.ExportedTypes)
+            .Where(static type =>
+                type.IsValueType && type.Name.Contains("Event", StringComparison.Ordinal))
+            .ToArray();
 }

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -351,7 +351,7 @@ public class ApiShapeTests
         {
             typeof(Shield).Assembly,
             typeof(ChaosEvent).Assembly,
-            typeof(RateLimiterRejectedEvent).Assembly,
+            typeof(RateLimiterAdapterRejectedEvent).Assembly,
         }
             .Distinct()
             .SelectMany(static assembly => assembly.ExportedTypes)

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -16,6 +16,145 @@ public class CircuitBreakerDynamicOptionsTests
     }
 
     [Test]
+    public async Task BreakDurationGenerator_Receives_Typed_Outcome_And_Failure_Stats()
+    {
+        CircuitBreakerBreakDurationEvent<int> ratioEvent = default;
+        var ratioBreaker = Shield.For<int>()
+            .WhenResult(static result => result < 0)
+            .CircuitBreaker(options =>
+            {
+                options.FailureRatio = 0.5;
+                options.MinimumThroughput = 4;
+                options.BreakDurationGenerator = item =>
+                {
+                    ratioEvent = item;
+                    return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+                };
+            });
+
+        foreach (var result in new[] { 1, -1, 2, -2 })
+        {
+            _ = await ratioBreaker.ExecuteAsync(_ => new ValueTask<int>(result));
+        }
+
+        await Assert.That(ratioEvent.Outcome.Result).IsEqualTo(-2);
+        await Assert.That(ratioEvent.FailureRate).IsEqualTo(0.5);
+        await Assert.That(ratioEvent.FailureCount).IsEqualTo(2);
+        await Assert.That(ratioEvent.ConsecutiveFailures).IsEqualTo(1);
+
+        CircuitBreakerBreakDurationEvent<int> consecutiveEvent = default;
+        var consecutiveBreaker = Shield.For<int>()
+            .WhenResult(static result => result < 0)
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 3;
+                options.BreakDurationGenerator = item =>
+                {
+                    consecutiveEvent = item;
+                    return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+                };
+            });
+
+        foreach (var result in new[] { -1, -2, -3 })
+        {
+            _ = await consecutiveBreaker.ExecuteAsync(_ => new ValueTask<int>(result));
+        }
+
+        await Assert.That(consecutiveEvent.Outcome.Result).IsEqualTo(-3);
+        await Assert.That(consecutiveEvent.FailureRate).IsEqualTo(1);
+        await Assert.That(consecutiveEvent.FailureCount).IsEqualTo(3);
+        await Assert.That(consecutiveEvent.ConsecutiveFailures).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task BreakDurationGenerator_Typed_Result_Not_Boxed()
+    {
+        var context = KevlarContext.Rent(
+            CancellationToken.None,
+            isSynchronous: false,
+            TimeProvider.System,
+            shieldName: null);
+        var generator = CircuitBreakerBreakDurationGenerator.Create<int>(static item =>
+        {
+            if (item.Outcome.Result != 42)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1));
+        });
+        var outcome = Outcome<int>.FromResult(42);
+        var statistics = new CircuitBreakerFailureStatistics(1, 1, 1);
+
+        try
+        {
+            for (var index = 0; index < 1_000; index++)
+            {
+                _ = generator.Invoke(in outcome, in statistics, context).Result;
+            }
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var index = 0; index < 10_000; index++)
+            {
+                _ = generator.Invoke(in outcome, in statistics, context).Result;
+            }
+
+            // TUnit may materialize one assertion object on this thread; a boxed int would add
+            // roughly 24 bytes for every invocation instead of this fixed allowance.
+            await Assert.That(GC.GetAllocatedBytesForCurrentThread() - before)
+                .IsLessThanOrEqualTo(64);
+        }
+        finally
+        {
+            KevlarContext.Return(context);
+        }
+    }
+
+    [Test]
+    public async Task StateChanged_Event_Carries_Triggering_And_Manual_Context()
+    {
+        var key = new KevlarKey<string>("breaker-state");
+        (string? Name, string? Value, int StrategyIndex) execution = default;
+        (string? Name, int PropertyCount, int StrategyIndex) manual = default;
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.Monitor = monitor;
+                options.OnStateChanged = item =>
+                {
+                    if (item.To == CircuitState.Open)
+                    {
+                        execution = (
+                            item.Context.ShieldName,
+                            item.Context.Properties.GetOrDefault<string>(key),
+                            item.Context.StrategyIndex);
+                    }
+                    else if (item.To == CircuitState.Isolated)
+                    {
+                        manual = (
+                            item.Context.ShieldName,
+                            item.Context.Properties.Count,
+                            item.Context.StrategyIndex);
+                    }
+                };
+            })
+            .WithName("orders");
+
+        _ = await Assert.That(async () => await shield.ExecuteWithContextAsync<int, int>(
+                42,
+                (_, properties) => properties.Set(key, "visible"),
+                static (_, _) => ValueTask.FromException<int>(new InvalidOperationException())))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(execution).IsEqualTo(("orders", "visible", 0));
+
+        monitor.Isolate();
+
+        await Assert.That(manual).IsEqualTo((null, 0, -1));
+    }
+
+    [Test]
     public async Task BreakDurationGenerator_Receives_Handled_Outcome_And_Context()
     {
         var timeProvider = new FakeTimeProvider();
@@ -28,7 +167,10 @@ public class CircuitBreakerDynamicOptionsTests
                 options.ConsecutiveFailures = 1;
                 options.BreakDurationGenerator = item =>
                 {
-                    observed.Add((item.Result, item.Exception, item.Context.ShieldName));
+                    observed.Add((
+                        item.Outcome.Result,
+                        item.Outcome.Exception,
+                        item.Context.ShieldName));
                     return new ValueTask<TimeSpan>(durations.Dequeue());
                 };
             })

--- a/tests/Kevlar.Tests/CircuitBreakerEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerEdgeCaseTests.cs
@@ -446,7 +446,7 @@ public class CircuitBreakerEdgeCaseTests
     public async Task Transition_Events_Carry_The_Causing_Exception()
     {
         var cause = new InvalidOperationException("cause");
-        CircuitStateChangedEvent? opened = null;
+        CircuitBreakerStateChangedEvent? opened = null;
         var shield = Shield.CircuitBreaker(options =>
         {
             options.ConsecutiveFailures = 1;

--- a/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
@@ -7,6 +7,100 @@ namespace Kevlar.Tests;
 public class CircuitBreakerTransitionOrderingTests
 {
     [Test]
+    public async Task Reentrant_Execution_Transition_Preserves_Triggering_Context()
+    {
+        var key = new KevlarKey<string>("reentrant-transition");
+        var monitor = new CircuitBreakerMonitor();
+        var opened = 0;
+        string? observed = null;
+        Shield shield = null!;
+        shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChanged = change =>
+            {
+                if (change.To != CircuitState.Open)
+                {
+                    return;
+                }
+
+                if (Interlocked.Increment(ref opened) == 1)
+                {
+                    monitor.Reset();
+                    try
+                    {
+                        shield.ExecuteWithContext<int>(context =>
+                        {
+                            context.Properties.Set(key, "nested");
+                            throw new InvalidOperationException("nested");
+                        });
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+
+                    return;
+                }
+
+                observed = change.Context.Properties.GetOrDefault<string>(key);
+            };
+        });
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("outer"));
+
+        await Assert.That(observed).IsEqualTo("nested");
+    }
+
+    [Test]
+    public async Task Async_Reentrant_Execution_Transition_Preserves_Triggering_Context()
+    {
+        var key = new KevlarKey<string>("async-reentrant-transition");
+        var monitor = new CircuitBreakerMonitor();
+        var opened = 0;
+        string? observed = null;
+        Shield shield = null!;
+        shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+            options.OnStateChangedAsync = async change =>
+            {
+                if (change.To != CircuitState.Open)
+                {
+                    return;
+                }
+
+                if (Interlocked.Increment(ref opened) == 1)
+                {
+                    await monitor.ResetAsync();
+                    try
+                    {
+                        await shield.ExecuteWithContextAsync<int>(context =>
+                        {
+                            context.Properties.Set(key, "nested");
+                            return ValueTask.FromException<int>(new InvalidOperationException("nested"));
+                        });
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+
+                    return;
+                }
+
+                observed = change.Context.Properties.GetOrDefault<string>(key);
+            };
+        });
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("outer"));
+
+        await Assert.That(observed).IsEqualTo("nested");
+    }
+
+    [Test]
     public async Task Concurrent_Control_Publishes_One_Ordered_NonConcurrent_Stream()
     {
         var monitor = new CircuitBreakerMonitor();

--- a/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTransitionOrderingTests.cs
@@ -75,7 +75,7 @@ public class CircuitBreakerTransitionOrderingTests
     {
         var monitor = new CircuitBreakerMonitor();
         var callbackFailure = new InvalidOperationException("option callback");
-        CircuitStateChangedEvent? observed = null;
+        CircuitBreakerStateChangedEvent? observed = null;
         var shield = Shield.CircuitBreaker(options =>
         {
             options.ConsecutiveFailures = 1;

--- a/tests/Kevlar.Tests/ConcurrencyTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyTests.cs
@@ -7,7 +7,7 @@ public class ConcurrencyTests
     [Test]
     public async Task A_Failure_Storm_Produces_Exactly_One_Open_Transition()
     {
-        var transitions = new List<CircuitStateChangedEvent>();
+        var transitions = new List<CircuitBreakerStateChangedEvent>();
         var gate = new object();
         var shield = Shield.CircuitBreaker(options =>
         {
@@ -25,7 +25,7 @@ public class ConcurrencyTests
         await Task.WhenAll(Enumerable.Range(0, 32).Select(_ =>
             shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException()).AsTask()));
 
-        List<CircuitStateChangedEvent> snapshot;
+        List<CircuitBreakerStateChangedEvent> snapshot;
         lock (gate)
         {
             snapshot = [.. transitions];

--- a/tests/Kevlar.Tests/EventStrategyIndexTests.cs
+++ b/tests/Kevlar.Tests/EventStrategyIndexTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class EventStrategyIndexTests
+{
+    [Test]
+    public async Task All_Events_Expose_StrategyIndex_Via_Context()
+    {
+        var observed = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var retry = TypedPrefix()
+            .WhenResult(-1)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = item => observed["retry"] = item.Context.StrategyIndex;
+            });
+        _ = await retry.ExecuteAsync(static _ => new ValueTask<int>(-1));
+
+        var timeout = Prefix().Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromMilliseconds(1);
+            options.OnTimeout = item => observed["timeout"] = item.Context.StrategyIndex;
+        });
+        _ = await timeout.ExecuteOutcomeAsync<int>(static async cancellationToken =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        });
+
+        var hedge = TypedPrefix().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.Zero;
+            options.OnHedge = item => observed["hedge"] = item.Context.StrategyIndex;
+            options.ActionGenerator = item =>
+            {
+                observed["hedge-generator"] = item.Context.StrategyIndex;
+                return null;
+            };
+        });
+        _ = await hedge.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+        var fallback = TypedPrefix()
+            .When<InvalidOperationException>()
+            .FallbackTo(42, options => options.OnFallback = item =>
+                observed["fallback"] = item.Context.StrategyIndex);
+        _ = await fallback.ExecuteAsync(static _ => throw new InvalidOperationException());
+
+        var breaker = TypedPrefix()
+            .WhenResult(-1)
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.BreakDurationGenerator = item =>
+                {
+                    observed["breaker-duration"] = item.Context.StrategyIndex;
+                    return new ValueTask<TimeSpan>(TimeSpan.FromMinutes(1));
+                };
+                options.OnStateChanged = item =>
+                    observed["breaker-state"] = item.Context.StrategyIndex;
+            });
+        _ = await breaker.ExecuteAsync(static _ => new ValueTask<int>(-1));
+
+        var timeProvider = new FakeTimeProvider();
+        var rateLimit = Prefix().RateLimit(options =>
+            {
+                options.Permits = 1;
+                options.Window = TimeSpan.FromMinutes(1);
+                options.OnRejected = item =>
+                    observed["rate-limit"] = item.Context.StrategyIndex;
+            })
+            .WithTimeProvider(timeProvider);
+        await rateLimit.ExecuteAsync(static _ => ValueTask.CompletedTask);
+        _ = await rateLimit.ExecuteOutcomeAsync<int>(static _ => new ValueTask<int>(0));
+
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var concurrencyLimit = Prefix().ConcurrencyLimit(options =>
+        {
+            options.MaxConcurrency = 1;
+            options.OnRejected = item =>
+                observed["concurrency-limit"] = item.Context.StrategyIndex;
+        });
+        var running = concurrencyLimit.ExecuteAsync(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+        }).AsTask();
+        await started.Task;
+        _ = await concurrencyLimit.ExecuteOutcomeAsync<int>(static _ => new ValueTask<int>(0));
+        release.SetResult();
+        await running;
+
+        var expected = new[]
+        {
+            "retry",
+            "timeout",
+            "hedge",
+            "hedge-generator",
+            "fallback",
+            "breaker-duration",
+            "breaker-state",
+            "rate-limit",
+            "concurrency-limit",
+        };
+        await Assert.That(observed.Keys).IsEquivalentTo(expected);
+        await Assert.That(observed.Values.All(static index => index == 1)).IsTrue();
+    }
+
+    private static Shield Prefix() => Shield.Use(new PassThroughStrategy());
+
+    private static Shield<int> TypedPrefix() =>
+        Shield<int>.Empty.Use(new PassThroughStrategy());
+
+    private sealed class PassThroughStrategy : Strategy
+    {
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context) => next.InvokeAsync(context);
+    }
+}

--- a/tests/Kevlar.Tests/EventStrategyIndexTests.cs
+++ b/tests/Kevlar.Tests/EventStrategyIndexTests.cs
@@ -123,6 +123,8 @@ public class EventStrategyIndexTests
 
         await Assert.That(outcome.Exception).IsNull();
         await Assert.That(outer.StrategyIndexAfterContinuations).IsEqualTo(0);
+        await Assert.That(inner.FirstStrategyIndexAfterRelease).IsEqualTo(1);
+        await Assert.That(inner.SecondStrategyIndexAfterRelease).IsEqualTo(1);
     }
 
     private static Shield Prefix() => Shield.Use(new PassThroughStrategy());
@@ -172,6 +174,10 @@ public class EventStrategyIndexTests
         public TaskCompletionSource ReleaseSecond { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public int FirstStrategyIndexAfterRelease { get; private set; } = -1;
+
+        public int SecondStrategyIndexAfterRelease { get; private set; } = -1;
+
         public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
             Continuation<T, TState> next,
             KevlarContext context)
@@ -183,6 +189,15 @@ public class EventStrategyIndexTests
             }
 
             await (invocation == 1 ? ReleaseFirst.Task : ReleaseSecond.Task);
+            if (invocation == 1)
+            {
+                FirstStrategyIndexAfterRelease = context.StrategyIndex;
+            }
+            else
+            {
+                SecondStrategyIndexAfterRelease = context.StrategyIndex;
+            }
+
             return await next.InvokeAsync(context);
         }
     }

--- a/tests/Kevlar.Tests/EventStrategyIndexTests.cs
+++ b/tests/Kevlar.Tests/EventStrategyIndexTests.cs
@@ -112,6 +112,19 @@ public class EventStrategyIndexTests
         await Assert.That(observed.Values.All(static index => index == 1)).IsTrue();
     }
 
+    [Test]
+    public async Task Parallel_Continuations_Restore_Owning_Strategy_Index()
+    {
+        var inner = new OutOfOrderCompletionStrategy();
+        var outer = new ParallelContinuationStrategy(inner);
+        var shield = Shield.Use(outer).Use(inner);
+
+        var outcome = await shield.ExecuteOutcomeAsync<int>(static _ => new ValueTask<int>(42));
+
+        await Assert.That(outcome.Exception).IsNull();
+        await Assert.That(outer.StrategyIndexAfterContinuations).IsEqualTo(0);
+    }
+
     private static Shield Prefix() => Shield.Use(new PassThroughStrategy());
 
     private static Shield<int> TypedPrefix() =>
@@ -122,5 +135,55 @@ public class EventStrategyIndexTests
         public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
             Continuation<T, TState> next,
             KevlarContext context) => next.InvokeAsync(context);
+    }
+
+    private sealed class ParallelContinuationStrategy(OutOfOrderCompletionStrategy inner) : Strategy
+    {
+        public int StrategyIndexAfterContinuations { get; private set; } = -1;
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            var first = next.InvokeAsync(context).AsTask();
+            var second = next.InvokeAsync(context).AsTask();
+
+            await inner.BothEntered.Task;
+            inner.ReleaseFirst.SetResult();
+            _ = await first;
+            inner.ReleaseSecond.SetResult();
+            var outcome = await second;
+
+            StrategyIndexAfterContinuations = context.StrategyIndex;
+            return outcome;
+        }
+    }
+
+    private sealed class OutOfOrderCompletionStrategy : Strategy
+    {
+        private int _invocations;
+
+        public TaskCompletionSource BothEntered { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseFirst { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseSecond { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            var invocation = Interlocked.Increment(ref _invocations);
+            if (invocation == 2)
+            {
+                BothEntered.SetResult();
+            }
+
+            await (invocation == 1 ? ReleaseFirst.Task : ReleaseSecond.Task);
+            return await next.InvokeAsync(context);
+        }
     }
 }

--- a/tests/Kevlar.Tests/ExecutionContextPlumbingTests.cs
+++ b/tests/Kevlar.Tests/ExecutionContextPlumbingTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.Extensions.Time.Testing;
 
@@ -139,6 +140,37 @@ public class ExecutionContextPlumbingTests
     }
 
     [Test]
+    public async Task Custom_Strategy_Can_Read_Its_Index_Before_And_After_Nested_Execution()
+    {
+        var before = new ConcurrentBag<int>();
+        var after = new ConcurrentBag<int>();
+        var shield = Shield
+            .Use(new IndexCapturingStrategy(new ConcurrentBag<int>(), new ConcurrentBag<int>()))
+            .Use(new IndexCapturingStrategy(before, after))
+            .Use(new IndexCapturingStrategy(new ConcurrentBag<int>(), new ConcurrentBag<int>()));
+
+        await shield.ExecuteAsync(static _ => ValueTask.CompletedTask);
+
+        await Assert.That(before).IsEquivalentTo([1]);
+        await Assert.That(after).IsEquivalentTo([1]);
+    }
+
+    [Test]
+    public async Task Hedge_Forks_Keep_The_Inner_Strategy_Index()
+    {
+        var before = new ConcurrentBag<int>();
+        var after = new ConcurrentBag<int>();
+        var shield = Shield
+            .Hedge(2, TimeSpan.Zero)
+            .Use(new IndexCapturingStrategy(before, after));
+
+        await shield.ExecuteAsync(static _ => ValueTask.CompletedTask);
+
+        await Assert.That(before).IsEquivalentTo([1, 1]);
+        await Assert.That(after).IsEquivalentTo([1, 1]);
+    }
+
+    [Test]
     public async Task Exception_Proxy_Never_Leaks_From_Public_Outcome_Members()
     {
         var original = new InvalidOperationException("original");
@@ -190,6 +222,21 @@ public class ExecutionContextPlumbingTests
         return parameter.ParameterType.IsValueType
             ? Activator.CreateInstance(parameter.ParameterType)
             : null;
+    }
+
+    private sealed class IndexCapturingStrategy(
+        ConcurrentBag<int> before,
+        ConcurrentBag<int> after) : Strategy
+    {
+        public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            before.Add(context.StrategyIndex);
+            var outcome = await next.InvokeAsync(context);
+            after.Add(context.StrategyIndex);
+            return outcome;
+        }
     }
 
     private static Exception CaptureReflectionFailure(Action action)

--- a/tests/Kevlar.Tests/LimiterRejectionHookTests.cs
+++ b/tests/Kevlar.Tests/LimiterRejectionHookTests.cs
@@ -11,6 +11,7 @@ public class LimiterRejectionHookTests
         var order = new List<string>();
         RateLimitRejectedEvent observed = default;
         string? observedShieldName = null;
+        var observedStrategyIndex = -1;
         var shield = Shield.For<int>()
             .RateLimit(options =>
             {
@@ -22,6 +23,7 @@ public class LimiterRejectionHookTests
                 {
                     observed = rejection;
                     observedShieldName = rejection.Context.ShieldName;
+                    observedStrategyIndex = rejection.Context.StrategyIndex;
                     order.Add("sync");
                 };
                 options.OnRejectedAsync = async rejection =>
@@ -44,7 +46,7 @@ public class LimiterRejectionHookTests
         await Assert.That(observed.Window).IsEqualTo(TimeSpan.FromSeconds(2));
         await Assert.That(observed.Burst).IsEqualTo(1);
         await Assert.That(observed.QueueLimit).IsEqualTo(0);
-        await Assert.That(observed.StrategyIndex).IsEqualTo(0);
+        await Assert.That(observedStrategyIndex).IsEqualTo(0);
         await Assert.That(observedShieldName).IsEqualTo("orders");
     }
 
@@ -54,6 +56,7 @@ public class LimiterRejectionHookTests
         var order = new List<string>();
         ConcurrencyLimitRejectedEvent observed = default;
         string? observedShieldName = null;
+        var observedStrategyIndex = -1;
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var shield = Shield
@@ -66,6 +69,7 @@ public class LimiterRejectionHookTests
                 {
                     observed = rejection;
                     observedShieldName = rejection.Context.ShieldName;
+                    observedStrategyIndex = rejection.Context.StrategyIndex;
                     order.Add("sync");
                 };
                 options.OnRejectedAsync = async rejection =>
@@ -91,7 +95,7 @@ public class LimiterRejectionHookTests
         await Assert.That(order.SequenceEqual(["sync", "async"])).IsTrue();
         await Assert.That(observed.MaxConcurrency).IsEqualTo(1);
         await Assert.That(observed.QueueLimit).IsEqualTo(0);
-        await Assert.That(observed.StrategyIndex).IsEqualTo(0);
+        await Assert.That(observedStrategyIndex).IsEqualTo(0);
         await Assert.That(observedShieldName).IsEqualTo("bulkhead");
 
         release.SetResult();


### PR DESCRIPTION
## Summary

- expose the active strategy position through `KevlarContext.StrategyIndex` and give every callback event a uniform guarded `Context`
- rename `CircuitStateChangedEvent`, carry triggering/manual contexts through breaker transitions, and add typed break-duration outcomes plus failure statistics
- store typed retry outcomes directly, preserving the zero-allocation callback path
- update `Kevlar.Testing` telemetry, public API baselines, docs, and cross-strategy regression coverage

`CircuitBreakerMonitor.StateChanged` deliberately remains `Action<CircuitBreakerStateChangedEvent>`; the callback contract is documented and pinned.

Closes #210

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -f net8.0 -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -f net10.0 -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Testing.Tests -c Release --no-build` (net8/net10)
- `dotnet run --project tests/Kevlar.Extensions.RateLimiting.Tests -c Release --no-build` (net8/net10)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build` (net8/net10)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m`
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/packages-issue210-lf -Version 1.1.0-issue210`
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/packages-issue210-lf -Version 1.1.0-issue210` with CI package metadata
- `npm ci && npm run build` in `docs/`