### PR TITLE
fix(validation): distinguish option errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ build spelled these `WhenResultDefault`/`OrResultDefault`; the `Is` makes the re
 - Hedging now supports synchronous and asynchronous per-attempt delay generators with access to
   the attempt number, execution context, and elapsed time. Standard endpoint-aware HTTP hedging
   exposes the same adaptive delay hooks, and `Kevlar.Testing` reports whether one is configured.
+- Invalid values supplied through strategy options now throw
+  `KevlarConfigurationException`, while direct shorthand overloads continue to throw
+  `ArgumentOutOfRangeException` with the invoked public parameter name.
 - Named DI registrations now expose symmetric configuration overloads, typed
   `IShieldProvider<TResult>` snapshots, and `AddReloadingShield<TResult>`.
 - Handling-clause builders now match their shield counterparts for configured timeouts, direct

--- a/docs/docs/exceptions.md
+++ b/docs/docs/exceptions.md
@@ -19,6 +19,7 @@ errors handled by a retry, breaker, hedge, or fallback.
 | Exception | Thrown by | Properties | Base class | Catch pattern | Default clause |
 |---|---|---|---|---|---|
 | `KevlarException` | Abstract base for exceptions raised by core strategies | Inherited `InnerException` carries a cause when the concrete exception has one. | `Exception` | `catch (KevlarException)` | N/A |
+| `KevlarConfigurationException` | Invalid values supplied through a strategy options callback or returned by a dynamic duration generator | `Message` names the options type, property, requirement, and offending value. | `KevlarException` | Catch during startup while building shields. | N/A |
 | `ExecutionRejectedException` | Abstract base for execution rejections | `RetryAfter` estimates when execution may be attempted again; inherited `InnerException` carries a cause when known. | `KevlarException` | `catch (ExecutionRejectedException e)` | N/A |
 | `KevlarProxyException` | Internal bookkeeping for adapter-owned exception proxies | `OriginalException` is the failure exposed to handling clauses, public outcomes, and adapter callers; inherited `InnerException` preserves the same cause. | `Exception` | Catch `OriginalException`'s concrete type, such as `RpcException`. | N/A |
 | `TimeoutExceededException` | Timeout | `Timeout` is the winning budget; a strategy-produced timeout carries the delegate's cancellation exception in inherited `InnerException`. `RetryAfter` is `null`. | `ExecutionRejectedException` | `catch (TimeoutExceededException e) when (e.Timeout == budget)` | Yes |
@@ -228,7 +229,13 @@ exception has an inner exception.
 
 ## Configuration failures
 
-There is currently no public `KevlarConfigurationException`. Direct shorthand arguments report
-`ArgumentException` or `ArgumentOutOfRangeException`; invalid values supplied through an options
-callback currently use the same framework exception family. Catch configuration failures during
-startup, not around every execution.
+Invalid values supplied through an options callback throw `KevlarConfigurationException`. Its
+message names the options type, property, requirement, and offending value—for example,
+`RetryOptions.MaxRetries must not be negative (was -1)`. Invalid values returned later by
+`TimeoutGenerator` or `BreakDurationGenerator` use the same exception and name the generator
+property.
+
+Direct shorthand arguments keep the framework exception family and the public parameter name:
+`Shield.Retry(-1)` throws `ArgumentOutOfRangeException` with `ParamName == "maxRetries"`. Catch
+configuration failures while building shields at startup; a generator failure can surface during
+execution because its value is produced per call.

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -42,6 +42,10 @@ Configure either `ConsecutiveFailures` *or* `FailureRatio` — not both. When ne
 | `HandlesException` | — | Local exception predicate; replaces the ambient clause for this breaker |
 | `HandlesResult` (`CircuitBreakerOptions<T>`) | — | Local result predicate on `Shield<T>`; replaces the ambient clause together with `HandlesException` |
 
