### PR TITLE
fix(circuit): harden state reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Circuit-breaker monitors and testing snapshots now report `HalfOpen` as soon as the break
+  duration elapses. Stale execution outcomes cannot alter a newer open/half-open generation, and
+  exceptions that opened a circuit are released when it closes or resets.
+
 ### Changed
 
 - Strategy callback events now expose their position through public

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -89,6 +89,13 @@ Closed ──(threshold crossed)──► Open ──(BreakDuration elapses)─�
 - **HalfOpen** — after the break duration, exactly **one** probe execution is allowed through. Success closes the circuit and resets metrics; failure re-opens it for another `BreakDuration`. Concurrent callers during the probe are rejected (`RetryAfter == null`).
 - **Isolated** — manually forced open via the monitor; rejected until `Reset()`.
 
+After the break duration elapses, `CircuitBreakerMonitor.State` reports `HalfOpen` immediately,
+even before another execution arrives. Admission remains lazy: the actual `Open` → `HalfOpen`
+transition and its state-change callbacks occur when the next execution claims the probe slot.
+Executions admitted before the current open/half-open generation cannot later close or re-open the
+circuit. The exception that opened the circuit is retained for open rejections, then released when
+the circuit closes or is reset.
+
 :::info Unhandled exceptions don't move the circuit
 An exception outside the breaker's handling clause says nothing about downstream health — it counts
 as neither success nor failure. This includes caller cancellation unless the clause explicitly

--- a/src/Kevlar.Testing/ShieldStateSnapshotExtensions.cs
+++ b/src/Kevlar.Testing/ShieldStateSnapshotExtensions.cs
@@ -50,7 +50,7 @@ public static class ShieldStateSnapshotExtensions
         switch (strategy)
         {
             case CircuitBreakerStrategy circuit:
-                return new CircuitBreakerStateSnapshot(strategyIndex, circuit.Core.State);
+                return new CircuitBreakerStateSnapshot(strategyIndex, circuit.Core.GetState(timeProvider));
             case RateLimitStrategy rateLimit:
                 var rate = rateLimit.CaptureState(timeProvider);
                 return new RateLimitStateSnapshot(strategyIndex, rate.Available, rate.Queued);

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -42,9 +42,9 @@ internal sealed class CircuitBreakerCore
     private double _openUntilTimestamp;
     private int _consecutiveFailures;
     private bool _probeInFlight;
-    private long _probeGeneration;
-    private long _activeProbeGeneration;
+    private long _admissionGeneration;
     private Exception? _lastException;
+    private TimeProvider? _openTimeProvider;
     private long _openingGeneration;
     private bool _openingPending;
     private bool _isPublishing;
@@ -148,8 +148,16 @@ internal sealed class CircuitBreakerCore
         {
             lock (_gate)
             {
-                return _state;
+                return GetReportedState(_openTimeProvider);
             }
+        }
+    }
+
+    internal CircuitState GetState(TimeProvider timeProvider)
+    {
+        lock (_gate)
+        {
+            return GetReportedState(timeProvider);
         }
     }
 
@@ -162,14 +170,14 @@ internal sealed class CircuitBreakerCore
         TimeProvider timeProvider,
         KevlarContext context,
         out CircuitOpenException? rejection,
