### PR TITLE
feat(handling): add contextual predicates

### DIFF
--- a/docs/docs/custom-strategies.md
+++ b/docs/docs/custom-strategies.md
@@ -101,8 +101,9 @@ public sealed class RetryOnceStrategy(HandlingClause handling) : Strategy
     public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
         Continuation<T, TState> next, KevlarContext context)
     {
+        var strategyIndex = context.StrategyIndex;
         var outcome = await next.InvokeAsync(context);
-        return handling.ShouldHandle(in outcome)
+        return handling.ShouldHandle(in outcome, context, attempt: 0, strategyIndex)
             ? await next.InvokeAsync(context)
             : outcome;
     }
@@ -113,7 +114,8 @@ var shield = Shield
     .Use(clause => new RetryOnceStrategy(clause));
 ```
 
-`ShouldHandle` works with exception and typed-result outcomes. The default handles ordinary
+`ShouldHandle` works with exception and typed-result outcomes. Pass the active context, attempt,
+and the strategy index captured before invoking `next` to support context-aware clauses. The default handles ordinary
 exceptions, excluding cancellation, Kevlar's fail-fast rejections, and fatal runtime failures. The
 existing `Use(Strategy)` overload remains the simpler choice for proactive strategies that do not
 inspect failures.

--- a/docs/docs/custom-strategies.md
+++ b/docs/docs/custom-strategies.md
@@ -103,7 +103,11 @@ public sealed class RetryOnceStrategy(HandlingClause handling) : Strategy
     {
         var strategyIndex = context.StrategyIndex;
         var outcome = await next.InvokeAsync(context);
-        return handling.ShouldHandle(in outcome, context, attempt: 0, strategyIndex)
+        return handling.ShouldHandle(
+            in outcome,
+            context,
+            attempt: 0,
+            strategyIndex: strategyIndex)
             ? await next.InvokeAsync(context)
             : outcome;
     }

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -163,12 +163,14 @@ with `WhenAnyError()`, which resets *handling* to Kevlar's default.
 
 Use a `HandlingEvent` predicate when handling depends on the current attempt, execution
 properties, or strategy position. `Attempt` is zero-based for retry and hedging, and zero for
-circuit breakers and fallbacks.
+circuit breakers and fallbacks. Start with `WhenContext`, continue exception or outcome
+alternatives with `OrContext`, and use `WhenResultContext` / `OrResultContext` when only successful
+typed results should reach the predicate.
 
 ```csharp
 var isRead = new KevlarKey<bool>("is-read");
 var contextual = Shield