+Invalid option values throw [`KevlarConfigurationException`](../exceptions.md#configuration-failures)
+and identify the options type, property, and offending value. This also applies when
+`BreakDurationGenerator` returns a non-positive duration.
+
 ### Dynamic break duration
 
 Use `BreakDurationGenerator` when the dependency supplies a recovery hint or different failures need different cooling periods:

--- a/docs/docs/strategies/concurrency-limit.md
+++ b/docs/docs/strategies/concurrency-limit.md
@@ -30,6 +30,9 @@ Shield.ConcurrencyLimit(o =>
 | `OnRejected` | — | Synchronous notification for an actual rejection |
 | `OnRejectedAsync` | — | Awaited notification after `OnRejected` |
 
+Invalid option values throw [`KevlarConfigurationException`](../exceptions.md#configuration-failures)
+and identify the options type, property, and offending value.
+
 Total capacity is `MaxConcurrency + QueueLimit`. Anything beyond that fails **immediately** with `ConcurrencyLimitExceededException` — the overflow check happens before any waiting, so rejection is instant and allocation-light.
 
 For an actual rejection, Kevlar publishes current limiter state and rejection metrics, invokes

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -37,6 +37,9 @@ Shield.Hedge(o =>
 | `HandlesException` | — | Local exception predicate; replaces the ambient clause for this hedge |
 | `HandlesResult` (`HedgeOptions<T>`) | — | Local result predicate on `Shield<T>`; replaces the ambient clause together with `HandlesException` |
 
+Invalid option values throw [`KevlarConfigurationException`](../exceptions.md#configuration-failures)
+and identify the options type, property, and offending value.
+
 ### Selecting another target
 
 Set the typed `ActionGenerator` to send a hedge to a different replica without boxing the result.

--- a/docs/docs/strategies/rate-limit.md
+++ b/docs/docs/strategies/rate-limit.md
@@ -117,6 +117,9 @@ queued is cancellation, not rejection, so hooks do not run.
 | `OnRejected` | — | Synchronous notification for an actual rejection |
 | `OnRejectedAsync` | — | Awaited notification after `OnRejected` |
 
+Invalid option values throw [`KevlarConfigurationException`](../exceptions.md#configuration-failures)
+and identify the options type, property, and offending value.
+
 ## Rejection vs queueing
 
 With `QueueLimit = 0`, an execution that finds the bucket empty fails immediately with `RateLimitExceededException`. The exception carries `RetryAfter` — an estimate of when a permit will next be available — which pairs naturally with an outer retry's `DelayGenerator`.

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -73,6 +73,9 @@ Shield.Retry(o =>
 | `HandlesException` | — | Local exception predicate; replaces the ambient clause for this retry |
 | `HandlesResult` (`RetryOptions<T>`) | — | Local result predicate; replaces the ambient clause together with `HandlesException` |
 
+Invalid option values throw [`KevlarConfigurationException`](../exceptions.md#configuration-failures)
+and identify the options type, property, and offending value.
+
 Order per retry: retry metrics are recorded → backoff computes the delay → `MaxDelay` clamps it → `DelayGenerator` may override it → the awaited `DelayGeneratorAsync` may override that result → `OnRetry`/`OnRetryAsync` see the final delay → sleep. Both generators ignore `null` and negative results, and `MaxDelay` clamps each override.
 
 `RetryOptions` and `RetryOptions<T>` are standalone sibling types. Both expose the same

--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -74,6 +74,10 @@ in asynchronous work. If caller cancellation wins while generation runs, the exe
 not started. The context is pooled: inspect it only during the generator or callback and never retain
 it.
 
+Invalid `TimeoutOptions` values—and invalid durations returned by `TimeoutGenerator`—throw
+[`KevlarConfigurationException`](../exceptions.md#configuration-failures) naming the property and
+offending value.
+
 After a timeout wins, Kevlar records timeout metrics, restores the caller token, disposes timer state,
 then invokes `OnTimeout` followed by awaited `OnTimeoutAsync`. A callback exception or cancellation
 is surfaced unchanged instead of `TimeoutExceededException`. Hooks may run concurrently when a shield

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -52,10 +52,7 @@ public static class KevlarServiceCollectionExtensions
         if (configuration is null) { throw new ArgumentNullException(nameof(configuration)); }
 
         return services.AddShield(name, _ =>
-        {
-            var definition = BindDefinition(configuration);
-            return definition.Build().WithName(name);
-        });
+            BuildConfiguredShield(configuration).WithName(name));
     }
 
     /// <summary>
@@ -86,7 +83,7 @@ public static class KevlarServiceCollectionExtensions
         services.AddKeyedSingleton<IShieldProvider>(
             name,
             (_, _) => new ReloadingShieldProvider(
-                () => BindDefinition(configuration).Build().WithName(name),
+                () => BuildConfiguredShield(configuration).WithName(name),
                 configuration.GetReloadToken,
                 onReloadFailure));
         services.AddSingleton(new ShieldRegistration(
@@ -133,7 +130,7 @@ public static class KevlarServiceCollectionExtensions
         if (configuration is null) { throw new ArgumentNullException(nameof(configuration)); }
 
         return services.AddShield<TResult>(name, _ =>
-            BindDefinition(configuration).Build<TResult>().WithName(name));
+            BuildConfiguredShield<TResult>(configuration).WithName(name));
     }
 
     /// <summary>
@@ -162,7 +159,7 @@ public static class KevlarServiceCollectionExtensions
         services.AddKeyedSingleton<IShieldProvider<TResult>>(
             name,
             (_, _) => new ReloadingShieldProvider<TResult>(
-                () => BindDefinition(configuration).Build<TResult>().WithName(name),
+                () => BuildConfiguredShield<TResult>(configuration).WithName(name),
                 configuration.GetReloadToken,
                 onReloadFailure));
         services.AddSingleton(new ShieldRegistration(
@@ -326,6 +323,42 @@ public static class KevlarServiceCollectionExtensions
         }
 
         return definition;
+    }
+
+    private static Shield BuildConfiguredShield(IConfiguration configuration)
+    {
+        try
+        {
+            return BindDefinition(configuration).Build();
+        }
+        catch (KevlarConfigurationException exception)
+        {
+            throw AddConfigurationPath(configuration, exception);
+        }
+    }
+
+    private static Shield<TResult> BuildConfiguredShield<TResult>(IConfiguration configuration)
+    {
+        try
+        {
+            return BindDefinition(configuration).Build<TResult>();
+        }
+        catch (KevlarConfigurationException exception)
+        {
+            throw AddConfigurationPath(configuration, exception);
+        }
+    }
+
+    private static KevlarConfigurationException AddConfigurationPath(
+        IConfiguration configuration,
+        KevlarConfigurationException exception)
+    {
+        var path = configuration is IConfigurationSection section && !string.IsNullOrEmpty(section.Path)
+            ? section.Path
+            : "<root>";
+        return new KevlarConfigurationException(
+            $"Configuration section '{path}' is invalid: {exception.Message}",
+            exception);
     }
 
     private static bool HasChildren(IConfigurationSection section) => section.GetChildren().Any();

--- a/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
+++ b/src/Kevlar.Extensions.DependencyInjection/KevlarServiceCollectionExtensions.cs
@@ -331,7 +331,7 @@ public static class KevlarServiceCollectionExtensions
         {
             return BindDefinition(configuration).Build();
         }
-        catch (KevlarConfigurationException exception)
+        catch (Exception exception) when (IsConfigurationFailure(exception))
         {
             throw AddConfigurationPath(configuration, exception);
         }
@@ -343,7 +343,7 @@ public static class KevlarServiceCollectionExtensions
         {
             return BindDefinition(configuration).Build<TResult>();
         }
-        catch (KevlarConfigurationException exception)
+        catch (Exception exception) when (IsConfigurationFailure(exception))
         {
             throw AddConfigurationPath(configuration, exception);
         }
@@ -351,15 +351,20 @@ public static class KevlarServiceCollectionExtensions
 
     private static KevlarConfigurationException AddConfigurationPath(
         IConfiguration configuration,
-        KevlarConfigurationException exception)
+        Exception exception)
     {
         var path = configuration is IConfigurationSection section && !string.IsNullOrEmpty(section.Path)
             ? section.Path
             : "<root>";
+        var configurationException = exception as KevlarConfigurationException
+            ?? new KevlarConfigurationException(exception.Message, exception);
         return new KevlarConfigurationException(
-            $"Configuration section '{path}' is invalid: {exception.Message}",
-            exception);
+            $"Configuration section '{path}' is invalid: {configurationException.Message}",
+            configurationException);
     }
+
+    private static bool IsConfigurationFailure(Exception exception) =>
+        exception is KevlarConfigurationException or ArgumentException or InvalidOperationException;
 
     private static bool HasChildren(IConfigurationSection section) => section.GetChildren().Any();
 

--- a/src/Kevlar/Exceptions/KevlarConfigurationException.cs
+++ b/src/Kevlar/Exceptions/KevlarConfigurationException.cs
@@ -1,0 +1,23 @@
+namespace Kevlar;
+
+/// <summary>Represents invalid strategy configuration supplied through an options callback.</summary>
+public sealed class KevlarConfigurationException : KevlarException
+{
+    /// <summary>Initializes the exception with the default message.</summary>
+    public KevlarConfigurationException()
+        : base("The Kevlar strategy configuration is invalid.")
+    {
+    }
+
+    /// <summary>Initializes the exception with a message.</summary>
+    public KevlarConfigurationException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes the exception with a message and inner exception.</summary>
+    public KevlarConfigurationException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Kevlar/Internal/ConfigurationValidation.cs
+++ b/src/Kevlar/Internal/ConfigurationValidation.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+
+namespace Kevlar.Internal;
+
+internal static class ConfigurationValidation
+{
+    public static void ThrowIf<T>(
+        bool invalid,
+        Type optionsType,
+        string propertyName,
+        T value,
+        string requirement)
+    {
+        if (!invalid)
+        {
+            return;
+        }
+
+        var tick = optionsType.Name.IndexOf('`');
+        var optionsName = tick < 0 ? optionsType.Name : optionsType.Name[..tick];
+        var formattedValue = value switch
+        {
+            null => "null",
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString(),
+        };
+
+        throw new KevlarConfigurationException(
+            $"{optionsName}.{propertyName} {requirement} (was {formattedValue}).");
+    }
+}

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -382,6 +382,10 @@ Kevlar.HedgeOptions.DelayGeneratorAsync.set -> void
 Kevlar.KevlarProxyException
 Kevlar.KevlarProxyException.KevlarProxyException(System.Exception! originalException) -> void
 Kevlar.KevlarProxyException.OriginalException.get -> System.Exception!
+Kevlar.KevlarConfigurationException
+Kevlar.KevlarConfigurationException.KevlarConfigurationException() -> void
+Kevlar.KevlarConfigurationException.KevlarConfigurationException(string! message) -> void
+Kevlar.KevlarConfigurationException.KevlarConfigurationException(string! message, System.Exception? innerException) -> void
 *REMOVED*Kevlar.ConcurrencyLimitOptions.MaxQueue.get -> int
 *REMOVED*Kevlar.ConcurrencyLimitOptions.MaxQueue.set -> void
 *REMOVED*Kevlar.Shield<TResult>.ConcurrencyLimit(int maxConcurrency, int maxQueue = 0) -> Kevlar.Shield<TResult>!

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -15,7 +15,12 @@ public static class ShieldExtensions
     /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
     /// total attempts — the initial call plus 3 retries.
     /// </param>
-    public static Shield Retry(this Shield shield, int maxRetries = 3) => shield.Retry(options => options.MaxRetries = maxRetries);
+    public static Shield Retry(this Shield shield, int maxRetries = 3)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfOutOfRange(maxRetries < 0, nameof(maxRetries), "Max retries must not be negative.");
+        return shield.Retry(options => options.MaxRetries = maxRetries);
+    }
 
     /// <summary>Appends a retry of handled exceptions, up to <paramref name="maxRetries"/> times, with the given backoff.</summary>
     /// <param name="shield">The shield to append the retry to.</param>
@@ -24,11 +29,17 @@ public static class ShieldExtensions
     /// total attempts — the initial call plus 3 retries.
     /// </param>
     /// <param name="backoff">The delay computation applied between attempts.</param>
-    public static Shield Retry(this Shield shield, int maxRetries, Backoff backoff) => shield.Retry(options =>
+    public static Shield Retry(this Shield shield, int maxRetries, Backoff backoff)
     {
-        options.MaxRetries = maxRetries;
-        options.Backoff = backoff;
-    });
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfOutOfRange(maxRetries < 0, nameof(maxRetries), "Max retries must not be negative.");
+        Throw.IfNull(backoff, nameof(backoff));
+        return shield.Retry(options =>
+        {
+            options.MaxRetries = maxRetries;
+            options.Backoff = backoff;
+        });
+    }
 
     /// <summary>Appends a retry strategy configured via <paramref name="configure"/>.</summary>
     /// <remarks>
@@ -63,7 +74,13 @@ public static class ShieldExtensions
     }
 
     /// <summary>Appends a timeout, surfacing <see cref="TimeoutExceededException"/> when exceeded.</summary>
-    public static Shield Timeout(this Shield shield, TimeSpan timeout) => shield.Timeout(options => options.Timeout = timeout);
+    public static Shield Timeout(this Shield shield, TimeSpan timeout)
+    {
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfOutOfRange(timeout <= TimeSpan.Zero, nameof(timeout), "Timeout must be positive.");
+        Throw.IfOutOfRange(timeout > DelayHelper.MaximumDelay, nameof(timeout), "Timeout exceeds the runtime timer limit.");
+        return shield.Timeout(options => options.Timeout = timeout);
+    }
 
     /// <summary>Appends a timeout strategy configured via <paramref name="configure"/>.</summary>
     public static Shield Timeout(this Shield shield, Action<TimeoutOptions> configure)
@@ -76,11 +93,17 @@ public static class ShieldExtensions
     }
 
     /// <summary>Appends a circuit breaker that opens for <paramref name="breakDuration"/> after <paramref name="consecutiveFailures"/> consecutive handled exceptions.</summary>
-    public static Shield CircuitBreaker(this Shield shield, int consecutiveFailures, TimeSpan breakDuration) => shield.CircuitBreaker(options =>
+    public static Shield CircuitBreaker(this Shield shield, int consecutiveFailures, TimeSpan breakDuration)
     {
-        options.ConsecutiveFailures = consecutiveFailures;
-        options.BreakDuration = breakDuration;
-    });
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfOutOfRange(consecutiveFailures <= 0, nameof(consecutiveFailures), "Consecutive failures must be positive.");
+        Throw.IfOutOfRange(breakDuration <= TimeSpan.Zero, nameof(breakDuration), "Break duration must be positive.");
+        return shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = consecutiveFailures;
+            options.BreakDuration = breakDuration;
+        });
+    }
 
     /// <summary>Appends a circuit breaker strategy configured via <paramref name="configure"/>.</summary>
     public static Shield CircuitBreaker(this Shield shield, Action<CircuitBreakerOptions> configure)