-        out long admittedProbeGeneration)
+        out long admissionGeneration)
     {
         var allowed = TryEnterCore(
             timeProvider,
             context,
             out rejection,
             out var transition,
-            out admittedProbeGeneration);
+            out admissionGeneration);
 
         try
         {
@@ -179,7 +187,7 @@ internal sealed class CircuitBreakerCore
         {
             if (transition?.StateChange.To == CircuitState.HalfOpen)
             {
-                AbandonProbe(admittedProbeGeneration);
+                AbandonProbe(admissionGeneration);
             }
 
             throw;
@@ -195,7 +203,7 @@ internal sealed class CircuitBreakerCore
             context,
             out var rejection,
             out var transition,
-            out var admittedProbeGeneration);
+            out var admissionGeneration);
         ValueTask publication;
         try
         {
@@ -205,7 +213,7 @@ internal sealed class CircuitBreakerCore
         {
             if (transition?.StateChange.To == CircuitState.HalfOpen)
             {
-                AbandonProbe(admittedProbeGeneration);
+                AbandonProbe(admissionGeneration);
             }
 
             throw;
@@ -214,7 +222,7 @@ internal sealed class CircuitBreakerCore
         if (publication.IsCompletedSuccessfully)
         {
             publication.GetAwaiter().GetResult();
-            return new ValueTask<EntryResult>(new EntryResult(allowed, rejection, admittedProbeGeneration));
+            return new ValueTask<EntryResult>(new EntryResult(allowed, rejection, admissionGeneration));
         }
 
         return AwaitEntryPublicationAsync(
@@ -222,7 +230,7 @@ internal sealed class CircuitBreakerCore
             allowed,
             rejection,
             transition,
-            admittedProbeGeneration);
+            admissionGeneration);
     }
 
     private bool TryEnterCore(
@@ -230,10 +238,10 @@ internal sealed class CircuitBreakerCore
         KevlarContext context,
         out CircuitOpenException? rejection,
         out TransitionPublication? transition,
-        out long admittedProbeGeneration)
+        out long admissionGeneration)
     {
         transition = null;
-        admittedProbeGeneration = 0;
+        admissionGeneration = 0;
         rejection = null;
 
         lock (_gate)
@@ -241,6 +249,7 @@ internal sealed class CircuitBreakerCore
             switch (_state)
             {
                 case CircuitState.Closed:
+                    admissionGeneration = _admissionGeneration;
                     return true;
 
                 case CircuitState.Isolated:
@@ -260,7 +269,7 @@ internal sealed class CircuitBreakerCore
 
                     transition = ChangeState(CircuitState.HalfOpen, context);
                     _probeInFlight = true;
-                    admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
+                    admissionGeneration = _admissionGeneration;
                     return true;
 
                 default: // HalfOpen
@@ -271,7 +280,7 @@ internal sealed class CircuitBreakerCore
                     }
 
                     _probeInFlight = true;
-                    admittedProbeGeneration = _activeProbeGeneration = ++_probeGeneration;
+                    admissionGeneration = _admissionGeneration;
                     return true;
             }
         }
@@ -282,18 +291,18 @@ internal sealed class CircuitBreakerCore
         bool allowed,
         CircuitOpenException? rejection,
         TransitionPublication? transition,