-    .When((HandlingEvent handling) =>
+    .WhenContext(handling =>
         handling.Exception is TimeoutExceededException
         && handling.Attempt < 2
         && handling.Context.Properties.GetOrDefault(isRead))

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -190,41 +190,6 @@ On `Shield<TResult>`, context-aware predicates receive `HandlingEvent<TResult>`.
 per-strategy override. A context-aware predicate that throws is reported through `Trace` and treated as not
 handled, so it cannot replace the execution's real outcome.
 
-## Clauses are ambient
-
-A clause applies to the strategy it is attached to *and* to every reactive strategy chained after
-it, until you write a new clause, call `WhenAnyError()`, or compose with `Wrap`/`Compose`:
-
-<!-- doc-test-ignore: Uses an ellipsis for the application-specific fallback implementation. -->
-```csharp
-Shield
-    .When<HttpRequestException>()      // clause #1
-    .Retry(3)                            //   ← uses clause #1
-    .CircuitBreaker(consecutiveFailures: 5, breakDuration: breakDuration)    //   ← also clause #1
-    .When<TimeoutExceededException>()  // clause #2 replaces #1 from here on
-    .Fallback(...);                      //   ← uses clause #2
-```
-
-This is why most chains only need one clause, written once at the top — and why you never repeat a `ShouldHandle` predicate per strategy like in Polly v8.
-
-A clause that never reaches a reactive strategy does nothing at all. The optional analyzer reports that as [`KEV007`](analyzers.md#kev007-dead-handling-clause). It also marks the strategies that *inherit* a clause, rather than declaring one, as the informational hint [`KEV009`](analyzers.md#kev009-inherited-handling-clause), so the span above is visible in the editor.
-
-### Reset to default handling
-
-Call `WhenAnyError()` to clear the ambient clause. Reactive strategies chained after it return to
-Kevlar's default handling: ordinary exceptions, excluding cancellation, Kevlar's fail-fast
-rejections, and fatal runtime failures.
-
-```csharp
-var shield = Shield
-    .When<HttpRequestException>()
-    .Retry(3)                                      // handles HttpRequestException only
-    .WhenAnyError()
-    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30)); // handles ordinary exceptions
-```
-
-`WhenAnyError()` preserves existing strategies, the shield name, and its `TimeProvider`; it only changes handling for reactive strategies added afterwards. It is available on both `Shield` and `Shield<T>`.
-
 ## Per-strategy overrides
 
 Use an options predicate when one reactive strategy needs different handling without changing the

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -159,6 +159,70 @@ Shield.For<int>().WhenResult(-1).Retry(2);            // clean: the failing valu
 All four are named after the `WhenResult` / `OrResult` family precisely so they cannot be confused
 with `WhenAnyError()`, which resets *handling* to Kevlar's default.
 
+## Context-aware clauses
+
+Use a `HandlingEvent` predicate when handling depends on the current attempt, execution
+properties, or strategy position. `Attempt` is zero-based for retry and hedging, and zero for
+circuit breakers and fallbacks.
+
+```csharp
+var isRead = new KevlarKey<bool>("is-read");
+var contextual = Shield
+    .When((HandlingEvent handling) =>
+        handling.Exception is TimeoutExceededException
+        && handling.Attempt < 2
+        && handling.Context.Properties.GetOrDefault(isRead))
+    .Retry(3, Backoff.None);
+
+await contextual.ExecuteWithContextAsync(
+    isRead,
+    static (key, properties) => properties.Set(key, true),
+    static (_, _) => ValueTask.FromException(
+        new TimeoutExceededException(TimeSpan.FromSeconds(1))),
+    cancellationToken);
+```
+
+On `Shield<TResult>`, context-aware predicates receive `HandlingEvent<TResult>`. Its typed
+`Outcome` exposes either the exception or result without boxing. Use the
+`HandlesExceptionWithContext` and `HandlesResultWithContext` option properties for a local
+per-strategy override. A context-aware predicate that throws is reported through `Trace` and treated as not
+handled, so it cannot replace the execution's real outcome.
+
+## Clauses are ambient
+
+A clause applies to the strategy it is attached to *and* to every reactive strategy chained after
+it, until you write a new clause, call `WhenAnyError()`, or compose with `Wrap`/`Compose`:
+
+<!-- doc-test-ignore: Uses an ellipsis for the application-specific fallback implementation. -->
+```csharp
+Shield
+    .When<HttpRequestException>()      // clause #1
+    .Retry(3)                            //   ← uses clause #1
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: breakDuration)    //   ← also clause #1
+    .When<TimeoutExceededException>()  // clause #2 replaces #1 from here on
+    .Fallback(...);                      //   ← uses clause #2
+```
+
+This is why most chains only need one clause, written once at the top — and why you never repeat a `ShouldHandle` predicate per strategy like in Polly v8.
+
+A clause that never reaches a reactive strategy does nothing at all. The optional analyzer reports that as [`KEV007`](analyzers.md#kev007-dead-handling-clause). It also marks the strategies that *inherit* a clause, rather than declaring one, as the informational hint [`KEV009`](analyzers.md#kev009-inherited-handling-clause), so the span above is visible in the editor.
+
+### Reset to default handling
+
+Call `WhenAnyError()` to clear the ambient clause. Reactive strategies chained after it return to
+Kevlar's default handling: ordinary exceptions, excluding cancellation, Kevlar's fail-fast
+rejections, and fatal runtime failures.
+
+```csharp
+var shield = Shield
+    .When<HttpRequestException>()
+    .Retry(3)                                      // handles HttpRequestException only
+    .WhenAnyError()
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30)); // handles ordinary exceptions
+```
+
+`WhenAnyError()` preserves existing strategies, the shield name, and its `TimeProvider`; it only changes handling for reactive strategies added afterwards. It is available on both `Shield` and `Shield<T>`.
+
 ## Per-strategy overrides
 
 Use an options predicate when one reactive strategy needs different handling without changing the
@@ -202,7 +266,9 @@ var shield = Shield.When<HttpRequestException>()
     .Use(clause => new RetryOnceStrategy(clause));
 ```
 
-The factory runs once and receives a `HandlingClause`. Call `clause.ShouldHandle(in outcome)` inside the strategy so exception and result rules stay aligned with the shield. See [Custom Strategies](custom-strategies.md#consume-handling-clauses) for a complete implementation.
+The factory runs once and receives a `HandlingClause`. Call its context-aware `ShouldHandle`
+overload inside the strategy so exception and result rules stay aligned with the shield. See
+[Custom Strategies](custom-strategies.md#consume-handling-clauses) for a complete implementation.
 
 :::info Lifting preserves clauses; composition seals them
 `shield.For<T>()`, `WithName(...)`, and `WithTimeProvider(...)` are same-chain copies, so they

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -90,7 +90,7 @@ context-aware clause:
 
 ```csharp
 var attemptAware = Shield
-    .When((HandlingEvent handling) =>
+    .WhenContext(handling =>
         handling.Exception is TimeoutExceededException && handling.Attempt < 2)
     .Retry(3, Backoff.None);
 ```

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -85,6 +85,18 @@ For a direct per-strategy translation, set `HandlesException` and `HandlesResult
 strategy's options. A local override replaces the ambient clause. `WhenAnyError()` returns later
 strategies to Kevlar's default handling.
 
+Polly predicates that inspect `args.AttemptNumber` or `args.Context.Properties` map to a
+context-aware clause:
+
+```csharp
+var attemptAware = Shield
+    .When((HandlingEvent handling) =>
+        handling.Exception is TimeoutExceededException && handling.Attempt < 2)
+    .Retry(3, Backoff.None);
+```
+
+`HandlingEvent.Attempt` is the direct zero-based counterpart to Polly's `AttemptNumber`.
+
 Polly's default predicate handles every exception except `OperationCanceledException`. Kevlar also
 lets execution-rejection exceptions and fatal runtime exceptions propagate by default. Use an
 explicit clause when a shield intentionally recovers `CircuitOpenException`,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -2200,7 +2200,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool StartsHandlingClause(IMethodSymbol method, KnownTypes knownTypes) =>
-        (method.Name is "When" or "WhenResult" or "WhenResultIsDefault" or "WhenResultIsNull" or "WhenAnyError")
+        (method.Name is "When" or "WhenContext" or "WhenResult" or "WhenResultContext"
+            or "WhenResultIsDefault" or "WhenResultIsNull" or "WhenAnyError")
         && (knownTypes.IsShield(method.ContainingType)
             || knownTypes.IsShieldExtensions(method.ContainingType));
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -2044,7 +2044,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 Target: IPropertyReferenceOperation propertyReference,
                 Value: { } value,
             }
-            && propertyReference.Property.Name is "HandlesException" or "HandlesResult"
+            && propertyReference.Property.Name is
+                "HandlesException"
+                or "HandlesResult"
+                or "HandlesExceptionWithContext"
+                or "HandlesResultWithContext"
             && propertyReference.Property.ContainingNamespace.ToDisplayString() == "Kevlar"
             && value.ConstantValue is not { HasValue: true, Value: null })
         {
@@ -2108,7 +2112,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             if (current.ContainingNamespace.ToDisplayString() == "Kevlar"
                 && (current.GetMembers("HandlesException").Length > 0
-                    || current.GetMembers("HandlesResult").Length > 0))
+                    || current.GetMembers("HandlesResult").Length > 0
+                    || current.GetMembers("HandlesExceptionWithContext").Length > 0
+                    || current.GetMembers("HandlesResultWithContext").Length > 0))
             {
                 return true;
             }

--- a/src/Kevlar.Testing/HandlingClauseDescriptor.cs
+++ b/src/Kevlar.Testing/HandlingClauseDescriptor.cs
@@ -1,0 +1,17 @@
+namespace Kevlar.Testing;
+
+/// <summary>Read-only handling-clause metadata.</summary>
+public sealed class HandlingClauseDescriptor
+{
+    internal HandlingClauseDescriptor(string? description, bool isContextAware)
+    {
+        Description = description;
+        IsContextAware = isContextAware;
+    }
+
+    /// <summary>The clause text used in pipeline descriptions, when explicitly configured.</summary>
+    public string? Description { get; }
+
+    /// <summary>Whether the clause consults execution or strategy context.</summary>
+    public bool IsContextAware { get; }
+}

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -149,3 +149,7 @@ Kevlar.Testing.TelemetryRecorder.WaitForMetricCountAsync(int count, System.Threa
 static Kevlar.Testing.ShieldExecutionExtensions.WaitForPendingAsync(this System.Threading.Tasks.Task! execution, System.Func<bool>! workStarted, string! workDescription, int maxYields = 100, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
 Kevlar.Testing.ConcurrencyLimitStrategyDescriptor.HasNotification.get -> bool
 Kevlar.Testing.RateLimitStrategyDescriptor.HasNotification.get -> bool
+Kevlar.Testing.HandlingClauseDescriptor
+Kevlar.Testing.HandlingClauseDescriptor.Description.get -> string?
+Kevlar.Testing.HandlingClauseDescriptor.IsContextAware.get -> bool
+Kevlar.Testing.StrategyDescriptor.HandlingClause.get -> Kevlar.Testing.HandlingClauseDescriptor?

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -53,7 +53,7 @@ public static class ShieldDescriptorExtensions
     private static StrategyDescriptor Describe(Strategy strategy)
     {
         var description = strategy.Describe();
-        return strategy switch
+        StrategyDescriptor descriptor = strategy switch
         {
             RetryStrategy retry => new RetryStrategyDescriptor(
                 description,
@@ -105,6 +105,11 @@ public static class ShieldDescriptorExtensions
                 strategy.GetType(),
                 strategy.ReactiveJudge is { } judge ? new HandlingClause(judge) : null),
         };
+
+        descriptor.SetHandlingClause(strategy.ReactiveJudge is { } handling
+            ? new HandlingClauseDescriptor(handling.Description, handling.IsContextAware)
+            : null);
+        return descriptor;
     }
 
     private static bool IsRateLimiterAdapterStrategy(Type strategyType) =>

--- a/src/Kevlar.Testing/StrategyDescriptor.cs
+++ b/src/Kevlar.Testing/StrategyDescriptor.cs
@@ -14,4 +14,10 @@ public abstract class StrategyDescriptor
 
     /// <summary>A human-readable diagnostic description. Do not parse this value as a contract.</summary>
     public string Description { get; }
+
+    /// <summary>The strategy's handling metadata, or <see langword="null"/> when proactive.</summary>
+    public HandlingClauseDescriptor? HandlingClause { get; private set; }
+
+    internal void SetHandlingClause(HandlingClauseDescriptor? handlingClause) =>
+        HandlingClause = handlingClause;
 }

--- a/src/Kevlar/HandlingClause.cs
+++ b/src/Kevlar/HandlingClause.cs
@@ -21,5 +21,20 @@ public readonly struct HandlingClause
     internal OutcomeJudge Judge => _judge ?? OutcomeJudge.Default;
 
     /// <summary>Returns whether <paramref name="outcome"/> is a handled failure.</summary>
-    public bool ShouldHandle<T>(in Outcome<T> outcome) => Judge.ShouldHandle(in outcome);
+    public bool ShouldHandle<T>(in Outcome<T> outcome) =>
+        Judge.ShouldHandle(in outcome, context: null, attempt: 0, strategyIndex: -1);
+
+    /// <summary>Returns whether an outcome is handled for the active execution and strategy.</summary>
+    public bool ShouldHandle<T>(
+        in Outcome<T> outcome,
+        KevlarContext context,
+        int attempt = 0,
+        int strategyIndex = -1)
+    {
+        Throw.IfNull(context, nameof(context));
+        return Judge.ShouldHandle(in outcome, context, attempt, strategyIndex);
+    }
+
+    /// <summary>Whether this clause consults execution or strategy context.</summary>
+    public bool IsContextAware => Judge.IsContextAware;
 }

--- a/src/Kevlar/HandlingEvent.cs
+++ b/src/Kevlar/HandlingEvent.cs
@@ -1,0 +1,50 @@
+namespace Kevlar;
+
+/// <summary>Context supplied to an exception handling predicate.</summary>
+public readonly struct HandlingEvent
+{
+    internal HandlingEvent(Exception exception, KevlarContext context, int attempt, int strategyIndex)
+    {
+        Exception = exception;
+        Context = context;
+        Attempt = attempt;
+        StrategyIndex = strategyIndex;
+    }
+
+    /// <summary>The exception being classified.</summary>
+    public Exception Exception { get; }
+
+    /// <summary>The active execution context. Do not retain this pooled object.</summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>The zero-based attempt number for retry and hedging; zero for other strategies.</summary>
+    public int Attempt { get; }
+
+    /// <summary>The zero-based index of the strategy evaluating the outcome.</summary>
+    public int StrategyIndex { get; }
+}
+
+/// <summary>Context supplied to a result-aware handling predicate.</summary>
+/// <typeparam name="TResult">The execution result type.</typeparam>
+public readonly struct HandlingEvent<TResult>
+{
+    internal HandlingEvent(Outcome<TResult> outcome, KevlarContext context, int attempt, int strategyIndex)
+    {
+        Outcome = outcome;
+        Context = context;
+        Attempt = attempt;
+        StrategyIndex = strategyIndex;
+    }
+
+    /// <summary>The exception or result being classified.</summary>
+    public Outcome<TResult> Outcome { get; }
+
+    /// <summary>The active execution context. Do not retain this pooled object.</summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>The zero-based attempt number for retry and hedging; zero for other strategies.</summary>
+    public int Attempt { get; }
+
+    /// <summary>The zero-based index of the strategy evaluating the outcome.</summary>
+    public int StrategyIndex { get; }
+}

--- a/src/Kevlar/HandlingEventOfT.cs
+++ b/src/Kevlar/HandlingEventOfT.cs
@@ -1,18 +1,19 @@
 namespace Kevlar;
 
-/// <summary>Context supplied to an exception handling predicate.</summary>
-public readonly struct HandlingEvent
+/// <summary>Context supplied to a result-aware handling predicate.</summary>
+/// <typeparam name="TResult">The execution result type.</typeparam>
+public readonly struct HandlingEvent<TResult>
 {
-    internal HandlingEvent(Exception exception, KevlarContext context, int attempt, int strategyIndex)
+    internal HandlingEvent(Outcome<TResult> outcome, KevlarContext context, int attempt, int strategyIndex)
     {
-        Exception = exception;
+        Outcome = outcome;
         Context = context;
         Attempt = attempt;
         StrategyIndex = strategyIndex;
     }
 
-    /// <summary>The exception being classified.</summary>
-    public Exception Exception { get; }
+    /// <summary>The exception or result being classified.</summary>
+    public Outcome<TResult> Outcome { get; }
 
     /// <summary>The active execution context. Do not retain this pooled object.</summary>
     public KevlarContext Context { get; }

--- a/src/Kevlar/Internal/HandlingOverride.cs
+++ b/src/Kevlar/Internal/HandlingOverride.cs
@@ -4,16 +4,48 @@ internal static class HandlingOverride
 {
     internal static OutcomeJudge Resolve(
         Func<Exception, bool>? handlesException,
+        Func<HandlingEvent, bool>? handlesExceptionWithContext,
         OutcomeJudge ambientJudge) =>
-        handlesException is null
+        handlesException is null && handlesExceptionWithContext is null
             ? ambientJudge
-            : new ExceptionJudge(handlesException);
+            : handlesExceptionWithContext is null
+                ? new ExceptionJudge(handlesException!)
+                : new ContextExceptionJudge(handlesException, handlesExceptionWithContext);
 
     internal static OutcomeJudge Resolve<TResult>(
         Func<Exception, bool>? handlesException,
         Func<TResult, bool>? handlesResult,
+        Func<HandlingEvent<TResult>, bool>? handlesExceptionWithContext,
+        Func<HandlingEvent<TResult>, bool>? handlesResultWithContext,
         OutcomeJudge ambientJudge) =>
-        handlesException is null && handlesResult is null
+        handlesException is null
+            && handlesResult is null
+            && handlesExceptionWithContext is null
+            && handlesResultWithContext is null
             ? ambientJudge
-            : new TypedJudge<TResult>(handlesException, handlesResult);
+            : new TypedJudge<TResult>(
+                handlesException,
+                handlesResult,
+                contextPredicate: Combine(handlesExceptionWithContext, handlesResultWithContext));
+
+    private static Func<HandlingEvent<TResult>, bool>? Combine<TResult>(
+        Func<HandlingEvent<TResult>, bool>? exceptionPredicate,
+        Func<HandlingEvent<TResult>, bool>? resultPredicate)
+    {
+        if (exceptionPredicate is null)
+        {
+            return resultPredicate is null
+                ? null
+                : handling => handling.Outcome.Exception is null && resultPredicate(handling);
+        }
+
+        if (resultPredicate is null)
+        {
+            return handling => handling.Outcome.Exception is not null && exceptionPredicate(handling);
+        }
+
+        return handling => handling.Outcome.Exception is not null
+            ? exceptionPredicate(handling)
+            : resultPredicate(handling);
+    }
 }

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -29,10 +29,19 @@ internal abstract class OutcomeJudge
 
     public virtual bool IsContextAware => false;
 
-    protected internal static void ReportPredicateFailure(Exception exception) =>
-        System.Diagnostics.Trace.TraceError(
-            "Kevlar handling predicate failed and was treated as not handled: {0}",
-            exception);
+    protected internal static void ReportPredicateFailure(Exception exception)
+    {
+        try
+        {
+            System.Diagnostics.Trace.TraceError(
+                "Kevlar handling predicate failed and was treated as not handled: {0}",
+                exception);
+        }
+        catch
+        {
+            // Diagnostics must not change the protected execution's outcome.
+        }
+    }
 
     private sealed class DefaultJudge : OutcomeJudge
     {

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -29,7 +29,7 @@ internal abstract class OutcomeJudge
 
     public virtual bool IsContextAware => false;
 
-    protected static void ReportPredicateFailure(Exception exception) =>
+    protected internal static void ReportPredicateFailure(Exception exception) =>
         System.Diagnostics.Trace.TraceError(
             "Kevlar handling predicate failed and was treated as not handled: {0}",
             exception);

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Kevlar.Internal;
 
 /// <summary>
@@ -16,11 +18,25 @@ internal abstract class OutcomeJudge
     /// </summary>
     public virtual string? Description => null;
 
-    public abstract bool ShouldHandle<T>(in Outcome<T> outcome);
+    public abstract bool ShouldHandle<T>(
+        in Outcome<T> outcome,
+        KevlarContext? context,
+        int attempt,
+        int strategyIndex);
+
+    public bool ShouldHandle<T>(in Outcome<T> outcome) =>
+        ShouldHandle(in outcome, context: null, attempt: 0, strategyIndex: -1);
+
+    public virtual bool IsContextAware => false;
+
+    protected static void ReportPredicateFailure(Exception exception) =>
+        System.Diagnostics.Trace.TraceError(
+            "Kevlar handling predicate failed and was treated as not handled: {0}",
+            exception);
 
     private sealed class DefaultJudge : OutcomeJudge
     {
-        public override bool ShouldHandle<T>(in Outcome<T> outcome) =>
+        public override bool ShouldHandle<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
             outcome.Exception is { } exception && IsOrdinaryError(exception);
 
         private static bool IsOrdinaryError(Exception exception) =>
@@ -51,8 +67,53 @@ internal sealed class ExceptionJudge : OutcomeJudge
 
     public override string? Description => _description;
 
-    public override bool ShouldHandle<T>(in Outcome<T> outcome) =>
+    public override bool ShouldHandle<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
         outcome.Exception is { } exception && _predicate(exception);
+}
+
+/// <summary>Handles exceptions using the active execution and strategy context.</summary>
+internal sealed class ContextExceptionJudge : OutcomeJudge
+{
+    private readonly Func<Exception, bool>? _exceptionPredicate;
+    private readonly Func<HandlingEvent, bool> _predicate;
+    private readonly string? _description;
+
+    public ContextExceptionJudge(
+        Func<Exception, bool>? exceptionPredicate,
+        Func<HandlingEvent, bool> predicate,
+        string? description = null)
+    {
+        _exceptionPredicate = exceptionPredicate;
+        _predicate = predicate;
+        _description = description;
+    }
+
+    public override string? Description => _description;
+
+    public override bool IsContextAware => true;
+
+    public override bool ShouldHandle<T>(
+        in Outcome<T> outcome,
+        KevlarContext? context,
+        int attempt,
+        int strategyIndex) =>
+        outcome.Exception is { } exception
+        && ((_exceptionPredicate?.Invoke(exception) ?? false)
+            || (context is not null
+                && InvokeSafely(new HandlingEvent(exception, context, attempt, strategyIndex))));
+
+    private bool InvokeSafely(HandlingEvent handlingEvent)
+    {
+        try
+        {
+            return _predicate(handlingEvent);
+        }
+        catch (Exception exception)
+        {
+            ReportPredicateFailure(exception);
+            return false;
+        }
+    }
 }
 
 /// <summary>
@@ -63,22 +124,48 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
 {
     private readonly Func<Exception, bool>? _exceptionPredicate;
     private readonly Func<TResult, bool>? _resultPredicate;
+    private readonly Func<HandlingEvent<TResult>, bool>? _contextPredicate;
     private readonly string? _description;
 
     public TypedJudge(
         Func<Exception, bool>? exceptionPredicate,
         Func<TResult, bool>? resultPredicate,
-        string? description = null)
+        string? description = null,
+        Func<HandlingEvent<TResult>, bool>? contextPredicate = null)
     {
         _exceptionPredicate = exceptionPredicate;
         _resultPredicate = resultPredicate;
+        _contextPredicate = contextPredicate;
         _description = description;
     }
 
     public override string? Description => _description;
 
-    public override bool ShouldHandle<T>(in Outcome<T> outcome)
+    public override bool IsContextAware => _contextPredicate is not null;
+
+    public override bool ShouldHandle<T>(
+        in Outcome<T> outcome,
+        KevlarContext? context,
+        int attempt,
+        int strategyIndex)
     {
+        if (_contextPredicate is not null && context is not null && typeof(T) == typeof(TResult))
+        {
+            var typedOutcome = Unsafe.As<Outcome<T>, Outcome<TResult>>(
+                ref Unsafe.AsRef(in outcome));
+            try
+            {
+                if (_contextPredicate(new HandlingEvent<TResult>(typedOutcome, context, attempt, strategyIndex)))
+                {
+                    return true;
+                }
+            }
+            catch (Exception predicateException)
+            {
+                ReportPredicateFailure(predicateException);
+            }
+        }
+
         if (outcome.Exception is { } exception)
         {
             return _exceptionPredicate?.Invoke(exception) ?? false;

--- a/src/Kevlar/KevlarContext.cs
+++ b/src/Kevlar/KevlarContext.cs
@@ -26,6 +26,7 @@ public sealed class KevlarContext
 
     private CancellationToken _cancellationToken;
     private bool _isSynchronous;
+    private int _strategyIndex;
     private string? _shieldName;
     private TimeProvider _timeProvider = TimeProvider.System;
 
@@ -77,7 +78,20 @@ public sealed class KevlarContext
         internal set => _shieldName = value;
     }
 
-    internal int StrategyIndex { get; set; }
+    /// <summary>
+    /// The zero-based index of the most recently entered strategy, or -1 before the first strategy.
+    /// A strategy should capture this before invoking a continuation because inner strategies update it.
+    /// </summary>
+    public int StrategyIndex
+    {
+        get
+        {
+            ThrowIfReturnedToPool();
+            return _strategyIndex;
+        }
+
+        internal set => _strategyIndex = value;
+    }
 
     /// <summary>The time provider used for delays, timeouts and time-window calculations.</summary>
     public TimeProvider TimeProvider

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -470,4 +470,3 @@ Kevlar.ShieldBuilder<TResult>.OrResultContext(System.Func<Kevlar.HandlingEvent<T
 static Kevlar.Shield.WhenContext(System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
 static Kevlar.ShieldExtensions.WhenContext(this Kevlar.Shield! shield, System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
 Kevlar.HandlingClause.ShouldHandle<T>(in Kevlar.Outcome<T> outcome, Kevlar.KevlarContext! context, int attempt = 0, int strategyIndex = -1) -> bool
-Kevlar.KevlarContext.StrategyIndex.get -> int

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -436,12 +436,12 @@ Kevlar.RetryOptions<TResult>.HandlesExceptionWithContext.get -> System.Func<Kevl
 Kevlar.RetryOptions<TResult>.HandlesExceptionWithContext.set -> void
 Kevlar.RetryOptions<TResult>.HandlesResultWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
 Kevlar.RetryOptions<TResult>.HandlesResultWithContext.set -> void
-Kevlar.Shield<TResult>.When(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
-Kevlar.Shield<TResult>.WhenResult(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
-Kevlar.ShieldBuilder.Or(System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
-Kevlar.ShieldBuilder<TResult>.Or(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
-Kevlar.ShieldBuilder<TResult>.OrResult(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
-static Kevlar.Shield.When(System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
-static Kevlar.ShieldExtensions.When(this Kevlar.Shield! shield, System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
+Kevlar.Shield<TResult>.WhenContext(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.Shield<TResult>.WhenResultContext(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.ShieldBuilder.OrContext(System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
+Kevlar.ShieldBuilder<TResult>.OrContext(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.ShieldBuilder<TResult>.OrResultContext(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+static Kevlar.Shield.WhenContext(System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
+static Kevlar.ShieldExtensions.WhenContext(this Kevlar.Shield! shield, System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
 Kevlar.HandlingClause.ShouldHandle<T>(in Kevlar.Outcome<T> outcome, Kevlar.KevlarContext! context, int attempt = 0, int strategyIndex = -1) -> bool
 Kevlar.KevlarContext.StrategyIndex.get -> int

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -399,3 +399,49 @@ Kevlar.TimeoutExceededException.TimeoutExceededException() -> void
 Kevlar.TimeoutExceededException.TimeoutExceededException(string! message) -> void
 Kevlar.TimeoutExceededException.TimeoutExceededException(string! message, System.Exception! innerException) -> void
 Kevlar.TimeoutExceededException.TimeoutExceededException(System.TimeSpan timeout, System.OperationCanceledException! innerException) -> void
+Kevlar.HandlingEvent
+Kevlar.HandlingEvent.Attempt.get -> int
+Kevlar.HandlingEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.HandlingEvent.Exception.get -> System.Exception!
+Kevlar.HandlingEvent.HandlingEvent() -> void
+Kevlar.HandlingEvent.StrategyIndex.get -> int
+Kevlar.HandlingEvent<TResult>
+Kevlar.HandlingEvent<TResult>.Attempt.get -> int
+Kevlar.HandlingEvent<TResult>.Context.get -> Kevlar.KevlarContext!
+Kevlar.HandlingEvent<TResult>.HandlingEvent() -> void
+Kevlar.HandlingEvent<TResult>.Outcome.get -> Kevlar.Outcome<TResult>
+Kevlar.HandlingEvent<TResult>.StrategyIndex.get -> int
+Kevlar.HandlingClause.IsContextAware.get -> bool
+Kevlar.CircuitBreakerOptions.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent, bool>?
+Kevlar.CircuitBreakerOptions.HandlesExceptionWithContext.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.CircuitBreakerOptions<TResult>.HandlesExceptionWithContext.set -> void
+Kevlar.CircuitBreakerOptions<TResult>.HandlesResultWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.CircuitBreakerOptions<TResult>.HandlesResultWithContext.set -> void
+Kevlar.FallbackOptions.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent, bool>?
+Kevlar.FallbackOptions.HandlesExceptionWithContext.set -> void
+Kevlar.FallbackOptions<TResult>.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.FallbackOptions<TResult>.HandlesExceptionWithContext.set -> void
+Kevlar.FallbackOptions<TResult>.HandlesResultWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.FallbackOptions<TResult>.HandlesResultWithContext.set -> void
+Kevlar.HedgeOptions.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent, bool>?
+Kevlar.HedgeOptions.HandlesExceptionWithContext.set -> void
+Kevlar.HedgeOptions<TResult>.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.HedgeOptions<TResult>.HandlesExceptionWithContext.set -> void
+Kevlar.HedgeOptions<TResult>.HandlesResultWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.HedgeOptions<TResult>.HandlesResultWithContext.set -> void
+Kevlar.RetryOptions.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent, bool>?
+Kevlar.RetryOptions.HandlesExceptionWithContext.set -> void
+Kevlar.RetryOptions<TResult>.HandlesExceptionWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.RetryOptions<TResult>.HandlesExceptionWithContext.set -> void
+Kevlar.RetryOptions<TResult>.HandlesResultWithContext.get -> System.Func<Kevlar.HandlingEvent<TResult>, bool>?
+Kevlar.RetryOptions<TResult>.HandlesResultWithContext.set -> void
+Kevlar.Shield<TResult>.When(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.Shield<TResult>.WhenResult(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.ShieldBuilder.Or(System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
+Kevlar.ShieldBuilder<TResult>.Or(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+Kevlar.ShieldBuilder<TResult>.OrResult(System.Func<Kevlar.HandlingEvent<TResult>, bool>! predicate) -> Kevlar.ShieldBuilder<TResult>!
+static Kevlar.Shield.When(System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
+static Kevlar.ShieldExtensions.When(this Kevlar.Shield! shield, System.Func<Kevlar.HandlingEvent, bool>! predicate) -> Kevlar.ShieldBuilder!
+Kevlar.HandlingClause.ShouldHandle<T>(in Kevlar.Outcome<T> outcome, Kevlar.KevlarContext! context, int attempt = 0, int strategyIndex = -1) -> bool
+Kevlar.KevlarContext.StrategyIndex.get -> int

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -197,11 +197,11 @@ public sealed class Shield
         => ShieldExtensions.When(Empty, predicate);
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>. Use <see cref="ShieldExtensions.WhenAnyError(Shield)"/> to return to default handling.</summary>
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public static ShieldBuilder When(Func<Exception, bool> predicate) => ShieldExtensions.When(Empty, predicate);
 
     /// <summary>Starts a handling clause using the active execution and strategy context.</summary>
-    public static ShieldBuilder When(Func<HandlingEvent, bool> predicate) => ShieldExtensions.When(Empty, predicate);
+    public static ShieldBuilder WhenContext(Func<HandlingEvent, bool> predicate) =>
+        ShieldExtensions.WhenContext(Empty, predicate);
 
     /// <summary>Starts a result-aware shield for executions returning <typeparamref name="TResult"/>.</summary>
     public static Shield<TResult> For<TResult>() => Shield<TResult>.Empty;

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -197,7 +197,11 @@ public sealed class Shield
         => ShieldExtensions.When(Empty, predicate);
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>. Use <see cref="ShieldExtensions.WhenAnyError(Shield)"/> to return to default handling.</summary>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public static ShieldBuilder When(Func<Exception, bool> predicate) => ShieldExtensions.When(Empty, predicate);
+
+    /// <summary>Starts a handling clause using the active execution and strategy context.</summary>
+    public static ShieldBuilder When(Func<HandlingEvent, bool> predicate) => ShieldExtensions.When(Empty, predicate);
 
     /// <summary>Starts a result-aware shield for executions returning <typeparamref name="TResult"/>.</summary>
     public static Shield<TResult> For<TResult>() => Shield<TResult>.Empty;

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -268,16 +268,28 @@ public sealed class ShieldBuilder
         }
 
         return handling =>
+            EvaluateContextPredicates(predicates, handling);
+    }
+
+    internal static bool EvaluateContextPredicates<TEvent>(
+        Func<TEvent, bool>[] predicates,
+        TEvent handling)
+    {
+        foreach (var predicate in predicates)
         {
-            foreach (var predicate in predicates)
+            try
             {
                 if (predicate(handling))
                 {
                     return true;
                 }
             }
+            catch (Exception exception)
+            {
+                OutcomeJudge.ReportPredicateFailure(exception);
+            }
+        }
 
-            return false;
-        };
+        return false;
     }
 }

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -69,7 +69,6 @@ public sealed class ShieldBuilder
     }
 
     /// <summary>Returns a new builder that also handles exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
@@ -77,7 +76,7 @@ public sealed class ShieldBuilder
     }
 
     /// <summary>Returns a new builder that also handles exceptions selected using execution context.</summary>
-    public ShieldBuilder Or(Func<HandlingEvent, bool> predicate)
+    public ShieldBuilder OrContext(Func<HandlingEvent, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         return WithContext(predicate, "custom");

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -33,17 +33,23 @@ public sealed class ShieldBuilder
 {
     private readonly Shield _parent;
     private readonly Func<Exception, bool>[] _predicates;
+    private readonly Func<HandlingEvent, bool>[] _contextPredicates;
     private readonly string[] _clauseTerms;
 
     internal ShieldBuilder(Shield parent)
-        : this(parent, [], [])
+        : this(parent, [], [], [])
     {
     }
 
-    private ShieldBuilder(Shield parent, Func<Exception, bool>[] predicates, string[] clauseTerms)
+    private ShieldBuilder(
+        Shield parent,
+        Func<Exception, bool>[] predicates,
+        Func<HandlingEvent, bool>[] contextPredicates,
+        string[] clauseTerms)
     {
         _parent = parent;
         _predicates = predicates;
+        _contextPredicates = contextPredicates;
         _clauseTerms = clauseTerms;
     }
 
@@ -63,10 +69,18 @@ public sealed class ShieldBuilder
     }
 
     /// <summary>Returns a new builder that also handles exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         return With(predicate, "exception predicate");
+    }
+
+    /// <summary>Returns a new builder that also handles exceptions selected using execution context.</summary>
+    public ShieldBuilder Or(Func<HandlingEvent, bool> predicate)
+    {
+        Throw.IfNull(predicate, nameof(predicate));
+        return WithContext(predicate, "custom");
     }
 
     /// <summary>Retries handled exceptions up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
@@ -184,16 +198,32 @@ public sealed class ShieldBuilder
     /// never mutated, and the description is rendered here, so no later chaining — on this builder
     /// or on any builder derived from it — can change the handling of a shield already built.
     /// </summary>
-    private Shield Seal() =>
-        new(
-            _parent.Strategies,
-            new ExceptionJudge(Combine(_predicates), DescribeHelper.Clause(_clauseTerms)),
-            _parent.Name,
-            _parent.Time);
+    private Shield Seal()
+    {
+        var description = DescribeHelper.Clause(_clauseTerms);
+        OutcomeJudge judge = _contextPredicates.Length == 0
+            ? new ExceptionJudge(Combine(_predicates), description)
+            : new ContextExceptionJudge(
+                _predicates.Length == 0 ? null : Combine(_predicates),
+                CombineContexts(_contextPredicates),
+                description);
+        return new Shield(_parent.Strategies, judge, _parent.Name, _parent.Time);
+    }
 
     /// <summary>Builds the successor holding this builder's terms plus one more.</summary>
     private ShieldBuilder With(Func<Exception, bool> predicate, string clauseTerm) =>
-        new(_parent, Append(_predicates, predicate), Append(_clauseTerms, clauseTerm));
+        new(
+            _parent,
+            Append(_predicates, predicate),
+            _contextPredicates,
+            Append(_clauseTerms, clauseTerm));
+
+    private ShieldBuilder WithContext(Func<HandlingEvent, bool> predicate, string clauseTerm) =>
+        new(
+            _parent,
+            _predicates,
+            Append(_contextPredicates, predicate),
+            Append(_clauseTerms, clauseTerm));
 
     /// <summary>Copies <paramref name="source"/> with <paramref name="item"/> appended.</summary>
     internal static T[] Append<T>(T[] source, T item)
@@ -221,6 +251,27 @@ public sealed class ShieldBuilder
             foreach (var predicate in predicates)
             {
                 if (predicate(exception))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+    }
+
+    private static Func<HandlingEvent, bool> CombineContexts(Func<HandlingEvent, bool>[] predicates)
+    {
+        if (predicates.Length == 1)
+        {
+            return predicates[0];
+        }
+
+        return handling =>
+        {
+            foreach (var predicate in predicates)
+            {
+                if (predicate(handling))
                 {
                     return true;
                 }

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -309,17 +309,6 @@ public sealed class ShieldBuilder<TResult>
             return predicates[0];
         }
 
-        return handling =>
-        {
-            foreach (var predicate in predicates)
-            {
-                if (predicate(handling))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        };
+        return handling => ShieldBuilder.EvaluateContextPredicates(predicates, handling);
     }
 }

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -73,7 +73,6 @@ public sealed class ShieldBuilder<TResult>
     }
 
     /// <summary>Returns a new builder that also handles exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
@@ -81,14 +80,13 @@ public sealed class ShieldBuilder<TResult>
     }
 
     /// <summary>Returns a new builder that also handles outcomes selected using execution context.</summary>
-    public ShieldBuilder<TResult> Or(Func<HandlingEvent<TResult>, bool> predicate)
+    public ShieldBuilder<TResult> OrContext(Func<HandlingEvent<TResult>, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         return WithContext(predicate, "custom");
     }
 
     /// <summary>Returns a new builder that also handles results matching <paramref name="predicate"/>.</summary>
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> OrResult(Func<TResult, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
@@ -96,7 +94,7 @@ public sealed class ShieldBuilder<TResult>
     }
 
     /// <summary>Returns a new builder that also handles results selected using execution context.</summary>
-    public ShieldBuilder<TResult> OrResult(Func<HandlingEvent<TResult>, bool> predicate)
+    public ShieldBuilder<TResult> OrResultContext(Func<HandlingEvent<TResult>, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         return WithContext(

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -35,10 +35,11 @@ public sealed class ShieldBuilder<TResult>
     private readonly Shield<TResult> _parent;
     private readonly Func<Exception, bool>[] _exceptionPredicates;
     private readonly Func<TResult, bool>[] _resultPredicates;
+    private readonly Func<HandlingEvent<TResult>, bool>[] _contextPredicates;
     private readonly string[] _clauseTerms;
 
     internal ShieldBuilder(Shield<TResult> parent)
-        : this(parent, [], [], [])
+        : this(parent, [], [], [], [])
     {
     }
 
@@ -46,11 +47,13 @@ public sealed class ShieldBuilder<TResult>
         Shield<TResult> parent,
         Func<Exception, bool>[] exceptionPredicates,
         Func<TResult, bool>[] resultPredicates,
+        Func<HandlingEvent<TResult>, bool>[] contextPredicates,
         string[] clauseTerms)
     {
         _parent = parent;
         _exceptionPredicates = exceptionPredicates;
         _resultPredicates = resultPredicates;
+        _contextPredicates = contextPredicates;
         _clauseTerms = clauseTerms;
     }
 
@@ -70,17 +73,35 @@ public sealed class ShieldBuilder<TResult>
     }
 
     /// <summary>Returns a new builder that also handles exceptions matching <paramref name="predicate"/>, whatever their type.</summary>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> Or(Func<Exception, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         return WithException(predicate, "exception predicate");
     }
 
+    /// <summary>Returns a new builder that also handles outcomes selected using execution context.</summary>
+    public ShieldBuilder<TResult> Or(Func<HandlingEvent<TResult>, bool> predicate)
+    {
+        Throw.IfNull(predicate, nameof(predicate));
+        return WithContext(predicate, "custom");
+    }
+
     /// <summary>Returns a new builder that also handles results matching <paramref name="predicate"/>.</summary>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> OrResult(Func<TResult, bool> predicate)
     {
         Throw.IfNull(predicate, nameof(predicate));
         return WithResult(predicate, "result predicate");
+    }
+
+    /// <summary>Returns a new builder that also handles results selected using execution context.</summary>
+    public ShieldBuilder<TResult> OrResult(Func<HandlingEvent<TResult>, bool> predicate)
+    {
+        Throw.IfNull(predicate, nameof(predicate));
+        return WithContext(
+            handling => handling.Outcome.Exception is null && predicate(handling),
+            "custom");
     }
 
     /// <summary>Returns a new builder that also handles results equal to <paramref name="result"/>.</summary>
@@ -206,7 +227,8 @@ public sealed class ShieldBuilder<TResult>
         var judge = new TypedJudge<TResult>(
             exceptionPredicate,
             resultPredicate,
-            DescribeHelper.Clause(_clauseTerms));
+            DescribeHelper.Clause(_clauseTerms),
+            CombineContexts(_contextPredicates));
         return new Shield<TResult>(_parent.Strategies, judge, _parent.Name, _parent.Time);
     }
 
@@ -226,6 +248,7 @@ public sealed class ShieldBuilder<TResult>
             _parent,
             ShieldBuilder.Append(_exceptionPredicates, predicate),
             _resultPredicates,
+            _contextPredicates,
             ShieldBuilder.Append(_clauseTerms, clauseTerm));
 
     /// <summary>Builds the successor holding this builder's terms plus one more result term.</summary>
@@ -234,6 +257,17 @@ public sealed class ShieldBuilder<TResult>
             _parent,
             _exceptionPredicates,
             ShieldBuilder.Append(_resultPredicates, predicate),
+            _contextPredicates,
+            ShieldBuilder.Append(_clauseTerms, clauseTerm));
+
+    private ShieldBuilder<TResult> WithContext(
+        Func<HandlingEvent<TResult>, bool> predicate,
+        string clauseTerm) =>
+        new(
+            _parent,
+            _exceptionPredicates,
+            _resultPredicates,
+            ShieldBuilder.Append(_contextPredicates, predicate),
             ShieldBuilder.Append(_clauseTerms, clauseTerm));
 
     private static Func<TResult, bool>? CombineResults(Func<TResult, bool>[] predicates)
@@ -253,6 +287,33 @@ public sealed class ShieldBuilder<TResult>
             foreach (var predicate in predicates)
             {
                 if (predicate(result))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+    }
+
+    private static Func<HandlingEvent<TResult>, bool>? CombineContexts(
+        Func<HandlingEvent<TResult>, bool>[] predicates)
+    {
+        if (predicates.Length == 0)
+        {
+            return null;
+        }
+
+        if (predicates.Length == 1)
+        {
+            return predicates[0];
+        }
+
+        return handling =>
+        {
+            foreach (var predicate in predicates)
+            {
+                if (predicate(handling))
                 {
                     return true;
                 }

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -41,7 +41,10 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new RetryOptions();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesExceptionWithContext,
+            shield.JudgeOrDefault);
         return shield.Append(new RetryStrategy(options, judge));
     }
 
@@ -89,7 +92,10 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new CircuitBreakerOptions();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesExceptionWithContext,
+            shield.JudgeOrDefault);
         return shield.Append(new CircuitBreakerStrategy(options, judge));
     }
 
@@ -153,7 +159,10 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new HedgeOptions();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesExceptionWithContext,
+            shield.JudgeOrDefault);
         return shield.Append(new HedgingStrategy(options, judge));
     }
 
@@ -174,7 +183,15 @@ public static class ShieldExtensions
     }
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public static ShieldBuilder When(this Shield shield, Func<Exception, bool> predicate)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        return new ShieldBuilder(shield).Or(predicate);
+    }
+
+    /// <summary>Starts a handling clause using the active execution and strategy context.</summary>
+    public static ShieldBuilder When(this Shield shield, Func<HandlingEvent, bool> predicate)
     {
         Throw.IfNull(shield, nameof(shield));
         return new ShieldBuilder(shield).Or(predicate);
@@ -283,13 +300,16 @@ public static class ShieldExtensions
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, shield.JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesExceptionWithContext,
+            shield.JudgeOrDefault);
         return shield.Append(new VoidFallbackStrategy(
             fallback,
             judge,
             options.OnFallback,
             options.OnFallbackAsync,
-            options.HandlesException is not null));
+            options.HasHandlingOverride));
     }
 
     /// <summary>

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -183,7 +183,6 @@ public static class ShieldExtensions
     }
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public static ShieldBuilder When(this Shield shield, Func<Exception, bool> predicate)
     {
         Throw.IfNull(shield, nameof(shield));
@@ -191,10 +190,10 @@ public static class ShieldExtensions
     }
 
     /// <summary>Starts a handling clause using the active execution and strategy context.</summary>
-    public static ShieldBuilder When(this Shield shield, Func<HandlingEvent, bool> predicate)
+    public static ShieldBuilder WhenContext(this Shield shield, Func<HandlingEvent, bool> predicate)
     {
         Throw.IfNull(shield, nameof(shield));
-        return new ShieldBuilder(shield).Or(predicate);
+        return new ShieldBuilder(shield).OrContext(predicate);
     }
 
     /// <summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -71,10 +71,20 @@ public sealed class Shield<TResult>
         => new ShieldBuilder<TResult>(this).Or(predicate);
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> When(Func<Exception, bool> predicate) => new ShieldBuilder<TResult>(this).Or(predicate);
 
+    /// <summary>Starts a handling clause using the typed outcome and active execution context.</summary>
+    public ShieldBuilder<TResult> When(Func<HandlingEvent<TResult>, bool> predicate) =>
+        new ShieldBuilder<TResult>(this).Or(predicate);
+
     /// <summary>Starts a handling clause for results matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> WhenResult(Func<TResult, bool> predicate) => new ShieldBuilder<TResult>(this).OrResult(predicate);
+
+    /// <summary>Starts a result handling clause using the typed outcome and active execution context.</summary>
+    public ShieldBuilder<TResult> WhenResult(Func<HandlingEvent<TResult>, bool> predicate) =>
+        new ShieldBuilder<TResult>(this).OrResult(predicate);
 
     /// <summary>Starts a handling clause for results equal to <paramref name="result"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
     public ShieldBuilder<TResult> WhenResult(TResult result) => new ShieldBuilder<TResult>(this).OrResult(result);
@@ -132,7 +142,12 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new RetryOptions<TResult>();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesResult,
+            options.HandlesExceptionWithContext,
+            options.HandlesResultWithContext,
+            JudgeOrDefault);
         return Append(RetryStrategy.Create(options, judge));
     }
 
@@ -176,7 +191,12 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new CircuitBreakerOptions<TResult>();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesResult,
+            options.HandlesExceptionWithContext,
+            options.HandlesResultWithContext,
+            JudgeOrDefault);
         return Append(CircuitBreakerStrategy.Create(options, judge));
     }
 
@@ -225,7 +245,12 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new HedgeOptions<TResult>();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesResult,
+            options.HandlesExceptionWithContext,
+            options.HandlesResultWithContext,
+            JudgeOrDefault);
         return Append(HedgingStrategy.Create(options, judge));
     }
 