@@ -94,11 +117,17 @@ public static class ShieldExtensions
     }
 
     /// <summary>Appends a token-bucket rate limit of <paramref name="permits"/> executions per <paramref name="perWindow"/>.</summary>
-    public static Shield RateLimit(this Shield shield, int permits, TimeSpan perWindow) => shield.RateLimit(options =>
+    public static Shield RateLimit(this Shield shield, int permits, TimeSpan perWindow)
     {
-        options.Permits = permits;
-        options.Window = perWindow;
-    });
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfOutOfRange(permits <= 0, nameof(permits), "Permits must be positive.");
+        Throw.IfOutOfRange(perWindow <= TimeSpan.Zero, nameof(perWindow), "Window must be positive.");
+        return shield.RateLimit(options =>
+        {
+            options.Permits = permits;
+            options.Window = perWindow;
+        });
+    }
 
     /// <summary>Appends a rate limit strategy configured via <paramref name="configure"/>.</summary>
     public static Shield RateLimit(this Shield shield, Action<RateLimitOptions> configure)
@@ -111,11 +140,17 @@ public static class ShieldExtensions
     }
 
     /// <summary>Appends a concurrency limit capping concurrency at <paramref name="maxConcurrency"/> with an optional wait queue.</summary>
-    public static Shield ConcurrencyLimit(this Shield shield, int maxConcurrency, int queueLimit = 0) => shield.ConcurrencyLimit(options =>
+    public static Shield ConcurrencyLimit(this Shield shield, int maxConcurrency, int queueLimit = 0)
     {
-        options.MaxConcurrency = maxConcurrency;
-        options.QueueLimit = queueLimit;
-    });
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfOutOfRange(maxConcurrency <= 0, nameof(maxConcurrency), "MaxConcurrency must be positive.");
+        Throw.IfOutOfRange(queueLimit < 0, nameof(queueLimit), "QueueLimit must not be negative.");
+        return shield.ConcurrencyLimit(options =>
+        {
+            options.MaxConcurrency = maxConcurrency;
+            options.QueueLimit = queueLimit;
+        });
+    }
 
     /// <summary>Appends a concurrency limit strategy configured via <paramref name="configure"/>.</summary>
     public static Shield ConcurrencyLimit(this Shield shield, Action<ConcurrencyLimitOptions> configure)
@@ -135,11 +170,21 @@ public static class ShieldExtensions
     /// hedge that later loses. Prefer <c>Shield.For&lt;T&gt;()</c>, where result clauses decide which
     /// attempt is acceptable, or confirm the action is safe to repeat.
     /// </remarks>
-    public static Shield Hedge(this Shield shield, int maxAttempts, TimeSpan delay) => shield.Hedge(options =>
+    public static Shield Hedge(this Shield shield, int maxAttempts, TimeSpan delay)
     {
-        options.MaxAttempts = maxAttempts;
-        options.Delay = delay;
-    });
+        Throw.IfNull(shield, nameof(shield));
+        Throw.IfOutOfRange(maxAttempts < 1, nameof(maxAttempts), "Maximum attempts must be at least 1.");
+        Throw.IfOutOfRange(
+            delay < TimeSpan.Zero && delay != System.Threading.Timeout.InfiniteTimeSpan,
+            nameof(delay),
+            "Delay must be non-negative or Timeout.InfiniteTimeSpan.");
+        Throw.IfOutOfRange(delay > DelayHelper.MaximumDelay, nameof(delay), "Delay exceeds the runtime timer limit.");
+        return shield.Hedge(options =>
+        {
+            options.MaxAttempts = maxAttempts;
+            options.Delay = delay;
+        });
+    }
 
     /// <summary>Appends a hedging strategy configured via <paramref name="configure"/>.</summary>
     /// <remarks>

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -103,7 +103,11 @@ public sealed class Shield<TResult>
     /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
     /// total attempts — the initial call plus 3 retries.
     /// </param>
-    public Shield<TResult> Retry(int maxRetries = 3) => Retry(options => options.MaxRetries = maxRetries);
+    public Shield<TResult> Retry(int maxRetries = 3)
+    {
+        Throw.IfOutOfRange(maxRetries < 0, nameof(maxRetries), "Max retries must not be negative.");
+        return Retry(options => options.MaxRetries = maxRetries);
+    }
 
     /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the given backoff.</summary>
     /// <param name="maxRetries">
@@ -111,11 +115,16 @@ public sealed class Shield<TResult>
     /// total attempts — the initial call plus 3 retries.
     /// </param>
     /// <param name="backoff">The delay computation applied between attempts.</param>
-    public Shield<TResult> Retry(int maxRetries, Backoff backoff) => Retry(options =>
+    public Shield<TResult> Retry(int maxRetries, Backoff backoff)
     {
-        options.MaxRetries = maxRetries;
-        options.Backoff = backoff;
-    });
+        Throw.IfOutOfRange(maxRetries < 0, nameof(maxRetries), "Max retries must not be negative.");
+        Throw.IfNull(backoff, nameof(backoff));
+        return Retry(options =>
+        {
+            options.MaxRetries = maxRetries;
+            options.Backoff = backoff;
+        });
+    }
 
     /// <summary>
     /// Adds a retry strategy configured via <paramref name="configure"/>. The options expose
@@ -152,7 +161,12 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Cancels executions that exceed <paramref name="timeout"/>, surfacing <see cref="TimeoutExceededException"/>.</summary>
-    public Shield<TResult> Timeout(TimeSpan timeout) => Timeout(options => options.Timeout = timeout);
+    public Shield<TResult> Timeout(TimeSpan timeout)
+    {
+        Throw.IfOutOfRange(timeout <= TimeSpan.Zero, nameof(timeout), "Timeout must be positive.");
+        Throw.IfOutOfRange(timeout > DelayHelper.MaximumDelay, nameof(timeout), "Timeout exceeds the runtime timer limit.");
+        return Timeout(options => options.Timeout = timeout);
+    }
 
     /// <summary>Adds a timeout strategy configured via <paramref name="configure"/>.</summary>
     public Shield<TResult> Timeout(Action<TimeoutOptions> configure)
@@ -164,11 +178,16 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Breaks the circuit for <paramref name="breakDuration"/> after <paramref name="consecutiveFailures"/> consecutive handled outcomes.</summary>
-    public Shield<TResult> CircuitBreaker(int consecutiveFailures, TimeSpan breakDuration) => CircuitBreaker(options =>
+    public Shield<TResult> CircuitBreaker(int consecutiveFailures, TimeSpan breakDuration)
     {
-        options.ConsecutiveFailures = consecutiveFailures;
-        options.BreakDuration = breakDuration;
-    });
+        Throw.IfOutOfRange(consecutiveFailures <= 0, nameof(consecutiveFailures), "Consecutive failures must be positive.");
+        Throw.IfOutOfRange(breakDuration <= TimeSpan.Zero, nameof(breakDuration), "Break duration must be positive.");
+        return CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = consecutiveFailures;
+            options.BreakDuration = breakDuration;
+        });
+    }
 
     /// <summary>Adds a circuit breaker strategy configured via <paramref name="configure"/>.</summary>
     public Shield<TResult> CircuitBreaker(Action<CircuitBreakerOptions<TResult>> configure)