-        long admittedProbeGeneration)
+        long admissionGeneration)
     {
         try
         {
             await publication.ConfigureAwait(false);
-            return new EntryResult(allowed, rejection, admittedProbeGeneration);
+            return new EntryResult(allowed, rejection, admissionGeneration);
         }
         catch
         {
             if (transition?.StateChange.To == CircuitState.HalfOpen)
             {
-                AbandonProbe(admittedProbeGeneration);
+                AbandonProbe(admissionGeneration);
             }
 
             throw;
@@ -303,22 +312,34 @@ internal sealed class CircuitBreakerCore
     public readonly record struct EntryResult(
         bool Allowed,
         CircuitOpenException? Rejection,
-        long AdmittedProbeGeneration);
+        long AdmissionGeneration);
 
-    public void RecordSuccess(TimeProvider timeProvider, KevlarContext context)
+    public void RecordSuccess(
+        TimeProvider timeProvider,
+        KevlarContext context,
+        long admissionGeneration)
     {
-        Publish(RecordSuccessCore(timeProvider, context));
+        Publish(RecordSuccessCore(timeProvider, context, admissionGeneration));
     }
 
-    public ValueTask RecordSuccessAsync(TimeProvider timeProvider, KevlarContext context) =>
-        PublishAsync(RecordSuccessCore(timeProvider, context));
+    public ValueTask RecordSuccessAsync(
+        TimeProvider timeProvider,
+        KevlarContext context,
+        long admissionGeneration) =>
+        PublishAsync(RecordSuccessCore(timeProvider, context, admissionGeneration));
 
     private TransitionPublication? RecordSuccessCore(
         TimeProvider timeProvider,
-        KevlarContext context)
+        KevlarContext context,
+        long admissionGeneration)
     {
         lock (_gate)
         {
+            if (admissionGeneration != _admissionGeneration)
+            {
+                return null;
+            }
+
             if (_state == CircuitState.HalfOpen)
             {
                 _probeInFlight = false;
@@ -343,25 +364,32 @@ internal sealed class CircuitBreakerCore
     public void RecordFailure(
         TimeProvider timeProvider,
         Exception? exception,
-        KevlarContext context)
+        KevlarContext context,
+        long admissionGeneration)
     {
-        Publish(RecordFailureCore(timeProvider, exception, context));
+        Publish(RecordFailureCore(timeProvider, exception, context, admissionGeneration));
     }
 
     public ValueTask RecordFailureAsync<T>(
         TimeProvider timeProvider,
         in Outcome<T> outcome,
-        KevlarContext context)
+        KevlarContext context,
+        long admissionGeneration)
     {
         if (_breakDurationGenerator is null)
         {
-            return PublishAsync(RecordFailureCore(timeProvider, outcome.Exception, context));
+            return PublishAsync(RecordFailureCore(
+                timeProvider,
+                outcome.Exception,
+                context,
+                admissionGeneration));
         }
 
         if (!TryReserveDynamicOpening(
                 timeProvider,
                 outcome.Exception,
                 context,
+                admissionGeneration,
                 out var reservation))
         {
             return default;
@@ -405,15 +433,21 @@ internal sealed class CircuitBreakerCore
     private TransitionPublication? RecordFailureCore(
         TimeProvider timeProvider,
         Exception? exception,
-        KevlarContext context)
+        KevlarContext context,
+        long admissionGeneration)
     {
         lock (_gate)
         {
-            _lastException = exception;
+            if (admissionGeneration != _admissionGeneration)
+            {
+                return null;
+            }
 
             if (_state == CircuitState.HalfOpen)
             {
                 _probeInFlight = false;
+                _lastException = exception;
+                _openTimeProvider = timeProvider;
                 _openUntilTimestamp = GetCurrentTimestamp(timeProvider) + _breakDurationTimestampUnits;
                 return ChangeState(CircuitState.Open, context);
             }
@@ -431,6 +465,8 @@ internal sealed class CircuitBreakerCore
                         timestamp = GetCurrentTimestamp(timeProvider);
                     }
 
+                    _lastException = exception;
+                    _openTimeProvider = timeProvider;
                     _openUntilTimestamp = timestamp + _breakDurationTimestampUnits;
                     return ChangeState(CircuitState.Open, context);
                 }
@@ -444,12 +480,17 @@ internal sealed class CircuitBreakerCore
         TimeProvider timeProvider,
         Exception? exception,
         KevlarContext context,
+        long admissionGeneration,
         out OpeningReservation reservation)
     {
         lock (_gate)
         {
             reservation = default;
-            _lastException = exception;
+            if (admissionGeneration != _admissionGeneration)
+            {
+                return false;
+            }
+
             if (_openingPending)
             {
                 if (_state == CircuitState.Closed)
@@ -492,6 +533,7 @@ internal sealed class CircuitBreakerCore
             _openingPending = true;
             reservation = new OpeningReservation(
                 ++_openingGeneration,
+                admissionGeneration,
                 _state,
                 exception,
                 context,
@@ -529,6 +571,7 @@ internal sealed class CircuitBreakerCore
         {
             if (!_openingPending
                 || _openingGeneration != reservation.Generation
+                || _admissionGeneration != reservation.AdmissionGeneration
                 || _state != reservation.ExpectedState)
             {
                 return null;
@@ -537,6 +580,7 @@ internal sealed class CircuitBreakerCore
             _openingPending = false;
             _probeInFlight = false;
             _lastException = reservation.Exception;
+            _openTimeProvider = timeProvider;
             _openUntilTimestamp = GetCurrentTimestamp(timeProvider)
                 + (duration.TotalSeconds * Stopwatch.Frequency);
             return ChangeState(CircuitState.Open, reservation.Context);
@@ -574,6 +618,7 @@ internal sealed class CircuitBreakerCore
 
     private readonly record struct OpeningReservation(
         long Generation,
+        long AdmissionGeneration,
         CircuitState ExpectedState,
         Exception? Exception,
         KevlarContext Context,
@@ -584,7 +629,7 @@ internal sealed class CircuitBreakerCore
     {
         lock (_gate)
         {
-            if (_state == CircuitState.HalfOpen && _activeProbeGeneration == probeGeneration)
+            if (_state == CircuitState.HalfOpen && _admissionGeneration == probeGeneration)
             {
                 _probeInFlight = false;
             }
@@ -622,8 +667,11 @@ internal sealed class CircuitBreakerCore
         lock (_gate)
         {
             CancelPendingOpening();
+            _admissionGeneration++;
             ResetMetrics();
             _probeInFlight = false;
+            _lastException = null;
+            _openTimeProvider = null;
             return _state == CircuitState.Closed
                 ? null
                 : ChangeState(CircuitState.Closed, KevlarContext.CreateManual());
@@ -729,6 +777,13 @@ internal sealed class CircuitBreakerCore
         return _latestTimestamp;
     }
 
+    private CircuitState GetReportedState(TimeProvider? timeProvider) =>
+        _state == CircuitState.Open
+        && timeProvider is not null
+        && GetCurrentTimestamp(timeProvider) >= _openUntilTimestamp
+            ? CircuitState.HalfOpen
+            : _state;
+
     private static TimeSpan GetElapsedTime(double timestampUnits)
     {
         var ticks = Math.Max(0, timestampUnits) * SecondsPerSystemTimestamp * TimeSpan.TicksPerSecond;
@@ -764,6 +819,15 @@ internal sealed class CircuitBreakerCore
             _lastException,
             context);
         _state = next;
+        if (next is CircuitState.Open or CircuitState.Isolated)
+        {
+            _admissionGeneration++;
+        }
+        else if (next == CircuitState.Closed)
+        {
+            _lastException = null;
+            _openTimeProvider = null;
+        }
         var publication = new TransitionPublication(transition);
         _pendingTransitions.Enqueue(publication);
         if (!_isPublishing)

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -75,7 +75,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
                 context.TimeProvider,
                 context,
                 out var rejection,
-                out var admittedProbeGeneration))
+                out var admissionGeneration))
         {
             if (recordState)
             {
@@ -94,7 +94,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
             }
             catch
             {
-                _core.AbandonProbe(admittedProbeGeneration);
+                _core.AbandonProbe(admissionGeneration);
                 throw;
             }
         }
@@ -102,41 +102,45 @@ internal sealed class CircuitBreakerStrategy : Strategy
         var execution = next.InvokeAsync(context);
         // Stryker disable once all: Route selection is performance-only; both branches call Complete.
         return execution.IsCompletedSuccessfully
-            ? new ValueTask<Outcome<T>>(Complete(execution.Result, context, admittedProbeGeneration, alias, recordState))
-            : AwaitOutcomeAsync(execution, context, admittedProbeGeneration, alias, recordState);
+            ? new ValueTask<Outcome<T>>(Complete(execution.Result, context, admissionGeneration, alias, recordState))
+            : AwaitOutcomeAsync(execution, context, admissionGeneration, alias, recordState);
     }
 
     private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,
-        long admittedProbeGeneration,
+        long admissionGeneration,
         StrategyMetricAlias alias,
         bool recordState)
     {
         // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
         var outcome = await execution.ConfigureAwait(false);
-        return Complete(outcome, context, admittedProbeGeneration, alias, recordState);
+        return Complete(outcome, context, admissionGeneration, alias, recordState);
     }
 
     private Outcome<T> Complete<T>(
         Outcome<T> outcome,
         KevlarContext context,
-        long admittedProbeGeneration,
+        long admissionGeneration,
         StrategyMetricAlias alias,
         bool recordState)
     {
         if (_judge.ShouldHandle(in outcome, context, attempt: 0, alias.StrategyIndex))
         {
-            _core.RecordFailure(context.TimeProvider, outcome.Exception, context);
+            _core.RecordFailure(
+                context.TimeProvider,
+                outcome.Exception,
+                context,
+                admissionGeneration);
         }
         else if (outcome.Exception is null)
         {
-            _core.RecordSuccess(context.TimeProvider, context);
+            _core.RecordSuccess(context.TimeProvider, context, admissionGeneration);
         }
         else
         {
             // An unhandled exception says nothing about downstream health; don't move the circuit.
-            _core.AbandonProbe(admittedProbeGeneration);
+            _core.AbandonProbe(admissionGeneration);
         }
 
         if (recordState)
@@ -288,18 +292,18 @@ internal sealed class CircuitBreakerStrategy : Strategy
             }
             catch
             {
-                _core.AbandonProbe(entry.AdmittedProbeGeneration);
+                _core.AbandonProbe(entry.AdmissionGeneration);
                 throw;
             }
         }
 
         var execution = next.InvokeAsync(context);
         return execution.IsCompletedSuccessfully
-            ? CompleteConfigured(execution.Result, context, entry.AdmittedProbeGeneration, alias, recordState)
+            ? CompleteConfigured(execution.Result, context, entry.AdmissionGeneration, alias, recordState)
             : AwaitConfiguredOutcomeAsync(
                 execution,
                 context,
-                entry.AdmittedProbeGeneration,
+                entry.AdmissionGeneration,
                 alias,
                 recordState);
     }
@@ -307,7 +311,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
     private async ValueTask<Outcome<T>> AwaitConfiguredOutcomeAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,
-        long admittedProbeGeneration,
+        long admissionGeneration,
         StrategyMetricAlias alias,
         bool recordState)
     {
@@ -315,7 +319,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
         return await CompleteConfigured(
             outcome,
             context,
-            admittedProbeGeneration,
+            admissionGeneration,
             alias,
             recordState).ConfigureAwait(false);
     }
@@ -323,22 +327,29 @@ internal sealed class CircuitBreakerStrategy : Strategy
     private ValueTask<Outcome<T>> CompleteConfigured<T>(
         Outcome<T> outcome,
         KevlarContext context,
-        long admittedProbeGeneration,
+        long admissionGeneration,
         StrategyMetricAlias alias,
         bool recordState)
     {
         ValueTask recording;
         if (_judge.ShouldHandle(in outcome, context, attempt: 0, alias.StrategyIndex))
         {
-            recording = _core.RecordFailureAsync(context.TimeProvider, in outcome, context);
+            recording = _core.RecordFailureAsync(
+                context.TimeProvider,
+                in outcome,
+                context,
+                admissionGeneration);
         }
         else if (outcome.Exception is null)
         {
-            recording = _core.RecordSuccessAsync(context.TimeProvider, context);
+            recording = _core.RecordSuccessAsync(
+                context.TimeProvider,
+                context,
+                admissionGeneration);
         }
         else
         {
-            _core.AbandonProbe(admittedProbeGeneration);
+            _core.AbandonProbe(admissionGeneration);
             recording = default;
         }
 

--- a/tests/Kevlar.Testing.Tests/StateProbeTests.cs
+++ b/tests/Kevlar.Testing.Tests/StateProbeTests.cs
@@ -6,6 +6,30 @@ namespace Kevlar.Testing.Tests;
 public class StateProbeTests
 {
     [Test]
+    public async Task Circuit_Snapshot_Reports_Time_Derived_HalfOpen_State()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield
+            .CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.BreakDuration = TimeSpan.FromSeconds(30);
+                options.Monitor = monitor;
+            })
+            .WithTimeProvider(timeProvider);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+
+        var snapshot = shield.GetStateSnapshot().Strategies
+            .OfType<CircuitBreakerStateSnapshot>()
+            .Single();
+        await Assert.That(snapshot.State).IsEqualTo(CircuitState.HalfOpen);
+        await Assert.That(snapshot.State).IsEqualTo(monitor.State);
+    }
+
+    [Test]
     public async Task StateSnapshot_Reports_Circuit_And_Limiter_State()
     {
         var timeProvider = new FakeTimeProvider();

--- a/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
@@ -1,0 +1,264 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Kevlar.Tests;
+
+public class CircuitBreakerStateReportingTests
+{
+    [Test]
+    public async Task State_Reports_HalfOpen_After_Break_Elapses_Without_A_Call()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var transitions = new List<(CircuitState From, CircuitState To)>();
+        var shield = CreateBreaker(timeProvider, monitor, change =>
+            transitions.Add((change.From, change.To)));
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+        await Assert.That(transitions).IsEquivalentTo(
+        [
+            (CircuitState.Closed, CircuitState.Open),
+        ]);
+
+        await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(transitions).IsEquivalentTo(
+        [
+            (CircuitState.Closed, CircuitState.Open),
+            (CircuitState.Open, CircuitState.HalfOpen),
+            (CircuitState.HalfOpen, CircuitState.Closed),
+        ]);
+    }
+
+    [Test]
+    public async Task Sync_State_Reports_HalfOpen_After_Break_Elapses()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = CreateBreaker(timeProvider, monitor);
+
+        await Assert.That(() => shield.Execute<int>(_ => throw new InvalidOperationException()))
+            .Throws<InvalidOperationException>();
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+        await Assert.That(shield.Execute(_ => 42)).IsEqualTo(42);
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Isolated_State_Is_Never_Time_Based()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        _ = CreateBreaker(timeProvider, monitor);
+
+        monitor.Isolate();
+        timeProvider.Advance(TimeSpan.FromDays(365));
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Isolated);
+    }
+
+    [Test]
+    public async Task Stale_Success_Does_Not_Close_HalfOpen()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = CreateBreaker(timeProvider, monitor);
+        var staleStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStale = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var probeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var stale = shield.ExecuteAsync<int>(async _ =>
+        {
+            staleStarted.SetResult();
+            await releaseStale.Task;
+            return 1;
+        }).AsTask();
+        await staleStarted.Task;
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("open"));
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+        var probe = shield.ExecuteAsync<int>(async _ =>
+        {
+            probeStarted.SetResult();
+            await releaseProbe.Task;
+            return 2;
+        }).AsTask();
+        await probeStarted.Task;
+
+        releaseStale.SetResult();
+        await stale;
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+
+        releaseProbe.SetResult();
+        await probe;
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Stale_Failure_Does_Not_Reopen_HalfOpen()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var transitions = new List<(CircuitState From, CircuitState To)>();
+        var shield = CreateBreaker(timeProvider, monitor, change =>
+            transitions.Add((change.From, change.To)));
+        var staleStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStale = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var probeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var stale = shield.ExecuteOutcomeAsync<int>(async _ =>
+        {
+            staleStarted.SetResult();
+            await releaseStale.Task;
+            throw new InvalidOperationException("stale");
+        }).AsTask();
+        await staleStarted.Task;
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("open"));
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+        var probe = shield.ExecuteAsync<int>(async _ =>
+        {
+            probeStarted.SetResult();
+            await releaseProbe.Task;
+            return 2;
+        }).AsTask();
+        await probeStarted.Task;
+
+        releaseStale.SetResult();
+        await stale;
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+        await Assert.That(transitions).DoesNotContain(
+            (CircuitState.HalfOpen, CircuitState.Open));
+
+        releaseProbe.SetResult();
+        await probe;
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Probe_Generation_Changes_Across_Reopens()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = CreateBreaker(timeProvider, monitor);
+        var firstProbeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondProbeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondProbe = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("first open"));
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+        var firstProbe = shield.ExecuteAsync<int>(async _ =>
+        {
+            firstProbeStarted.SetResult();
+            await releaseFirstProbe.Task;
+            return 1;
+        }).AsTask();
+        await firstProbeStarted.Task;
+
+        monitor.Reset();
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("second open"));
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+        var secondProbe = shield.ExecuteAsync<int>(async _ =>
+        {
+            secondProbeStarted.SetResult();
+            await releaseSecondProbe.Task;
+            return 2;
+        }).AsTask();
+        await secondProbeStarted.Task;
+
+        releaseFirstProbe.SetResult();
+        await firstProbe;
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+
+        releaseSecondProbe.SetResult();
+        await secondProbe;
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+    }
+
+    [Test]
+    public async Task Closed_Circuit_Does_Not_Retain_The_Previous_Exception()
+    {
+        var (shield, weakException) = await OpenAndCloseCircuit();
+
+        CollectGarbage();
+        await Assert.That(weakException.IsAlive).IsFalse();
+
+        var current = new ApplicationException("current");
+        await shield.ExecuteOutcomeAsync<int>(_ => throw current);
+        var rejection = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+
+        await Assert.That(ReferenceEquals(rejection.Exception!.InnerException, current)).IsTrue();
+    }
+
+    [Test]
+    public async Task RetryAfter_Tracks_The_Remaining_Break_Duration()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = CreateBreaker(timeProvider, monitor);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+
+        var initial = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+        await Assert.That(((CircuitOpenException)initial.Exception!).RetryAfter)
+            .IsEqualTo(TimeSpan.FromSeconds(30));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(12));
+        var later = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
+        await Assert.That(((CircuitOpenException)later.Exception!).RetryAfter)
+            .IsEqualTo(TimeSpan.FromSeconds(18));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(18));
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.HalfOpen);
+    }
+
+    private static Shield CreateBreaker(
+        TimeProvider timeProvider,
+        CircuitBreakerMonitor monitor,
+        Action<CircuitBreakerStateChangedEvent>? onStateChanged = null) => Shield
+        .CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromSeconds(30);
+            options.Monitor = monitor;
+            options.OnStateChanged = onStateChanged;
+        })
+        .WithTimeProvider(timeProvider);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<(Shield Shield, WeakReference Exception)>
+        OpenAndCloseCircuit()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var shield = CreateBreaker(timeProvider, monitor);
+        var previous = new InvalidOperationException("previous");
+        var weakException = new WeakReference(previous);
+
+        await shield.ExecuteOutcomeAsync<int>(_ => throw previous);
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
+        await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        return (shield, weakException);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void CollectGarbage()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+}