@@ -240,13 +265,18 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions<TResult>();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesResult,
+            options.HandlesExceptionWithContext,
+            options.HandlesResultWithContext,
+            JudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (_, _) => new ValueTask<TResult>(fallbackValue),
             judge,
             options.OnFallback,
             options.OnFallbackAsync,
-            options.HandlesException is not null || options.HandlesResult is not null));
+            options.HasHandlingOverride));
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>.</summary>
@@ -266,13 +296,18 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions<TResult>();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesResult,
+            options.HandlesExceptionWithContext,
+            options.HandlesResultWithContext,
+            JudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (_, context) => fallback(context.CancellationToken),
             judge,
             options.OnFallback,
             options.OnFallbackAsync,
-            options.HandlesException is not null || options.HandlesResult is not null));
+            options.HasHandlingOverride));
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/>, which receives the handled outcome.</summary>
@@ -295,13 +330,18 @@ public sealed class Shield<TResult>
         Throw.IfNull(configure, nameof(configure));
         var options = new FallbackOptions<TResult>();
         configure(options);
-        var judge = HandlingOverride.Resolve(options.HandlesException, options.HandlesResult, JudgeOrDefault);
+        var judge = HandlingOverride.Resolve(
+            options.HandlesException,
+            options.HandlesResult,
+            options.HandlesExceptionWithContext,
+            options.HandlesResultWithContext,
+            JudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (outcome, context) => fallback(outcome, context.CancellationToken),
             judge,
             options.OnFallback,
             options.OnFallbackAsync,
-            options.HandlesException is not null || options.HandlesResult is not null));
+            options.HasHandlingOverride));
     }
 
     /// <summary>Appends a custom <see cref="Strategy"/> implementation to the pipeline.</summary>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -71,20 +71,18 @@ public sealed class Shield<TResult>
         => new ShieldBuilder<TResult>(this).Or(predicate);
 
     /// <summary>Starts a handling clause for exceptions matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> When(Func<Exception, bool> predicate) => new ShieldBuilder<TResult>(this).Or(predicate);
 
     /// <summary>Starts a handling clause using the typed outcome and active execution context.</summary>