@@ -181,11 +200,16 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Limits throughput to <paramref name="permits"/> executions per <paramref name="perWindow"/> (token bucket).</summary>
-    public Shield<TResult> RateLimit(int permits, TimeSpan perWindow) => RateLimit(options =>
+    public Shield<TResult> RateLimit(int permits, TimeSpan perWindow)
     {
-        options.Permits = permits;
-        options.Window = perWindow;
-    });
+        Throw.IfOutOfRange(permits <= 0, nameof(permits), "Permits must be positive.");
+        Throw.IfOutOfRange(perWindow <= TimeSpan.Zero, nameof(perWindow), "Window must be positive.");
+        return RateLimit(options =>
+        {
+            options.Permits = permits;
+            options.Window = perWindow;
+        });
+    }
 
     /// <summary>Adds a rate limit strategy configured via <paramref name="configure"/>.</summary>
     public Shield<TResult> RateLimit(Action<RateLimitOptions> configure)
@@ -197,11 +221,16 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Caps concurrent executions at <paramref name="maxConcurrency"/> with an optional wait queue.</summary>
-    public Shield<TResult> ConcurrencyLimit(int maxConcurrency, int queueLimit = 0) => ConcurrencyLimit(options =>
+    public Shield<TResult> ConcurrencyLimit(int maxConcurrency, int queueLimit = 0)
     {
-        options.MaxConcurrency = maxConcurrency;
-        options.QueueLimit = queueLimit;
-    });
+        Throw.IfOutOfRange(maxConcurrency <= 0, nameof(maxConcurrency), "MaxConcurrency must be positive.");
+        Throw.IfOutOfRange(queueLimit < 0, nameof(queueLimit), "QueueLimit must not be negative.");
+        return ConcurrencyLimit(options =>
+        {
+            options.MaxConcurrency = maxConcurrency;
+            options.QueueLimit = queueLimit;
+        });
+    }
 
     /// <summary>Adds a concurrency limit strategy configured via <paramref name="configure"/>.</summary>
     public Shield<TResult> ConcurrencyLimit(Action<ConcurrencyLimitOptions> configure)
@@ -213,11 +242,20 @@ public sealed class Shield<TResult>
     }
 
     /// <summary>Races up to <paramref name="maxAttempts"/> concurrent attempts staggered by <paramref name="delay"/>; first acceptable outcome wins.</summary>
-    public Shield<TResult> Hedge(int maxAttempts, TimeSpan delay) => Hedge(options =>
+    public Shield<TResult> Hedge(int maxAttempts, TimeSpan delay)
     {
-        options.MaxAttempts = maxAttempts;
-        options.Delay = delay;
-    });
+        Throw.IfOutOfRange(maxAttempts < 1, nameof(maxAttempts), "Maximum attempts must be at least 1.");
+        Throw.IfOutOfRange(
+            delay < TimeSpan.Zero && delay != System.Threading.Timeout.InfiniteTimeSpan,
+            nameof(delay),
+            "Delay must be non-negative or Timeout.InfiniteTimeSpan.");
+        Throw.IfOutOfRange(delay > DelayHelper.MaximumDelay, nameof(delay), "Delay exceeds the runtime timer limit.");
+        return Hedge(options =>
+        {
+            options.MaxAttempts = maxAttempts;
+            options.Delay = delay;
+        });
+    }
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>
     public Shield<TResult> Hedge(Action<HedgeOptions<TResult>> configure)

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -28,6 +28,7 @@ internal sealed class CircuitBreakerCore
     private readonly Action<CircuitBreakerStateChangedEvent>? _onStateChanged;
     private readonly Func<CircuitBreakerStateChangedEvent, ValueTask>? _onStateChangedAsync;
     private readonly CircuitBreakerMonitor? _monitor;
+    private readonly Type _optionsType;
     private readonly Queue<TransitionPublication> _pendingTransitions = new();
     private readonly AsyncLocal<TransitionPublication?>? _ambientPublication;
 
@@ -53,23 +54,48 @@ internal sealed class CircuitBreakerCore
     public CircuitBreakerCore(
         CircuitBreakerOptions options,
         CircuitBreakerBreakDurationGenerator? breakDurationGenerator,
-        Action<CircuitState> recordState)
+        Action<CircuitState> recordState,
+        Type optionsType)
     {
-        Throw.IfOutOfRange(options.ConsecutiveFailures is <= 0, nameof(options.ConsecutiveFailures), "ConsecutiveFailures must be positive.");
-        Throw.IfOutOfRange(
+        ConfigurationValidation.ThrowIf(
+            options.ConsecutiveFailures is <= 0,
+            optionsType,
+            nameof(options.ConsecutiveFailures),
+            options.ConsecutiveFailures,
+            "must be positive when set");
+        ConfigurationValidation.ThrowIf(
             options.FailureRatio is { } ratio && (double.IsNaN(ratio) || ratio <= 0 || ratio > 1),
+            optionsType,
             nameof(options.FailureRatio),
-            "FailureRatio must be between 0 (exclusive) and 1 (inclusive).");
-        Throw.IfOutOfRange(
+            options.FailureRatio,
+            "must be between 0 (exclusive) and 1 (inclusive)");
+        ConfigurationValidation.ThrowIf(
             options.ConsecutiveFailures is not null && options.FailureRatio is not null,
-            nameof(options),
-            "ConsecutiveFailures and FailureRatio select different trip modes and cannot both be set. " +
-            "Clear ConsecutiveFailures to trip on the failure ratio within SamplingWindow, clear " +
+            optionsType,
+            $"{nameof(options.ConsecutiveFailures)} and {nameof(options.FailureRatio)}",
+            $"{options.ConsecutiveFailures} and {options.FailureRatio}",
+            "select different trip modes and cannot both be set; " +
+            "Clear ConsecutiveFailures to trip on the failure ratio within SamplingWindow or clear " +
             "FailureRatio to trip on consecutive failures, or leave both unset to trip after 5 " +
-            "consecutive failures.");
-        Throw.IfOutOfRange(options.MinimumThroughput < 1, nameof(options), "MinimumThroughput must be at least 1.");
-        Throw.IfOutOfRange(options.SamplingWindow <= TimeSpan.Zero, nameof(options), "SamplingWindow must be positive.");
-        Throw.IfOutOfRange(options.BreakDuration <= TimeSpan.Zero, nameof(options), "BreakDuration must be positive.");
+            "consecutive failures");
+        ConfigurationValidation.ThrowIf(
+            options.MinimumThroughput < 1,
+            optionsType,
+            nameof(options.MinimumThroughput),
+            options.MinimumThroughput,
+            "must be at least 1");
+        ConfigurationValidation.ThrowIf(
+            options.SamplingWindow <= TimeSpan.Zero,
+            optionsType,
+            nameof(options.SamplingWindow),
+            options.SamplingWindow,
+            "must be positive");
+        ConfigurationValidation.ThrowIf(
+            options.BreakDuration <= TimeSpan.Zero,
+            optionsType,
+            nameof(options.BreakDuration),
+            options.BreakDuration,
+            "must be positive");
 
         _failureRatio = options.FailureRatio;
         _consecutiveFailureLimit = options.FailureRatio is null ? options.ConsecutiveFailures ?? 5 : null;
@@ -82,6 +108,7 @@ internal sealed class CircuitBreakerCore
         _breakDurationGenerator = breakDurationGenerator;
         _onStateChanged = options.OnStateChanged;
         _onStateChangedAsync = options.OnStateChangedAsync;
+        _optionsType = optionsType;
         _ambientPublication = options.OnStateChangedAsync is null
             ? null
             : new AsyncLocal<TransitionPublication?>();
@@ -537,11 +564,13 @@ internal sealed class CircuitBreakerCore
         _openingGeneration++;
     }
 
-    private static void ValidateGeneratedBreakDuration(TimeSpan duration) =>
-        Throw.IfOutOfRange(
+    private void ValidateGeneratedBreakDuration(TimeSpan duration) =>
+        ConfigurationValidation.ThrowIf(
             duration <= TimeSpan.Zero,
-            nameof(duration),
-            "Generated break duration must be positive.");
+            _optionsType,
+            nameof(CircuitBreakerOptions.BreakDurationGenerator),
+            duration,
+            "must return a positive duration");
 
     private readonly record struct OpeningReservation(
         long Generation,

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -18,7 +18,8 @@ internal sealed class CircuitBreakerStrategy : Strategy
             options.HasHandlingOverride,
             options.BreakDurationGenerator is null
                 ? null
-                : CircuitBreakerBreakDurationGenerator.Create(options.BreakDurationGenerator))
+                : CircuitBreakerBreakDurationGenerator.Create(options.BreakDurationGenerator),
+            options.GetType())
     {
     }
 
@@ -26,12 +27,14 @@ internal sealed class CircuitBreakerStrategy : Strategy
         CircuitBreakerOptions options,
         OutcomeJudge judge,
         bool hasHandlingOverride,