--- a/tests/Kevlar.Tests/StrategyModelTests.cs
+++ b/tests/Kevlar.Tests/StrategyModelTests.cs
@@ -166,6 +166,11 @@ public class StrategyModelTests
                 case CircuitCommandKind.Advance:
                     timeProvider.Advance(TimeSpan.FromSeconds(command.Amount));
                     elapsedSeconds += command.Amount;
+                    if (state == CircuitState.Open && elapsedSeconds >= openUntil)
+                    {
+                        state = CircuitState.HalfOpen;
+                    }
+
                     break;
 
                 case CircuitCommandKind.MoveUtcBackward:


### PR DESCRIPTION
Closes #227.

Reports time-derived HalfOpen state through monitors and Kevlar.Testing snapshots while keeping admission transitions lazy. Admission generations now prevent stale successes or failures from mutating newer circuit cycles, and opening exceptions are released on close/reset.

Validation:
- dotnet build Kevlar.slnx -c Release
- Kevlar.Tests: net8.0 988 passed; net10.0 1013 passed
- Kevlar.Testing.Tests: net8.0 54 passed; net10.0 56 passed
- Kevlar.AllocationTests: 4 passed on each TFM
- Verify-DocSnippets.ps1: 169 snippets compiled and executed in both modes
- docs npm run build