-    public ShieldBuilder<TResult> When(Func<HandlingEvent<TResult>, bool> predicate) =>
-        new ShieldBuilder<TResult>(this).Or(predicate);
+    public ShieldBuilder<TResult> WhenContext(Func<HandlingEvent<TResult>, bool> predicate) =>
+        new ShieldBuilder<TResult>(this).OrContext(predicate);
 
     /// <summary>Starts a handling clause for results matching <paramref name="predicate"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
-    [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
     public ShieldBuilder<TResult> WhenResult(Func<TResult, bool> predicate) => new ShieldBuilder<TResult>(this).OrResult(predicate);
 
     /// <summary>Starts a result handling clause using the typed outcome and active execution context.</summary>
-    public ShieldBuilder<TResult> WhenResult(Func<HandlingEvent<TResult>, bool> predicate) =>
-        new ShieldBuilder<TResult>(this).OrResult(predicate);
+    public ShieldBuilder<TResult> WhenResultContext(Func<HandlingEvent<TResult>, bool> predicate) =>
+        new ShieldBuilder<TResult>(this).OrResultContext(predicate);
 
     /// <summary>Starts a handling clause for results equal to <paramref name="result"/>. Use <see cref="WhenAnyError"/> to return to default handling.</summary>
     public ShieldBuilder<TResult> WhenResult(TResult result) => new ShieldBuilder<TResult>(this).OrResult(result);

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -20,7 +20,11 @@ public sealed class CircuitBreakerOptions
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
-    internal bool HasHandlingOverride => HandlesException is not null;
+    /// <summary>Locally handles exceptions using execution context and strategy metadata.</summary>
+    public Func<HandlingEvent, bool>? HandlesExceptionWithContext { get; set; }
+
+    internal bool HasHandlingOverride =>
+        HandlesException is not null || HandlesExceptionWithContext is not null;
 
     /// <summary>Trips the circuit after this many consecutive handled failures.</summary>
     public int? ConsecutiveFailures { get; set; }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptionsOfT.cs
@@ -13,6 +13,9 @@ public sealed class CircuitBreakerOptions<TResult>
     /// <inheritdoc cref="CircuitBreakerOptions.HandlesException"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
+    /// <summary>Locally handles exceptions using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesExceptionWithContext { get; set; }
+
     /// <summary>
     /// Setting this — or <see cref="HandlesException"/> — makes this circuit
     /// breaker ignore the ambient <c>When…</c> handling clause; this predicate then selects the
@@ -26,8 +29,14 @@ public sealed class CircuitBreakerOptions<TResult>
     /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
+    /// <summary>Locally handles results using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesResultWithContext { get; set; }
+
     internal bool HasHandlingOverride =>
-        HandlesException is not null || HandlesResult is not null;
+        HandlesException is not null
+        || HandlesResult is not null
+        || HandlesExceptionWithContext is not null
+        || HandlesResultWithContext is not null;
 
     /// <inheritdoc cref="CircuitBreakerOptions.ConsecutiveFailures"/>
     public int? ConsecutiveFailures { get; set; }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -101,7 +101,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
         StrategyMetricAlias alias,
         bool recordState)
     {
-        if (_judge.ShouldHandle(in outcome))
+        if (_judge.ShouldHandle(in outcome, context, attempt: 0, alias.StrategyIndex))
         {
             _core.RecordFailure(context.TimeProvider, outcome.Exception);
         }
@@ -304,7 +304,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
         bool recordState)
     {
         ValueTask recording;
-        if (_judge.ShouldHandle(in outcome))
+        if (_judge.ShouldHandle(in outcome, context, attempt: 0, alias.StrategyIndex))
         {
             recording = _core.RecordFailureAsync(context.TimeProvider, in outcome, context);
         }

--- a/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
@@ -20,6 +20,12 @@ public sealed class FallbackOptions
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
+    /// <summary>Locally handles exceptions using execution context and strategy metadata.</summary>
+    public Func<HandlingEvent, bool>? HandlesExceptionWithContext { get; set; }
+
+    internal bool HasHandlingOverride =>
+        HandlesException is not null || HandlesExceptionWithContext is not null;
+
     /// <summary>Invoked synchronously before the recovery action.</summary>
     public Action<FallbackEvent>? OnFallback { get; set; }
 

--- a/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
@@ -23,6 +23,9 @@ public sealed class FallbackOptions<TResult>
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
+    /// <summary>Locally handles exceptions using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesExceptionWithContext { get; set; }
+
     /// <summary>
     /// Setting this — or <see cref="HandlesException"/> — makes this fallback ignore the ambient
     /// <c>When…</c> handling clause; this predicate then selects the results it handles.
@@ -34,6 +37,15 @@ public sealed class FallbackOptions<TResult>
     /// </remarks>
     /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
+
+    /// <summary>Locally handles results using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesResultWithContext { get; set; }
+
+    internal bool HasHandlingOverride =>
+        HandlesException is not null
+        || HandlesResult is not null
+        || HandlesExceptionWithContext is not null
+        || HandlesResultWithContext is not null;
 
     /// <summary>Invoked synchronously before the recovery factory, with the typed handled outcome.</summary>
     public Action<FallbackEvent<TResult>>? OnFallback { get; set; }

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -48,21 +48,25 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
+        var strategyIndex = context.StrategyIndex;
         var execution = next.InvokeAsync(context);
         return execution.IsCompletedSuccessfully
-            ? HandleOutcome(execution.Result, context)
-            : AwaitOutcomeAsync(execution, context);
+            ? HandleOutcome(execution.Result, context, strategyIndex)
+            : AwaitOutcomeAsync(execution, context, strategyIndex);
     }
 
-    private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(ValueTask<Outcome<T>> execution, KevlarContext context)
+    private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(
+        ValueTask<Outcome<T>> execution,
+        KevlarContext context,
+        int strategyIndex)
     {
         var outcome = await execution.ConfigureAwait(false);
-        return await HandleOutcome(outcome, context).ConfigureAwait(false);
+        return await HandleOutcome(outcome, context, strategyIndex).ConfigureAwait(false);
     }
 
-    private ValueTask<Outcome<T>> HandleOutcome<T>(Outcome<T> outcome, KevlarContext context)
+    private ValueTask<Outcome<T>> HandleOutcome<T>(Outcome<T> outcome, KevlarContext context, int strategyIndex)
     {
-        if (!_judge.ShouldHandle(in outcome))
+        if (!_judge.ShouldHandle(in outcome, context, attempt: 0, strategyIndex))
         {
             return new ValueTask<Outcome<T>>(outcome);
         }
@@ -173,9 +177,11 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
 
     public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
+        var strategyIndex = context.StrategyIndex;
         var outcome = await next.InvokeAsync(context).ConfigureAwait(false);
 
-        if (outcome.Exception is not { } exception || !_judge.ShouldHandle(in outcome))
+        if (outcome.Exception is not { } exception
+            || !_judge.ShouldHandle(in outcome, context, attempt: 0, strategyIndex))
         {
             return outcome;
         }

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -27,7 +27,11 @@ public sealed class HedgeOptions
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
-    internal bool HasHandlingOverride => HandlesException is not null;
+    /// <summary>Locally handles exceptions using execution context and attempt metadata.</summary>
+    public Func<HandlingEvent, bool>? HandlesExceptionWithContext { get; set; }
+
+    internal bool HasHandlingOverride =>
+        HandlesException is not null || HandlesExceptionWithContext is not null;
 
     /// <summary>Total attempts including the original. Default 2.</summary>
     public int MaxAttempts { get; set; } = 2;

--- a/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
@@ -12,6 +12,9 @@ public sealed class HedgeOptions<TResult>
     /// <inheritdoc cref="HedgeOptions.HandlesException"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
+    /// <summary>Locally handles exceptions using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesExceptionWithContext { get; set; }
+
     /// <summary>
     /// Setting this — or <see cref="HandlesException"/> — makes this hedging strategy
     /// ignore the ambient <c>When…</c> handling clause; this predicate then selects the results it
@@ -25,8 +28,14 @@ public sealed class HedgeOptions<TResult>
     /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
+    /// <summary>Locally handles results using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesResultWithContext { get; set; }
+
     internal bool HasHandlingOverride =>
-        HandlesException is not null || HandlesResult is not null;
+        HandlesException is not null
+        || HandlesResult is not null
+        || HandlesExceptionWithContext is not null
+        || HandlesResultWithContext is not null;
 
     /// <inheritdoc cref="HedgeOptions.MaxAttempts"/>
     public int MaxAttempts { get; set; } = 2;

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -366,12 +366,13 @@ internal sealed class HedgingStrategy : Strategy
     {
         var cancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);
         var fork = context.Fork(cancellation.Token);
+        OriginalActionContextCapture? contextCapture = null;
         try
         {
             Func<CancellationToken, ValueTask<T>>? generatedAction = null;
             if (_actionGenerator is not null)
             {
-                var contextCapture = new OriginalActionContextCapture(fork);
+                contextCapture = new OriginalActionContextCapture(fork, cancellation);
                 Func<CancellationToken, ValueTask<T>> originalAction =
                     token => InvokeOriginalAction(next, contextCapture, token);
                 try
@@ -385,7 +386,8 @@ internal sealed class HedgingStrategy : Strategy
                         new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception)),
                         cancellation,
                         fork,
-                        attemptNumber - 1);
+                        attemptNumber - 1,
+                        contextCapture);
                 }
 
                 context.CancellationToken.ThrowIfCancellationRequested();
@@ -395,12 +397,11 @@ internal sealed class HedgingStrategy : Strategy
             var execution = generatedAction is null
                 ? next.InvokeAsync(fork)
                 : InvokeGeneratedAction(generatedAction, fork.CancellationToken);
-            return new StartedAttempt<T>(execution, cancellation, fork, attemptNumber - 1);
+            return new StartedAttempt<T>(execution, cancellation, fork, attemptNumber - 1, contextCapture);
         }
         catch
         {
-            KevlarContext.Return(fork);
-            cancellation.Dispose();
+            ReleaseAttemptResources(fork, cancellation, contextCapture);
             throw;
         }
     }
@@ -480,29 +481,110 @@ internal sealed class HedgingStrategy : Strategy
         }
         finally
         {
-            KevlarContext.Return(invocationContext);
+            try
+            {
+                KevlarContext.Return(invocationContext);
+            }
+            finally
+            {
+                contextCapture.ReleaseInvocation();
+            }
         }
     }
 
-    private readonly struct OriginalActionContextCapture(KevlarContext context)
+    private static void ReleaseAttemptResources(
+        KevlarContext context,
+        CancellationTokenSource cancellation,
+        OriginalActionContextCapture? contextCapture)
     {
+        if (contextCapture is not null)
+        {
+            contextCapture.ReleaseAttempt();
+            return;
+        }
+
+        try
+        {
+            KevlarContext.Return(context);
+        }
+        finally
+        {
+            cancellation.Dispose();
+        }
+    }
+
+    private sealed class OriginalActionContextCapture(
+        KevlarContext context,
+        CancellationTokenSource cancellation)
+    {
+        private readonly object _sync = new();
         private readonly KevlarContext _context = context;
+        private readonly CancellationTokenSource _cancellation = cancellation;
+        private bool _acceptingInvocations = true;
+        private int _references = 1;
 
         public KevlarContext Fork(CancellationToken cancellationToken)
         {
-            lock (_context.Properties)
+            lock (_sync)
             {
-                return _context.Fork(cancellationToken);
+                if (!_acceptingInvocations)
+                {
+                    throw new ObjectDisposedException(nameof(OriginalActionContextCapture));
+                }
+
+                _references++;
+                try
+                {
+                    return _context.Fork(cancellationToken);
+                }
+                catch
+                {
+                    _references--;
+                    throw;
+                }
             }
         }
 
         public void Capture(KevlarContext source)
         {
-            lock (_context.Properties)
+            lock (_sync)
             {
                 _context.CancellationToken = source.CancellationToken;
                 _context.Properties.Clear();
                 source.Properties.CopyTo(_context.Properties);
+            }
+        }
+
+        public void ReleaseInvocation() => ReleaseReference(stopAcceptingInvocations: false);
+
+        public void ReleaseAttempt() => ReleaseReference(stopAcceptingInvocations: true);
+
+        private void ReleaseReference(bool stopAcceptingInvocations)
+        {
+            bool releaseResources;
+            lock (_sync)
+            {
+                if (stopAcceptingInvocations)
+                {
+                    _acceptingInvocations = false;
+                }
+
+                _references--;
+                releaseResources = _references == 0;
+            }
+
+            if (!releaseResources)
+            {
+                return;
+            }
+
+            try
+            {
+                KevlarContext.Return(_context);
+            }
+            finally
+            {
+                _cancellation.Dispose();
             }
         }
     }
@@ -638,12 +720,14 @@ internal sealed class HedgingStrategy : Strategy
             Task<Outcome<T>> task,
             CancellationTokenSource cancellation,
             KevlarContext context,
-            int attempt)
+            int attempt,
+            OriginalActionContextCapture? contextCapture)
         {
             Task = task;
             Cancellation = cancellation;
             Context = context;
             Attempt = attempt;
+            ContextCapture = contextCapture;
         }
 
         public Task<Outcome<T>> Task { get; }
@@ -654,11 +738,9 @@ internal sealed class HedgingStrategy : Strategy
 
         public int Attempt { get; }
 
-        public void Dispose()
-        {
-            KevlarContext.Return(Context);
-            Cancellation.Dispose();
-        }
+        private OriginalActionContextCapture? ContextCapture { get; }
+
+        public void Dispose() => ReleaseAttemptResources(Context, Cancellation, ContextCapture);
     }
 
     private readonly struct StartedAttempt<T>
@@ -667,12 +749,14 @@ internal sealed class HedgingStrategy : Strategy
             ValueTask<Outcome<T>> execution,
             CancellationTokenSource cancellation,
             KevlarContext context,
-            int attempt)
+            int attempt,
+            OriginalActionContextCapture? contextCapture = null)
         {
             Execution = execution;
             Cancellation = cancellation;
             Context = context;
             Attempt = attempt;
+            ContextCapture = contextCapture;
         }
 
         public ValueTask<Outcome<T>> Execution { get; }
@@ -683,12 +767,10 @@ internal sealed class HedgingStrategy : Strategy
 
         private int Attempt { get; }
 
-        public HedgeAttempt<T> AsPending() => new(Execution.AsTask(), Cancellation, Context, Attempt);
+        private OriginalActionContextCapture? ContextCapture { get; }
 
-        public void Dispose()
-        {
-            KevlarContext.Return(Context);
-            Cancellation.Dispose();
-        }
+        public HedgeAttempt<T> AsPending() => new(Execution.AsTask(), Cancellation, Context, Attempt, ContextCapture);
+
+        public void Dispose() => ReleaseAttemptResources(Context, Cancellation, ContextCapture);
     }
 }

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -95,16 +95,22 @@ internal sealed class HedgingStrategy : Strategy
         }
 
         Outcome<T> outcome;
+        bool shouldHandle;
         try
         {
             outcome = primary.Execution.Result;
+            shouldHandle = _judge.ShouldHandle(
+                in outcome,
+                primary.Context,
+                attempt: 0,
+                strategyIndex);
         }
         finally
         {
             primary.Dispose();
         }
 
-        if (!_judge.ShouldHandle(in outcome, context, attempt: 0, strategyIndex))
+        if (!shouldHandle)
         {
             return new ValueTask<Outcome<T>>(NormalizeCancellation(outcome, context));
         }
@@ -191,9 +197,22 @@ internal sealed class HedgingStrategy : Strategy
                 }
 
                 var outcome = NormalizeCancellation(await completed.ConfigureAwait(false), context);
-                var attempt = Remove(pending, completed);
+                var completedAttempt = Remove(pending, completed);
+                bool shouldHandle;
+                try
+                {
+                    shouldHandle = _judge.ShouldHandle(
+                        in outcome,
+                        completedAttempt.Context,
+                        completedAttempt.Attempt,
+                        strategyIndex);
+                }
+                finally
+                {
+                    completedAttempt.Dispose();
+                }
 
-                if (!_judge.ShouldHandle(in outcome, context, attempt, strategyIndex))
+                if (!shouldHandle)
                 {
                     return outcome;
                 }
@@ -526,14 +545,13 @@ internal sealed class HedgingStrategy : Strategy
         return null;
     }
 