-        CircuitBreakerBreakDurationGenerator? breakDurationGenerator)
+        CircuitBreakerBreakDurationGenerator? breakDurationGenerator,
+        Type optionsType)
     {
         _core = new CircuitBreakerCore(
             options,
             breakDurationGenerator,
-            RecordTransitionState);
+            RecordTransitionState,
+            optionsType);
         _judge = judge;
         HasHandlingOverride = hasHandlingOverride;
     }
@@ -45,7 +48,8 @@ internal sealed class CircuitBreakerStrategy : Strategy
             options.HasHandlingOverride,
             options.BreakDurationGenerator is null
                 ? null
-                : CircuitBreakerBreakDurationGenerator.Create(options.BreakDurationGenerator));
+                : CircuitBreakerBreakDurationGenerator.Create(options.BreakDurationGenerator),
+            options.GetType());
 
     internal override OutcomeJudge? ReactiveJudge => _judge;
 

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -40,8 +40,18 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
     {
-        Throw.IfOutOfRange(options.MaxConcurrency <= 0, nameof(options), "MaxConcurrency must be positive.");
-        Throw.IfOutOfRange(options.QueueLimit < 0, nameof(options), "QueueLimit must not be negative.");
+        ConfigurationValidation.ThrowIf(
+            options.MaxConcurrency <= 0,
+            typeof(ConcurrencyLimitOptions),
+            nameof(options.MaxConcurrency),
+            options.MaxConcurrency,
+            "must be positive");
+        ConfigurationValidation.ThrowIf(
+            options.QueueLimit < 0,
+            typeof(ConcurrencyLimitOptions),
+            nameof(options.QueueLimit),
+            options.QueueLimit,
+            "must not be negative");
         _semaphore = new SemaphoreSlim(0, options.MaxConcurrency);
         _maxConcurrency = options.MaxConcurrency;
         _queueLimit = options.QueueLimit;

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -15,15 +15,34 @@ internal sealed class HedgingStrategy : Strategy
     private readonly HedgeActionGenerator? _actionGenerator;
 
     public HedgingStrategy(HedgeOptions options, OutcomeJudge judge)
-        : this(options, judge, options.HasHandlingOverride)
+        : this(options, judge, options.HasHandlingOverride, options.GetType())
     {
     }
 
-    private HedgingStrategy(HedgeOptions options, OutcomeJudge judge, bool hasHandlingOverride)
+    private HedgingStrategy(
+        HedgeOptions options,
+        OutcomeJudge judge,
+        bool hasHandlingOverride,
+        Type optionsType)
     {
-        Throw.IfOutOfRange(options.MaxAttempts < 1, nameof(options), "MaxAttempts must be at least 1.");
-        Throw.IfOutOfRange(options.Delay < TimeSpan.Zero && options.Delay != System.Threading.Timeout.InfiniteTimeSpan, nameof(options), "Delay must be non-negative or Timeout.InfiniteTimeSpan.");
-        Throw.IfOutOfRange(options.Delay > DelayHelper.MaximumDelay, nameof(options.Delay), "Delay exceeds the runtime timer limit.");
+        ConfigurationValidation.ThrowIf(
+            options.MaxAttempts < 1,
+            optionsType,
+            nameof(options.MaxAttempts),
+            options.MaxAttempts,
+            "must be at least 1");
+        ConfigurationValidation.ThrowIf(
+            options.Delay < TimeSpan.Zero && options.Delay != System.Threading.Timeout.InfiniteTimeSpan,
+            optionsType,
+            nameof(options.Delay),
+            options.Delay,
+            "must be non-negative or Timeout.InfiniteTimeSpan");
+        ConfigurationValidation.ThrowIf(
+            options.Delay > DelayHelper.MaximumDelay,
+            optionsType,
+            nameof(options.Delay),
+            options.Delay,
+            "must not exceed the runtime timer limit");
 
         _judge = judge;
         _maxAttempts = options.MaxAttempts;
@@ -43,7 +62,8 @@ internal sealed class HedgingStrategy : Strategy
                     ? null
                     : HedgeActionGenerator.Create(options.ActionGenerator)),
             judge,
-            options.HasHandlingOverride);
+            options.HasHandlingOverride,
+            options.GetType());
 
     internal void ValidateResultType(Type resultType) => _actionGenerator?.ValidateResultType(resultType);
 

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -54,10 +54,30 @@ internal sealed class RateLimitStrategy : Strategy
 
     public RateLimitStrategy(RateLimitOptions options)
     {
-        Throw.IfOutOfRange(options.Permits <= 0, nameof(options), "Permits must be positive.");
-        Throw.IfOutOfRange(options.Window <= TimeSpan.Zero, nameof(options), "Window must be positive.");
-        Throw.IfOutOfRange(options.Burst is <= 0, nameof(options), "Burst must be positive.");
-        Throw.IfOutOfRange(options.QueueLimit < 0, nameof(options), "QueueLimit must not be negative.");
+        ConfigurationValidation.ThrowIf(
+            options.Permits <= 0,
+            typeof(RateLimitOptions),
+            nameof(options.Permits),
+            options.Permits,
+            "must be positive");
+        ConfigurationValidation.ThrowIf(
+            options.Window <= TimeSpan.Zero,
+            typeof(RateLimitOptions),
+            nameof(options.Window),
+            options.Window,
+            "must be positive");
+        ConfigurationValidation.ThrowIf(
+            options.Burst is <= 0,
+            typeof(RateLimitOptions),
+            nameof(options.Burst),
+            options.Burst,
+            "must be positive when set");
+        ConfigurationValidation.ThrowIf(
+            options.QueueLimit < 0,
+            typeof(RateLimitOptions),
+            nameof(options.QueueLimit),
+            options.QueueLimit,
+            "must not be negative");
 
         _permits = options.Permits;
         _window = options.Window;

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -25,7 +25,8 @@ internal sealed class RetryStrategy : Strategy
             options.DelayGenerator,
             options.DelayGeneratorAsync,
             options.HasHandlingOverride,
-            callbackResultType: null)
+            callbackResultType: null,
+            optionsType: options.GetType())
     {
     }
 
@@ -39,16 +40,37 @@ internal sealed class RetryStrategy : Strategy
         Delegate? delayGenerator,
         Delegate? delayGeneratorAsync,
         bool hasHandlingOverride,
-        Type? callbackResultType)
+        Type? callbackResultType,
+        Type optionsType)
     {
-        Throw.IfOutOfRange(maxRetries < 0, "options", "MaxRetries must not be negative.");
-        Throw.IfNull(backoff, "options");
-        Throw.IfOutOfRange(maxDelay.HasValue && maxDelay.Value < TimeSpan.Zero, "MaxDelay", "MaxDelay must not be negative.");
-        Throw.IfOutOfRange(maxDelay > DelayHelper.MaximumDelay, "MaxDelay", "MaxDelay exceeds the runtime timer limit.");
+        ConfigurationValidation.ThrowIf(
+            maxRetries < 0,
+            optionsType,
+            nameof(RetryOptions.MaxRetries),
+            maxRetries,
+            "must not be negative");
+        ConfigurationValidation.ThrowIf(
+            backoff is null,
+            optionsType,
+            nameof(RetryOptions.Backoff),
+            backoff,
+            "must not be null");
+        ConfigurationValidation.ThrowIf(
+            maxDelay.HasValue && maxDelay.Value < TimeSpan.Zero,
+            optionsType,
+            nameof(RetryOptions.MaxDelay),
+            maxDelay,
+            "must not be negative");
+        ConfigurationValidation.ThrowIf(
+            maxDelay > DelayHelper.MaximumDelay,
+            optionsType,
+            nameof(RetryOptions.MaxDelay),
+            maxDelay,
+            "must not exceed the runtime timer limit");
 
         _judge = judge;
         _maxRetries = maxRetries;
-        _backoff = backoff;
+        _backoff = backoff!;
         _maxDelay = maxDelay;
         _onRetry = onRetry;
         _onRetryAsync = onRetryAsync;
@@ -70,7 +92,8 @@ internal sealed class RetryStrategy : Strategy
             options.DelayGenerator,
             options.DelayGeneratorAsync,
             options.HasHandlingOverride,
-            typeof(TResult));
+            typeof(TResult),
+            options.GetType());
     }
 
     internal override OutcomeJudge? ReactiveJudge => _judge;

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -19,8 +19,18 @@ internal sealed class TimeoutStrategy : Strategy
 
     public TimeoutStrategy(TimeoutOptions options)
     {
-        Throw.IfOutOfRange(options.Timeout <= TimeSpan.Zero, nameof(options), "Timeout must be positive.");
-        Throw.IfOutOfRange(options.Timeout > DelayHelper.MaximumDelay, nameof(options.Timeout), "Timeout exceeds the runtime timer limit.");
+        ConfigurationValidation.ThrowIf(
+            options.Timeout <= TimeSpan.Zero,
+            typeof(TimeoutOptions),
+            nameof(options.Timeout),
+            options.Timeout,
+            "must be positive");
+        ConfigurationValidation.ThrowIf(
+            options.Timeout > DelayHelper.MaximumDelay,
+            typeof(TimeoutOptions),
+            nameof(options.Timeout),
+            options.Timeout,
+            "must not exceed the runtime timer limit");
         _timeout = options.Timeout;
         _timeoutGenerator = options.TimeoutGenerator;
         _onTimeout = options.OnTimeout;
@@ -257,7 +267,17 @@ internal sealed class TimeoutStrategy : Strategy
 
     private static void ValidateGeneratedTimeout(TimeSpan timeout)
     {
-        Throw.IfOutOfRange(timeout <= TimeSpan.Zero, nameof(timeout), "Generated timeout must be positive.");
-        Throw.IfOutOfRange(timeout > DelayHelper.MaximumDelay, nameof(timeout), "Generated timeout exceeds the runtime timer limit.");
+        ConfigurationValidation.ThrowIf(
+            timeout <= TimeSpan.Zero,
+            typeof(TimeoutOptions),
+            nameof(TimeoutOptions.TimeoutGenerator),
+            timeout,
+            "must return a positive timeout");
+        ConfigurationValidation.ThrowIf(
+            timeout > DelayHelper.MaximumDelay,
+            typeof(TimeoutOptions),
+            nameof(TimeoutOptions.TimeoutGenerator),
+            timeout,
+            "must not return a timeout above the runtime timer limit");
     }
 }

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -291,8 +291,8 @@ public class CircuitBreakerDynamicOptionsTests
         });
 
         await Assert.That(async () =>
-                await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
-            .Throws<ArgumentOutOfRangeException>();
+            await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<KevlarConfigurationException>();
     }
 
     [Test]
