### PR TITLE
fix(http): harden standard shield options

### DIFF
--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -57,8 +57,11 @@ services.AddHttpClient("api")
 ```
 
 `StandardHttpShieldOptions` exposes the total timeout, typed retry and circuit-breaker options,
-optional concurrency limiter, attempt timeout, and handler replay/routing options. Invalid strategy
-values fail while the registration is built; handler replay/routing values fail when
+optional concurrency limiter, attempt timeout, and handler replay/routing options. Replacing
+`Retry` still honours `Retry-After` by default; set `UseRetryAfterHeader = false` to opt out. Set
+either timeout's `Timeout` to `Timeout.InfiniteTimeSpan` to omit that stage. A finite attempt timeout
+cannot exceed a finite total timeout. Invalid strategy values fail while the registration is built;
+handler replay/routing values fail when
 `HttpClientFactory` builds its handler pipeline, before a request is sent.
 
 The breaker is a `CircuitBreakerOptions<HttpResponseMessage>`, so `HandlesResult` can replace the
@@ -117,7 +120,7 @@ services.AddHttpClient("api")
 Timeouts accept either a scalar (`TotalTimeout`) or the options-shaped
 `TotalTimeout:Timeout` key. Retry keys are `MaxRetries`, `Backoff` (`None`, `Constant`, `Linear`,
 or `Exponential`), `BaseDelay`, `Factor`, `Jitter` (`None`, `Equal`, `Full`, or `Decorrelated`),
-`BackoffMaxDelay`, and `MaxDelay`. Circuit
+`BackoffMaxDelay`, and `MaxDelay`; `UseRetryAfterHeader` is a root standard-shield key. Circuit
 breaker, concurrency-limit, handler, routing, and endpoint keys match their public option-property
 names. Endpoint entries accept either a URI scalar or `Uri` plus optional `Weight` children.
 
@@ -218,6 +221,11 @@ shape.
 ### `HttpShield.RetryAfter`
 
 A `DelayGenerator` for retry options: when the failed response carries a `Retry-After` header (delta or date form), the retry waits what the server asked for. The server's suggestion is used only when it's *longer* than the computed backoff; no header → normal backoff applies.
+
+The standard shield composes this with a custom synchronous `Retry.DelayGenerator` and uses the
+longer result. Set `UseRetryAfterHeader` to `false` when the custom generator must have exclusive
+control. An asynchronous delay generator still runs afterward, following the normal retry callback
+ordering.
 
 The standard shield caps every retry delay at 10 seconds, so one excessive server suggestion cannot
 impose an unbounded wait. Custom shields can cap server-suggested delays directly:

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -219,7 +219,7 @@ public static class HttpShield
         var onRetry = source.OnRetry;
         target.MaxRetries = source.MaxRetries;
         target.Backoff = source.Backoff;
-        target.MaxDelay = source.MaxDelay;
+        target.MaxDelay = source.MaxDelay ?? StandardHttpShieldOptions.DefaultRetryMaxDelay;
         target.DelayGenerator = ComposeRetryDelayGenerator(
             source.DelayGenerator,
             useRetryAfterHeader);

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -61,10 +61,12 @@ public static class HttpShield
 
         Validate(options);
 
-        var shield = WhenTransient(
-                Shield.Timeout(timeout => Copy(options.TotalTimeout, timeout))
-                    .For<HttpResponseMessage>())
-            .Retry(retry => Copy(options.Retry, retry))
+        var pipelineStart = IsDisabled(options.TotalTimeout)
+            ? Shield.For<HttpResponseMessage>()
+            : Shield.Timeout(timeout => Copy(options.TotalTimeout, timeout))
+                .For<HttpResponseMessage>();
+        var shield = WhenTransient(pipelineStart)
+            .Retry(retry => Copy(options.Retry, retry, options.UseRetryAfterHeader))
             .CircuitBreaker(circuitBreaker => Copy(options.CircuitBreaker, circuitBreaker));
 
         if (options.ConcurrencyLimit is { } concurrencyLimit)
@@ -72,7 +74,9 @@ public static class HttpShield
             shield = shield.ConcurrencyLimit(target => Copy(concurrencyLimit, target));
         }
 
-        return shield.Timeout(timeout => Copy(options.AttemptTimeout, timeout));
+        return IsDisabled(options.AttemptTimeout)
+            ? shield
+            : shield.Timeout(timeout => Copy(options.AttemptTimeout, timeout));
     }
 
     /// <summary>
@@ -153,6 +157,17 @@ public static class HttpShield
         ValidateTimeout(options.TotalTimeout, nameof(StandardHttpShieldOptions.TotalTimeout));
         ValidateTimeout(options.AttemptTimeout, nameof(StandardHttpShieldOptions.AttemptTimeout));
 
+        if (!IsDisabled(options.TotalTimeout)
+            && !IsDisabled(options.AttemptTimeout)
+            && options.TotalTimeout.TimeoutGenerator is null
+            && options.AttemptTimeout.TimeoutGenerator is null
+            && options.AttemptTimeout.Timeout > options.TotalTimeout.Timeout)
+        {
+            throw new KevlarConfigurationException(
+                "StandardHttpShieldOptions.AttemptTimeout.Timeout must not exceed " +
+                "StandardHttpShieldOptions.TotalTimeout.Timeout.");
+        }
+
         if (options.Retry is null)
         {
             throw new ArgumentException("StandardHttpShieldOptions.Retry cannot be null.", nameof(options));
@@ -176,13 +191,17 @@ public static class HttpShield
             throw new ArgumentException($"StandardHttpShieldOptions.{propertyName} cannot be null.", "options");
         }
 
-        if (timeout.Timeout <= TimeSpan.Zero)
+        if (timeout.Timeout <= TimeSpan.Zero
+            && timeout.Timeout != System.Threading.Timeout.InfiniteTimeSpan)
         {
-            throw new ArgumentOutOfRangeException(
-                "options",
-                $"StandardHttpShieldOptions.{propertyName}.Timeout must be positive.");
+            throw new KevlarConfigurationException(
+                $"StandardHttpShieldOptions.{propertyName}.Timeout must be positive or " +
+                "Timeout.InfiniteTimeSpan.");
         }
     }
+
+    private static bool IsDisabled(TimeoutOptions timeout) =>
+        timeout.Timeout == System.Threading.Timeout.InfiniteTimeSpan;
 
     private static void Copy(TimeoutOptions source, TimeoutOptions target)
     {
@@ -194,13 +213,16 @@ public static class HttpShield
 
     private static void Copy(
         RetryOptions<HttpResponseMessage> source,
-        RetryOptions<HttpResponseMessage> target)
+        RetryOptions<HttpResponseMessage> target,
+        bool useRetryAfterHeader)
     {
         var onRetry = source.OnRetry;
         target.MaxRetries = source.MaxRetries;
         target.Backoff = source.Backoff;
         target.MaxDelay = source.MaxDelay;
-        target.DelayGenerator = source.DelayGenerator;
+        target.DelayGenerator = ComposeRetryDelayGenerator(
+            source.DelayGenerator,
+            useRetryAfterHeader);
         target.DelayGeneratorAsync = source.DelayGeneratorAsync;
         target.HandlesException = source.HandlesException;
         target.HandlesResult = source.HandlesResult;
@@ -210,6 +232,33 @@ public static class HttpShield
             onRetry?.Invoke(retry);
         };
         target.OnRetryAsync = source.OnRetryAsync;
+    }
+
+    private static Func<RetryEvent<HttpResponseMessage>, TimeSpan?>? ComposeRetryDelayGenerator(
+        Func<RetryEvent<HttpResponseMessage>, TimeSpan?>? custom,
+        bool useRetryAfterHeader)
+    {
+        if (!useRetryAfterHeader)
+        {
+            return custom;
+        }
+
+        if (custom is null)
+        {
+            return RetryAfter;
+        }
+
+        return retry => Longer(custom(retry), RetryAfter(retry));
+    }
+
+    private static TimeSpan? Longer(TimeSpan? first, TimeSpan? second)
+    {
+        if (first is null)
+        {
+            return second;
+        }
+
+        return second is null || first >= second ? first : second;
     }
 
     private static void Copy(

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -92,6 +92,8 @@ Kevlar.Extensions.Http.StandardHttpShieldOptions.Retry.set -> void
 Kevlar.Extensions.Http.StandardHttpShieldOptions.StandardHttpShieldOptions() -> void
 Kevlar.Extensions.Http.StandardHttpShieldOptions.TotalTimeout.get -> Kevlar.TimeoutOptions!
 Kevlar.Extensions.Http.StandardHttpShieldOptions.TotalTimeout.set -> void
+Kevlar.Extensions.Http.StandardHttpShieldOptions.UseRetryAfterHeader.get -> bool
+Kevlar.Extensions.Http.StandardHttpShieldOptions.UseRetryAfterHeader.set -> void
 static Kevlar.Extensions.Http.HttpShield.IsTransientException(System.Exception? exception, System.Threading.CancellationToken callerCancellationToken) -> bool
 static Kevlar.Extensions.Http.HttpShield.Standard(Kevlar.Extensions.Http.StandardHttpShieldOptions! options) -> Kevlar.Shield<System.Net.Http.HttpResponseMessage!>!
 static Kevlar.Extensions.Http.HttpShield.RetryAfter(System.TimeSpan maxDelay) -> System.Func<Kevlar.RetryEvent<System.Net.Http.HttpResponseMessage!>, System.TimeSpan?>!

--- a/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
@@ -11,6 +11,10 @@ internal static class StandardHttpConfigurationBinder
 
         BindTimeout(configuration, nameof(options.TotalTimeout), options.TotalTimeout);
         BindRetry(configuration.GetSection(nameof(options.Retry)), options.Retry);
+        SetBool(
+            configuration,
+            nameof(options.UseRetryAfterHeader),
+            value => options.UseRetryAfterHeader = value);
         BindCircuitBreaker(configuration.GetSection(nameof(options.CircuitBreaker)), options.CircuitBreaker);
         BindConcurrencyLimit(configuration.GetSection(nameof(options.ConcurrencyLimit)), options);
         BindTimeout(configuration, nameof(options.AttemptTimeout), options.AttemptTimeout);
@@ -225,7 +229,10 @@ internal static class StandardHttpConfigurationBinder
         IConfiguration configuration,
         StandardHttpShieldOptions options)
     {
-        Ensure(options.TotalTimeout.Timeout > TimeSpan.Zero, TimeoutSection(configuration, nameof(options.TotalTimeout)), "must be positive");
+        Ensure(
+            IsValidStandardTimeout(options.TotalTimeout),
+            TimeoutSection(configuration, nameof(options.TotalTimeout)),
+            "must be positive or Timeout.InfiniteTimeSpan");
         Ensure(options.Retry.MaxRetries >= 0, configuration.GetSection("Retry:MaxRetries"), "must not be negative");
         Ensure(options.Retry.MaxDelay is null || options.Retry.MaxDelay >= TimeSpan.Zero, configuration.GetSection("Retry:MaxDelay"), "must not be negative");
         ValidateCircuitBreaker(configuration.GetSection(nameof(options.CircuitBreaker)), options.CircuitBreaker);
@@ -235,7 +242,18 @@ internal static class StandardHttpConfigurationBinder
             Ensure(concurrency.QueueLimit >= 0, configuration.GetSection("ConcurrencyLimit:QueueLimit"), "must not be negative");
         }
 
-        Ensure(options.AttemptTimeout.Timeout > TimeSpan.Zero, TimeoutSection(configuration, nameof(options.AttemptTimeout)), "must be positive");
+        Ensure(
+            IsValidStandardTimeout(options.AttemptTimeout),
+            TimeoutSection(configuration, nameof(options.AttemptTimeout)),
+            "must be positive or Timeout.InfiniteTimeSpan");
+        Ensure(
+            options.TotalTimeout.Timeout == Timeout.InfiniteTimeSpan
+                || options.AttemptTimeout.Timeout == Timeout.InfiniteTimeSpan
+                || options.TotalTimeout.TimeoutGenerator is not null
+                || options.AttemptTimeout.TimeoutGenerator is not null
+                || options.AttemptTimeout.Timeout <= options.TotalTimeout.Timeout,
+            TimeoutSection(configuration, nameof(options.AttemptTimeout)),
+            "must not exceed TotalTimeout");
         Ensure(options.Handler.MaximumBufferSize > 0, configuration.GetSection("Handler:MaximumBufferSize"), "must be positive");
         if (options.Handler.Routing is { } routing)
         {
@@ -307,6 +325,9 @@ internal static class StandardHttpConfigurationBinder
             ? section
             : section.GetSection(nameof(TimeoutOptions.Timeout));
     }
+
+    private static bool IsValidStandardTimeout(TimeoutOptions options) =>
+        options.Timeout > TimeSpan.Zero || options.Timeout == Timeout.InfiniteTimeSpan;
 
     private static void Ensure(bool condition, IConfigurationSection section, string requirement)
     {

--- a/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
@@ -3,6 +3,8 @@ namespace Kevlar.Extensions.Http;
 /// <summary>Configures the standard HTTP resilience pipeline and its request handler.</summary>
 public sealed class StandardHttpShieldOptions
 {
+    internal static readonly TimeSpan DefaultRetryMaxDelay = TimeSpan.FromSeconds(10);
+
     /// <summary>
     /// Configures the outer total timeout. Defaults to 30 seconds. Set
     /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to omit this stage.
@@ -15,7 +17,7 @@ public sealed class StandardHttpShieldOptions
     /// </summary>
     public RetryOptions<HttpResponseMessage> Retry { get; set; } = new()
     {
-        MaxDelay = TimeSpan.FromSeconds(10),
+        MaxDelay = DefaultRetryMaxDelay,
     };
 
     /// <summary>

--- a/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
@@ -3,7 +3,10 @@ namespace Kevlar.Extensions.Http;
 /// <summary>Configures the standard HTTP resilience pipeline and its request handler.</summary>
 public sealed class StandardHttpShieldOptions
 {
-    /// <summary>Configures the outer total timeout. Defaults to 30 seconds.</summary>
+    /// <summary>
+    /// Configures the outer total timeout. Defaults to 30 seconds. Set
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to omit this stage.
+    /// </summary>
     public TimeoutOptions TotalTimeout { get; set; } = new();
 
     /// <summary>
@@ -12,9 +15,16 @@ public sealed class StandardHttpShieldOptions
     /// </summary>
     public RetryOptions<HttpResponseMessage> Retry { get; set; } = new()
     {
-        DelayGenerator = HttpShield.RetryAfter,
         MaxDelay = TimeSpan.FromSeconds(10),
     };
+
+    /// <summary>
+    /// Whether retry delays honour the response's <c>Retry-After</c> header. Defaults to
+    /// <see langword="true"/> and composes with
+    /// <see cref="RetryOptions{HttpResponseMessage}.DelayGenerator"/>
+    /// by using the longer delay.
+    /// </summary>
+    public bool UseRetryAfterHeader { get; set; } = true;
 
     /// <summary>
     /// Configures the circuit breaker. Defaults to a 50% failure ratio over 30 seconds, with a
@@ -31,7 +41,10 @@ public sealed class StandardHttpShieldOptions
     /// </summary>
     public ConcurrencyLimitOptions? ConcurrencyLimit { get; set; }
 
-    /// <summary>Configures the per-attempt timeout. Defaults to 10 seconds.</summary>
+    /// <summary>
+    /// Configures the per-attempt timeout. Defaults to 10 seconds. Set
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to omit this stage.
+    /// </summary>
     public TimeoutOptions AttemptTimeout { get; set; } = new()
     {
         Timeout = TimeSpan.FromSeconds(10),

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net;
+using System.Net.Http.Headers;
 using Kevlar.Extensions.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -70,6 +71,7 @@ public class HttpConfigurationReloadTests
             ("Retry:BaseDelay", "00:00:00.100"),
             ("Retry:BackoffMaxDelay", "00:00:02"),
             ("Retry:MaxDelay", "00:00:01"),
+            ("UseRetryAfterHeader", "false"),
             ("CircuitBreaker:ConsecutiveFailures", "2"),
             ("CircuitBreaker:FailureRatio", ""),
             ("CircuitBreaker:MinimumThroughput", "5"),
@@ -103,6 +105,7 @@ public class HttpConfigurationReloadTests
         await Assert.That(bound.Retry.MaxRetries).IsEqualTo(4);
         await Assert.That(bound.Retry.Backoff.ToString()).IsEqualTo("linear 100ms steps, equal jitter, cap 2s");
         await Assert.That(bound.Retry.MaxDelay).IsEqualTo(TimeSpan.FromSeconds(1));
+        await Assert.That(bound.UseRetryAfterHeader).IsFalse();
         await Assert.That(bound.CircuitBreaker.ConsecutiveFailures).IsEqualTo(2);
         await Assert.That(bound.CircuitBreaker.FailureRatio).IsNull();
         await Assert.That(bound.CircuitBreaker.MinimumThroughput).IsEqualTo(5);
@@ -243,7 +246,7 @@ public class HttpConfigurationReloadTests
     }
 
     [Test]
-    [Arguments("TotalTimeout", "00:00:00", "must be positive")]
+    [Arguments("TotalTimeout", "00:00:00", "must be positive or Timeout.InfiniteTimeSpan")]
     [Arguments("Retry:MaxRetries", "-1", "must not be negative")]
     [Arguments("Retry:MaxDelay", "-00:00:01", "must not be negative")]
     [Arguments("Retry:BaseDelay", "-00:00:01", "must not be negative")]
@@ -256,7 +259,7 @@ public class HttpConfigurationReloadTests
     [Arguments("CircuitBreaker:BreakDuration", "00:00:00", "must be positive")]
     [Arguments("ConcurrencyLimit:MaxConcurrency", "0", "must be positive")]
     [Arguments("ConcurrencyLimit:QueueLimit", "-1", "must not be negative")]
-    [Arguments("AttemptTimeout", "00:00:00", "must be positive")]
+    [Arguments("AttemptTimeout", "00:00:00", "must be positive or Timeout.InfiniteTimeSpan")]
     [Arguments("Handler:MaximumBufferSize", "0", "must be positive")]
     [Arguments("Handler:Routing:Endpoints:0:Weight", "0", "must be positive")]
     public async Task Invalid_Standard_Ranges_Report_Exact_Paths(
@@ -347,6 +350,84 @@ public class HttpConfigurationReloadTests
         }
 
         await Assert.That(transport.Calls).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task Configuration_Bound_RetryAfter_Survives_Reload()
+    {
+        var configuration = BuildConfiguration(
+            ("Retry:MaxRetries", "1"),
+            ("Retry:Backoff", "None"));
+        var transport = new FuncHandler((_, _) =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(2));
+            return Task.FromResult(response);
+        });
+        CancellationTokenSource? requestCancellation = null;
+        TimeSpan? observedDelay = null;
+        var services = new ServiceCollection();
+        services.AddHttpClient("client")
+            .ConfigurePrimaryHttpMessageHandler(() => transport)
+            .AddStandardShield(
+                configuration,
+                (_, options) => options.Retry.OnRetry = retry =>
+                {
+                    observedDelay = retry.Delay;
+                    requestCancellation!.Cancel();
+                });
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+
+        async Task AssertRetryAfterAsync()
+        {
+            observedDelay = null;
+            using var cancellation = new CancellationTokenSource();
+            requestCancellation = cancellation;
+            await Assert.That(async () => await client.GetAsync(
+                    "https://example.test/",
+                    cancellation.Token))
+                .Throws<OperationCanceledException>();
+            await Assert.That(observedDelay).IsEqualTo(TimeSpan.FromSeconds(2));
+        }
+
+        await AssertRetryAfterAsync();
+        configuration["Retry:MaxRetries"] = "2";
+        configuration.Reload();
+        await AssertRetryAfterAsync();
+    }
+
+    [Test]
+    public async Task AttemptTimeout_Cannot_Exceed_TotalTimeout_In_Configuration()
+    {
+        var configuration = BuildConfiguration(
+            ("TotalTimeout", "00:00:05"),
+            ("AttemptTimeout", "00:00:06"));
+        var builder = new ServiceCollection().AddHttpClient("client");
+
+        var exception = await Assert.That(() => builder.AddStandardShield(configuration))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).Contains("AttemptTimeout");
+        await Assert.That(exception.Message).Contains("TotalTimeout");
+    }
+
+    [Test]
+    public async Task Infinite_Timeouts_Are_Accepted_From_Configuration()
+    {
+        var configuration = BuildConfiguration(
+            ("TotalTimeout", "-00:00:00.001"),
+            ("AttemptTimeout", "-00:00:00.001"));
+        StandardHttpShieldOptions? bound = null;
+        var services = new ServiceCollection();
+        services.AddHttpClient("client")
+            .AddStandardShield(configuration, (_, options) => bound = options);
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+
+        await Assert.That(bound!.TotalTimeout.Timeout).IsEqualTo(Timeout.InfiniteTimeSpan);
+        await Assert.That(bound.AttemptTimeout.Timeout).IsEqualTo(Timeout.InfiniteTimeSpan);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -385,6 +385,25 @@ public class HttpContractTests
     }
 
     [Test]
+    public async Task Replacing_Retry_Options_Keeps_Standard_MaxDelay()
+    {
+        var options = new StandardHttpShieldOptions
+        {
+            Retry = new RetryOptions<HttpResponseMessage>
+            {
+                MaxRetries = 1,
+                Backoff = Backoff.None,
+            },
+        };
+
+        var delay = await ObserveStandardRetryDelay(
+            options,
+            retryAfter: TimeSpan.FromMinutes(1));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromSeconds(10));
+    }
+
+    [Test]
     public async Task UseRetryAfterHeader_False_Ignores_Header()
     {
         var options = new StandardHttpShieldOptions
@@ -523,7 +542,7 @@ public class HttpContractTests
 
         await Assert.That(HttpShield.Standard(options).ToString()).IsEqualTo(
             "Timeout(20s) → [when HttpRequestException | TaskCanceledException matching predicate | TimeoutExceededException | result predicate] "
-            + "Retry(1, no delay) → CircuitBreaker(8 consecutive, break 5s) → ConcurrencyLimit(12, queue 4) → Timeout(3s)");
+            + "Retry(1, no delay, ≤10s) → CircuitBreaker(8 consecutive, break 5s) → ConcurrencyLimit(12, queue 4) → Timeout(3s)");
     }
 
     [Test]

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -366,6 +366,64 @@ public class HttpContractTests
     }
 
     [Test]
+    public async Task Replacing_Retry_Options_Keeps_RetryAfter()
+    {
+        var options = new StandardHttpShieldOptions
+        {
+            Retry = new RetryOptions<HttpResponseMessage>
+            {
+                MaxRetries = 1,
+                Backoff = Backoff.None,
+            },
+        };
+
+        var delay = await ObserveStandardRetryDelay(
+            options,
+            retryAfter: TimeSpan.FromSeconds(2));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task UseRetryAfterHeader_False_Ignores_Header()
+    {
+        var options = new StandardHttpShieldOptions
+        {
+            UseRetryAfterHeader = false,
+            Retry = new RetryOptions<HttpResponseMessage>
+            {
+                MaxRetries = 1,
+                Backoff = Backoff.Constant(TimeSpan.FromSeconds(3)),
+            },
+        };
+
+        var delay = await ObserveStandardRetryDelay(
+            options,
+            retryAfter: TimeSpan.FromSeconds(7));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromSeconds(3));
+    }
+
+    [Test]
+    [Arguments(2, 5)]
+    [Arguments(7, 7)]
+    public async Task Custom_DelayGenerator_Composes_With_RetryAfter(
+        int retryAfterSeconds,
+        int expectedSeconds)
+    {
+        var options = new StandardHttpShieldOptions();
+        options.Retry.MaxRetries = 1;
+        options.Retry.Backoff = Backoff.None;
+        options.Retry.DelayGenerator = static _ => TimeSpan.FromSeconds(5);
+
+        var delay = await ObserveStandardRetryDelay(
+            options,
+            retryAfter: TimeSpan.FromSeconds(retryAfterSeconds));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromSeconds(expectedSeconds));
+    }
+
+    [Test]
     public async Task Standard_Default_Retry_MaxDelay_Is_Ten_Seconds() =>
         await Assert.That(new StandardHttpShieldOptions().Retry.MaxDelay)
             .IsEqualTo(TimeSpan.FromSeconds(10));
@@ -375,6 +433,68 @@ public class HttpContractTests
         await Assert.That(HttpShield.Standard().ToString()).IsEqualTo(
             "Timeout(30s) → [when HttpRequestException | TaskCanceledException matching predicate | TimeoutExceededException | result predicate] "
             + "Retry(3, exponential 250ms ×2, equal jitter, cap 30s, ≤10s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
+
+    [Test]
+    public async Task AttemptTimeout_Greater_Than_TotalTimeout_Throws_At_Build()
+    {
+        var options = new StandardHttpShieldOptions();
+        options.TotalTimeout.Timeout = TimeSpan.FromSeconds(5);
+        options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(6);
+
+        var exception = await Assert.That(() => HttpShield.Standard(options))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains("AttemptTimeout.Timeout");
+        await Assert.That(exception.Message).Contains("TotalTimeout.Timeout");
+    }
+
+    [Test]
+    public async Task Infinite_TotalTimeout_Disables_Total_Timeout()
+    {
+        var options = new StandardHttpShieldOptions();
+        options.TotalTimeout.Timeout = Timeout.InfiniteTimeSpan;
+
+        await Assert.That(HttpShield.Standard(options).ToString()).IsEqualTo(
+            "[when HttpRequestException | TaskCanceledException matching predicate | TimeoutExceededException | result predicate] "
+            + "Retry(3, exponential 250ms ×2, equal jitter, cap 30s, ≤10s) → CircuitBreaker(50% over 30s, min 10, break 15s) → Timeout(10s)");
+    }
+
+    [Test]
+    public async Task Infinite_AttemptTimeout_Disables_Per_Attempt_Timeout()
+    {
+        var options = new StandardHttpShieldOptions();
+        options.AttemptTimeout.Timeout = Timeout.InfiniteTimeSpan;
+
+        await Assert.That(HttpShield.Standard(options).ToString()).IsEqualTo(
+            "Timeout(30s) → [when HttpRequestException | TaskCanceledException matching predicate | TimeoutExceededException | result predicate] "
+            + "Retry(3, exponential 250ms ×2, equal jitter, cap 30s, ≤10s) → CircuitBreaker(50% over 30s, min 10, break 15s)");
+    }
+
+    [Test]
+    [Arguments(true, 0)]
+    [Arguments(true, -2)]
+    [Arguments(false, 0)]
+    [Arguments(false, -2)]
+    public async Task Zero_Or_Negative_Timeouts_Throw_With_Property_Name(
+        bool total,
+        long ticks)
+    {
+        var options = new StandardHttpShieldOptions();
+        var propertyName = total ? "TotalTimeout.Timeout" : "AttemptTimeout.Timeout";
+        if (total)
+        {
+            options.TotalTimeout.Timeout = TimeSpan.FromTicks(ticks);
+        }
+        else
+        {
+            options.AttemptTimeout.Timeout = TimeSpan.FromTicks(ticks);
+        }
+
+        var exception = await Assert.That(() => HttpShield.Standard(options))
+            .Throws<KevlarConfigurationException>();
+
+        await Assert.That(exception!.Message).Contains(propertyName);
+    }
 
     [Test]
     public async Task Configured_Standard_Has_Custom_Stages()
@@ -626,7 +746,7 @@ public class HttpContractTests
         var exception = await Assert.That(() => builder.AddStandardShield(options =>
         {
             options.AttemptTimeout.Timeout = TimeSpan.Zero;
-        })).Throws<ArgumentOutOfRangeException>();
+        })).Throws<KevlarConfigurationException>();
 
         await Assert.That(exception!.Message).Contains("AttemptTimeout.Timeout");
     }
@@ -1066,6 +1186,33 @@ public class HttpContractTests
 
         var task = shield.ExecuteAsync(_ => new ValueTask<HttpResponseMessage>(
             ++calls == 1 ? firstAttempt() : new HttpResponseMessage(HttpStatusCode.OK))).AsTask();
+        await WaitUntilAsync(() => observed.HasValue);
+        timeProvider.Advance(observed!.Value);
+        using var response = await task;
+        return observed.Value;
+    }
+
+    private static async Task<TimeSpan> ObserveStandardRetryDelay(
+        StandardHttpShieldOptions options,
+        TimeSpan retryAfter)
+    {
+        var timeProvider = new FakeTimeProvider();
+        var calls = 0;
+        TimeSpan? observed = null;
+        options.Retry.OnRetry = retry => observed = retry.Delay;
+        var shield = HttpShield.Standard(options).WithTimeProvider(timeProvider);
+        var task = shield.ExecuteAsync(_ =>
+        {
+            var response = new HttpResponseMessage(
+                ++calls == 1 ? HttpStatusCode.TooManyRequests : HttpStatusCode.OK);
+            if (calls == 1)
+            {
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(retryAfter);
+            }
+
+            return new ValueTask<HttpResponseMessage>(response);
+        }).AsTask();
+
         await WaitUntilAsync(() => observed.HasValue);
         timeProvider.Advance(observed!.Value);
         using var response = await task;


### PR DESCRIPTION
## Summary

- preserve automatic `Retry-After` handling when callers replace `StandardHttpShieldOptions.Retry`, with explicit opt-out and longest-delay precedence for custom generators
- validate finite attempt timeouts against total timeouts and treat `Timeout.InfiniteTimeSpan` as disabling the corresponding timeout stage
- support binding and reloading the new behavior, with pinned pipeline descriptions and updated HTTP documentation

Closes #229

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build -- --timeout 5m` (974/974 net8.0, 999/999 net10.0)
- `dotnet run --project tests/Kevlar.AllocationTests -c Release --no-build -- --timeout 5m` (4/4 both TFMs)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (151/151)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/issue229 -Version 0.0.0-issue229.1`
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/verify-committed -Version 0.0.0-local`
- `npm run build` (`docs/`)