-    private static int Remove<T>(List<HedgeAttempt<T>> pending, Task<Outcome<T>> task)
+    private static HedgeAttempt<T> Remove<T>(List<HedgeAttempt<T>> pending, Task<Outcome<T>> task)
     {
         for (var i = 0; i < pending.Count; i++)
         {
             if (ReferenceEquals(pending[i].Task, task))
             {
-                var attempt = pending[i].Attempt;
-                pending[i].Dispose();
+                var attempt = pending[i];
                 pending.RemoveAt(i);
                 return attempt;
             }
@@ -620,7 +638,7 @@ internal sealed class HedgingStrategy : Strategy
 
         private CancellationTokenSource Cancellation { get; }
 
-        private KevlarContext Context { get; }
+        public KevlarContext Context { get; }
 
         private int Attempt { get; }
 

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -372,9 +372,12 @@ internal sealed class HedgingStrategy : Strategy
             Func<CancellationToken, ValueTask<T>>? generatedAction = null;
             if (_actionGenerator is not null)
             {
-                contextCapture = new OriginalActionContextCapture(fork, cancellation);
+                contextCapture = OriginalActionContextCapture.Rent(
+                    fork,
+                    cancellation,
+                    out var captureVersion);
                 Func<CancellationToken, ValueTask<T>> originalAction =
-                    token => InvokeOriginalAction(next, contextCapture, token);
+                    token => InvokeOriginalAction(next, contextCapture, captureVersion, token);
                 try
                 {
                     generatedAction = _actionGenerator.Generate(attemptNumber, fork, originalAction, outcome);
@@ -420,9 +423,10 @@ internal sealed class HedgingStrategy : Strategy
     private static ValueTask<T> InvokeOriginalAction<T, TState>(
         Continuation<T, TState> next,
         OriginalActionContextCapture contextCapture,
+        int captureVersion,
         CancellationToken cancellationToken)
     {
-        var invocationContext = contextCapture.Fork(cancellationToken);
+        var invocationContext = contextCapture.Fork(captureVersion, cancellationToken);
         ValueTask<Outcome<T>> execution;
         try
         {
@@ -513,21 +517,46 @@ internal sealed class HedgingStrategy : Strategy
         }
     }
 
-    private sealed class OriginalActionContextCapture(
-        KevlarContext context,
-        CancellationTokenSource cancellation)
+    private sealed class OriginalActionContextCapture
     {
-        private readonly object _sync = new();
-        private readonly KevlarContext _context = context;
-        private readonly CancellationTokenSource _cancellation = cancellation;
-        private bool _acceptingInvocations = true;
-        private int _references = 1;
+        private static readonly ObjectPool<OriginalActionContextCapture, PoolPolicy> Pool = new(
+            maxCapacity: KevlarContext.PoolCapacity);
 
-        public KevlarContext Fork(CancellationToken cancellationToken)
+        private readonly object _sync = new();
+        private KevlarContext? _context;
+        private CancellationTokenSource? _cancellation;
+        private bool _acceptingInvocations;
+        private int _references;
+        private int _version;
+
+        private OriginalActionContextCapture()
+        {
+        }
+
+        public static OriginalActionContextCapture Rent(
+            KevlarContext context,
+            CancellationTokenSource cancellation,
+            out int version)
+        {
+            var capture = Pool.Rent();
+            lock (capture._sync)
+            {
+                capture._context = context;
+                capture._cancellation = cancellation;
+                capture._acceptingInvocations = true;
+                capture._references = 1;
+                capture._version++;
+                version = capture._version;
+            }
+
+            return capture;
+        }
+
+        public KevlarContext Fork(int version, CancellationToken cancellationToken)
         {
             lock (_sync)
             {
-                if (!_acceptingInvocations)
+                if (!_acceptingInvocations || _version != version)
                 {
                     throw new ObjectDisposedException(nameof(OriginalActionContextCapture));
                 }
@@ -535,7 +564,7 @@ internal sealed class HedgingStrategy : Strategy
                 _references++;
                 try
                 {
-                    return _context.Fork(cancellationToken);
+                    return _context!.Fork(cancellationToken);
                 }
                 catch
                 {
@@ -549,7 +578,7 @@ internal sealed class HedgingStrategy : Strategy
         {
             lock (_sync)
             {
-                _context.CancellationToken = source.CancellationToken;
+                _context!.CancellationToken = source.CancellationToken;
                 _context.Properties.Clear();
                 source.Properties.CopyTo(_context.Properties);
             }
@@ -561,7 +590,8 @@ internal sealed class HedgingStrategy : Strategy
 
         private void ReleaseReference(bool stopAcceptingInvocations)
         {
-            bool releaseResources;
+            KevlarContext? context = null;
+            CancellationTokenSource? cancellation = null;
             lock (_sync)
             {
                 if (stopAcceptingInvocations)
@@ -570,22 +600,36 @@ internal sealed class HedgingStrategy : Strategy
                 }
 
                 _references--;
-                releaseResources = _references == 0;
+                if (_references == 0)
+                {
+                    context = _context;
+                    cancellation = _cancellation;
+                    _context = null;
+                    _cancellation = null;
+                }
             }
 
-            if (!releaseResources)
+            if (context is null)
             {
                 return;
             }
 
             try
             {
-                KevlarContext.Return(_context);
+                KevlarContext.Return(context);
             }
             finally
             {
-                _cancellation.Dispose();
+                cancellation!.Dispose();
+                Pool.Return(this);
             }
+        }
+
+        private readonly struct PoolPolicy : IPooledObjectPolicy<OriginalActionContextCapture>
+        {
+            public OriginalActionContextCapture Create() => new();
+
+            public bool TryReset(OriginalActionContextCapture capture) => true;
         }
     }
 

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -68,6 +68,7 @@ internal sealed class HedgingStrategy : Strategy
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
+        var strategyIndex = context.StrategyIndex;
         if (_maxAttempts == 1
             || context.Properties.SuppressAdditionalAttempts)
         {
@@ -83,7 +84,14 @@ internal sealed class HedgingStrategy : Strategy
         var primary = StartPrimaryAttempt(next, context);
         if (_delay == TimeSpan.Zero || !primary.Execution.IsCompletedSuccessfully)
         {
-            return ExecuteCoreAsync(next, context, primary.AsPending(), launched: 1, default, startedAt);
+            return ExecuteCoreAsync(
+                next,
+                context,
+                primary.AsPending(),
+                launched: 1,
+                default,
+                startedAt,
+                strategyIndex);
         }
 
         Outcome<T> outcome;
@@ -96,12 +104,19 @@ internal sealed class HedgingStrategy : Strategy
             primary.Dispose();
         }
 
-        if (!_judge.ShouldHandle(in outcome))
+        if (!_judge.ShouldHandle(in outcome, context, attempt: 0, strategyIndex))
         {
             return new ValueTask<Outcome<T>>(NormalizeCancellation(outcome, context));
         }
 
-        return ExecuteCoreAsync(next, context, initial: null, launched: 1, outcome, startedAt);
+        return ExecuteCoreAsync(
+            next,
+            context,
+            initial: null,
+            launched: 1,
+            outcome,
+            startedAt,
+            strategyIndex);
     }
 
     private async ValueTask<Outcome<T>> ExecuteCoreAsync<T, TState>(
@@ -110,7 +125,8 @@ internal sealed class HedgingStrategy : Strategy
         HedgeAttempt<T>? initial,
         int launched,
         Outcome<T>? lastOutcome,
-        long startedAt)
+        long startedAt,
+        int strategyIndex)
     {
         var pending = ListPool<HedgeAttempt<T>>.Shared.Rent();
 
@@ -175,9 +191,9 @@ internal sealed class HedgingStrategy : Strategy
                 }
 
                 var outcome = NormalizeCancellation(await completed.ConfigureAwait(false), context);
-                Remove(pending, completed);
+                var attempt = Remove(pending, completed);
 
-                if (!_judge.ShouldHandle(in outcome))
+                if (!_judge.ShouldHandle(in outcome, context, attempt, strategyIndex))
                 {
                     return outcome;
                 }
@@ -311,7 +327,7 @@ internal sealed class HedgingStrategy : Strategy
         var fork = context.Fork(cancellation.Token);
         try
         {
-            return new StartedAttempt<T>(next.InvokeAsync(fork), cancellation, fork);
+            return new StartedAttempt<T>(next.InvokeAsync(fork), cancellation, fork, attempt: 0);
         }
         catch
         {
@@ -346,7 +362,8 @@ internal sealed class HedgingStrategy : Strategy
                     return new StartedAttempt<T>(
                         new ValueTask<Outcome<T>>(Outcome<T>.FromException(exception)),
                         cancellation,
-                        fork);
+                        fork,
+                        attemptNumber - 1);
                 }
 
                 context.CancellationToken.ThrowIfCancellationRequested();
@@ -356,7 +373,7 @@ internal sealed class HedgingStrategy : Strategy
             var execution = generatedAction is null
                 ? next.InvokeAsync(fork)
                 : InvokeGeneratedAction(generatedAction, fork.CancellationToken);
-            return new StartedAttempt<T>(execution, cancellation, fork);
+            return new StartedAttempt<T>(execution, cancellation, fork, attemptNumber - 1);
         }
         catch
         {
@@ -509,17 +526,20 @@ internal sealed class HedgingStrategy : Strategy
         return null;
     }
 
-    private static void Remove<T>(List<HedgeAttempt<T>> pending, Task<Outcome<T>> task)
+    private static int Remove<T>(List<HedgeAttempt<T>> pending, Task<Outcome<T>> task)
     {
         for (var i = 0; i < pending.Count; i++)
         {
             if (ReferenceEquals(pending[i].Task, task))
             {
+                var attempt = pending[i].Attempt;
                 pending[i].Dispose();
                 pending.RemoveAt(i);
-                return;
+                return attempt;
             }
         }
+
+        throw new InvalidOperationException("The completed hedge attempt was not pending.");
     }
 
     private static void Cleanup<T>(HedgeAttempt<T> attempt)
@@ -555,11 +575,16 @@ internal sealed class HedgingStrategy : Strategy
 
     private readonly struct HedgeAttempt<T>
     {
-        public HedgeAttempt(Task<Outcome<T>> task, CancellationTokenSource cancellation, KevlarContext context)
+        public HedgeAttempt(
+            Task<Outcome<T>> task,
+            CancellationTokenSource cancellation,
+            KevlarContext context,
+            int attempt)
         {
             Task = task;
             Cancellation = cancellation;
             Context = context;
+            Attempt = attempt;
         }
 
         public Task<Outcome<T>> Task { get; }
@@ -567,6 +592,8 @@ internal sealed class HedgingStrategy : Strategy
         public CancellationTokenSource Cancellation { get; }
 
         public KevlarContext Context { get; }
+
+        public int Attempt { get; }
 
         public void Dispose()
         {
@@ -577,11 +604,16 @@ internal sealed class HedgingStrategy : Strategy
 
     private readonly struct StartedAttempt<T>
     {
-        public StartedAttempt(ValueTask<Outcome<T>> execution, CancellationTokenSource cancellation, KevlarContext context)
+        public StartedAttempt(
+            ValueTask<Outcome<T>> execution,
+            CancellationTokenSource cancellation,
+            KevlarContext context,
+            int attempt)
         {
             Execution = execution;
             Cancellation = cancellation;
             Context = context;
+            Attempt = attempt;
         }
 
         public ValueTask<Outcome<T>> Execution { get; }
@@ -590,7 +622,9 @@ internal sealed class HedgingStrategy : Strategy
 
         private KevlarContext Context { get; }
 
-        public HedgeAttempt<T> AsPending() => new(Execution.AsTask(), Cancellation, Context);
+        private int Attempt { get; }
+
+        public HedgeAttempt<T> AsPending() => new(Execution.AsTask(), Cancellation, Context, Attempt);
 
         public void Dispose()
         {

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -369,8 +369,9 @@ internal sealed class HedgingStrategy : Strategy
             Func<CancellationToken, ValueTask<T>>? generatedAction = null;
             if (_actionGenerator is not null)
             {
+                var contextCapture = new OriginalActionContextCapture(fork);
                 Func<CancellationToken, ValueTask<T>> originalAction =
-                    token => InvokeOriginalAction(next, fork, token);
+                    token => InvokeOriginalAction(next, contextCapture, token);
                 try
                 {
                     generatedAction = _actionGenerator.Generate(attemptNumber, fork, originalAction, outcome);
@@ -415,10 +416,10 @@ internal sealed class HedgingStrategy : Strategy
 
     private static ValueTask<T> InvokeOriginalAction<T, TState>(
         Continuation<T, TState> next,
-        KevlarContext attemptContext,
+        OriginalActionContextCapture contextCapture,
         CancellationToken cancellationToken)
     {
-        var invocationContext = attemptContext.Fork(cancellationToken);
+        var invocationContext = contextCapture.Fork(cancellationToken);
         ValueTask<Outcome<T>> execution;
         try
         {
@@ -426,13 +427,13 @@ internal sealed class HedgingStrategy : Strategy
         }
         catch
         {
-            KevlarContext.Return(invocationContext);
+            CaptureAndReturn(contextCapture, invocationContext);
             throw;
         }
 
         if (!execution.IsCompletedSuccessfully)
         {
-            return AwaitOriginalResultAsync(execution, invocationContext);
+            return AwaitOriginalResultAsync(execution, invocationContext, contextCapture);
         }
 
         try
@@ -441,7 +442,7 @@ internal sealed class HedgingStrategy : Strategy
         }
         finally
         {
-            KevlarContext.Return(invocationContext);
+            CaptureAndReturn(contextCapture, invocationContext);
         }
     }
 
@@ -453,7 +454,8 @@ internal sealed class HedgingStrategy : Strategy
 
     private static async ValueTask<T> AwaitOriginalResultAsync<T>(
         ValueTask<Outcome<T>> execution,
-        KevlarContext invocationContext)
+        KevlarContext invocationContext,
+        OriginalActionContextCapture contextCapture)
     {
         try
         {
@@ -462,7 +464,44 @@ internal sealed class HedgingStrategy : Strategy
         }
         finally
         {
+            CaptureAndReturn(contextCapture, invocationContext);
+        }
+    }
+
+    private static void CaptureAndReturn(
+        OriginalActionContextCapture contextCapture,
+        KevlarContext invocationContext)
+    {
+        try
+        {
+            contextCapture.Capture(invocationContext);
+        }
+        finally
+        {
             KevlarContext.Return(invocationContext);
+        }
+    }
+
+    private readonly struct OriginalActionContextCapture(KevlarContext context)
+    {
+        private readonly KevlarContext _context = context;
+
+        public KevlarContext Fork(CancellationToken cancellationToken)
+        {
+            lock (_context.Properties)
+            {
+                return _context.Fork(cancellationToken);
+            }
+        }
+
+        public void Capture(KevlarContext source)
+        {
+            lock (_context.Properties)
+            {
+                _context.CancellationToken = source.CancellationToken;
+                _context.Properties.Clear();
+                source.Properties.CopyTo(_context.Properties);
+            }
         }
     }
 

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -203,6 +203,7 @@ internal sealed class HedgingStrategy : Strategy
                 bool shouldHandle;
                 try
                 {
+                    completedAttempt.FreezeContext();
                     shouldHandle = _judge.ShouldHandle(
                         in outcome,
                         completedAttempt.Context,
@@ -526,6 +527,7 @@ internal sealed class HedgingStrategy : Strategy
         private KevlarContext? _context;
         private CancellationTokenSource? _cancellation;
         private bool _acceptingInvocations;
+        private bool _frozen;
         private int _references;
         private int _version;
 
@@ -544,6 +546,7 @@ internal sealed class HedgingStrategy : Strategy
                 capture._context = context;
                 capture._cancellation = cancellation;
                 capture._acceptingInvocations = true;
+                capture._frozen = false;
                 capture._references = 1;
                 capture._version++;
                 version = capture._version;
@@ -578,6 +581,11 @@ internal sealed class HedgingStrategy : Strategy
         {
             lock (_sync)
             {
+                if (_frozen)
+                {
+                    return;
+                }
+
                 _context!.CancellationToken = source.CancellationToken;
                 _context.Properties.Clear();
                 source.Properties.CopyTo(_context.Properties);
@@ -585,6 +593,14 @@ internal sealed class HedgingStrategy : Strategy
         }
 
         public void ReleaseInvocation() => ReleaseReference(stopAcceptingInvocations: false);
+
+        public void Freeze()
+        {
+            lock (_sync)
+            {
+                _frozen = true;
+            }
+        }
 
         public void ReleaseAttempt() => ReleaseReference(stopAcceptingInvocations: true);
 
@@ -597,6 +613,7 @@ internal sealed class HedgingStrategy : Strategy
                 if (stopAcceptingInvocations)
                 {
                     _acceptingInvocations = false;
+                    _frozen = true;
                 }
 
                 _references--;
@@ -783,6 +800,8 @@ internal sealed class HedgingStrategy : Strategy
         public int Attempt { get; }
 
         private OriginalActionContextCapture? ContextCapture { get; }
+
+        public void FreezeContext() => ContextCapture?.Freeze();
 
         public void Dispose() => ReleaseAttemptResources(Context, Cancellation, ContextCapture);
     }

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -203,7 +203,7 @@ internal sealed class HedgingStrategy : Strategy
                 bool shouldHandle;
                 try
                 {
-                    completedAttempt.FreezeContext();
+                    completedAttempt.FreezeContext(in outcome);
                     shouldHandle = _judge.ShouldHandle(
                         in outcome,
                         completedAttempt.Context,
@@ -367,13 +367,13 @@ internal sealed class HedgingStrategy : Strategy
     {
         var cancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);
         var fork = context.Fork(cancellation.Token);
-        OriginalActionContextCapture? contextCapture = null;
+        OriginalActionContextCapture<T>? contextCapture = null;
         try
         {
             Func<CancellationToken, ValueTask<T>>? generatedAction = null;
             if (_actionGenerator is not null)
             {
-                contextCapture = OriginalActionContextCapture.Rent(
+                contextCapture = OriginalActionContextCapture<T>.Rent(
                     fork,
                     cancellation,
                     out var captureVersion);
@@ -423,7 +423,7 @@ internal sealed class HedgingStrategy : Strategy
 
     private static ValueTask<T> InvokeOriginalAction<T, TState>(
         Continuation<T, TState> next,
-        OriginalActionContextCapture contextCapture,
+        OriginalActionContextCapture<T> contextCapture,
         int captureVersion,
         CancellationToken cancellationToken)
     {
@@ -433,9 +433,10 @@ internal sealed class HedgingStrategy : Strategy
         {
             execution = next.InvokeAsync(invocationContext);
         }
-        catch
+        catch (Exception exception)
         {
-            CaptureAndReturn(contextCapture, invocationContext);
+            var failedOutcome = Outcome<T>.FromException(exception);
+            CaptureAndReturn(contextCapture, invocationContext, in failedOutcome);
             throw;
         }
 
@@ -444,13 +445,14 @@ internal sealed class HedgingStrategy : Strategy
             return AwaitOriginalResultAsync(execution, invocationContext, contextCapture);
         }
 
+        var outcome = execution.Result;
         try
         {
-            return new ValueTask<T>(execution.Result.GetResultOrRethrowInternal());
+            return new ValueTask<T>(outcome.GetResultOrRethrowInternal());
         }
         finally
         {
-            CaptureAndReturn(contextCapture, invocationContext);
+            CaptureAndReturn(contextCapture, invocationContext, in outcome);
         }
     }
 
@@ -463,32 +465,49 @@ internal sealed class HedgingStrategy : Strategy
     private static async ValueTask<T> AwaitOriginalResultAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext invocationContext,
-        OriginalActionContextCapture contextCapture)
+        OriginalActionContextCapture<T> contextCapture)
     {
+        Outcome<T> outcome;
         try
         {
             // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
-            return (await execution.ConfigureAwait(false)).GetResultOrRethrowInternal();
+            outcome = await execution.ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            outcome = Outcome<T>.FromException(exception);
+            CaptureAndReturn(contextCapture, invocationContext, in outcome);
+            throw;
+        }
+
+        try
+        {
+            return outcome.GetResultOrRethrowInternal();
         }
         finally
         {
-            CaptureAndReturn(contextCapture, invocationContext);
+            CaptureAndReturn(contextCapture, invocationContext, in outcome);
         }
     }
 
-    private static void CaptureAndReturn(
-        OriginalActionContextCapture contextCapture,
-        KevlarContext invocationContext)
+    private static void CaptureAndReturn<T>(
+        OriginalActionContextCapture<T> contextCapture,
+        KevlarContext invocationContext,
+        in Outcome<T> outcome)
     {
+        var retained = false;
         try
         {
-            contextCapture.Capture(invocationContext);
+            retained = contextCapture.Capture(invocationContext, in outcome);
         }
         finally
         {
             try
             {
-                KevlarContext.Return(invocationContext);
+                if (!retained)
+                {
+                    KevlarContext.Return(invocationContext);
+                }
             }
             finally
             {
@@ -497,10 +516,10 @@ internal sealed class HedgingStrategy : Strategy
         }
     }
 
-    private static void ReleaseAttemptResources(
+    private static void ReleaseAttemptResources<T>(
         KevlarContext context,
         CancellationTokenSource cancellation,
-        OriginalActionContextCapture? contextCapture)
+        OriginalActionContextCapture<T>? contextCapture)
     {
         if (contextCapture is not null)
         {
@@ -518,15 +537,18 @@ internal sealed class HedgingStrategy : Strategy
         }
     }
 
-    private sealed class OriginalActionContextCapture
+    private sealed class OriginalActionContextCapture<T>
     {
-        private static readonly ObjectPool<OriginalActionContextCapture, PoolPolicy> Pool = new(
+        private static readonly ObjectPool<OriginalActionContextCapture<T>, PoolPolicy> Pool = new(
             maxCapacity: KevlarContext.PoolCapacity);
 
         private readonly object _sync = new();
         private KevlarContext? _context;
         private CancellationTokenSource? _cancellation;
+        private List<CapturedOriginalAction>? _additionalCompletions;
+        private Outcome<T> _firstOutcome;
         private bool _acceptingInvocations;
+        private bool _hasFirstOutcome;
         private bool _frozen;
         private int _references;
         private int _version;
@@ -535,7 +557,7 @@ internal sealed class HedgingStrategy : Strategy
         {
         }
 
-        public static OriginalActionContextCapture Rent(
+        public static OriginalActionContextCapture<T> Rent(
             KevlarContext context,
             CancellationTokenSource cancellation,
             out int version)
@@ -545,7 +567,10 @@ internal sealed class HedgingStrategy : Strategy
             {
                 capture._context = context;
                 capture._cancellation = cancellation;
+                capture._additionalCompletions = null;
+                capture._firstOutcome = default;
                 capture._acceptingInvocations = true;
+                capture._hasFirstOutcome = false;
                 capture._frozen = false;
                 capture._references = 1;
                 capture._version++;
@@ -561,7 +586,7 @@ internal sealed class HedgingStrategy : Strategy
             {
                 if (!_acceptingInvocations || _version != version)
                 {
-                    throw new ObjectDisposedException(nameof(OriginalActionContextCapture));
+                    throw new ObjectDisposedException(nameof(OriginalActionContextCapture<T>));
                 }
 
                 _references++;
@@ -577,29 +602,59 @@ internal sealed class HedgingStrategy : Strategy
             }
         }
 
-        public void Capture(KevlarContext source)
+        public bool Capture(KevlarContext source, in Outcome<T> outcome)
         {
             lock (_sync)
             {
                 if (_frozen)
                 {
-                    return;
+                    return false;
                 }
 
-                _context!.CancellationToken = source.CancellationToken;
-                _context.Properties.Clear();
-                source.Properties.CopyTo(_context.Properties);
+                if (!_hasFirstOutcome)
+                {
+                    CopyContext(source, _context!);
+                    _firstOutcome = outcome;
+                    _hasFirstOutcome = true;
+                    return false;
+                }
+
+                _additionalCompletions ??= [];
+                _additionalCompletions.Add(new CapturedOriginalAction(source, outcome));
+                return true;
             }
         }
 
         public void ReleaseInvocation() => ReleaseReference(stopAcceptingInvocations: false);
 
-        public void Freeze()
+        public void Freeze(in Outcome<T> selectedOutcome)
         {
+            List<CapturedOriginalAction>? additionalCompletions;
             lock (_sync)
             {
                 _frozen = true;
+                additionalCompletions = _additionalCompletions;
+                _additionalCompletions = null;
+                if (additionalCompletions is not null)
+                {
+                    var selected = additionalCompletions[^1];
+                    if (!_hasFirstOutcome || !Matches(_firstOutcome, selectedOutcome))
+                    {
+                        foreach (var completion in additionalCompletions)
+                        {
+                            if (Matches(completion.Outcome, selectedOutcome))
+                            {
+                                selected = completion;
+                                break;
+                            }
+                        }
+
+                        CopyContext(selected.Context, _context!);
+                    }
+                }
             }
+
+            ReturnContexts(additionalCompletions);
         }
 
         public void ReleaseAttempt() => ReleaseReference(stopAcceptingInvocations: true);
@@ -608,12 +663,15 @@ internal sealed class HedgingStrategy : Strategy
         {
             KevlarContext? context = null;
             CancellationTokenSource? cancellation = null;
+            List<CapturedOriginalAction>? additionalCompletions = null;
             lock (_sync)
             {
                 if (stopAcceptingInvocations)
                 {
                     _acceptingInvocations = false;
                     _frozen = true;
+                    additionalCompletions = _additionalCompletions;
+                    _additionalCompletions = null;
                 }
 
                 _references--;
@@ -623,9 +681,12 @@ internal sealed class HedgingStrategy : Strategy
                     cancellation = _cancellation;
                     _context = null;
                     _cancellation = null;
+                    _firstOutcome = default;
+                    _hasFirstOutcome = false;
                 }
             }
 
+            ReturnContexts(additionalCompletions);
             if (context is null)
             {
                 return;
@@ -642,11 +703,57 @@ internal sealed class HedgingStrategy : Strategy
             }
         }
 
-        private readonly struct PoolPolicy : IPooledObjectPolicy<OriginalActionContextCapture>
+        private static bool Matches(Outcome<T> candidate, Outcome<T> selected)
         {
-            public OriginalActionContextCapture Create() => new();
+            if (candidate.IsSuccess != selected.IsSuccess)
+            {
+                return false;
+            }
 
-            public bool TryReset(OriginalActionContextCapture capture) => true;
+            if (!candidate.IsSuccess)
+            {
+                return ReferenceEquals(candidate.Exception, selected.Exception);
+            }
+
+            try
+            {
+                return EqualityComparer<T>.Default.Equals(candidate.Result!, selected.Result!);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void CopyContext(KevlarContext source, KevlarContext target)
+        {
+            target.CancellationToken = source.CancellationToken;
+            target.Properties.Clear();
+            source.Properties.CopyTo(target.Properties);
+        }
+
+        private static void ReturnContexts(List<CapturedOriginalAction>? completions)
+        {
+            if (completions is null)
+            {
+                return;
+            }
+
+            foreach (var completion in completions)
+            {
+                KevlarContext.Return(completion.Context);
+            }
+        }
+
+        private readonly record struct CapturedOriginalAction(
+            KevlarContext Context,
+            Outcome<T> Outcome);
+
+        private readonly struct PoolPolicy : IPooledObjectPolicy<OriginalActionContextCapture<T>>
+        {
+            public OriginalActionContextCapture<T> Create() => new();
+
+            public bool TryReset(OriginalActionContextCapture<T> capture) => true;
         }
     }
 
@@ -782,7 +889,7 @@ internal sealed class HedgingStrategy : Strategy
             CancellationTokenSource cancellation,
             KevlarContext context,
             int attempt,
-            OriginalActionContextCapture? contextCapture)
+            OriginalActionContextCapture<T>? contextCapture)
         {
             Task = task;
             Cancellation = cancellation;
@@ -799,9 +906,9 @@ internal sealed class HedgingStrategy : Strategy
 
         public int Attempt { get; }
 
-        private OriginalActionContextCapture? ContextCapture { get; }
+        private OriginalActionContextCapture<T>? ContextCapture { get; }
 
-        public void FreezeContext() => ContextCapture?.Freeze();
+        public void FreezeContext(in Outcome<T> outcome) => ContextCapture?.Freeze(in outcome);
 
         public void Dispose() => ReleaseAttemptResources(Context, Cancellation, ContextCapture);
     }
@@ -813,7 +920,7 @@ internal sealed class HedgingStrategy : Strategy
             CancellationTokenSource cancellation,
             KevlarContext context,
             int attempt,
-            OriginalActionContextCapture? contextCapture = null)
+            OriginalActionContextCapture<T>? contextCapture = null)
         {
             Execution = execution;
             Cancellation = cancellation;
@@ -830,7 +937,7 @@ internal sealed class HedgingStrategy : Strategy
 
         private int Attempt { get; }
 
-        private OriginalActionContextCapture? ContextCapture { get; }
+        private OriginalActionContextCapture<T>? ContextCapture { get; }
 
         public HedgeAttempt<T> AsPending() => new(Execution.AsTask(), Cancellation, Context, Attempt, ContextCapture);
 

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -21,7 +21,11 @@ public sealed class RetryOptions
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
-    internal bool HasHandlingOverride => HandlesException is not null;
+    /// <summary>Locally handles exceptions using execution context and attempt metadata.</summary>
+    public Func<HandlingEvent, bool>? HandlesExceptionWithContext { get; set; }
+
+    internal bool HasHandlingOverride =>
+        HandlesException is not null || HandlesExceptionWithContext is not null;
 
     /// <summary>
     /// The number of <em>retries</em> made after the initial attempt — not the number of attempts.
@@ -105,6 +109,9 @@ public sealed class RetryOptions<TResult>
     /// <seealso cref="HandlingClause"/>
     public Func<Exception, bool>? HandlesException { get; set; }
 
+    /// <summary>Locally handles exceptions using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesExceptionWithContext { get; set; }
+
     /// <summary>
     /// Setting this — or <see cref="HandlesException"/> — makes this retry ignore the ambient
     /// <c>When…</c> handling clause; this predicate then selects the results it handles.
@@ -117,8 +124,14 @@ public sealed class RetryOptions<TResult>
     /// <seealso cref="HandlingClause"/>
     public Func<TResult, bool>? HandlesResult { get; set; }
 
+    /// <summary>Locally handles results using the typed outcome and execution context.</summary>
+    public Func<HandlingEvent<TResult>, bool>? HandlesResultWithContext { get; set; }
+
     internal bool HasHandlingOverride =>
-        HandlesException is not null || HandlesResult is not null;
+        HandlesException is not null
+        || HandlesResult is not null
+        || HandlesExceptionWithContext is not null
+        || HandlesResultWithContext is not null;
 
     /// <summary>Invoked synchronously before each retry sleeps, with the typed handled outcome.</summary>
     public Action<RetryEvent<TResult>>? OnRetry { get; set; }

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -101,12 +101,13 @@ internal sealed class RetryStrategy : Strategy
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
+        var strategyIndex = context.StrategyIndex;
         var execution = next.InvokeAsync(context);
         var firstOutcomeShouldRetry = false;
         if (execution.IsCompletedSuccessfully)
         {
             var outcome = execution.Result;
-            if (!ShouldRetry(in outcome, retriesUsed: 0, context))
+            if (!ShouldRetry(in outcome, retriesUsed: 0, context, strategyIndex))
             {
                 return new ValueTask<Outcome<T>>(outcome);
             }
@@ -115,21 +116,22 @@ internal sealed class RetryStrategy : Strategy
             firstOutcomeShouldRetry = true;
         }
 
-        return ExecuteCoreAsync(next, context, execution, firstOutcomeShouldRetry);
+        return ExecuteCoreAsync(next, context, execution, firstOutcomeShouldRetry, strategyIndex);
     }
 
     private async ValueTask<Outcome<T>> ExecuteCoreAsync<T, TState>(
         Continuation<T, TState> next,
         KevlarContext context,
         ValueTask<Outcome<T>> execution,
-        bool firstOutcomeShouldRetry)
+        bool firstOutcomeShouldRetry,
+        int strategyIndex)
     {
         var previousBackoffDelay = TimeSpan.Zero;
         for (var retriesUsed = 0; ; retriesUsed++)
         {
             var outcome = await execution.ConfigureAwait(false);
 
-            if (!firstOutcomeShouldRetry && !ShouldRetry(in outcome, retriesUsed, context))
+            if (!firstOutcomeShouldRetry && !ShouldRetry(in outcome, retriesUsed, context, strategyIndex))
             {
                 return outcome;
             }
@@ -197,10 +199,14 @@ internal sealed class RetryStrategy : Strategy
         }
     }
 
-    private bool ShouldRetry<T>(in Outcome<T> outcome, int retriesUsed, KevlarContext context) =>
+    private bool ShouldRetry<T>(
+        in Outcome<T> outcome,
+        int retriesUsed,
+        KevlarContext context,
+        int strategyIndex) =>
         retriesUsed < _maxRetries
         && !context.Properties.SuppressAdditionalAttempts
-        && _judge.ShouldHandle(in outcome)
+        && _judge.ShouldHandle(in outcome, context, retriesUsed, strategyIndex)
         && !context.CancellationToken.IsCancellationRequested;
 
     private TimeSpan ApplyGeneratedDelay(TimeSpan current, TimeSpan? generated)

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -78,7 +78,7 @@ public class AllocationBudgetTests
         .WhenResult(-1)
         .Retry(3, Backoff.None);
     private readonly Shield<int> _contextTypedJudge = Shield.For<int>()
-        .WhenResult(static handling =>
+        .WhenResultContext(static handling =>
             handling.Outcome.TryGetResult(out var result) && result < 0)
         .Retry(3, Backoff.None);
     private readonly Shield _composed = Shield

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -77,6 +77,10 @@ public class AllocationBudgetTests
     private readonly Shield<int> _typedJudge = Shield.For<int>()
         .WhenResult(-1)
         .Retry(3, Backoff.None);
+    private readonly Shield<int> _contextTypedJudge = Shield.For<int>()
+        .WhenResult(static handling =>
+            handling.Outcome.TryGetResult(out var result) && result < 0)
+        .Retry(3, Backoff.None);
     private readonly Shield _composed = Shield
         .RateLimit(1_000_000_000, TimeSpan.FromSeconds(1))
         .Timeout(TimeSpan.FromMinutes(1))
@@ -205,6 +209,8 @@ public class AllocationBudgetTests
             test._concurrencyLimitWithRejectionHooks.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("typed result judging", this, static test =>
             test._typedJudge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
+        AssertZero("context-aware typed result judging", this, static test =>
+            test._contextTypedJudge.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("composed pipeline", this, static test =>
             test._composed.ExecuteAsync(static _ => new ValueTask<int>(42)).GetAwaiter().GetResult());
         AssertZero("hedge primary wins", this, static test =>

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -330,8 +330,8 @@ public class AllocationBudgetTests
             test._syncDelayGeneratedHedgeState.WaitForLoserCompletion();
         }, AllocationScope.AllThreads);
         // The eight-byte margin catches boxing the typed Outcome<int> while allowing
-        // the existing generator-path allocations.
-        AssertBudget("typed hedge generator", 576, this, static test =>
+        // the generator delegate's pooled-context version token.
+        AssertBudget("typed hedge generator", 584, this, static test =>
             test._typedGeneratedHedge.ExecuteAsync(static _ => throw RecoverableFailure)
                 .GetAwaiter()
                 .GetResult());

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -631,6 +631,7 @@ public class PipelineHazardAnalyzerTests
         {
             "Shield.When<InvalidOperationException>();",
             "Shield.When<InvalidOperationException>().Or<TimeoutException>();",
+            "Shield.When((HandlingEvent handling) => handling.Attempt == 0);",
             "Shield.When<InvalidOperationException>().Or<TimeoutException>().Or(static exception => exception is null);",
             "_ = Shield.When<InvalidOperationException>();",
             "_ = Shield.Empty.When<InvalidOperationException>();",
@@ -1026,6 +1027,7 @@ public class PipelineHazardAnalyzerTests
         var cases = new[]
         {
             "_ = Shield.When<InvalidOperationException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.When((HandlingEvent handling) => handling.Attempt == 0).Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.When<InvalidOperationException>().Retry(1).RetryForever(Backoff.None);",
             "_ = Shield.For<int>().WhenResult(0).Retry(1).Hedge(2, TimeSpan.Zero);",
@@ -1078,6 +1080,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Compose(Shield.When<InvalidOperationException>().Retry(1), Shield.Empty).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.For<int>().When<InvalidOperationException>().Retry(1).CircuitBreaker(options => options.HandlesException = exception => exception is TimeoutException);",
             "_ = Shield.For<int>().When<InvalidOperationException>().CircuitBreaker(options => options.HandlesException = exception => exception is TimeoutException).Retry(1);",
+            "_ = Shield.For<int>().When<InvalidOperationException>().Retry(1).CircuitBreaker(options => options.HandlesExceptionWithContext = handling => handling.Attempt == 0);",
             "_ = CreateShield().CircuitBreaker(2, TimeSpan.FromSeconds(1));",
         };
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -631,7 +631,7 @@ public class PipelineHazardAnalyzerTests
         {
             "Shield.When<InvalidOperationException>();",
             "Shield.When<InvalidOperationException>().Or<TimeoutException>();",
-            "Shield.When((HandlingEvent handling) => handling.Attempt == 0);",
+            "Shield.WhenContext((HandlingEvent handling) => handling.Attempt == 0);",
             "Shield.When<InvalidOperationException>().Or<TimeoutException>().Or(static exception => exception is null);",
             "_ = Shield.When<InvalidOperationException>();",
             "_ = Shield.Empty.When<InvalidOperationException>();",
@@ -1027,7 +1027,7 @@ public class PipelineHazardAnalyzerTests
         var cases = new[]
         {
             "_ = Shield.When<InvalidOperationException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
-            "_ = Shield.When((HandlingEvent handling) => handling.Attempt == 0).Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
+            "_ = Shield.WhenContext((HandlingEvent handling) => handling.Attempt == 0).Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.When<InvalidOperationException>().Or<TimeoutException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));",
             "_ = Shield.When<InvalidOperationException>().Retry(1).RetryForever(Backoff.None);",
             "_ = Shield.For<int>().WhenResult(0).Retry(1).Hedge(2, TimeSpan.Zero);",

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -182,6 +182,25 @@ public class PipelineDescriptorTests
     }
 
     [Test]
+    public async Task Handling_Descriptor_Reports_Context_Aware_Clauses()
+    {
+        var contextAware = Shield
+            .When(handling => handling.Attempt == 0)
+            .Retry(1, Backoff.None)
+            .GetDescriptor()
+            .AssertContainsSingle<RetryStrategyDescriptor>();
+        var simple = Shield.When<InvalidOperationException>()
+            .Retry(1, Backoff.None)
+            .GetDescriptor()
+            .AssertContainsSingle<RetryStrategyDescriptor>();
+
+        await Assert.That(contextAware.HandlingClause).IsNotNull();
+        await Assert.That(contextAware.HandlingClause!.IsContextAware).IsTrue();
+        await Assert.That(contextAware.HandlingClause.Description).IsEqualTo("custom");
+        await Assert.That(simple.HandlingClause!.IsContextAware).IsFalse();
+    }
+
+    [Test]
     public async Task Custom_Strategy_Uses_A_Diagnostic_Descriptor()
     {
         var shield = Shield.Empty.Use(new PassThroughStrategy());

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -185,7 +185,7 @@ public class PipelineDescriptorTests
     public async Task Handling_Descriptor_Reports_Context_Aware_Clauses()
     {
         var contextAware = Shield
-            .When(handling => handling.Attempt == 0)
+            .WhenContext(handling => handling.Attempt == 0)
             .Retry(1, Backoff.None)
             .GetDescriptor()
             .AssertContainsSingle<RetryStrategyDescriptor>();

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -391,6 +391,8 @@ public class ApiShapeTests
             .Distinct()
             .SelectMany(static assembly => assembly.ExportedTypes)
             .Where(static type =>
-                type.IsValueType && type.Name.Contains("Event", StringComparison.Ordinal))
+                type.IsValueType
+                && type.Name.Contains("Event", StringComparison.Ordinal)
+                && !type.Name.StartsWith("HandlingEvent", StringComparison.Ordinal))
             .ToArray();
 }

--- a/tests/Kevlar.Tests/ApiShapeTests.cs
+++ b/tests/Kevlar.Tests/ApiShapeTests.cs
@@ -271,7 +271,42 @@ public class ApiShapeTests
         await Assert.That(errors[0].Id).IsEqualTo("CS0121");
     }
 
-    private static CSharpCompilation CreateCompilation(string source)
+    [Test]
+    public async Task Handling_Predicates_Remain_Unambiguous_For_CSharp_12_Consumers()
+    {
+        var compilation = CreateCompilation(
+            """
+            using Kevlar;
+
+            public static class Consumer
+            {
+                public static void Build()
+                {
+                    _ = Shield.When(_ => true);
+                    _ = Shield.Empty.When(_ => true);
+                    _ = Shield.For<int>().When(_ => true);
+                    _ = Shield.For<int>().WhenResult(_ => true);
+                    _ = Shield.When<System.Exception>().Or(_ => true);
+                    _ = Shield.For<int>().When<System.Exception>().Or(_ => true).OrResult(_ => true);
+
+                    _ = Shield.WhenContext(handling => handling.Attempt == 0);
+                    _ = Shield.For<int>().WhenResultContext(handling => handling.Attempt == 0);
+                }
+            }
+            """,
+            LanguageVersion.CSharp12);
+
+        var errors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(static diagnostic => $"{diagnostic.Id}: {diagnostic.GetMessage()}")
+            .ToArray();
+
+        await Assert.That(errors).IsEmpty();
+    }
+
+    private static CSharpCompilation CreateCompilation(
+        string source,
+        LanguageVersion languageVersion = LanguageVersion.Preview)
     {
         var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
             .Split(Path.PathSeparator)
@@ -282,7 +317,7 @@ public class ApiShapeTests
 
         return CSharpCompilation.Create(
             "FallbackApiShape",
-            [CSharpSyntaxTree.ParseText(source)],
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(languageVersion))],
             references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
     }

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -11,8 +11,8 @@ public class ContextAwarePredicateTests
     public async Task Predicate_Receives_Attempt_Number_In_Retry()
     {
         var shield = Shield
-            .When(handling => handling.Exception is TimeoutException && handling.Attempt < 1)
-            .Or(handling => handling.Exception is HttpRequestException && handling.Attempt < 3)
+            .WhenContext(handling => handling.Exception is TimeoutException && handling.Attempt < 1)
+            .OrContext(handling => handling.Exception is HttpRequestException && handling.Attempt < 3)
             .Retry(5, Backoff.None);
 
         await AssertAttemptsAsync<TimeoutException>(shield, expected: 2);
@@ -24,7 +24,7 @@ public class ContextAwarePredicateTests
     {
         HandlingEvent observed = default;
         var shield = Shield.Timeout(TimeSpan.FromMinutes(1))
-            .When(handling =>
+            .WhenContext(handling =>
             {
                 observed = handling;
                 return handling.Context.Properties.GetOrDefault(IsRead);
@@ -52,7 +52,7 @@ public class ContextAwarePredicateTests
     {
         var attempts = new List<int>();
         var breaker = Shield
-            .When(handling =>
+            .WhenContext(handling =>
             {
                 attempts.Add(handling.Attempt);
                 return true;
@@ -64,7 +64,7 @@ public class ContextAwarePredicateTests
             .Throws<InvalidOperationException>();
 
         var fallback = Shield.For<int>()
-            .When(handling =>
+            .WhenContext(handling =>
             {
                 attempts.Add(handling.Attempt);
                 return handling.Outcome.Exception is InvalidOperationException;
@@ -82,7 +82,7 @@ public class ContextAwarePredicateTests
     {
         var attempts = 0;
         var shield = Shield
-            .When(handling => handling.Context.Properties.GetOrDefault(IsRead))
+            .WhenContext(handling => handling.Context.Properties.GetOrDefault(IsRead))
             .Retry(1, Backoff.None)
             .CircuitBreaker(consecutiveFailures: 2, breakDuration: TimeSpan.FromMinutes(1));
 
@@ -103,7 +103,7 @@ public class ContextAwarePredicateTests
     public async Task Context_Aware_Clause_Is_Sealed_By_Wrap_And_Compose()
     {
         var contextual = Shield
-            .When(handling => handling.Exception is TimeoutException)
+            .WhenContext(handling => handling.Exception is TimeoutException)
             .Retry(1, Backoff.None);
         var wrapped = contextual.Wrap(Shield.Empty).Retry(1, Backoff.None);
         var composed = Shield.Compose(contextual, Shield.Empty).Retry(1, Backoff.None);
@@ -118,7 +118,7 @@ public class ContextAwarePredicateTests
         var observedAttempts = new List<int>();
         var executions = 0;
         var shield = Shield.For<int>()
-            .WhenResult(handling =>
+            .WhenResultContext(handling =>
             {
                 observedAttempts.Add(handling.Attempt);
                 return handling.Outcome.TryGetResult(out var result) && result < 0;
@@ -138,7 +138,7 @@ public class ContextAwarePredicateTests
         var observedValues = new List<int>();
         var executions = 0;
         var shield = Shield.For<int>()
-            .WhenResult(handling =>
+            .WhenResultContext(handling =>
             {
                 observedValues.Add(handling.Context.Properties.GetOrDefault(HedgeAttempt));
                 return handling.Outcome.TryGetResult(out var result) && result < 0;
@@ -165,7 +165,7 @@ public class ContextAwarePredicateTests
         var observedValue = -1;
         var observedToken = default(CancellationToken);
         var shield = Shield.For<int>()
-            .WhenResult(handling =>
+            .WhenResultContext(handling =>
             {
                 if (handling.Attempt == 1)
                 {
@@ -227,7 +227,7 @@ public class ContextAwarePredicateTests
     public async Task Predicate_Exception_Is_Treated_As_Not_Handled()
     {
         var predicateFailure = new DivideByZeroException("predicate");
-        var shield = Shield.When((HandlingEvent handling) => throw predicateFailure)
+        var shield = Shield.WhenContext((HandlingEvent handling) => throw predicateFailure)
             .Retry(1, Backoff.None);
         var attempts = 0;
 
@@ -250,7 +250,7 @@ public class ContextAwarePredicateTests
 
         try
         {
-            var shield = Shield.When((HandlingEvent _) => throw new DivideByZeroException("predicate"))
+            var shield = Shield.WhenContext((HandlingEvent _) => throw new DivideByZeroException("predicate"))
                 .Retry(1, Backoff.None);
             var executionFailure = new InvalidOperationException("execution");
 
@@ -270,8 +270,8 @@ public class ContextAwarePredicateTests
     {
         var alternatives = 0;
         var shield = Shield
-            .When((HandlingEvent _) => throw new DivideByZeroException("first"))
-            .Or((HandlingEvent _) =>
+            .WhenContext((HandlingEvent _) => throw new DivideByZeroException("first"))
+            .OrContext((HandlingEvent _) =>
             {
                 alternatives++;
                 return true;
@@ -301,8 +301,8 @@ public class ContextAwarePredicateTests
     {
         var alternatives = 0;
         var shield = Shield.For<int>()
-            .WhenResult((HandlingEvent<int> _) => throw new DivideByZeroException("first"))
-            .Or((HandlingEvent<int> _) =>
+            .WhenResultContext((HandlingEvent<int> _) => throw new DivideByZeroException("first"))
+            .OrContext((HandlingEvent<int> _) =>
             {
                 alternatives++;
                 return true;
@@ -322,7 +322,7 @@ public class ContextAwarePredicateTests
     {
         var attempts = 0;
         var shield = Shield
-            .When(handling => handling.Attempt == 0)
+            .WhenContext(handling => handling.Attempt == 0)
             .Retry(3, Backoff.None);
 
         await Assert.That(() => shield.Execute<int>(_ =>
@@ -337,7 +337,7 @@ public class ContextAwarePredicateTests
     public async Task Describe_Renders_Context_Aware_Clause_As_Custom()
     {
         var shield = Shield
-            .When(handling => handling.Context.Properties.GetOrDefault(IsRead))
+            .WhenContext(handling => handling.Context.Properties.GetOrDefault(IsRead))
             .Retry(1, Backoff.None);
 
         await Assert.That(shield.ToString()).IsEqualTo("[when custom] Retry(1, no delay)");

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Kevlar.Tests;
 
 public class ContextAwarePredicateTests
@@ -240,6 +242,30 @@ public class ContextAwarePredicateTests
     }
 
     [Test]
+    [NotInParallel]
+    public async Task Trace_Listener_Exception_Does_Not_Replace_Execution_Failure()
+    {
+        var listener = new ThrowingTraceListener();
+        Trace.Listeners.Add(listener);
+
+        try
+        {
+            var shield = Shield.When((HandlingEvent _) => throw new DivideByZeroException("predicate"))
+                .Retry(1, Backoff.None);
+            var executionFailure = new InvalidOperationException("execution");
+
+            var thrown = await Assert.That(async () => await shield.ExecuteAsync<int>(
+                _ => throw executionFailure)).Throws<InvalidOperationException>();
+
+            await Assert.That(thrown).IsSameReferenceAs(executionFailure);
+        }
+        finally
+        {
+            Trace.Listeners.Remove(listener);
+        }
+    }
+
+    [Test]
     public async Task Predicate_Exception_Does_Not_Skip_Later_Context_Alternative()
     {
         var alternatives = 0;
@@ -261,6 +287,13 @@ public class ContextAwarePredicateTests
 
         await Assert.That(attempts).IsEqualTo(2);
         await Assert.That(alternatives).IsEqualTo(1);
+    }
+
+    private sealed class ThrowingTraceListener : TraceListener
+    {
+        public override void Write(string? message) => throw new InvalidOperationException("listener");
+
+        public override void WriteLine(string? message) => throw new InvalidOperationException("listener");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -3,6 +3,7 @@ namespace Kevlar.Tests;
 public class ContextAwarePredicateTests
 {
     private static readonly KevlarKey<bool> IsRead = new("is-read");
+    private static readonly KevlarKey<int> HedgeAttempt = new("hedge-attempt");
 
     [Test]
     public async Task Predicate_Receives_Attempt_Number_In_Retry()
@@ -127,6 +128,31 @@ public class ContextAwarePredicateTests
 
         await Assert.That(result).IsEqualTo(42);
         await Assert.That(observedAttempts).IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
+    public async Task Hedge_Predicate_Receives_Each_Attempts_Context()
+    {
+        var observedValues = new List<int>();
+        var executions = 0;
+        var shield = Shield.For<int>()
+            .WhenResult(handling =>
+            {
+                observedValues.Add(handling.Context.Properties.GetOrDefault(HedgeAttempt));
+                return handling.Outcome.TryGetResult(out var result) && result < 0;
+            })
+            .Hedge(maxAttempts: 2, delay: Timeout.InfiniteTimeSpan);
+
+        var result = await shield.ExecuteWithContextAsync(async context =>
+        {
+            await Task.Yield();
+            var execution = Interlocked.Increment(ref executions);
+            context.Properties.Set(HedgeAttempt, execution);
+            return execution == 1 ? -1 : 42;
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observedValues).IsEquivalentTo([1, 2]);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -196,6 +196,56 @@ public class ContextAwarePredicateTests
     }
 
     [Test]
+    public async Task Hedge_Predicate_Context_Is_Frozen_Before_Classification()
+    {
+        var releaseSlowOriginal = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<int>? slowOriginal = null;
+        var executions = 0;
+        var observedValue = -1;
+        var shield = Shield.For<int>()
+            .WhenResultContext(handling =>
+            {
+                if (handling.Attempt == 1)
+                {
+                    releaseSlowOriginal.SetResult();
+                    slowOriginal!.GetAwaiter().GetResult();
+                    observedValue = handling.Context.Properties.GetOrDefault(HedgeAttempt, -1);
+                }
+
+                return handling.Outcome.TryGetResult(out var result) && result < 0;
+            })
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 2;
+                options.Delay = Timeout.InfiniteTimeSpan;
+                options.ActionGenerator = hedge => async token =>
+                {
+                    var selectedOriginal = hedge.OriginalAction(token);
+                    slowOriginal = hedge.OriginalAction(token).AsTask();
+                    return await selectedOriginal;
+                };
+            });
+
+        var result = await shield.ExecuteWithContextAsync(async context =>
+        {
+            await Task.Yield();
+            var execution = Interlocked.Increment(ref executions);
+            context.Properties.Set(HedgeAttempt, execution);
+            if (execution == 3)
+            {
+                await releaseSlowOriginal.Task;
+            }
+
+            return execution == 1 ? -1 : execution;
+        });
+
+        await Assert.That(result).IsEqualTo(2);
+        await Assert.That(observedValue).IsEqualTo(2);
+        await Assert.That(await slowOriginal!).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task HandlesException_Context_Override_Replaces_Ambient_Clause()
     {
         var attempts = 0;

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -1,0 +1,215 @@
+namespace Kevlar.Tests;
+
+public class ContextAwarePredicateTests
+{
+    private static readonly KevlarKey<bool> IsRead = new("is-read");
+
+    [Test]
+    public async Task Predicate_Receives_Attempt_Number_In_Retry()
+    {
+        var shield = Shield
+            .When(handling => handling.Exception is TimeoutException && handling.Attempt < 1)
+            .Or(handling => handling.Exception is HttpRequestException && handling.Attempt < 3)
+            .Retry(5, Backoff.None);
+
+        await AssertAttemptsAsync<TimeoutException>(shield, expected: 2);
+        await AssertAttemptsAsync<HttpRequestException>(shield, expected: 4);
+    }
+
+    [Test]
+    public async Task Predicate_Receives_Context_Properties_And_Strategy_Index()
+    {
+        HandlingEvent observed = default;
+        var shield = Shield.Timeout(TimeSpan.FromMinutes(1))
+            .When(handling =>
+            {
+                observed = handling;
+                return handling.Context.Properties.GetOrDefault(IsRead);
+            })
+            .Retry(1, Backoff.None);
+        var attempts = 0;
+
+        await Assert.That(async () => await shield.ExecuteWithContextAsync(
+            true,
+            static (isRead, properties) => properties.Set(IsRead, isRead),
+            (_, _) =>
+            {
+                attempts++;
+                return ValueTask.FromException<int>(new InvalidOperationException());
+            }))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(observed.Attempt).IsEqualTo(0);
+        await Assert.That(observed.StrategyIndex).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Predicate_Attempt_Is_Zero_For_Non_Attempting_Strategies()
+    {
+        var attempts = new List<int>();
+        var breaker = Shield
+            .When(handling =>
+            {
+                attempts.Add(handling.Attempt);
+                return true;
+            })
+            .CircuitBreaker(consecutiveFailures: 2, breakDuration: TimeSpan.FromMinutes(1));
+
+        await Assert.That(async () => await breaker.ExecuteAsync<int>(
+            _ => ValueTask.FromException<int>(new InvalidOperationException())))
+            .Throws<InvalidOperationException>();
+
+        var fallback = Shield.For<int>()
+            .When(handling =>
+            {
+                attempts.Add(handling.Attempt);
+                return handling.Outcome.Exception is InvalidOperationException;
+            })
+            .FallbackTo(42);
+        var result = await fallback.ExecuteAsync(
+            _ => ValueTask.FromException<int>(new InvalidOperationException()));
+        await Assert.That(result).IsEqualTo(42);
+
+        await Assert.That(attempts).IsEquivalentTo([0, 0]);
+    }
+
+    [Test]
+    public async Task Ambient_Context_Aware_Clause_Applies_To_Later_Strategies()
+    {
+        var attempts = 0;
+        var shield = Shield
+            .When(handling => handling.Context.Properties.GetOrDefault(IsRead))
+            .Retry(1, Backoff.None)
+            .CircuitBreaker(consecutiveFailures: 2, breakDuration: TimeSpan.FromMinutes(1));
+
+        await Assert.That(async () => await shield.ExecuteWithContextAsync(
+            true,
+            static (isRead, properties) => properties.Set(IsRead, isRead),
+            (_, _) =>
+            {
+                attempts++;
+                return ValueTask.FromException<int>(new InvalidOperationException());
+            }))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Context_Aware_Clause_Is_Sealed_By_Wrap_And_Compose()
+    {
+        var contextual = Shield
+            .When(handling => handling.Exception is TimeoutException)
+            .Retry(1, Backoff.None);
+        var wrapped = contextual.Wrap(Shield.Empty).Retry(1, Backoff.None);
+        var composed = Shield.Compose(contextual, Shield.Empty).Retry(1, Backoff.None);
+
+        await AssertAttemptsAsync<InvalidOperationException>(wrapped, expected: 2);
+        await AssertAttemptsAsync<InvalidOperationException>(composed, expected: 2);
+    }
+
+    [Test]
+    public async Task Typed_Result_Predicate_Receives_Outcome_And_Hedge_Attempt()
+    {
+        var observedAttempts = new List<int>();
+        var executions = 0;
+        var shield = Shield.For<int>()
+            .WhenResult(handling =>
+            {
+                observedAttempts.Add(handling.Attempt);
+                return handling.Outcome.TryGetResult(out var result) && result < 0;
+            })
+            .Hedge(maxAttempts: 2, delay: Timeout.InfiniteTimeSpan);
+
+        var result = await shield.ExecuteAsync(_ =>
+            new ValueTask<int>(++executions == 1 ? -1 : 42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observedAttempts).IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
+    public async Task HandlesException_Context_Override_Replaces_Ambient_Clause()
+    {
+        var attempts = 0;
+        var shield = Shield.When<InvalidOperationException>().Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.Backoff = Backoff.None;
+            options.HandlesExceptionWithContext = handling =>
+                handling.Exception is ArgumentException && handling.Attempt == 0;
+        });
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new ArgumentException();
+        })).Throws<ArgumentException>();
+        await Assert.That(attempts).IsEqualTo(2);
+
+        attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Predicate_Exception_Is_Treated_As_Not_Handled()
+    {
+        var predicateFailure = new DivideByZeroException("predicate");
+        var shield = Shield.When((HandlingEvent handling) => throw predicateFailure)
+            .Retry(1, Backoff.None);
+        var attempts = 0;
+
+        var executionFailure = await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException("execution");
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(executionFailure).IsNotSameReferenceAs(predicateFailure);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Sync_Predicate_Receives_Attempt_Number()
+    {
+        var attempts = 0;
+        var shield = Shield
+            .When(handling => handling.Attempt == 0)
+            .Retry(3, Backoff.None);
+
+        await Assert.That(() => shield.Execute<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException();
+        })).Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Describe_Renders_Context_Aware_Clause_As_Custom()
+    {
+        var shield = Shield
+            .When(handling => handling.Context.Properties.GetOrDefault(IsRead))
+            .Retry(1, Backoff.None);
+
+        await Assert.That(shield.ToString()).IsEqualTo("[when custom] Retry(1, no delay)");
+    }
+
+    private static async Task AssertAttemptsAsync<TException>(Shield shield, int expected)
+        where TException : Exception, new()
+    {
+        var attempts = 0;
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new TException();
+        })).Throws<TException>();
+        await Assert.That(attempts).IsEqualTo(expected);
+    }
+}

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -156,6 +156,44 @@ public class ContextAwarePredicateTests
     }
 
     [Test]
+    public async Task Hedge_Predicate_Receives_Generated_Original_Action_Context()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var executions = 0;
+        var observedValue = -1;
+        var observedToken = default(CancellationToken);
+        var shield = Shield.For<int>()
+            .WhenResult(handling =>
+            {
+                if (handling.Attempt == 1)
+                {
+                    observedValue = handling.Context.Properties.GetOrDefault(HedgeAttempt, -1);
+                    observedToken = handling.Context.CancellationToken;
+                }
+
+                return handling.Outcome.TryGetResult(out var result) && result < 0;
+            })
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 2;
+                options.Delay = Timeout.InfiniteTimeSpan;
+                options.ActionGenerator = hedge => _ => hedge.OriginalAction(cancellation.Token);
+            });
+
+        var result = await shield.ExecuteWithContextAsync(async context =>
+        {
+            await Task.Yield();
+            var execution = Interlocked.Increment(ref executions);
+            context.Properties.Set(HedgeAttempt, execution);
+            return execution == 1 ? -1 : 42;
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observedValue).IsEqualTo(2);
+        await Assert.That(observedToken).IsEqualTo(cancellation.Token);
+    }
+
+    [Test]
     public async Task HandlesException_Context_Override_Replaces_Ambient_Clause()
     {
         var attempts = 0;
@@ -199,6 +237,51 @@ public class ContextAwarePredicateTests
 
         await Assert.That(executionFailure).IsNotSameReferenceAs(predicateFailure);
         await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Predicate_Exception_Does_Not_Skip_Later_Context_Alternative()
+    {
+        var alternatives = 0;
+        var shield = Shield
+            .When((HandlingEvent _) => throw new DivideByZeroException("first"))
+            .Or((HandlingEvent _) =>
+            {
+                alternatives++;
+                return true;
+            })
+            .Retry(1, Backoff.None);
+        var attempts = 0;
+
+        await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
+        {
+            attempts++;
+            throw new InvalidOperationException("execution");
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(alternatives).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Typed_Predicate_Exception_Does_Not_Skip_Later_Context_Alternative()
+    {
+        var alternatives = 0;
+        var shield = Shield.For<int>()
+            .WhenResult((HandlingEvent<int> _) => throw new DivideByZeroException("first"))
+            .Or((HandlingEvent<int> _) =>
+            {
+                alternatives++;
+                return true;
+            })
+            .Retry(1, Backoff.None);
+        var attempts = 0;
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(++attempts));
+
+        await Assert.That(result).IsEqualTo(2);
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(alternatives).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -246,6 +246,59 @@ public class ContextAwarePredicateTests
     }
 
     [Test]
+    public async Task Hedge_Predicate_Context_Matches_Returned_Original_Result()
+    {
+        var releaseSelected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLater = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var executions = 0;
+        var observedValue = -1;
+        var shield = Shield.For<int>()
+            .WhenResultContext(handling =>
+            {
+                if (handling.Attempt == 1)
+                {
+                    observedValue = handling.Context.Properties.GetOrDefault(HedgeAttempt, -1);
+                }
+
+                return handling.Outcome.TryGetResult(out var result) && result < 0;
+            })
+            .Hedge(options =>
+            {
+                options.MaxAttempts = 2;
+                options.Delay = Timeout.InfiniteTimeSpan;
+                options.ActionGenerator = hedge => async token =>
+                {
+                    var selectedOriginal = hedge.OriginalAction(token).AsTask();
+                    var laterOriginal = hedge.OriginalAction(token).AsTask();
+                    releaseSelected.SetResult();
+                    var selected = await selectedOriginal;
+                    releaseLater.SetResult();
+                    _ = await laterOriginal;
+                    return selected;
+                };
+            });
+
+        var result = await shield.ExecuteWithContextAsync(async context =>
+        {
+            var execution = Interlocked.Increment(ref executions);
+            context.Properties.Set(HedgeAttempt, execution);
+            if (execution == 2)
+            {
+                await releaseSelected.Task;
+            }
+            else if (execution == 3)
+            {
+                await releaseLater.Task;
+            }
+
+            return execution == 1 ? -1 : execution;
+        });
+
+        await Assert.That(result).IsEqualTo(2);
+        await Assert.That(observedValue).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task HandlesException_Context_Override_Replaces_Ambient_Clause()
     {
         var attempts = 0;

--- a/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
@@ -725,6 +725,52 @@ public class HedgingActionGeneratorTests
     }
 
     [Test]
+    public async Task Incomplete_Original_Action_Keeps_The_Attempt_Context_Leased()
+    {
+        var observer = new ContextIdentityObserver();
+        var releaseOriginal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<int>? originalTask = null;
+        KevlarContext? hedgeContext = null;
+        var calls = 0;
+        var shield = Shield.For<int>().Hedge(options =>
+            {
+                options.MaxAttempts = 2;
+                options.Delay = Timeout.InfiniteTimeSpan;
+                options.ActionGenerator = hedge =>
+                {
+                    hedgeContext = hedge.Context;
+                    return token =>
+                    {
+                        originalTask = hedge.OriginalAction(token).AsTask();
+                        return new ValueTask<int>(42);
+                    };
+                };
+            })
+            .Use(observer);
+
+        var firstResult = await shield.ExecuteAsync(async _ =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                throw new InvalidOperationException("primary");
+            }
+
+            await releaseOriginal.Task;
+            return 21;
+        });
+
+        var secondResult = await shield.ExecuteAsync(static _ => new ValueTask<int>(7));
+        var secondExecutionContext = observer.Contexts.ToArray()[^1];
+
+        await Assert.That(firstResult).IsEqualTo(42);
+        await Assert.That(secondResult).IsEqualTo(7);
+        await Assert.That(ReferenceEquals(hedgeContext, secondExecutionContext)).IsFalse();
+
+        releaseOriginal.SetResult();
+        await Assert.That(await originalTask!).IsEqualTo(21);
+    }
+
+    [Test]
     public async Task Void_Generated_Action_Is_Awaited_To_Completion()
     {
         var actionCompleted = false;

--- a/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingActionGeneratorTests.cs
@@ -771,6 +771,48 @@ public class HedgingActionGeneratorTests
     }
 
     [Test]
+    public async Task Retained_Original_Action_Cannot_Use_A_Recycled_Attempt_Context()
+    {
+        var secondGenerated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecond = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Func<CancellationToken, ValueTask<int>>? retainedOriginal = null;
+        var generatedActions = 0;
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = Timeout.InfiniteTimeSpan;
+            options.ActionGenerator = hedge =>
+            {
+                if (Interlocked.Increment(ref generatedActions) == 1)
+                {
+                    retainedOriginal = hedge.OriginalAction;
+                    return static _ => new ValueTask<int>(42);
+                }
+
+                secondGenerated.SetResult();
+                return async _ =>
+                {
+                    await releaseSecond.Task;
+                    return 43;
+                };
+            };
+        });
+
+        var firstResult = await shield.ExecuteAsync(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary")));
+        var secondExecution = shield.ExecuteAsync(static _ =>
+            ValueTask.FromException<int>(new InvalidOperationException("primary"))).AsTask();
+        await secondGenerated.Task;
+
+        await Assert.That(async () => await retainedOriginal!(CancellationToken.None))
+            .Throws<ObjectDisposedException>();
+
+        releaseSecond.SetResult();
+        await Assert.That(await secondExecution).IsEqualTo(43);
+        await Assert.That(firstResult).IsEqualTo(42);
+    }
+
+    [Test]
     public async Task Void_Generated_Action_Is_Awaited_To_Completion()
     {
         var actionCompleted = false;

--- a/tests/Kevlar.Tests/NewApiTests.cs
+++ b/tests/Kevlar.Tests/NewApiTests.cs
@@ -522,7 +522,7 @@ public class NewApiTests
     }
 
     [Test]
-    public async Task Or_Is_The_Only_Predicate_Continuation_On_The_Builders()
+    public async Task Or_Exposes_Simple_And_Context_Aware_Predicate_Continuations()
     {
         foreach (var builderType in new[] { typeof(ShieldBuilder), typeof(ShieldBuilder<int>) })
         {
@@ -532,10 +532,16 @@ public class NewApiTests
 
             await Assert.That(declared.Any(static method => method.Name == "OrWhen")).IsFalse();
 
-            var predicateContinuation = declared
-                .Single(static method => method.Name == "Or" && !method.IsGenericMethodDefinition);
-            await Assert.That(predicateContinuation.GetParameters().Single().ParameterType)
-                .IsEqualTo(typeof(Func<Exception, bool>));
+            var predicateContinuations = declared
+                .Where(static method => method.Name == "Or" && !method.IsGenericMethodDefinition)
+                .Select(static method => method.GetParameters().Single().ParameterType)
+                .ToArray();
+            var contextType = builderType == typeof(ShieldBuilder)
+                ? typeof(Func<HandlingEvent, bool>)
+                : typeof(Func<HandlingEvent<int>, bool>);
+
+            await Assert.That(predicateContinuations)
+                .IsEquivalentTo([typeof(Func<Exception, bool>), contextType]);
         }
     }
 

--- a/tests/Kevlar.Tests/NewApiTests.cs
+++ b/tests/Kevlar.Tests/NewApiTests.cs
@@ -522,7 +522,7 @@ public class NewApiTests
     }
 
     [Test]
-    public async Task Or_Exposes_Simple_And_Context_Aware_Predicate_Continuations()
+    public async Task Or_Uses_Distinct_Names_For_Simple_And_Context_Aware_Predicates()
     {
         foreach (var builderType in new[] { typeof(ShieldBuilder), typeof(ShieldBuilder<int>) })
         {
@@ -532,16 +532,20 @@ public class NewApiTests
 
             await Assert.That(declared.Any(static method => method.Name == "OrWhen")).IsFalse();
 
-            var predicateContinuations = declared
+            var simpleContinuations = declared
                 .Where(static method => method.Name == "Or" && !method.IsGenericMethodDefinition)
                 .Select(static method => method.GetParameters().Single().ParameterType)
                 .ToArray();
             var contextType = builderType == typeof(ShieldBuilder)
                 ? typeof(Func<HandlingEvent, bool>)
                 : typeof(Func<HandlingEvent<int>, bool>);
+            var contextContinuations = declared
+                .Where(static method => method.Name == "OrContext")
+                .Select(static method => method.GetParameters().Single().ParameterType)
+                .ToArray();
 
-            await Assert.That(predicateContinuations)
-                .IsEquivalentTo([typeof(Func<Exception, bool>), contextType]);
+            await Assert.That(simpleContinuations).IsEquivalentTo([typeof(Func<Exception, bool>)]);
+            await Assert.That(contextContinuations).IsEquivalentTo([contextType]);
         }
     }
 


### PR DESCRIPTION
Closes #234.

Adds context-aware handling events and fluent/local predicate overloads with retry/hedge attempt metadata, execution properties, stable strategy indexes, typed no-boxing outcomes, Testing descriptors, analyzer awareness, and docs.

Validation:
- dotnet build Kevlar.slnx -c Release
- Kevlar.Tests: 958 passed
- Kevlar.Analyzers.Tests: 86 passed
- Kevlar.Testing.Tests: 53 passed
- Kevlar.AllocationTests: 3 passed
- Verify-Docs.ps1: 27 pages
- Verify-DocSnippets.ps1: 156 snippets on net8.0/net10.0
- Docusaurus production build

Latest review validation (9b17675):
- `dotnet build Kevlar.slnx -c Release`
- Kevlar.Tests: 974 net8.0 / 999 net10.0
- Kevlar.AllocationTests: 4/4 on net8.0 and net10.0
- ContextAwarePredicateTests: 17/17 on net8.0 and net10.0
- BenchmarkDotNet `HedgingBenchmarks.FixedHedge`: 2.532 us, 1.12 KB/op before; 2.495 us, 1.12 KB/op after