@@ -311,8 +311,8 @@ public class CircuitBreakerDynamicOptionsTests
         });
 
         _ = await Assert.That(async () =>
-                await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
-            .Throws<ArgumentOutOfRangeException>();
+            await shield.ExecuteAsync<int>(_ => throw new InvalidOperationException()))
+            .Throws<KevlarConfigurationException>();
         await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
     }
 

--- a/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyLimitTests.cs
@@ -24,11 +24,11 @@ public class BulkheadTests
     {
         await Assert.That(() => Shield.ConcurrencyLimit(maxConcurrency: 0))
             .Throws<ArgumentOutOfRangeException>()
-            .WithMessage("MaxConcurrency must be positive. (Parameter 'options')");
+            .WithMessage("MaxConcurrency must be positive. (Parameter 'maxConcurrency')");
 
         await Assert.That(() => Shield.ConcurrencyLimit(maxConcurrency: 1, queueLimit: -1))
             .Throws<ArgumentOutOfRangeException>()
-            .WithMessage("QueueLimit must not be negative. (Parameter 'options')");
+            .WithMessage("QueueLimit must not be negative. (Parameter 'queueLimit')");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ConfigurationBindingTests.cs
+++ b/tests/Kevlar.Tests/ConfigurationBindingTests.cs
@@ -122,9 +122,12 @@ public class ConfigurationBindingTests
         services.AddShield("invalid", configuration);
         using var provider = services.BuildServiceProvider();
 
-        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
-            .Throws<InvalidOperationException>()
-            .WithMessage("Configuration value 'quadratic' for 'Retry:Backoff' is not a BackoffKind.");
+        var exception = await Assert.That(
+                () => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains("Retry:Backoff");
+        await Assert.That(exception.Message).Contains("not a BackoffKind");
     }
 
     [Test]
@@ -157,9 +160,12 @@ public class ConfigurationBindingTests
         services.AddShield("invalid", configuration);
         using var provider = services.BuildServiceProvider();
 
-        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
-            .Throws<InvalidOperationException>()
-            .WithMessage("Configuration value 'randomish' for 'Retry:Jitter' is not a Jitter.");
+        var exception = await Assert.That(
+                () => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains("Retry:Jitter");
+        await Assert.That(exception.Message).Contains("not a Jitter");
     }
 
     [Test]
@@ -170,11 +176,12 @@ public class ConfigurationBindingTests
         services.AddShield("invalid", configuration);
         using var provider = services.BuildServiceProvider();
 
-        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
-            .Throws<InvalidOperationException>()
-            .WithMessage(
-                "Configuration value 'Custom' for 'Retry:Backoff' is not a configurable "
-                + "BackoffKind (None, Constant, Linear, or Exponential).");
+        var exception = await Assert.That(
+                () => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains("Retry:Backoff");
+        await Assert.That(exception.Message).Contains("not a configurable BackoffKind");
     }
 
     [Test]
@@ -243,7 +250,7 @@ public class ConfigurationBindingTests
 
         var exception = await Assert.That(
                 () => provider.GetRequiredService<IKevlarRegistry>().GetShield("legacy"))
-            .Throws<InvalidOperationException>();
+            .Throws<KevlarConfigurationException>();
 
         await Assert.That(exception!.Message).Contains("ConcurrencyLimit:MaxQueue");
         await Assert.That(exception.Message).Contains("QueueLimit");
@@ -299,9 +306,12 @@ public class ConfigurationBindingTests
         services.AddShield("invalid", configuration);
         using var provider = services.BuildServiceProvider();
 
-        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
-            .Throws<InvalidOperationException>()
-            .WithMessage("Configuration value 'abc' for 'Retry:MaxRetries' is not an integer.");
+        var exception = await Assert.That(
+                () => provider.GetRequiredService<IKevlarRegistry>().GetShield("invalid"))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains("Retry:MaxRetries");
+        await Assert.That(exception.Message).Contains("not an integer");
     }
 
     [Test]
@@ -312,9 +322,12 @@ public class ConfigurationBindingTests
         services.AddShield("empty", configuration);
         using var provider = services.BuildServiceProvider();
 
-        await Assert.That(() => provider.GetRequiredService<IKevlarRegistry>().GetShield("empty"))
-            .Throws<InvalidOperationException>()
-            .WithMessage("Configuration value '' for 'Retry:MaxRetries' is not an integer.");
+        var exception = await Assert.That(
+                () => provider.GetRequiredService<IKevlarRegistry>().GetShield("empty"))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains("Retry:MaxRetries");
+        await Assert.That(exception.Message).Contains("not an integer");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -416,6 +416,8 @@ public class DependencyInjectionContractTests
             ("AttemptTimeout", "00:00:00", true),
             ("ConcurrencyLimit:MaxConcurrency", "0", false),
             ("Retry:BaseDelay", "-00:00:01", false),
+            ("Retry:MaxRetries", "abc", true),
+            ("ConcurrencyLimit:MaxQueue", "5", false),
         ];
 
         foreach (var item in cases)

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -383,6 +383,30 @@ public class DependencyInjectionContractTests
         await Assert.That(second.ToString()).IsEqualTo("dynamic: Retry(4, no delay)");
     }
 
+    [Test]
+    public async Task Invalid_Configuration_Reports_Section_And_Property()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Resilience:Retry:MaxRetries"] = "-1",
+            })
+            .Build()
+            .GetSection("Resilience");
+        var services = new ServiceCollection();
+        services.AddShield("invalid", configuration);
+        using var provider = services.BuildServiceProvider();
+        var registry = provider.GetRequiredService<IKevlarRegistry>();
+
+        var exception = await Assert.That(() => registry.GetShield("invalid"))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains("Resilience");
+        await Assert.That(exception.Message).Contains("RetryOptions.MaxRetries");
+        await Assert.That(exception.Message).Contains("-1");
+        await Assert.That(exception.InnerException).IsTypeOf<KevlarConfigurationException>();
+    }
+
     private static async Task AssertNullNameAsync(Action action)
     {
         await AssertNullParameterAsync(action, "name");

--- a/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
+++ b/tests/Kevlar.Tests/DependencyInjectionContractTests.cs
@@ -407,6 +407,49 @@ public class DependencyInjectionContractTests
         await Assert.That(exception.InnerException).IsTypeOf<KevlarConfigurationException>();
     }
 
