### PR TITLE
feat(hedging): add delay generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
 
 ### Changed
 
+- Hedging now supports synchronous and asynchronous per-attempt delay generators with access to
+  the attempt number, execution context, and elapsed time. Standard endpoint-aware HTTP hedging
+  exposes the same adaptive delay hooks, and `Kevlar.Testing` reports whether one is configured.
 - Named DI registrations now expose symmetric configuration overloads, typed
   `IShieldProvider<TResult>` snapshots, and `AddReloadingShield<TResult>`.
 - Handling-clause builders now match their shield counterparts for configured timeouts, direct

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -267,13 +267,17 @@ services.AddHttpClient("routed")
         options.SelectionMode = HttpEndpointSelectionMode.Weighted;
         options.MaxAttempts = 2;
         options.HedgeDelay = TimeSpan.FromMilliseconds(500);
+        options.HedgeDelayGenerator = hedge => hedge.Elapsed < TimeSpan.FromSeconds(1)
+            ? TimeSpan.FromMilliseconds(100)
+            : TimeSpan.Zero;
     });
 ```
 
 `AddStandardHedgeShield` installs a 30s total timeout and up to two hedged attempts. Each endpoint
 gets its own 10-concurrent/zero-queue limiter, 50%-over-30s circuit breaker (minimum 10 attempts,
 15s break), and 10s attempt timeout. Configure those defaults through `TotalTimeout`, `MaxAttempts`,
-`HedgeDelay`, `MaxConcurrency`, `QueueLimit`, `FailureRatio` or `ConsecutiveFailures`,
+`HedgeDelay`, `HedgeDelayGenerator`, `HedgeDelayGeneratorAsync`, `MaxConcurrency`, `QueueLimit`,
+`FailureRatio` or `ConsecutiveFailures`,
 `MinimumThroughput`, `SamplingWindow`, `BreakDuration`, and `AttemptTimeout`.
 
 The registration also exposes `ContentReplayPolicy`, `MaximumBufferSize`,

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -494,7 +494,7 @@ if (pollyLimiterOptions.DefaultRateLimiterOptions.PermitLimit != 1000 ||
 | `TimeoutGenerator` | `TimeoutGenerator` |
 | hedging `ActionGenerator` | `HedgeActionGenerator.Create<T>` |
 | circuit `BreakDurationGenerator` | `BreakDurationGenerator` |
-| hedging `DelayGenerator` | no equivalent; hedging currently uses a fixed `Delay` |
+| hedging `DelayGenerator` | `HedgeOptions.DelayGenerator` or `DelayGeneratorAsync`; `HedgeDelayEvent` exposes `AttemptNumber`, `Context`, and `Elapsed` |
 | `OnOpened` / `OnClosed` / `OnHalfOpened` | one `OnStateChanged` callback |
 
 Polly's `CircuitBreakerManualControl` and `CircuitBreakerStateProvider` are separately shareable.

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -29,6 +29,8 @@ Shield.Hedge(o =>
 |---|---|---|
 | `MaxAttempts` | `2` | Total attempts, including the first |
 | `Delay` | `1s` | Wait before launching the next attempt (see special values below) |
+| `DelayGenerator` | — | Select a delay for each pending hedge from its attempt number, context, and elapsed execution time |
+| `DelayGeneratorAsync` | — | Awaited delay selector; runs after `DelayGenerator` and determines the delay when both are set |
 | `OnHedge` | — | Callback when a hedge launches — `e.AttemptNumber` is a 1-based execution number, so `2` = first hedge |
 | `OnHedgeAsync` | — | Awaited callback after `OnHedge` and before the attempt starts |
 | `ActionGenerator` | — | Select a different operation for each additional attempt; `null` uses the original |
@@ -65,6 +67,32 @@ var response = await shield.ExecuteAsync(ct => replicas[0](ct));
 For an untyped or void shield, use `HedgeActionGenerator.Create`. Lifting an untyped generator into
 a shield with a different result type fails while that typed shield is built.
 
+### Adaptive delays
+
+Use a delay generator when each execution or hedge needs different timing. Generator delays are
+relative to the previous hedge launch, so `100ms` followed by `300ms` launches attempts 2 and 3 at
+approximately 100ms and 400ms. A handled failure still launches the next attempt immediately.
+
+```csharp
+var hedgeDelay = new KevlarKey<TimeSpan>("hedge-delay");
+var adaptiveHedge = Shield.Hedge(options =>
+{
+    options.MaxAttempts = 3;
+    options.DelayGenerator = hedge =>
+        hedge.Context.Properties.GetOrDefault(hedgeDelay, TimeSpan.FromMilliseconds(100));
+});
+
+var adaptiveResult = await adaptiveHedge.ExecuteWithContextAsync(
+    TimeSpan.FromMilliseconds(75),
+    (delay, properties) => properties.Set(hedgeDelay, delay),
+    static (_, _) => new ValueTask<int>(42));
+```
+
+`HedgeDelayEvent.AttemptNumber` is the 1-based execution number (`2` = first hedge), and `Elapsed`
+is measured from the primary attempt's start through the shield's `TimeProvider`. Generated
+negative delays become zero, values above the runtime timer limit are clamped, and the same special
+zero/infinite meanings apply. Generator exceptions fail the execution and cancel in-flight attempts.
+
 ### Special delay values
 
 - `TimeSpan.Zero` — race **all** attempts at once.
@@ -87,7 +115,7 @@ flags untyped `Hedge(...)` for exactly this reason.
 :::
 
 - Losing attempts are cancelled through their token (use the token you're handed!).
-- Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside `OnHedge`/`OnHedgeAsync`. A cancellation already observable at the launch boundary suppresses both callbacks.
+- Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside a delay generator, `OnHedge`, or `OnHedgeAsync`. A cancellation already observable at the launch boundary suppresses callbacks.
 - Launch ordering is `OnHedge`, awaited `OnHedgeAsync`, action generation, metrics, then the selected operation. Callback or generator failures preserve their exception identity, cancel in-flight attempts, and are not counted as launched hedges.
 - Each attempt gets a forked context — `Properties` are copied at launch time, so attempts don't see each other's writes.
 - Callback contexts are pooled. Do not retain them after the synchronous callback or returned `ValueTask` completes; a generated action's isolated context remains valid until that attempt completes.

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -50,6 +50,10 @@ Kevlar.Extensions.Http.StandardHedgeShieldOptions.FailureRatio.get -> double?
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.FailureRatio.set -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelay.get -> System.TimeSpan
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelay.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelayGenerator.get -> System.Func<Kevlar.HedgeDelayEvent, System.TimeSpan>?
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelayGenerator.set -> void
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelayGeneratorAsync.get -> System.Func<Kevlar.HedgeDelayEvent, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.HedgeDelayGeneratorAsync.set -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaxAttempts.get -> int
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaxAttempts.set -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.MaxConcurrency.get -> int

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -348,7 +348,13 @@ public static class ShieldHttpClientBuilderExtensions
                     .For<HttpResponseMessage>())
             .Or<ConcurrencyLimitExceededException>()
             .Or<CircuitOpenException>()
-            .Hedge(options.MaxAttempts, options.HedgeDelay);
+            .Hedge(hedge =>
+            {
+                hedge.MaxAttempts = options.MaxAttempts;
+                hedge.Delay = options.HedgeDelay;
+                hedge.DelayGenerator = options.HedgeDelayGenerator;
+                hedge.DelayGeneratorAsync = options.HedgeDelayGeneratorAsync;
+            });
 
     private static ShieldHttpHandlerOptions CreateHandlerOptions(StandardHedgeShieldOptions options)
     {

--- a/src/Kevlar.Extensions.Http/StandardHedgeShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHedgeShieldOptions.cs
@@ -12,6 +12,12 @@ public sealed class StandardHedgeShieldOptions
     /// <summary>The delay before another hedged attempt starts. Default 1 second.</summary>
     public TimeSpan HedgeDelay { get; set; } = TimeSpan.FromSeconds(1);
 
+    /// <summary>Selects the delay before each additional endpoint attempt.</summary>
+    public Func<HedgeDelayEvent, TimeSpan>? HedgeDelayGenerator { get; set; }
+
+    /// <summary>Asynchronously selects the delay before each additional endpoint attempt.</summary>
+    public Func<HedgeDelayEvent, ValueTask<TimeSpan>>? HedgeDelayGeneratorAsync { get; set; }
+
     /// <summary>The maximum duration of each endpoint attempt. Default 10 seconds.</summary>
     public TimeSpan AttemptTimeout { get; set; } = TimeSpan.FromSeconds(10);
 

--- a/src/Kevlar.Testing/HedgeStrategyDescriptor.cs
+++ b/src/Kevlar.Testing/HedgeStrategyDescriptor.cs
@@ -7,6 +7,7 @@ public sealed class HedgeStrategyDescriptor : StrategyDescriptor
         string description,
         int maxAttempts,
         TimeSpan delay,
+        bool hasDelayGenerator,
         bool hasNotification,
         bool hasActionGenerator,
         bool hasHandlingOverride)
@@ -14,6 +15,7 @@ public sealed class HedgeStrategyDescriptor : StrategyDescriptor
     {
         MaxAttempts = maxAttempts;
         Delay = delay;
+        HasDelayGenerator = hasDelayGenerator;
         HasNotification = hasNotification;
         HasActionGenerator = hasActionGenerator;
         HasHandlingOverride = hasHandlingOverride;
@@ -24,6 +26,9 @@ public sealed class HedgeStrategyDescriptor : StrategyDescriptor
 
     /// <summary>The stagger delay between attempts.</summary>
     public TimeSpan Delay { get; }
+
+    /// <summary>Whether a per-attempt delay generator is configured.</summary>
+    public bool HasDelayGenerator { get; }
 
     /// <summary>Whether a hedge notification is configured.</summary>
     public bool HasNotification { get; }

--- a/src/Kevlar.Testing/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Testing/PublicAPI.Unshipped.txt
@@ -75,6 +75,7 @@ static Kevlar.Testing.ShieldDescriptorExtensions.GetDescriptor<TResult>(this Kev
 Kevlar.Testing.CircuitBreakerStrategyDescriptor.HasHandlingOverride.get -> bool
 Kevlar.Testing.FallbackStrategyDescriptor.HasHandlingOverride.get -> bool
 Kevlar.Testing.HedgeStrategyDescriptor.HasHandlingOverride.get -> bool
+Kevlar.Testing.HedgeStrategyDescriptor.HasDelayGenerator.get -> bool
 Kevlar.Testing.RetryStrategyDescriptor.HasHandlingOverride.get -> bool
 Kevlar.Testing.CircuitBreakerStateSnapshot
 Kevlar.Testing.CircuitBreakerStateSnapshot.State.get -> Kevlar.CircuitState

--- a/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
+++ b/src/Kevlar.Testing/ShieldDescriptorExtensions.cs
@@ -81,6 +81,7 @@ public static class ShieldDescriptorExtensions
                 description,
                 hedging.MaxAttempts,
                 hedging.Delay,
+                hedging.HasDelayGenerator,
                 hedging.HasNotification,
                 hedging.HasActionGenerator,
                 hedging.HasHandlingOverride),

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -330,6 +330,10 @@ Kevlar.CircuitBreakerOptions<TResult>.SamplingWindow.get -> System.TimeSpan
 Kevlar.CircuitBreakerOptions<TResult>.SamplingWindow.set -> void
 Kevlar.HedgeOptions<TResult>.ActionGenerator.get -> System.Func<Kevlar.HedgeActionGeneratorEvent<TResult>, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<TResult>>?>?
 Kevlar.HedgeOptions<TResult>.ActionGenerator.set -> void
+Kevlar.HedgeOptions<TResult>.DelayGenerator.get -> System.Func<Kevlar.HedgeDelayEvent, System.TimeSpan>?
+Kevlar.HedgeOptions<TResult>.DelayGenerator.set -> void
+Kevlar.HedgeOptions<TResult>.DelayGeneratorAsync.get -> System.Func<Kevlar.HedgeDelayEvent, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Kevlar.HedgeOptions<TResult>.DelayGeneratorAsync.set -> void
 Kevlar.HedgeOptions<TResult>.Delay.get -> System.TimeSpan
 Kevlar.HedgeOptions<TResult>.Delay.set -> void
 Kevlar.HedgeOptions<TResult>.HandlesException.get -> System.Func<System.Exception!, bool>?
@@ -340,6 +344,15 @@ Kevlar.HedgeOptions<TResult>.OnHedge.get -> System.Action<Kevlar.HedgeEvent>?
 Kevlar.HedgeOptions<TResult>.OnHedge.set -> void
 Kevlar.HedgeOptions<TResult>.OnHedgeAsync.get -> System.Func<Kevlar.HedgeEvent, System.Threading.Tasks.ValueTask>?
 Kevlar.HedgeOptions<TResult>.OnHedgeAsync.set -> void
+Kevlar.HedgeDelayEvent
+Kevlar.HedgeDelayEvent.HedgeDelayEvent() -> void
+Kevlar.HedgeDelayEvent.AttemptNumber.get -> int
+Kevlar.HedgeDelayEvent.Context.get -> Kevlar.KevlarContext!
+Kevlar.HedgeDelayEvent.Elapsed.get -> System.TimeSpan
+Kevlar.HedgeOptions.DelayGenerator.get -> System.Func<Kevlar.HedgeDelayEvent, System.TimeSpan>?
+Kevlar.HedgeOptions.DelayGenerator.set -> void
+Kevlar.HedgeOptions.DelayGeneratorAsync.get -> System.Func<Kevlar.HedgeDelayEvent, System.Threading.Tasks.ValueTask<System.TimeSpan>>?
+Kevlar.HedgeOptions.DelayGeneratorAsync.set -> void
 Kevlar.KevlarProxyException
 Kevlar.KevlarProxyException.KevlarProxyException(System.Exception! originalException) -> void
 Kevlar.KevlarProxyException.OriginalException.get -> System.Exception!

--- a/src/Kevlar/Strategies/Hedging/HedgeDelayEvent.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeDelayEvent.cs
@@ -1,0 +1,23 @@
+namespace Kevlar;
+
+/// <summary>Describes an additional hedged attempt whose stagger delay is being selected.</summary>
+public readonly struct HedgeDelayEvent
+{
+    internal HedgeDelayEvent(int attemptNumber, KevlarContext context, TimeSpan elapsed)
+    {
+        AttemptNumber = attemptNumber;
+        Context = context;
+        Elapsed = elapsed;
+    }
+
+    /// <summary>The 1-based number of the attempt that would be launched (2 = first hedge).</summary>
+    public int AttemptNumber { get; }
+
+    /// <summary>
+    /// The ambient execution context. It is pooled; do not retain it after the generator completes.
+    /// </summary>
+    public KevlarContext Context { get; }
+
+    /// <summary>The elapsed time since the primary attempt started.</summary>
+    public TimeSpan Elapsed { get; }
+}

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -40,6 +40,20 @@ public sealed class HedgeOptions
     /// </summary>
     public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// Selects the delay before each additional attempt while earlier attempts remain pending.
+    /// The generated value replaces <see cref="Delay"/> for that attempt. Negative values are
+    /// treated as <see cref="TimeSpan.Zero"/> and values above the runtime timer limit are clamped.
+    /// </summary>
+    public Func<HedgeDelayEvent, TimeSpan>? DelayGenerator { get; set; }
+
+    /// <summary>
+    /// Asynchronously selects the delay before each additional attempt while earlier attempts
+    /// remain pending. When both generators are configured, this generator runs second and its
+    /// value determines the delay.
+    /// </summary>
+    public Func<HedgeDelayEvent, ValueTask<TimeSpan>>? DelayGeneratorAsync { get; set; }
+
     /// <summary>Invoked when an additional hedged attempt is launched.</summary>
     public Action<HedgeEvent>? OnHedge { get; set; }
 

--- a/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
@@ -34,6 +34,12 @@ public sealed class HedgeOptions<TResult>
     /// <inheritdoc cref="HedgeOptions.Delay"/>
     public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(1);
 
+    /// <inheritdoc cref="HedgeOptions.DelayGenerator"/>
+    public Func<HedgeDelayEvent, TimeSpan>? DelayGenerator { get; set; }
+
+    /// <inheritdoc cref="HedgeOptions.DelayGeneratorAsync"/>
+    public Func<HedgeDelayEvent, ValueTask<TimeSpan>>? DelayGeneratorAsync { get; set; }
+
     /// <inheritdoc cref="HedgeOptions.OnHedge"/>
     public Action<HedgeEvent>? OnHedge { get; set; }
 
@@ -52,6 +58,8 @@ public sealed class HedgeOptions<TResult>
         HandlesException = HandlesException,
         MaxAttempts = MaxAttempts,
         Delay = Delay,
+        DelayGenerator = DelayGenerator,
+        DelayGeneratorAsync = DelayGeneratorAsync,
         OnHedge = OnHedge,
         OnHedgeAsync = OnHedgeAsync,
         ActionGenerator = actionGenerator,

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -8,6 +8,8 @@ internal sealed class HedgingStrategy : Strategy
     private readonly OutcomeJudge _judge;
     private readonly int _maxAttempts;
     private readonly TimeSpan _delay;
+    private readonly Func<HedgeDelayEvent, TimeSpan>? _delayGenerator;
+    private readonly Func<HedgeDelayEvent, ValueTask<TimeSpan>>? _delayGeneratorAsync;
     private readonly Action<HedgeEvent>? _onHedge;
     private readonly Func<HedgeEvent, ValueTask>? _onHedgeAsync;
     private readonly HedgeActionGenerator? _actionGenerator;
@@ -26,6 +28,8 @@ internal sealed class HedgingStrategy : Strategy
         _judge = judge;
         _maxAttempts = options.MaxAttempts;
         _delay = options.Delay;
+        _delayGenerator = options.DelayGenerator;
+        _delayGeneratorAsync = options.DelayGeneratorAsync;
         _onHedge = options.OnHedge;
         _onHedgeAsync = options.OnHedgeAsync;
         _actionGenerator = options.ActionGenerator;
@@ -51,13 +55,16 @@ internal sealed class HedgingStrategy : Strategy
 
     internal TimeSpan Delay => _delay;
 
+    internal bool HasDelayGenerator => _delayGenerator is not null || _delayGeneratorAsync is not null;
+
     internal bool HasNotification => _onHedge is not null;
 
     internal bool HasActionGenerator => _actionGenerator is not null;
 
     protected internal override bool InvokesContinuationAtMostOnce => _maxAttempts == 1;
 
-    public override string Describe() => $"Hedge({_maxAttempts} attempts, delay {DescribeHelper.Time(_delay)})";
+    public override string Describe() =>
+        $"Hedge({_maxAttempts} attempts, delay {(HasDelayGenerator ? "generator" : DescribeHelper.Time(_delay))})";
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
@@ -72,10 +79,11 @@ internal sealed class HedgingStrategy : Strategy
             throw new NotSupportedException("Hedging requires asynchronous execution. Use ExecuteAsync instead of Execute.");
         }
 
+        var startedAt = HasDelayGenerator ? context.TimeProvider.GetTimestamp() : 0;
         var primary = StartPrimaryAttempt(next, context);
         if (_delay == TimeSpan.Zero || !primary.Execution.IsCompletedSuccessfully)
         {
-            return ExecuteCoreAsync(next, context, primary.AsPending(), launched: 1, default);
+            return ExecuteCoreAsync(next, context, primary.AsPending(), launched: 1, default, startedAt);
         }
 
         Outcome<T> outcome;
@@ -93,7 +101,7 @@ internal sealed class HedgingStrategy : Strategy
             return new ValueTask<Outcome<T>>(NormalizeCancellation(outcome, context));
         }
 
-        return ExecuteCoreAsync(next, context, initial: null, launched: 1, outcome);
+        return ExecuteCoreAsync(next, context, initial: null, launched: 1, outcome, startedAt);
     }
 
     private async ValueTask<Outcome<T>> ExecuteCoreAsync<T, TState>(
@@ -101,7 +109,8 @@ internal sealed class HedgingStrategy : Strategy
         KevlarContext context,
         HedgeAttempt<T>? initial,
         int launched,
-        Outcome<T>? lastOutcome)
+        Outcome<T>? lastOutcome,
+        long startedAt)
     {
         var pending = ListPool<HedgeAttempt<T>>.Shared.Rent();
 
@@ -119,19 +128,31 @@ internal sealed class HedgingStrategy : Strategy
 
             while (true)
             {
-                if (launched < _maxAttempts && _delay == TimeSpan.Zero)
+                // Preserve fixed zero-delay parallel mode: launch all configured hedges before
+                // selecting even an already-completed outcome. A generator, however, must not run
+                // after an acceptable outcome has already completed.
+                Task<Outcome<T>>? completed = HasDelayGenerator
+                    ? FindCompletedAttempt(pending)
+                    : null;
+                var delay = _delay;
+
+                if (completed is null && launched < _maxAttempts)
                 {
-                    pending.Add(await StartHedgeAttemptAsync(next, context, launched + 1, lastOutcome).ConfigureAwait(false));
-                    launched++;
-                    continue;
+                    delay = await GetDelayAsync(launched + 1, context, startedAt).ConfigureAwait(false);
+                    if (delay == TimeSpan.Zero)
+                    {
+                        pending.Add(await StartHedgeAttemptAsync(next, context, launched + 1, lastOutcome).ConfigureAwait(false));
+                        launched++;
+                        continue;
+                    }
                 }
 
-                Task<Outcome<T>> completed;
-
-                if (launched < _maxAttempts && _delay != System.Threading.Timeout.InfiniteTimeSpan)
+                if (completed is null
+                    && launched < _maxAttempts
+                    && delay != System.Threading.Timeout.InfiniteTimeSpan)
                 {
                     using var delayCancellation = CancellationTokenSourcePool.Shared.RentLinked(context.CancellationToken);
-                    var delayTask = DelayHelper.CreateDelayTask(context.TimeProvider, _delay, delayCancellation.Token);
+                    var delayTask = DelayHelper.CreateDelayTask(context.TimeProvider, delay, delayCancellation.Token);
                     var winner = await WhenAnyAttemptOr(pending, delayTask).ConfigureAwait(false);
 
                     if (winner == delayTask)
@@ -144,7 +165,7 @@ internal sealed class HedgingStrategy : Strategy
                     delayCancellation.Cancel();
                     completed = (Task<Outcome<T>>)winner;
                 }
-                else
+                else if (completed is null)
                 {
                     // A single pending attempt needs no WhenAny machinery; awaiting it directly
                     // is equivalent and skips the Task[] allocation.
@@ -184,6 +205,61 @@ internal sealed class HedgingStrategy : Strategy
 
             ListPool<HedgeAttempt<T>>.Shared.Return(pending);
         }
+    }
+
+    private ValueTask<TimeSpan> GetDelayAsync(
+        int attemptNumber,
+        KevlarContext context,
+        long startedAt)
+    {
+        if (!HasDelayGenerator)
+        {
+            return new ValueTask<TimeSpan>(_delay);
+        }
+
+        context.CancellationToken.ThrowIfCancellationRequested();
+        var delayEvent = new HedgeDelayEvent(
+            attemptNumber,
+            context,
+            context.TimeProvider.GetElapsedTime(startedAt));
+        var delay = _delayGenerator is null
+            ? _delay
+            : NormalizeGeneratedDelay(_delayGenerator(delayEvent));
+
+        context.CancellationToken.ThrowIfCancellationRequested();
+        if (_delayGeneratorAsync is not { } delayGeneratorAsync)
+        {
+            return new ValueTask<TimeSpan>(delay);
+        }
+
+        var generated = delayGeneratorAsync(delayEvent);
+        if (!generated.IsCompletedSuccessfully)
+        {
+            return AwaitGeneratedDelayAsync(generated, context);
+        }
+
+        delay = NormalizeGeneratedDelay(generated.Result);
+        context.CancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<TimeSpan>(delay);
+    }
+
+    private static async ValueTask<TimeSpan> AwaitGeneratedDelayAsync(
+        ValueTask<TimeSpan> generated,
+        KevlarContext context)
+    {
+        var delay = NormalizeGeneratedDelay(await generated.ConfigureAwait(false));
+        context.CancellationToken.ThrowIfCancellationRequested();
+        return delay;
+    }
+
+    private static TimeSpan NormalizeGeneratedDelay(TimeSpan delay)
+    {
+        if (delay == System.Threading.Timeout.InfiniteTimeSpan)
+        {
+            return delay;
+        }
+
+        return delay < TimeSpan.Zero ? TimeSpan.Zero : DelayHelper.Clamp(delay);
     }
 
     private ValueTask<HedgeAttempt<T>> StartHedgeAttemptAsync<T, TState>(
@@ -418,6 +494,19 @@ internal sealed class HedgingStrategy : Strategy
         }
 
         return Task.WhenAny(tasks);
+    }
+
+    private static Task<Outcome<T>>? FindCompletedAttempt<T>(List<HedgeAttempt<T>> pending)
+    {
+        for (var i = 0; i < pending.Count; i++)
+        {
+            if (pending[i].Task.IsCompleted)
+            {
+                return pending[i].Task;
+            }
+        }
+
+        return null;
     }
 
     private static void Remove<T>(List<HedgeAttempt<T>> pending, Task<Outcome<T>> task)

--- a/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
+++ b/tests/Kevlar.AllocationTests/AllocationBudgetTests.cs
@@ -114,6 +114,11 @@ public class AllocationBudgetTests
         .When<InvalidOperationException>()
         .Fallback(static (_, _) => ValueTask.CompletedTask);
     private readonly Shield _parallelHedge = Shield.Hedge(2, TimeSpan.Zero);
+    private readonly Shield _syncDelayGeneratedHedge = Shield.Hedge(options =>
+    {
+        options.MaxAttempts = 2;
+        options.DelayGenerator = static _ => TimeSpan.Zero;
+    });
     private readonly Shield<int> _typedGeneratedHedge = Shield.For<int>().Hedge(options =>
     {
         options.MaxAttempts = 2;
@@ -126,6 +131,7 @@ public class AllocationBudgetTests
     private readonly Counter _retryCounter = new();
     private readonly Counter _asyncDelayRetryCounter = new();
     private readonly ParallelHedgeState _parallelHedgeState = new();
+    private readonly ParallelHedgeState _syncDelayGeneratedHedgeState = new();
     private readonly int _metadataValue = 42;
 
     public AllocationBudgetTests() => _ = _partitioned.GetShield(42);
@@ -287,6 +293,14 @@ public class AllocationBudgetTests
                 static (state, cancellationToken) => state.ExecuteAsync(cancellationToken))
                 .GetAwaiter().GetResult();
             test._parallelHedgeState.WaitForLoserCompletion();
+        }, AllocationScope.AllThreads);
+        AssertBudget("sync delay generator launches second attempt", 3_072, this, static test =>
+        {
+            test._syncDelayGeneratedHedge.ExecuteAsync(
+                test._syncDelayGeneratedHedgeState,
+                static (state, cancellationToken) => state.ExecuteAsync(cancellationToken))
+                .GetAwaiter().GetResult();
+            test._syncDelayGeneratedHedgeState.WaitForLoserCompletion();
         }, AllocationScope.AllThreads);
         // The eight-byte margin catches boxing the typed Outcome<int> while allowing
         // the existing generator-path allocations.

--- a/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
@@ -227,6 +227,45 @@ public class HttpResilienceTests
     }
 
     [Test]
+    public async Task HttpClientFactory_Standard_Hedge_Uses_Adaptive_Delay()
+    {
+        await using var slow = FlakyHttpServer.Start(async (_, context) =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(3));
+            await FlakyHttpServer.Respond(context, 200, "slow");
+        });
+        await using var healthy = FlakyHttpServer.Start((_, context) =>
+            FlakyHttpServer.Respond(context, 200, "adaptive hedge"));
+        var observedAttempt = 0;
+        using var services = new ServiceCollection()
+            .AddHttpClient("adaptive-hedge")
+            .AddStandardHedgeShield(options =>
+            {
+                options.Endpoints.Add(new HttpEndpoint(new Uri(slow.Url)));
+                options.Endpoints.Add(new HttpEndpoint(new Uri(healthy.Url)));
+                options.HedgeDelay = TimeSpan.FromMinutes(1);
+                options.HedgeDelayGenerator = hedge =>
+                {
+                    observedAttempt = hedge.AttemptNumber;
+                    return TimeSpan.Zero;
+                };
+            })
+            .Services
+            .BuildServiceProvider();
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("adaptive-hedge");
+
+        var stopwatch = Stopwatch.StartNew();
+        using var response = await client.GetAsync("http://origin.invalid/adaptive");
+        stopwatch.Stop();
+
+        await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("adaptive hedge");
+        await Assert.That(observedAttempt).IsEqualTo(2);
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(2.5));
+        await Assert.That(slow.CallCount).IsEqualTo(1);
+        await Assert.That(healthy.CallCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Caller_Cancellation_Stops_Loopback_Retry_And_Preserves_The_Token()
     {
         var requestStarted = new TaskCompletionSource(

--- a/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
+++ b/tests/Kevlar.Testing.Tests/PipelineDescriptorTests.cs
@@ -49,6 +49,7 @@ public class PipelineDescriptorTests
             {
                 options.MaxAttempts = 3;
                 options.Delay = TimeSpan.FromMilliseconds(25);
+                options.DelayGenerator = static _ => TimeSpan.Zero;
                 options.OnHedge = _ => { };
                 options.ActionGenerator = HedgeActionGenerator.Create(static _ => null);
             })
@@ -104,6 +105,7 @@ public class PipelineDescriptorTests
         var hedge = descriptor.AssertContainsSingle<HedgeStrategyDescriptor>();
         await Assert.That(hedge.MaxAttempts).IsEqualTo(3);
         await Assert.That(hedge.Delay).IsEqualTo(TimeSpan.FromMilliseconds(25));
+        await Assert.That(hedge.HasDelayGenerator).IsTrue();
         await Assert.That(hedge.HasNotification).IsTrue();
         await Assert.That(hedge.HasActionGenerator).IsTrue();
     }

--- a/tests/Kevlar.Tests/DescribeTests.cs
+++ b/tests/Kevlar.Tests/DescribeTests.cs
@@ -73,6 +73,11 @@ public class DescribeTests
             .IsEqualTo("ConcurrencyLimit(10)");
         await Assert.That(Shield.Hedge(2, TimeSpan.FromMilliseconds(100)).ToString())
             .IsEqualTo("Hedge(2 attempts, delay 100ms)");
+        await Assert.That(Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = static _ => TimeSpan.Zero;
+        }).ToString()).IsEqualTo("Hedge(2 attempts, delay generator)");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/HedgingDelayGeneratorTests.cs
+++ b/tests/Kevlar.Tests/HedgingDelayGeneratorTests.cs
@@ -1,0 +1,333 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class HedgingDelayGeneratorTests
+{
+    private static readonly KevlarKey<TimeSpan> DelayKey = new("hedge-delay");
+
+    [Test]
+    public async Task DelayGenerator_Controls_Each_Hedge_Start_Time()
+    {
+        var time = new FakeTimeProvider();
+        var origin = time.GetUtcNow();
+        var starts = new ConcurrentQueue<TimeSpan>();
+        var attempts = new AsyncCounter("hedge attempts");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.DelayGenerator = hedge => hedge.AttemptNumber == 2
+                ? TimeSpan.FromMilliseconds(100)
+                : TimeSpan.FromMilliseconds(300);
+        }).WithTimeProvider(time);
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            var attempt = attempts.Signal();
+            starts.Enqueue(time.GetUtcNow() - origin);
+            if (attempt < 3)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+
+            return attempt;
+        }).AsTask();
+
+        time.Advance(TimeSpan.FromMilliseconds(99));
+        await Assert.That(attempts.Count).IsEqualTo(1);
+
+        time.Advance(TimeSpan.FromMilliseconds(1));
+        await attempts.WaitForAsync(2);
+        time.Advance(TimeSpan.FromMilliseconds(299));
+        await Assert.That(attempts.Count).IsEqualTo(2);
+
+        time.Advance(TimeSpan.FromMilliseconds(1));
+        await Assert.That(await execution).IsEqualTo(3);
+        await Assert.That(starts).IsEquivalentTo([
+            TimeSpan.Zero,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(400),
+        ]);
+    }
+
+    [Test]
+    public async Task DelayGenerator_Infinite_Waits_For_Previous_Attempt_To_Complete()
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = new AsyncCounter("hedge attempts");
+        var generatorCalls = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = _ =>
+            {
+                generatorCalls++;
+                return Timeout.InfiniteTimeSpan;
+            };
+        });
+
+        var execution = shield.ExecuteAsync(async _ =>
+        {
+            var attempt = attempts.Signal();
+            if (attempt == 1)
+            {
+                await release.Task;
+                throw new InvalidOperationException("primary failed");
+            }
+
+            return attempt;
+        }).AsTask();
+
+        await Assert.That(attempts.Count).IsEqualTo(1);
+        await Assert.That(generatorCalls).IsEqualTo(1);
+        release.SetResult();
+
+        await Assert.That(await execution).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DelayGenerator_Zero_Fires_Immediately()
+    {
+        var attempts = new AsyncCounter("hedge attempts");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.Delay = TimeSpan.FromDays(1);
+            options.DelayGenerator = _ => TimeSpan.Zero;
+        });
+
+        var result = await shield.ExecuteAsync(async token =>
+        {
+            var attempt = attempts.Signal();
+            if (attempt == 1)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+
+            return attempt;
+        });
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DelayGenerator_Receives_Attempt_Context_And_Elapsed()
+    {
+        var time = new FakeTimeProvider();
+        var observed = new List<(int Attempt, TimeSpan Delay, TimeSpan Elapsed)>();
+        var attempts = new AsyncCounter("hedge attempts");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 3;
+            options.DelayGenerator = hedge =>
+            {
+                var delay = hedge.Context.Properties.GetOrDefault(DelayKey);
+                observed.Add((hedge.AttemptNumber, delay, hedge.Elapsed));
+                return delay;
+            };
+        }).WithTimeProvider(time);
+
+        var execution = shield.ExecuteWithContextAsync(
+            TimeSpan.FromMilliseconds(50),
+            static (delay, properties) => properties.Set(DelayKey, delay),
+            async (_, context) =>
+            {
+                var attempt = attempts.Signal();
+                if (attempt < 3)
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, context.CancellationToken);
+                }
+
+                return attempt;
+            }).AsTask();
+
+        time.Advance(TimeSpan.FromMilliseconds(50));
+        await attempts.WaitForAsync(2);
+        time.Advance(TimeSpan.FromMilliseconds(50));
+
+        await Assert.That(await execution).IsEqualTo(3);
+        await Assert.That(observed).IsEquivalentTo([
+            (2, TimeSpan.FromMilliseconds(50), TimeSpan.Zero),
+            (3, TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50)),
+        ]);
+    }
+
+    [Test]
+    public async Task DelayGenerator_Reads_Properties_From_Context()
+    {
+        var observed = TimeSpan.Zero;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = hedge =>
+            {
+                observed = hedge.Context.Properties.GetOrDefault(DelayKey);
+                return TimeSpan.Zero;
+            };
+        });
+
+        var attempts = 0;
+        var result = await shield.ExecuteWithContextAsync(
+            TimeSpan.FromMilliseconds(125),
+            static (delay, properties) => properties.Set(DelayKey, delay),
+            async (_, context) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, context.CancellationToken);
+                }
+
+                return attempts;
+            });
+
+        await Assert.That(result).IsEqualTo(2);
+        await Assert.That(observed).IsEqualTo(TimeSpan.FromMilliseconds(125));
+    }
+
+    [Test]
+    public async Task DelayGeneratorAsync_Is_Awaited_And_Cancellable()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGeneratorAsync = async hedge =>
+            {
+                entered.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, hedge.Context.CancellationToken);
+                return TimeSpan.Zero;
+            };
+        });
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            Interlocked.Increment(ref attempts);
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 0;
+        }, cancellation.Token).AsTask();
+
+        await entered.Task;
+        cancellation.Cancel();
+
+        await Assert.That(async () => await execution).Throws<OperationCanceledException>();
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DelayGenerator_Exception_Surfaces_As_Execution_Failure()
+    {
+        var expected = new InvalidOperationException("delay failed");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = _ => throw expected;
+        });
+
+        var caught = await Assert.That(async () => await shield.ExecuteAsync(async token =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 0;
+        })).Throws<InvalidOperationException>();
+
+        await Assert.That(ReferenceEquals(caught, expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task Negative_Delay_From_Generator_Is_Clamped_To_Zero()
+    {
+        var attempts = new AsyncCounter("hedge attempts");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = _ => TimeSpan.FromTicks(-2);
+        });
+
+        var result = await shield.ExecuteAsync(async token =>
+        {
+            var attempt = attempts.Signal();
+            if (attempt == 1)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+
+            return attempt;
+        });
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Delay_Above_MaximumDelay_Is_Clamped()
+    {
+        var time = new FakeTimeProvider();
+        var attempts = new AsyncCounter("hedge attempts");
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = _ => TimeSpan.MaxValue;
+        }).WithTimeProvider(time);
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            var attempt = attempts.Signal();
+            if (attempt == 1)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+
+            return attempt;
+        }).AsTask();
+
+        var maximum = Kevlar.Internal.DelayHelper.MaximumDelay;
+        time.Advance(maximum - TimeSpan.FromMilliseconds(1));
+        await Assert.That(attempts.Count).IsEqualTo(1);
+        time.Advance(TimeSpan.FromMilliseconds(1));
+
+        await Assert.That(await execution).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Generator_Not_Called_After_Winner_Completes()
+    {
+        var calls = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = _ =>
+            {
+                calls++;
+                return TimeSpan.Zero;
+            };
+        });
+
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(42))).IsEqualTo(42);
+        await Assert.That(calls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Typed_DelayGenerator_Controls_Hedge()
+    {
+        var attempts = new AsyncCounter("typed hedge attempts");
+        var shield = Shield.For<int>().Hedge(options =>
+        {
+            options.MaxAttempts = 2;
+            options.DelayGenerator = _ => TimeSpan.Zero;
+        });
+
+        var result = await shield.ExecuteAsync(async token =>
+        {
+            var attempt = attempts.Signal();
+            if (attempt == 1)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+
+            return attempt;
+        });
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+}

--- a/tests/Kevlar.Tests/StrategyInspectionTests.cs
+++ b/tests/Kevlar.Tests/StrategyInspectionTests.cs
@@ -48,14 +48,17 @@ public class StrategyInspectionTests
         {
             options.MaxAttempts = 4;
             options.Delay = TimeSpan.FromMilliseconds(17);
+            options.DelayGenerator = static _ => TimeSpan.Zero;
             options.OnHedge = static _ => { };
         }));
         var fixedHedge = GetStrategy<HedgingStrategy>(Shield.Hedge(2, TimeSpan.Zero));
         await Assert.That(notifiedHedge.MaxAttempts).IsEqualTo(4);
         await Assert.That(notifiedHedge.Delay).IsEqualTo(TimeSpan.FromMilliseconds(17));
+        await Assert.That(notifiedHedge.HasDelayGenerator).IsTrue();
         await Assert.That(notifiedHedge.HasNotification).IsTrue();
         await Assert.That(fixedHedge.MaxAttempts).IsEqualTo(2);
         await Assert.That(fixedHedge.Delay).IsEqualTo(TimeSpan.Zero);
+        await Assert.That(fixedHedge.HasDelayGenerator).IsFalse();
         await Assert.That(fixedHedge.HasNotification).IsFalse();
 
         var monitoredCircuit = GetStrategy<CircuitBreakerStrategy>(Shield.CircuitBreaker(options =>


### PR DESCRIPTION
## Summary

- add synchronous and asynchronous per-attempt hedge delay generators
- expose attempt number, context, and elapsed execution time through `HedgeDelayEvent`
- plumb adaptive delays into standard HTTP hedging and `Kevlar.Testing` descriptors
- document cumulative delay semantics, clamping, cancellation, and Polly migration

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net8.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net10.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.AllocationTests -c Release -f net8.0 --no-build -- --timeout 5m`
- `pwsh scripts/Verify-Docs.ps1`
- `npm ci && npm run build` from `docs/`

`Verify-DocSnippets.ps1` currently reaches unrelated baseline compile errors in custom-strategy APIs referenced by #284 and supplied by pending #293; the new adaptive hedging snippet itself introduces no diagnostic.

Closes #233