+    [Test]
+    public async Task Bound_Validation_Failures_Report_Configuration_Path()
+    {
+        (string Key, string Value, bool Typed)[] cases =
+        [
+            ("Timeout", "00:00:00", false),
+            ("AttemptTimeout", "00:00:00", true),
+            ("ConcurrencyLimit:MaxConcurrency", "0", false),
+            ("Retry:BaseDelay", "-00:00:01", false),
+        ];
+
+        foreach (var item in cases)
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [$"Resilience:{item.Key}"] = item.Value,
+                })
+                .Build()
+                .GetSection("Resilience");
+            var services = new ServiceCollection();
+            if (item.Typed)
+            {
+                services.AddShield<int>("invalid", configuration);
+            }
+            else
+            {
+                services.AddShield("invalid", configuration);
+            }
+
+            using var provider = services.BuildServiceProvider();
+            var registry = provider.GetRequiredService<IKevlarRegistry>();
+            var exception = item.Typed
+                ? await Assert.That(() => registry.GetShield<int>("invalid"))
+                    .Throws<KevlarConfigurationException>()
+                : await Assert.That(() => registry.GetShield("invalid"))
+                    .Throws<KevlarConfigurationException>();
+
+            await Assert.That(exception!.Message).Contains("Resilience");
+            await Assert.That(exception.InnerException).IsTypeOf<KevlarConfigurationException>();
+        }
+    }
+
     private static async Task AssertNullNameAsync(Action action)
     {
         await AssertNullParameterAsync(action, "name");

--- a/tests/Kevlar.Tests/NumericBoundaryTests.cs
+++ b/tests/Kevlar.Tests/NumericBoundaryTests.cs
@@ -79,20 +79,20 @@ public class NumericBoundaryTests
     [Test]
     public async Task Strategies_Reject_Unsupported_Delay_And_Capacity_Values_Early()
     {
-        await AssertOutOfRangeAsync(
+        await AssertConfigurationErrorAsync(
             () => Shield.Retry(options => options.MaxDelay = TimeSpan.FromTicks(-1)),
-            "MaxDelay",
-            "MaxDelay must not be negative.");
-        await AssertOutOfRangeAsync(
+            "RetryOptions.MaxDelay",
+            "must not be negative");
+        await AssertConfigurationErrorAsync(
             () => Shield.Retry(options => options.MaxDelay = TimeSpan.MaxValue),
-            "MaxDelay",
-            "MaxDelay exceeds the runtime timer limit.");
+            "RetryOptions.MaxDelay",
+            "must not exceed the runtime timer limit");
         await AssertOutOfRangeAsync(
             () => Shield.Timeout(TimeSpan.MaxValue),
-            "Timeout");
+            "timeout");
         await AssertOutOfRangeAsync(
             () => Shield.Hedge(2, TimeSpan.MaxValue),
-            "Delay");
+            "delay");
     }
 
     [Test]
@@ -124,9 +124,9 @@ public class NumericBoundaryTests
     [Test]
     public async Task Circuit_Breaker_Rejects_NaN_Ratio()
     {
-        await AssertOutOfRangeAsync(
+        await AssertConfigurationErrorAsync(
             () => Shield.CircuitBreaker(options => options.FailureRatio = double.NaN),
-            "FailureRatio");
+            "CircuitBreakerOptions.FailureRatio");
     }
 
     [Test]
@@ -253,6 +253,19 @@ public class NumericBoundaryTests
     {
         var exception = await Assert.That(action).Throws<ArgumentOutOfRangeException>();
         await Assert.That(exception!.ParamName).IsEqualTo(paramName);
+        if (expectedMessage is not null)
+        {
+            await Assert.That(exception.Message).Contains(expectedMessage);
+        }
+    }
+
+    private static async Task AssertConfigurationErrorAsync(
+        Action action,
+        string expectedProperty,
+        string? expectedMessage = null)
+    {
+        var exception = await Assert.That(action).Throws<KevlarConfigurationException>();
+        await Assert.That(exception!.Message).Contains(expectedProperty);
         if (expectedMessage is not null)
         {
             await Assert.That(exception.Message).Contains(expectedMessage);

--- a/tests/Kevlar.Tests/OptionsValidationTests.cs
+++ b/tests/Kevlar.Tests/OptionsValidationTests.cs
@@ -3,15 +3,93 @@ namespace Kevlar.Tests;
 public class OptionsValidationTests
 {
     [Test]
-    public async Task Retry_Rejects_Invalid_Options()
+    public async Task Configuration_Errors_Name_Options_Property_And_Value()
     {
-        var retries = await Assert.That(() => Shield.Retry(-1)).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(retries!.ParamName).IsEqualTo("options");
-        await Assert.That(retries.Message).Contains("MaxRetries must not be negative.");
+        ConfigurationCase[] cases =
+        [
+            new(() => Shield.Retry(options => options.MaxRetries = -1), "RetryOptions", "MaxRetries", "-1"),
+            new(() => Shield.Retry(options => options.Backoff = null!), "RetryOptions", "Backoff", "null"),
+            new(() => Shield.Retry(options => options.MaxDelay = TimeSpan.FromSeconds(-1)), "RetryOptions", "MaxDelay", "-00:00:01"),
+            new(() => Shield.Retry(options => options.MaxDelay = TimeSpan.MaxValue), "RetryOptions", "MaxDelay", TimeSpan.MaxValue.ToString()),
+            new(() => Shield.Timeout(options => options.Timeout = TimeSpan.Zero), "TimeoutOptions", "Timeout", "00:00:00"),
+            new(() => Shield.Timeout(options => options.Timeout = TimeSpan.MaxValue), "TimeoutOptions", "Timeout", TimeSpan.MaxValue.ToString()),
+            new(() => Shield.CircuitBreaker(options => options.ConsecutiveFailures = 0), "CircuitBreakerOptions", "ConsecutiveFailures", "0"),
+            new(() => Shield.CircuitBreaker(options => options.FailureRatio = double.NaN), "CircuitBreakerOptions", "FailureRatio", "NaN"),
+            new(() => Shield.CircuitBreaker(options => options.MinimumThroughput = 0), "CircuitBreakerOptions", "MinimumThroughput", "0"),
+            new(() => Shield.CircuitBreaker(options => options.SamplingWindow = TimeSpan.Zero), "CircuitBreakerOptions", "SamplingWindow", "00:00:00"),
+            new(() => Shield.CircuitBreaker(options => options.BreakDuration = TimeSpan.Zero), "CircuitBreakerOptions", "BreakDuration", "00:00:00"),
+            new(() => Shield.Hedge(options => options.MaxAttempts = 0), "HedgeOptions", "MaxAttempts", "0"),
+            new(() => Shield.Hedge(options => options.Delay = TimeSpan.FromSeconds(-1)), "HedgeOptions", "Delay", "-00:00:01"),
+            new(() => Shield.RateLimit(options => options.Permits = 0), "RateLimitOptions", "Permits", "0"),
+            new(() => Shield.RateLimit(options => options.Window = TimeSpan.Zero), "RateLimitOptions", "Window", "00:00:00"),
+            new(() => Shield.RateLimit(options => options.Burst = 0), "RateLimitOptions", "Burst", "0"),
+            new(() => Shield.RateLimit(options => options.QueueLimit = -1), "RateLimitOptions", "QueueLimit", "-1"),
+            new(() => Shield.ConcurrencyLimit(options => options.MaxConcurrency = 0), "ConcurrencyLimitOptions", "MaxConcurrency", "0"),
+            new(() => Shield.ConcurrencyLimit(options => options.QueueLimit = -1), "ConcurrencyLimitOptions", "QueueLimit", "-1"),
+        ];
 
-        var backoff = await Assert.That(() => Shield.Retry(options => options.Backoff = null!))
+        foreach (var item in cases)
+        {
+            var exception = await Assert.That(item.Build).Throws<KevlarConfigurationException>();
+            await Assert.That(exception!.Message).Contains(item.OptionsType);
+            await Assert.That(exception.Message).Contains(item.Property);
+            await Assert.That(exception.Message).Contains(item.Value);
+            await Assert.That(exception is KevlarException).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Direct_Argument_Errors_Keep_Correct_ParamName()
+    {
+        DirectArgumentCase[] cases =
+        [
+            new(() => Shield.Retry(-1), typeof(Shield), nameof(Shield.Retry), [typeof(int)]),
+            new(() => Shield.Timeout(TimeSpan.Zero), typeof(Shield), nameof(Shield.Timeout), [typeof(TimeSpan)]),
+            new(() => Shield.CircuitBreaker(0, TimeSpan.FromSeconds(1)), typeof(Shield), nameof(Shield.CircuitBreaker), [typeof(int), typeof(TimeSpan)]),
+            new(() => Shield.RateLimit(0, TimeSpan.FromSeconds(1)), typeof(Shield), nameof(Shield.RateLimit), [typeof(int), typeof(TimeSpan)]),
+            new(() => Shield.ConcurrencyLimit(0), typeof(Shield), nameof(Shield.ConcurrencyLimit), [typeof(int), typeof(int)]),
+            new(() => Shield.Hedge(0, TimeSpan.Zero), typeof(Shield), nameof(Shield.Hedge), [typeof(int), typeof(TimeSpan)]),
+            new(() => Shield.For<int>().Retry(-1), typeof(Shield<int>), nameof(Shield<int>.Retry), [typeof(int)]),
+            new(() => Shield.When<InvalidOperationException>().Retry(-1), typeof(ShieldBuilder), nameof(ShieldBuilder.Retry), [typeof(int)]),
+        ];
+
+        foreach (var item in cases)
+        {
+            var exception = await Assert.That(item.Invoke).Throws<ArgumentOutOfRangeException>();
+            var method = item.DeclaringType.GetMethod(item.MethodName, item.ParameterTypes)!;
+            await Assert.That(method.GetParameters().Select(static parameter => parameter.Name))
+                .Contains(exception!.ParamName);
+        }
+    }
+
+    [Test]
+    public async Task Null_Fallback_Delegate_Reports_The_Public_Parameter()
+    {
+        var exception = await Assert.That(() => Shield.Fallback(
+                (Func<CancellationToken, ValueTask>)null!))
             .Throws<ArgumentNullException>();
-        await Assert.That(backoff!.ParamName).IsEqualTo("options");
+
+        await Assert.That(exception!.ParamName).IsEqualTo("fallback");
+    }
+
+    [Test]
+    public async Task Typed_And_Builder_Configuration_Overloads_Have_Parity()
+    {
+        Action[] invalidConfigurations =
+        [
+            () => Shield.Retry(options => options.MaxRetries = -1),
+            () => Shield.For<int>().Retry(options => options.MaxRetries = -1),
+            () => Shield.When<InvalidOperationException>().Retry(options => options.MaxRetries = -1),
+            () => Shield.For<int>().When<InvalidOperationException>().Retry(options => options.MaxRetries = -1),
+        ];
+
+        foreach (var invalidConfiguration in invalidConfigurations)
+        {
+            var exception = await Assert.That(invalidConfiguration).Throws<KevlarConfigurationException>();
+            await Assert.That(exception!.Message).Contains("RetryOptions");
+            await Assert.That(exception.Message).Contains("MaxRetries");
+            await Assert.That(exception.Message).Contains("-1");
+        }
     }
 
     [Test]
@@ -42,14 +120,14 @@ public class OptionsValidationTests
         await Assert.That(() => Shield.CircuitBreaker(0, TimeSpan.FromSeconds(1))).Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => Shield.CircuitBreaker(-3, TimeSpan.FromSeconds(1))).Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => Shield.CircuitBreaker(1, TimeSpan.Zero)).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => Shield.CircuitBreaker(options => options.FailureRatio = 0)).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => Shield.CircuitBreaker(options => options.FailureRatio = 1.5)).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => Shield.CircuitBreaker(options => options.MinimumThroughput = 0)).Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => Shield.CircuitBreaker(options => options.FailureRatio = 0)).Throws<KevlarConfigurationException>();
+        await Assert.That(() => Shield.CircuitBreaker(options => options.FailureRatio = 1.5)).Throws<KevlarConfigurationException>();
+        await Assert.That(() => Shield.CircuitBreaker(options => options.MinimumThroughput = 0)).Throws<KevlarConfigurationException>();
         await Assert.That(() => Shield.CircuitBreaker(options =>
         {
             options.FailureRatio = 0.5;
             options.SamplingWindow = TimeSpan.Zero;
-        })).Throws<ArgumentOutOfRangeException>();
+        })).Throws<KevlarConfigurationException>();
     }
 
     [Test]
@@ -59,13 +137,13 @@ public class OptionsValidationTests
         {
             options.ConsecutiveFailures = 3;
             options.FailureRatio = 0.5;
-        })).Throws<ArgumentOutOfRangeException>();
+        })).Throws<KevlarConfigurationException>();
 
         var typed = await Assert.That(() => Shield.For<int>().CircuitBreaker(options =>
         {
             options.ConsecutiveFailures = 3;
             options.FailureRatio = 0.5;
-        })).Throws<ArgumentOutOfRangeException>();
+        })).Throws<KevlarConfigurationException>();
 
         foreach (var message in new[] { untyped!.Message, typed!.Message })
         {
@@ -91,8 +169,8 @@ public class OptionsValidationTests
     {
         await Assert.That(() => Shield.RateLimit(0, TimeSpan.FromSeconds(1))).Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => Shield.RateLimit(10, TimeSpan.Zero)).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => Shield.RateLimit(options => options.Burst = 0)).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => Shield.RateLimit(options => options.QueueLimit = -1)).Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => Shield.RateLimit(options => options.Burst = 0)).Throws<KevlarConfigurationException>();
+        await Assert.That(() => Shield.RateLimit(options => options.QueueLimit = -1)).Throws<KevlarConfigurationException>();
     }
 
     [Test]
@@ -116,6 +194,33 @@ public class OptionsValidationTests
         var shield = Shield.Hedge(2, System.Threading.Timeout.InfiniteTimeSpan);
         var result = await shield.ExecuteAsync(_ => new ValueTask<int>(1));
         await Assert.That(result).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dynamic_Generators_Report_Their_Configuration_Property()
+    {
+        var timeout = Shield.Timeout(options =>
+            options.TimeoutGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.Zero));
+        var timeoutException = await Assert.That(
+            async () => await timeout.ExecuteAsync<int>(static _ => new ValueTask<int>(42)))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(timeoutException!.Message).Contains("TimeoutOptions.TimeoutGenerator");
+        await Assert.That(timeoutException.Message).Contains("00:00:00");
+
+        var breaker = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDurationGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.Zero);
+        });
+        var breakerException = await Assert.That(
+            async () => await breaker.ExecuteAsync<int>(static _ =>
+                throw new InvalidOperationException("operation")))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(breakerException!.Message)
+            .Contains("CircuitBreakerOptions.BreakDurationGenerator");
+        await Assert.That(breakerException.Message).Contains("00:00:00");
     }
 
     [Test]
@@ -217,4 +322,16 @@ public class OptionsValidationTests
         await Assert.That(breaker.HasHandlingOverride).IsTrue();
         await Assert.That(hedge.HasHandlingOverride).IsTrue();
     }
+
+    private sealed record ConfigurationCase(
+        Action Build,
+        string OptionsType,
+        string Property,
+        string Value);
+
+    private sealed record DirectArgumentCase(
+        Action Invoke,
+        Type DeclaringType,
+        string MethodName,
+        Type[] ParameterTypes);
 }

--- a/tests/Kevlar.Tests/ReloadingShieldTests.cs
+++ b/tests/Kevlar.Tests/ReloadingShieldTests.cs
@@ -121,9 +121,9 @@ public class ReloadingShieldTests
         configuration.Reload();
 
         await Assert.That(ReferenceEquals(live.Current, lastGood)).IsTrue();
-        await Assert.That(reported).IsTypeOf<InvalidOperationException>();
-        await Assert.That(reported!.Message)
-            .IsEqualTo("Configuration value 'invalid' for 'Retry:MaxRetries' is not an integer.");
+        await Assert.That(reported).IsTypeOf<KevlarConfigurationException>();
+        await Assert.That(reported!.Message).Contains("Retry:MaxRetries");
+        await Assert.That(reported.Message).Contains("not an integer");
     }
 
     [Test]
@@ -185,9 +185,9 @@ public class ReloadingShieldTests
         configuration.Reload();
 
         await Assert.That(ReferenceEquals(shieldProvider.Current, lastGood)).IsTrue();
-        await Assert.That(reported).IsTypeOf<InvalidOperationException>();
-        await Assert.That(reported!.Message)
-            .IsEqualTo("Configuration value 'invalid' for 'Retry:MaxRetries' is not an integer.");
+        await Assert.That(reported).IsTypeOf<KevlarConfigurationException>();
+        await Assert.That(reported!.Message).Contains("Retry:MaxRetries");
+        await Assert.That(reported.Message).Contains("not an integer");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/TimeoutDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/TimeoutDynamicOptionsTests.cs
@@ -135,7 +135,7 @@ public class TimeoutDynamicOptionsTests
         });
 
         await Assert.That(actionStarted).IsFalse();
-        await Assert.That(outcome.Exception).IsTypeOf<ArgumentOutOfRangeException>();
+        await Assert.That(outcome.Exception).IsTypeOf<KevlarConfigurationException>();
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- add `KevlarConfigurationException` for invalid strategy options and dynamic duration generator results
- preserve real `ArgumentOutOfRangeException.ParamName` values on direct shorthand overloads
- include configuration-section paths in DI binding failures
- add exhaustive parity, runtime-generator, DI, docs, and API-contract coverage

Fixes #213

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (net8: 936; net10: 961)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (150)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (86)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -f net8.0` (3)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -f net10.0` (3)
- `pwsh scripts/Verify-Docs.ps1`
- packed all packages at `0.0.0-pr213a`; `pwsh scripts/Verify-DocSnippets.ps1 ...` compiled/executed 155 snippets on both target frameworks
- `npm run build` in `docs/`

## Benchmark

`PipelineBenchmarks.Kevlar_TokenBucketRatioFiveStrategyChain` (.NET 10):

| | Mean | Allocated |
|---|---:|---:|
| Before | 507.9 ns | 0 B |
| After | 505.8 ns | 0 B |

No material throughput or allocation regression.