### PR TITLE
feat(analyzers): diagnose pooled context hazards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,6 @@ body:
       label: Package
       options:
         - Kevlar
-        - Kevlar.Analyzers
         - Kevlar.Chaos
         - Kevlar.Extensions.DependencyInjection
         - Kevlar.Extensions.Grpc

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,6 @@ body:
       label: Package
       options:
         - Kevlar
-        - Kevlar.Analyzers
         - Kevlar.Chaos
         - Kevlar.Extensions.DependencyInjection
         - Kevlar.Extensions.Grpc

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -9,7 +9,6 @@ body:
       label: Package
       options:
         - Kevlar
-        - Kevlar.Analyzers
         - Kevlar.Chaos
         - Kevlar.Extensions.DependencyInjection
         - Kevlar.Extensions.Grpc

--- a/.github/scripts/benchmark_docs.py
+++ b/.github/scripts/benchmark_docs.py
@@ -210,7 +210,7 @@ def build_page(classes, host_info, history, window, commit):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     lines = [
         "---",
-        "sidebar_position: 17",
+        "sidebar_position: 18",
         "sidebar_label: Benchmarks",
         "---",
         "",

--- a/.github/scripts/stress_docs.py
+++ b/.github/scripts/stress_docs.py
@@ -55,7 +55,7 @@ def build_page(data, commit):
 
     lines = [
         "---",
-        "sidebar_position: 18",
+        "sidebar_position: 19",
         "sidebar_label: Stress Tests",
         "---",
         "",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,8 +414,8 @@ jobs:
         run: |
           $packageIds = @(Get-ChildItem packages -Filter *.nupkg | ForEach-Object { $_.BaseName -replace '\.[0-9].*$', '' } | Sort-Object)
           $symbolPackageIds = @(Get-ChildItem packages -Filter *.snupkg | ForEach-Object { $_.BaseName -replace '\.[0-9].*$', '' } | Sort-Object)
-          if ($packageIds.Count -ne 8 -or ($packageIds -join ',') -ne ($symbolPackageIds -join ',')) {
-            throw "Expected 8 matching nupkg/snupkg artifacts; got nupkg=[$($packageIds -join ', ')], snupkg=[$($symbolPackageIds -join ', ')]."
+          if ($packageIds.Count -ne 7 -or ($packageIds -join ',') -ne ($symbolPackageIds -join ',')) {
+            throw "Expected 7 matching nupkg/snupkg artifacts; got nupkg=[$($packageIds -join ', ')], snupkg=[$($symbolPackageIds -join ', ')]."
           }
 
       - name: Extract release notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- The `Kevlar` package now includes its Roslyn analyzers and code fixes automatically. `KEV013`
+  detects asynchronous work assigned to synchronous strategy callbacks, and `KEV014` detects
+  pooled event contexts captured by deferred work.
 - `Kevlar.Extensions.Logging` emits stable, structured `ILogger` events for retry, timeout,
   circuit-state, hedge, fallback, rejection, and callback-error activity. `WithLogging` decorates
   individual shields, while `AddKevlarLogging` applies to named, reloading, partitioned, and HTTP

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,7 @@
 
     <!-- Analyzers -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
 
     <!-- Tests -->

--- a/Kevlar.slnx
+++ b/Kevlar.slnx
@@ -12,6 +12,7 @@
     <Project Path="src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj" />
     <Project Path="src/Kevlar/Kevlar.csproj" />
     <Project Path="src/Kevlar.Analyzers/Kevlar.Analyzers.csproj" />
+    <Project Path="src/Kevlar.Analyzers.CodeFixes/Kevlar.Analyzers.CodeFixes.csproj" />
     <Project Path="src/Kevlar.Testing/Kevlar.Testing.csproj" />
   </Folder>
   <Folder Name="/tests/">

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ stateful strategies: calls made through the same shield share its circuit breake
   [BenchmarkDotNet results](https://thomhurst.github.io/Kevlar/docs/benchmarks).
 - **Production concerns are built in.** Shields support `TimeProvider`, describe their own pipeline,
   publish metrics through the `Kevlar` meter, and can emit structured `ILogger` events through
-  `Kevlar.Extensions.Logging`. An optional analyzer catches cancellation and pipeline mistakes at
+  `Kevlar.Extensions.Logging`. Built-in analyzers catch cancellation and pipeline mistakes at
   compile time.
 
 The core package targets `netstandard2.0`, `net8.0`, and `net10.0`.
@@ -154,14 +154,13 @@ configuration-bound shields and `IKevlarRegistry`.
 
 | Package | What it adds |
 |---|---|
-| [`Kevlar`](https://www.nuget.org/packages/Kevlar) | Core strategies and the Shield API |
+| [`Kevlar`](https://www.nuget.org/packages/Kevlar) | Core strategies, Shield API, analyzers, and code fixes |
 | [`Kevlar.Chaos`](https://www.nuget.org/packages/Kevlar.Chaos) | Controlled latency, faults, outcomes and custom behaviour |
 | [`Kevlar.Extensions.DependencyInjection`](https://www.nuget.org/packages/Kevlar.Extensions.DependencyInjection) | Named and configuration-bound shields for Microsoft DI |
 | [`Kevlar.Extensions.Http`](https://www.nuget.org/packages/Kevlar.Extensions.Http) | `HttpClientFactory` integration, request replay and transient-fault handling |
 | [`Kevlar.Extensions.Logging`](https://www.nuget.org/packages/Kevlar.Extensions.Logging) | Structured `ILogger` events for every built-in strategy |
 | [`Kevlar.Extensions.Grpc`](https://www.nuget.org/packages/Kevlar.Extensions.Grpc) | gRPC client resilience for unary and streaming calls |
 | [`Kevlar.Extensions.RateLimiting`](https://www.nuget.org/packages/Kevlar.Extensions.RateLimiting) | Adapters for `System.Threading.RateLimiting` and custom leases |
-| [`Kevlar.Analyzers`](https://www.nuget.org/packages/Kevlar.Analyzers) | Compile-time checks for common resilience mistakes |
 | [`Kevlar.Testing`](https://www.nuget.org/packages/Kevlar.Testing) | Pipeline assertions, state snapshots and deterministic time helpers |
 
 ## Where next?

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -4,11 +4,8 @@ sidebar_position: 13
 
 # Analyzers
 
-Install the optional analyzer package in each project that builds Kevlar pipelines:
-
-```bash
-dotnet add package Kevlar.Analyzers
-```
+The `Kevlar` package includes these analyzers automatically. No separate analyzer package is
+required.
 
 The analyzers report only hazards that are provable from the current expression or a stable local
 initializer. They do not guess what a factory method returns or follow a local that is reassigned.
@@ -28,6 +25,8 @@ Generated code is ignored.
 | `KEV010` | Info | default-result clause is written for a value type, whose default is usually valid |
 | `KEV011` | Info | reactive strategy relies on implicit default handling, which includes programming errors |
 | `KEV012` | Warning | asynchronous strategy configuration is passed to synchronous `Execute` |
+| `KEV013` | Warning | asynchronous work is assigned to a synchronous strategy callback |
+| `KEV014` | Warning | a pooled event context is captured by deferred work |
 
 ## KEV001: ignored execution cancellation
 
@@ -378,6 +377,55 @@ factories, so a custom extension that merely inspects genuine Kevlar options rem
 The analyzer does not guess through fields, parameters, local delegates, or opaque factories; the
 runtime check still protects those cases. `ExecuteAsync` and configurations containing only
 synchronous callbacks remain clean.
+
+## KEV013: asynchronous work in a synchronous callback
+
+Synchronous callback properties such as `OnRetry` accept `Action<TEvent>`. An `async` lambda
+assigned there becomes `async void`: the strategy cannot await it, callback failures escape the
+pipeline, and its pooled event context may expire while the lambda is suspended.
+
+```csharp
+static ValueTask WriteAuditAsync(int retryNumber) => ValueTask.CompletedTask;
+
+#pragma warning disable KEV013 // Deliberately demonstrates the unsafe form.
+var shield = Shield.Retry(options =>
+{
+    options.OnRetry = async item => await WriteAuditAsync(item.RetryNumber);
+    //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ KEV013
+});
+#pragma warning restore KEV013
+```
+
+Use the matching asynchronous property so Kevlar awaits the work and keeps the event context valid:
+
+```csharp
+static ValueTask WriteAuditAsync(int retryNumber) => ValueTask.CompletedTask;
+
+var shield = Shield.Retry(options =>
+{
+    options.OnRetryAsync = async item => await WriteAuditAsync(item.RetryNumber);
+});
+```
+
+`KEV013` also reports expression lambdas that discard a `Task` or `ValueTask`. Synchronous lambdas
+and delegates assigned to `OnRetryAsync`, `OnTimeoutAsync`, and the other `…Async` hooks are valid.
+For async lambdas whose callback has an `…Async` twin, the code fix changes the assigned property.
+
+## KEV014: deferred event-context capture
+
+Scheduling work from a callback can outlive the pooled event context. Copy required values first:
+
+```csharp
+var shield = Shield.Retry(options => options.OnRetry = item =>
+{
+    var shieldName = item.Context.ShieldName;
+    _ = Task.Run(() => Console.WriteLine(shieldName));
+});
+```
+
+`KEV014` reports `Task.Run` and `ThreadPool.QueueUserWorkItem` calls that capture an event's
+`Context` or `Properties`. Deferred access can race with context pooling and observe state from a
+later execution, so this diagnostic is a warning.
 
 ## Suppression
 

--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 sidebar_label: Benchmarks
 ---
 

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -109,7 +109,7 @@ var shield = Shield
     // ↑ the breaker counts HttpRequestException failures only
 ```
 
-Proactive strategies — timeout, rate limit, concurrency limit — never consult a clause, but they do not end it either: the clause stays ambient for the next reactive strategy. A clause that reaches no reactive strategy at all is dead, and the optional analyzer reports it as [`KEV007`](analyzers.md#kev007-dead-handling-clause).
+Proactive strategies — timeout, rate limit, concurrency limit — never consult a clause, but they do not end it either: the clause stays ambient for the next reactive strategy. A clause that reaches no reactive strategy at all is dead, and the built-in analyzer reports it as [`KEV007`](analyzers.md#kev007-dead-handling-clause).
 
 Writing a new clause mid-chain replaces the previous one from that point on:
 

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -21,7 +21,7 @@ these outcomes propagate without retrying, opening a circuit, hedging, or fallin
 
 Other exceptions—including programming errors such as `NullReferenceException`, and
 `TimeoutExceededException`—remain handled by default for compatibility. Narrow expected failures
-with a clause in production pipelines. The optional analyzer reports implicit default handling as
+with a clause in production pipelines. The built-in analyzer reports implicit default handling as
 [`KEV011`](analyzers.md#kev011-implicit-default-handling).
 
 An explicit clause can opt into an excluded exception when recovery is intentional:
@@ -78,7 +78,7 @@ Shield
 This is why most chains only need one clause, written once at the top—and why you never repeat a
 `ShouldHandle` predicate per strategy like in Polly v8.
 
-A clause that never reaches a reactive strategy does nothing at all. The optional analyzer reports
+A clause that never reaches a reactive strategy does nothing at all. The built-in analyzer reports
 that as [`KEV007`](analyzers.md#kev007-dead-handling-clause). It also marks strategies that
 *inherit* a clause as the informational hint
 [`KEV009`](analyzers.md#kev009-inherited-handling-clause), so the span above is visible in the
@@ -148,7 +148,7 @@ say what they match and cannot be written where they would surprise you.
 
 For a value type or for generic code, `WhenResultIsDefault` / `OrResultIsDefault` match
 `default(T)` instead — and there the check needs a second thought, because `0`, `false`, and an
-empty struct are usually legitimate results rather than failures. The optional analyzer raises that
+empty struct are usually legitimate results rather than failures. The built-in analyzer raises that
 question as the informational hint [`KEV010`](analyzers.md#kev010-default-result-clause-on-a-value-type):
 
 ```csharp

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -28,7 +28,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 - **Intuitive first.** `Shield.When<TimeoutExceededException>().Retry(3)` reads like what it does. No context pooling ceremony, no predicate-builder classes, no options objects for the simple cases — and full options objects when you want them.
 - **Fast.** Outcomes flow between pipeline layers as structs instead of thrown exceptions; contexts are pooled internally; state-passing overloads eliminate closures; `ValueTask` end to end.
 - **Production defaults.** `Shield.Retry(3)` gives you exponential backoff *with equal jitter* capped at 30s — the thing you'd have configured anyway.
-- **Hard to hold wrong.** `Task` and `ValueTask` delegates both flow straight in; impossible chain orders throw at build time with a fix in the message; the `Kevlar.Analyzers` package flags cancellation and pipeline hazards at compile time.
+- **Hard to hold wrong.** `Task` and `ValueTask` delegates both flow straight in; impossible chain orders throw at build time with a fix in the message; built-in analyzers flag cancellation and pipeline hazards at compile time.
 - **Observable out of the box.** Every shield describes itself (`shield.ToString()` prints the whole pipeline) and publishes metrics through a built-in `Meter` — no telemetry package, no setup.
 - **Composable.** Shields merge with `Wrap` and `Compose`, chain fluently, and stateful strategies (breakers, limiters) intentionally share their state wherever the same shield instance is reused.
 - **Broad reach.** `netstandard2.0` (covers .NET Framework 4.6.2+) and `net10.0` targets.
@@ -36,7 +36,7 @@ Build a shield once, reuse it everywhere. Shields are **immutable and thread-saf
 ## Packages
 
 The README maintains the canonical [package table](https://github.com/thomhurst/Kevlar#packages),
-including optional gRPC, testing, analyzer, and integration packages.
+including optional gRPC, testing, and integration packages.
 
 ## Where to next?
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -6,8 +6,8 @@ sidebar_position: 15
 
 Shields describe their configured pipeline, publish metrics through built-in `Meter` instances,
 and expose strategy events for request-level telemetry. Use
-[`Kevlar.Extensions.Logging`](logging.md) for structured `ILogger` events. The optional analyzer
-package catches resilience mistakes at compile time.
+[`Kevlar.Extensions.Logging`](logging.md) for structured `ILogger` events. Built-in analyzers catch
+resilience mistakes at compile time.
 
 ## Pipeline descriptions
 
@@ -186,11 +186,7 @@ Telemetry cost depends on the runtime, pipeline, listener, exporter, and deploym
 
 ## Compile-time checks
 
-Install `Kevlar.Analyzers` to catch resilience mistakes during compilation:
-
-```bash
-dotnet add package Kevlar.Analyzers
-```
+The `Kevlar` package includes compile-time checks for resilience mistakes automatically.
 
 See [Analyzer rules](analyzers.md) for the complete current rule set, rationale, safe alternatives, conservative analysis limits, and suppression guidance.
 

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 sidebar_label: Stress Tests
 ---
 

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -19,7 +19,6 @@ target frameworks are also compatibility concerns even when a signature does not
 | Package | Target frameworks |
 |---|---|
 | `Kevlar` | `netstandard2.0`, `net8.0`, `net10.0` |
-| `Kevlar.Analyzers` | `netstandard2.0` |
 | `Kevlar.Chaos` | `netstandard2.0`, `net8.0`, `net10.0` |
 | `Kevlar.Extensions.DependencyInjection` | `netstandard2.0`, `net8.0`, `net10.0` |
 | `Kevlar.Extensions.Grpc` | `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0` |

--- a/scripts/Assert-PrGreen.ps1
+++ b/scripts/Assert-PrGreen.ps1
@@ -126,18 +126,28 @@ else {
     $owner, $name = $nwo.Trim() -split '/', 2
 }
 
-$query = 'query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}'
-$threadsRaw = gh api graphql -f query=$query -F owner=$owner -F repo=$name -F pr=$Pr 2>$null
-if ($LASTEXITCODE -ne 0) { Deny "could not fetch review threads (exit $LASTEXITCODE)" }
-try {
-    $reviewThreads = ($threadsRaw | ConvertFrom-Json).data.repository.pullRequest.reviewThreads
-}
-catch {
-    Deny "could not parse review threads: $($_.Exception.Message)"
-}
-# More than one page means we cannot see every thread; deny rather than pass blind.
-if ($reviewThreads.pageInfo.hasNextPage) { Deny "more than 100 review threads -- too many to inspect safely" }
-$unresolved = @($reviewThreads.nodes | Where-Object { -not $_.isResolved }).Count
+$query = 'query($owner:String!,$repo:String!,$pr:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}'
+$after = $null
+$unresolved = 0
+do {
+    $cursorArgs = if ($after) { @('-f', "after=$after") } else { @() }
+    $threadsRaw = gh api graphql -f query=$query -F owner=$owner -F repo=$name -F pr=$Pr @cursorArgs 2>$null
+    if ($LASTEXITCODE -ne 0) { Deny "could not fetch review threads (exit $LASTEXITCODE)" }
+    try {
+        $reviewThreads = ($threadsRaw | ConvertFrom-Json).data.repository.pullRequest.reviewThreads
+    }
+    catch {
+        Deny "could not parse review threads: $($_.Exception.Message)"
+    }
+    if ($null -eq $reviewThreads) { Deny "review-thread response was empty" }
+
+    $unresolved += @($reviewThreads.nodes | Where-Object { -not $_.isResolved }).Count
+    $after = $reviewThreads.pageInfo.endCursor
+    if ($reviewThreads.pageInfo.hasNextPage -and -not $after) {
+        Deny "review-thread response omitted the next-page cursor"
+    }
+} while ($reviewThreads.pageInfo.hasNextPage)
+
 if ($unresolved -gt 0) { Deny "$unresolved unresolved review thread(s)" }
 
 Write-Host "OK #${Pr} -- MERGEABLE, CLEAN, $($checks.Count) check(s) green, no unresolved threads. Safe to merge."

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -28,7 +28,6 @@ $documentPaths = @(
 
 $requiredPackages = @(
     'Kevlar'
-    'Kevlar.Analyzers'
     'Kevlar.Chaos'
     'Kevlar.Extensions.DependencyInjection'
     'Kevlar.Extensions.Grpc'

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -433,8 +433,23 @@ foreach ($packageId in $expectedDependencies.Keys)
 
             foreach ($dependency in $dependencies)
             {
-                Assert-Set "$packageId $framework $($dependency.GetAttribute('id')) excluded assets" ($dependency.GetAttribute('exclude') -split ',') @('Build', 'Analyzers')
                 $dependencyId = $dependency.GetAttribute('id')
+                $expectedExcludedAssets = if ($dependencyId -eq 'Kevlar' -and $packageId -ne 'Kevlar')
+                {
+                    @()
+                }
+                else
+                {
+                    @('Build', 'Analyzers')
+                }
+                Assert-Set "$packageId $framework $dependencyId excluded assets" ($dependency.GetAttribute('exclude') -split ',') $expectedExcludedAssets
+                if ($dependencyId -eq 'Kevlar' -and $packageId -ne 'Kevlar')
+                {
+                    Assert-Set `
+                        "$packageId $framework Kevlar included assets" `
+                        ($dependency.GetAttribute('include') -split ',') `
+                        @('Runtime', 'Compile', 'Native', 'ContentFiles', 'Analyzers', 'BuildTransitive')
+                }
                 if ($dependencyId -eq 'Kevlar' -and
                     $packageId -in @('Kevlar.Testing', 'Kevlar.Extensions.RateLimiting'))
                 {
@@ -918,7 +933,7 @@ sealed class ExpectedConsumerException : Exception;
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Kevlar" Version="$Version" />
+    <PackageReference Include="Kevlar.Extensions.Http" Version="$Version" />
   </ItemGroup>
 </Project>
 "@
@@ -942,7 +957,7 @@ await Shield.Empty.ExecuteAsync(cancellationToken => ValueTask.CompletedTask);
     )
     if ($analyzerExitCode -eq 0)
     {
-        throw "Kevlar package did not fail the consumer build with KEV001.`n$analyzerOutput"
+        throw "Kevlar.Extensions.Http did not transitively run KEV001.`n$analyzerOutput"
     }
 
     Assert-Set 'analyzer consumer error codes' $analyzerErrorCodes @('KEV001')

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -93,22 +93,22 @@ function Invoke-DotNet([string[]]$Arguments)
 
 function Get-ExpectedSymbolAssets([string]$PackageId)
 {
-    if ($PackageId -eq 'Kevlar.Analyzers')
-    {
-        return @('analyzers/dotnet/cs/Kevlar.Analyzers.pdb')
-    }
-
     $frameworks = @('net10.0', 'net8.0', 'netstandard2.0')
     if ($PackageId -eq 'Kevlar.Extensions.Grpc')
     {
         $frameworks += 'netstandard2.1'
     }
-    elseif ($PackageId -eq 'Kevlar.Extensions.Grpc')
+
+    $assets = @($frameworks | ForEach-Object { "lib/$_/$PackageId.pdb" })
+    if ($PackageId -eq 'Kevlar')
     {
-        $frameworks += 'netstandard2.1'
+        $assets += @(
+            'analyzers/dotnet/cs/Kevlar.Analyzers.CodeFixes.pdb',
+            'analyzers/dotnet/cs/Kevlar.Analyzers.pdb'
+        )
     }
 
-    return @($frameworks | ForEach-Object { "lib/$_/$PackageId.pdb" })
+    return $assets
 }
 
 function Assert-DeterministicAssembly(
@@ -323,9 +323,6 @@ $expectedDependencies = @{
         '.NETStandard2.1' = @('Grpc.Core.Api', 'Grpc.Net.ClientFactory', 'Kevlar', 'Kevlar.Extensions.DependencyInjection')
         '.NETStandard2.0' = @('Grpc.Core.Api', 'Grpc.Net.ClientFactory', 'Kevlar', 'Kevlar.Extensions.DependencyInjection')
     }
-    'Kevlar.Analyzers' = @{
-        '.NETStandard2.0' = @()
-    }
 }
 
 $expectedDependencyVersions = @{}
@@ -456,7 +453,11 @@ foreach ($packageId in $expectedDependencies.Keys)
             }
         }
 
-        $privateDependencies = @('Polyfill', 'Microsoft.CodeAnalysis.CSharp', 'Microsoft.CodeAnalysis.PublicApiAnalyzers')
+        $privateDependencies = @(
+            'Polyfill',
+            'Microsoft.CodeAnalysis.CSharp',
+            'Microsoft.CodeAnalysis.CSharp.Workspaces',
+            'Microsoft.CodeAnalysis.PublicApiAnalyzers')
         $allDependencyIds = @($groups | ForEach-Object { $_.SelectNodes("*[local-name()='dependency']") } | ForEach-Object { $_.GetAttribute('id') })
         foreach ($privateDependency in $privateDependencies)
         {
@@ -466,44 +467,42 @@ foreach ($packageId in $expectedDependencies.Keys)
             }
         }
 
-        if ($packageId -eq 'Kevlar.Analyzers')
+        $expectedAssets = @(
+            "lib/net10.0/$packageId.dll",
+            "lib/net10.0/$packageId.xml",
+            "lib/net8.0/$packageId.dll",
+            "lib/net8.0/$packageId.xml",
+            "lib/netstandard2.0/$packageId.dll",
+            "lib/netstandard2.0/$packageId.xml"
+        )
+        if ($packageId -eq 'Kevlar.Extensions.Grpc')
         {
-            Assert-Equal `
-                "$packageId development dependency" `
-                (Get-NodeText $metadata "*[local-name()='developmentDependency']") `
-                'true'
-            $assemblyEntries = @($entries | Where-Object { $_ -like '*.dll' })
-            Assert-Set "$packageId assemblies" $assemblyEntries @('analyzers/dotnet/cs/Kevlar.Analyzers.dll')
+            $expectedAssets += @(
+                "lib/netstandard2.1/$packageId.dll",
+                "lib/netstandard2.1/$packageId.xml"
+            )
+        }
+        Assert-Set "$packageId library assets" ($entries | Where-Object { $_ -like 'lib/*' }) $expectedAssets
+
+        if ($packageId -eq 'Kevlar')
+        {
             Assert-Set "$packageId analyzer assets" `
                 ($entries | Where-Object { $_ -like 'analyzers/dotnet/cs/*' }) `
-                @('analyzers/dotnet/cs/Kevlar.Analyzers.dll', 'analyzers/dotnet/cs/Kevlar.Analyzers.pdb')
-            if ($entries | Where-Object { $_ -match '^(lib|build|buildTransitive|tools)/' })
-            {
-                throw "$packageId contains an unexpected runtime or build asset."
-            }
-        }
-        else
-        {
-            $expectedAssets = @(
-                "lib/net10.0/$packageId.dll",
-                "lib/net10.0/$packageId.xml",
-                "lib/net8.0/$packageId.dll",
-                "lib/net8.0/$packageId.xml",
-                "lib/netstandard2.0/$packageId.dll",
-                "lib/netstandard2.0/$packageId.xml"
-            )
-            if ($packageId -eq 'Kevlar.Extensions.Grpc')
-            {
-                $expectedAssets += @(
-                    "lib/netstandard2.1/$packageId.dll",
-                    "lib/netstandard2.1/$packageId.xml"
+                @(
+                    'analyzers/dotnet/cs/Kevlar.Analyzers.CodeFixes.dll',
+                    'analyzers/dotnet/cs/Kevlar.Analyzers.CodeFixes.pdb',
+                    'analyzers/dotnet/cs/Kevlar.Analyzers.dll',
+                    'analyzers/dotnet/cs/Kevlar.Analyzers.pdb'
                 )
-            }
-            Assert-Set "$packageId library assets" ($entries | Where-Object { $_ -like 'lib/*' }) $expectedAssets
-            if ($entries | Where-Object { $_ -match '^(analyzers|build|buildTransitive|tools)/' })
-            {
-                throw "$packageId contains an unexpected analyzer or build asset."
-            }
+        }
+        elseif ($entries | Where-Object { $_ -match '^analyzers/' })
+        {
+            throw "$packageId contains an unexpected analyzer asset."
+        }
+
+        if ($entries | Where-Object { $_ -match '^(build|buildTransitive|tools)/' })
+        {
+            throw "$packageId contains an unexpected build asset."
         }
 
         foreach ($assemblyEntry in $archive.Entries | Where-Object { $_.FullName -like '*.dll' })
@@ -844,7 +843,8 @@ using var limiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
     QueueLimit = 0,
     QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
 });
-if (await Shield.Empty.UseRateLimiter(limiter).ExecuteAsync(static _ => new ValueTask<int>(42)) != 42)
+var rateLimitedShield = CreateRateLimitedShield(limiter);
+if (await rateLimitedShield.ExecuteAsync(static _ => new ValueTask<int>(42)) != 42)
 {
     throw new InvalidOperationException("Rate limiting adapter execution failed.");
 }
@@ -853,6 +853,9 @@ Console.WriteLine("Kevlar package consumer passed.");
 [MethodImpl(MethodImplOptions.NoInlining)]
 static void ThrowFromKevlar() =>
     Shield.Retry(0).Execute(static _ => throw new ExpectedConsumerException());
+
+static Shield CreateRateLimitedShield(RateLimiter limiter) =>
+    Shield.Empty.UseRateLimiter(limiter);
 
 sealed class ExpectedConsumerException : Exception;
 '@
@@ -916,7 +919,6 @@ sealed class ExpectedConsumerException : Exception;
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Kevlar" Version="$Version" />
-    <PackageReference Include="Kevlar.Analyzers" Version="$Version" PrivateAssets="all" />
   </ItemGroup>
 </Project>
 "@
@@ -940,7 +942,7 @@ await Shield.Empty.ExecuteAsync(cancellationToken => ValueTask.CompletedTask);
     )
     if ($analyzerExitCode -eq 0)
     {
-        throw "Kevlar.Analyzers package did not fail the consumer build with KEV001.`n$analyzerOutput"
+        throw "Kevlar package did not fail the consumer build with KEV001.`n$analyzerOutput"
     }
 
     Assert-Set 'analyzer consumer error codes' $analyzerErrorCodes @('KEV001')
@@ -951,64 +953,6 @@ await Shield.Empty.ExecuteAsync(cancellationToken => ValueTask.CompletedTask);
     if ($unexpectedAnalyzerErrors.Count -gt 0)
     {
         throw "Analyzer consumer produced errors other than KEV001:`n$($unexpectedAnalyzerErrors -join [Environment]::NewLine)"
-    }
-
-    $analyzerFlowDirectory = Join-Path $temporaryRoot 'analyzer-flow'
-    $analyzerFlowProject = @"
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <IsPackable>true</IsPackable>
-    <PackageId>AnalyzerFlowConsumer</PackageId>
-  </PropertyGroup>
-</Project>
-"@
-    $analyzerFlowProjectPath = Join-Path $analyzerFlowDirectory 'AnalyzerFlowConsumer.csproj'
-    Write-TextFile $analyzerFlowProjectPath $analyzerFlowProject
-    Write-TextFile (Join-Path $analyzerFlowDirectory 'Library.cs') 'public sealed class Library;'
-    Invoke-DotNet @(
-        'add', $analyzerFlowProjectPath,
-        'package', 'Kevlar.Analyzers',
-        '--version', $Version,
-        '--source', $packageDirectory,
-        '--package-directory', $env:NUGET_PACKAGES)
-    $analyzerFlowPackages = Join-Path $analyzerFlowDirectory 'packages'
-    Invoke-DotNet @(
-        'pack', $analyzerFlowProjectPath,
-        '-c', 'Release',
-        '--no-restore',
-        '-p:PackageVersion=0.0.0-verification',
-        "-p:PackageOutputPath=$analyzerFlowPackages")
-
-    $analyzerFlowPackage = Join-Path $analyzerFlowPackages 'AnalyzerFlowConsumer.0.0.0-verification.nupkg'
-    $analyzerFlowArchive = [System.IO.Compression.ZipFile]::OpenRead($analyzerFlowPackage)
-    try
-    {
-        $analyzerFlowNuspecEntry = @(
-            $analyzerFlowArchive.Entries |
-                Where-Object { $_.FullName -like '*.nuspec' })
-        Assert-Equal 'analyzer-flow nuspec count' $analyzerFlowNuspecEntry.Count 1
-        $analyzerFlowReader = [System.IO.StreamReader]::new($analyzerFlowNuspecEntry[0].Open())
-        try
-        {
-            [xml]$analyzerFlowNuspec = $analyzerFlowReader.ReadToEnd()
-        }
-        finally
-        {
-            $analyzerFlowReader.Dispose()
-        }
-
-        $analyzerFlowDependencyIds = @(
-            $analyzerFlowNuspec.SelectNodes("//*[local-name()='dependency']") |
-                ForEach-Object { $_.GetAttribute('id') })
-        if ($analyzerFlowDependencyIds -contains 'Kevlar.Analyzers')
-        {
-            throw 'Kevlar.Analyzers flowed transitively from a consumer library package.'
-        }
-    }
-    finally
-    {
-        $analyzerFlowArchive.Dispose()
     }
 
     Write-Host 'All package layout, symbols, determinism, SourceLink, consumer, and analyzer checks passed.'

--- a/scripts/Verify-PublishCompatibility.ps1
+++ b/scripts/Verify-PublishCompatibility.ps1
@@ -172,10 +172,12 @@ var retryAttempts = 0;
 var retried = await Shield.Retry(1, Backoff.None).ExecuteAsync(_ =>
     ++retryAttempts == 1 ? throw new InvalidOperationException() : new ValueTask<int>(42));
 var timed = await Shield.Timeout(TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
-var broken = await Shield.CircuitBreaker(2, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
-var limited = await Shield.RateLimit(1, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
-var isolated = await Shield.ConcurrencyLimit(1).ExecuteAsync(static _ => new ValueTask<int>(42));
-var hedged = await Shield.Hedge(2, TimeSpan.FromSeconds(1)).ExecuteAsync(static _ => new ValueTask<int>(42));
+var broken = await CreateCircuitBreaker().ExecuteAsync(static _ => new ValueTask<int>(42));
+var limited = await CreateRateLimit().ExecuteAsync(static _ => new ValueTask<int>(42));
+var isolated = await CreateConcurrencyLimit().ExecuteAsync(static _ => new ValueTask<int>(42));
+var hedged = await Shield.For<int>()
+    .Hedge(maxHedgedAttempts: 2, delay: TimeSpan.FromSeconds(1))
+    .ExecuteAsync(static _ => new ValueTask<int>(42));
 var fallback = await Shield.For<int>().When<InvalidOperationException>().FallbackTo(42)
     .ExecuteAsync<int>(static _ => throw new InvalidOperationException());
 using var frameworkLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
@@ -184,7 +186,7 @@ using var frameworkLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOption
     QueueLimit = 0,
     QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
 });
-var adapted = await Shield.Empty.UseRateLimiter(frameworkLimiter)
+var adapted = await CreateRateLimitedShield(frameworkLimiter)
     .ExecuteAsync(static _ => new ValueTask<int>(42));
 if (retried + timed + broken + limited + isolated + hedged + fallback + adapted != 336)
 {
@@ -228,6 +230,18 @@ if (response.StatusCode != HttpStatusCode.OK)
 }
 
 Console.WriteLine("Kevlar publish compatibility passed.");
+
+static Shield CreateCircuitBreaker() =>
+    Shield.CircuitBreaker(consecutiveFailures: 2, breakDuration: TimeSpan.FromSeconds(1));
+
+static Shield CreateRateLimit() =>
+    Shield.RateLimit(1, perWindow: TimeSpan.FromSeconds(1));
+
+static Shield CreateConcurrencyLimit() =>
+    Shield.ConcurrencyLimit(1);
+
+static Shield CreateRateLimitedShield(RateLimiter limiter) =>
+    Shield.Empty.UseRateLimiter(limiter);
 
 file sealed class StubHandler : HttpMessageHandler
 {

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -103,7 +103,7 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
     {
         var pendingBodies = new Stack<(SyntaxNode Body, SemanticModel SemanticModel)>();
         var visitedMethods = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-        var visitedDelegateLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+        var visitedDelegates = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         pendingBodies.Push((body, semanticModel));
         while (pendingBodies.Count > 0)
         {
@@ -126,7 +126,7 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                         invocation,
                         pending.SemanticModel,
                         cancellationToken,
-                        visitedDelegateLocals,
+                        visitedDelegates,
                         out var delegateBody))
                 {
                     pendingBodies.Push((delegateBody, pending.SemanticModel));
@@ -140,7 +140,7 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                                 expression,
                                 pending.SemanticModel,
                                 cancellationToken,
-                                visitedDelegateLocals,
+                                visitedDelegates,
                                 out var argumentBody))
                         {
                             continue;
@@ -200,7 +200,7 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         InvocationExpressionSyntax invocation,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        HashSet<ILocalSymbol> visited,
+        HashSet<ISymbol> visited,
         out SyntaxNode body)
     {
         var invokedExpression = invocation.Expression is MemberAccessExpressionSyntax
@@ -221,7 +221,7 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         ExpressionSyntax expression,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        HashSet<ILocalSymbol> visited,
+        HashSet<ISymbol> visited,
         out SyntaxNode body)
     {
         if (UnwrapReceiver(expression) is AnonymousFunctionExpressionSyntax anonymousExpression)
@@ -230,9 +230,28 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
             return true;
         }
 
-        if (UnwrapReceiver(expression) is not IdentifierNameSyntax identifier
-            || semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
-                is not ILocalSymbol { Type.TypeKind: TypeKind.Delegate } local
+        if (UnwrapReceiver(expression) is not IdentifierNameSyntax identifier)
+        {
+            body = null!;
+            return false;
+        }
+
+        var symbol = semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol;
+        if (symbol is IMethodSymbol
+            {
+                MethodKind: MethodKind.LocalFunction,
+                DeclaringSyntaxReferences.Length: 1,
+            } localFunction
+            && visited.Add(localFunction)
+            && localFunction.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken)
+                is LocalFunctionStatementSyntax localFunctionDeclaration
+            && GetSourceMethodBody(localFunctionDeclaration) is { } localFunctionBody)
+        {
+            body = localFunctionBody;
+            return true;
+        }
+
+        if (symbol is not ILocalSymbol { Type.TypeKind: TypeKind.Delegate } local
             || !visited.Add(local)
             || local.DeclaringSyntaxReferences.Length != 1
             || local.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken)

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Kevlar.Analyzers;
 
@@ -133,6 +132,21 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                     pendingBodies.Push((delegateBody, pending.SemanticModel));
                 }
 
+                foreach (var argument in invocation.ArgumentList.Arguments)
+                {
+                    if (!TryGetStableDelegateExpressionBody(
+                            argument.Expression,
+                            pending.SemanticModel,
+                            cancellationToken,
+                            visitedDelegateLocals,
+                            out var argumentBody))
+                    {
+                        continue;
+                    }
+
+                    pendingBodies.Push((argumentBody, pending.SemanticModel));
+                }
+
                 if (pending.SemanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
                         is not IMethodSymbol
                         {
@@ -156,26 +170,6 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                         ? pending.SemanticModel
                         : pending.SemanticModel.Compilation.GetSemanticModel(declaration.SyntaxTree);
 #pragma warning restore RS1030
-                    foreach (var argument in invocation.ArgumentList.Arguments)
-                    {
-                        if (pending.SemanticModel.GetOperation(argument, cancellationToken)
-                                is not IArgumentOperation
-                                {
-                                    Parameter.Type.TypeKind: TypeKind.Delegate,
-                                }
-                            || !TryGetStableDelegateExpressionBody(
-                                argument.Expression,
-                                pending.SemanticModel,
-                                cancellationToken,
-                                visitedDelegateLocals,
-                                out var argumentBody))
-                        {
-                            continue;
-                        }
-
-                        pendingBodies.Push((argumentBody, pending.SemanticModel));
-                    }
-
                     if (inspectMethodBody)
                     {
                         pendingBodies.Push((methodBody, methodSemanticModel));

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -54,8 +54,11 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
             return;
         }
 
-        if (callback.Body is BlockSyntax block
-            && ContainsUnawaitedTaskInvocation(block, semanticModel!, context.CancellationToken))
+        if ((callback.Body is BlockSyntax || !callback.AsyncKeyword.IsKind(SyntaxKind.None))
+            && ContainsUnawaitedTaskInvocation(
+                callback.Body,
+                semanticModel!,
+                context.CancellationToken))
         {
             return;
         }
@@ -94,13 +97,14 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
     }
 
     private static bool ContainsUnawaitedTaskInvocation(
-        BlockSyntax block,
+        SyntaxNode body,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
         var pendingBodies = new Stack<SyntaxNode>();
         var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-        pendingBodies.Push(block);
+        var visitedDelegateLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+        pendingBodies.Push(body);
         while (pendingBodies.Count > 0)
         {
             foreach (var invocation in pendingBodies.Pop()
@@ -110,11 +114,19 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                          .OfType<InvocationExpressionSyntax>())
             {
                 if (IsTaskLike(semanticModel.GetTypeInfo(invocation, cancellationToken).Type)
-                    && !invocation.Ancestors()
-                        .TakeWhile(static ancestor => ancestor is not StatementSyntax)
-                        .Any(static ancestor => ancestor is AwaitExpressionSyntax))
+                    && !IsDirectlyAwaited(invocation))
                 {
                     return true;
+                }
+
+                if (TryGetStableDelegateBody(
+                        invocation,
+                        semanticModel,
+                        cancellationToken,
+                        visitedDelegateLocals,
+                        out var delegateBody))
+                {
+                    pendingBodies.Push(delegateBody);
                 }
 
                 if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
@@ -136,6 +148,57 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         }
 
         return false;
+    }
+
+    private static bool IsDirectlyAwaited(InvocationExpressionSyntax invocation)
+    {
+        SyntaxNode current = invocation;
+        while (current.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax
+               or PostfixUnaryExpressionSyntax)
+        {
+            current = current.Parent;
+        }
+
+        return current.Parent is AwaitExpressionSyntax;
+    }
+
+    private static bool TryGetStableDelegateBody(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        HashSet<ILocalSymbol> visited,
+        out SyntaxNode body)
+    {
+        var identifier = invocation.Expression switch
+        {
+            IdentifierNameSyntax direct => direct,
+            MemberAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax receiver,
+                Name.Identifier.ValueText: "Invoke",
+            } => receiver,
+            _ => null,
+        };
+        if (identifier is null
+            || semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
+                is not ILocalSymbol { Type.TypeKind: TypeKind.Delegate } local
+            || !visited.Add(local)
+            || local.DeclaringSyntaxReferences.Length != 1
+            || local.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken)
+                is not VariableDeclaratorSyntax
+            {
+                Initializer.Value: { } initializer,
+            } declarator
+            || semanticModel.SyntaxTree != declarator.SyntaxTree
+            || IsWrittenAfterDeclaration(local, declarator, semanticModel, cancellationToken)
+            || UnwrapReceiver(initializer) is not AnonymousFunctionExpressionSyntax anonymous)
+        {
+            body = null!;
+            return false;
+        }
+
+        body = anonymous.Body;
+        return true;
     }
 
     private static SyntaxNode? GetLocalFunctionBody(SyntaxNode declaration) => declaration switch

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -124,6 +124,8 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         SyntaxNode scope = assignment.FirstAncestorOrSelf<InitializerExpressionSyntax>(
                 static initializer => initializer.IsKind(SyntaxKind.ObjectInitializerExpression))
             ?? assignment.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>()
+            ?? assignment.FirstAncestorOrSelf<LocalFunctionStatementSyntax>()
+            ?? assignment.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>()
             ?? assignment.FirstAncestorOrSelf<BlockSyntax>()
             ?? assignment.Parent!;
         foreach (var candidate in scope.DescendantNodes().OfType<AssignmentExpressionSyntax>())

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -134,17 +134,20 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
 
                 foreach (var argument in invocation.ArgumentList.Arguments)
                 {
-                    if (!TryGetStableDelegateExpressionBody(
-                            argument.Expression,
-                            pending.SemanticModel,
-                            cancellationToken,
-                            visitedDelegateLocals,
-                            out var argumentBody))
+                    foreach (var expression in GetDelegateValueParts(argument.Expression))
                     {
-                        continue;
-                    }
+                        if (!TryGetStableDelegateExpressionBody(
+                                expression,
+                                pending.SemanticModel,
+                                cancellationToken,
+                                visitedDelegateLocals,
+                                out var argumentBody))
+                        {
+                            continue;
+                        }
 
-                    pendingBodies.Push((argumentBody, pending.SemanticModel));
+                        pendingBodies.Push((argumentBody, pending.SemanticModel));
+                    }
                 }
 
                 if (pending.SemanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
@@ -247,6 +250,52 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
 
         body = anonymous.Body;
         return true;
+    }
+
+    private static IEnumerable<ExpressionSyntax> GetDelegateValueParts(
+        ExpressionSyntax expression)
+    {
+        expression = UnwrapReceiver(expression);
+        switch (expression)
+        {
+            case ConditionalExpressionSyntax conditional:
+                foreach (var part in GetDelegateValueParts(conditional.WhenTrue))
+                {
+                    yield return part;
+                }
+
+                foreach (var part in GetDelegateValueParts(conditional.WhenFalse))
+                {
+                    yield return part;
+                }
+
+                break;
+            case BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.CoalesceExpression):
+                foreach (var part in GetDelegateValueParts(binary.Left))
+                {
+                    yield return part;
+                }
+
+                foreach (var part in GetDelegateValueParts(binary.Right))
+                {
+                    yield return part;
+                }
+
+                break;
+            case SwitchExpressionSyntax switchExpression:
+                foreach (var arm in switchExpression.Arms)
+                {
+                    foreach (var part in GetDelegateValueParts(arm.Expression))
+                    {
+                        yield return part;
+                    }
+                }
+
+                break;
+            default:
+                yield return expression;
+                break;
+        }
     }
 
     private static SyntaxNode? GetSourceMethodBody(SyntaxNode declaration) => declaration switch

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -182,7 +182,13 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         HashSet<ILocalSymbol> visited,
         out SyntaxNode body)
     {
-        if (UnwrapReceiver(invocation.Expression)
+        var invokedExpression = invocation.Expression is MemberAccessExpressionSyntax
+        {
+            Name.Identifier.ValueText: "Invoke",
+        } memberAccess
+            ? memberAccess.Expression
+            : invocation.Expression;
+        if (UnwrapReceiver(invokedExpression)
                 is AnonymousFunctionExpressionSyntax immediatelyInvoked)
         {
             body = immediatelyInvoked.Body;

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Kevlar.Analyzers;
 
@@ -136,12 +137,12 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                         is not IMethodSymbol
                         {
                             MethodKind: MethodKind.LocalFunction or MethodKind.Ordinary,
-                        } method
-                    || !visitedMethods.Add(method))
+                        } method)
                 {
                     continue;
                 }
 
+                var inspectMethodBody = visitedMethods.Add(method);
                 foreach (var syntaxReference in method.DeclaringSyntaxReferences)
                 {
                     var declaration = syntaxReference.GetSyntax(cancellationToken);
@@ -155,7 +156,30 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                         ? pending.SemanticModel
                         : pending.SemanticModel.Compilation.GetSemanticModel(declaration.SyntaxTree);
 #pragma warning restore RS1030
-                    pendingBodies.Push((methodBody, methodSemanticModel));
+                    foreach (var argument in invocation.ArgumentList.Arguments)
+                    {
+                        if (pending.SemanticModel.GetOperation(argument, cancellationToken)
+                                is not IArgumentOperation
+                                {
+                                    Parameter.Type.TypeKind: TypeKind.Delegate,
+                                }
+                            || !TryGetStableDelegateExpressionBody(
+                                argument.Expression,
+                                pending.SemanticModel,
+                                cancellationToken,
+                                visitedDelegateLocals,
+                                out var argumentBody))
+                        {
+                            continue;
+                        }
+
+                        pendingBodies.Push((argumentBody, pending.SemanticModel));
+                    }
+
+                    if (inspectMethodBody)
+                    {
+                        pendingBodies.Push((methodBody, methodSemanticModel));
+                    }
                 }
             }
         }
@@ -188,24 +212,28 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         } memberAccess
             ? memberAccess.Expression
             : invocation.Expression;
-        if (UnwrapReceiver(invokedExpression)
-                is AnonymousFunctionExpressionSyntax immediatelyInvoked)
+        return TryGetStableDelegateExpressionBody(
+            invokedExpression,
+            semanticModel,
+            cancellationToken,
+            visited,
+            out body);
+    }
+
+    private static bool TryGetStableDelegateExpressionBody(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        HashSet<ILocalSymbol> visited,
+        out SyntaxNode body)
+    {
+        if (UnwrapReceiver(expression) is AnonymousFunctionExpressionSyntax anonymousExpression)
         {
-            body = immediatelyInvoked.Body;
+            body = anonymousExpression.Body;
             return true;
         }
 
-        var identifier = invocation.Expression switch
-        {
-            IdentifierNameSyntax direct => direct,
-            MemberAccessExpressionSyntax
-            {
-                Expression: IdentifierNameSyntax receiver,
-                Name.Identifier.ValueText: "Invoke",
-            } => receiver,
-            _ => null,
-        };
-        if (identifier is null
+        if (UnwrapReceiver(expression) is not IdentifierNameSyntax identifier
             || semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
                 is not ILocalSymbol { Type.TypeKind: TypeKind.Delegate } local
             || !visited.Add(local)

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -122,12 +122,11 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                     return true;
                 }
 
-                if (TryGetStableDelegateBody(
-                        invocation,
-                        pending.SemanticModel,
-                        cancellationToken,
-                        visitedDelegates,
-                        out var delegateBody))
+                foreach (var delegateBody in GetStableDelegateBodies(
+                             invocation,
+                             pending.SemanticModel,
+                             cancellationToken,
+                             visitedDelegates))
                 {
                     pendingBodies.Push((delegateBody, pending.SemanticModel));
                 }
@@ -136,17 +135,14 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                 {
                     foreach (var expression in GetDelegateValueParts(argument.Expression))
                     {
-                        if (!TryGetStableDelegateExpressionBody(
-                                expression,
-                                pending.SemanticModel,
-                                cancellationToken,
-                                visitedDelegates,
-                                out var argumentBody))
+                        foreach (var argumentBody in GetStableDelegateExpressionBodies(
+                                     expression,
+                                     pending.SemanticModel,
+                                     cancellationToken,
+                                     visitedDelegates))
                         {
-                            continue;
+                            pendingBodies.Push((argumentBody, pending.SemanticModel));
                         }
-
-                        pendingBodies.Push((argumentBody, pending.SemanticModel));
                     }
                 }
 
@@ -196,12 +192,11 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         return current.Parent is AwaitExpressionSyntax;
     }
 
-    private static bool TryGetStableDelegateBody(
+    private static IEnumerable<SyntaxNode> GetStableDelegateBodies(
         InvocationExpressionSyntax invocation,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        HashSet<ISymbol> visited,
-        out SyntaxNode body)
+        HashSet<ISymbol> visited)
     {
         var invokedExpression = invocation.Expression is MemberAccessExpressionSyntax
         {
@@ -209,31 +204,28 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         } memberAccess
             ? memberAccess.Expression
             : invocation.Expression;
-        return TryGetStableDelegateExpressionBody(
+        return GetStableDelegateExpressionBodies(
             invokedExpression,
             semanticModel,
             cancellationToken,
-            visited,
-            out body);
+            visited);
     }
 
-    private static bool TryGetStableDelegateExpressionBody(
+    private static IEnumerable<SyntaxNode> GetStableDelegateExpressionBodies(
         ExpressionSyntax expression,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        HashSet<ISymbol> visited,
-        out SyntaxNode body)
+        HashSet<ISymbol> visited)
     {
         if (UnwrapReceiver(expression) is AnonymousFunctionExpressionSyntax anonymousExpression)
         {
-            body = anonymousExpression.Body;
-            return true;
+            yield return anonymousExpression.Body;
+            yield break;
         }
 
         if (UnwrapReceiver(expression) is not IdentifierNameSyntax identifier)
         {
-            body = null!;
-            return false;
+            yield break;
         }
 
         var symbol = semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol;
@@ -247,8 +239,8 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                 is LocalFunctionStatementSyntax localFunctionDeclaration
             && GetSourceMethodBody(localFunctionDeclaration) is { } localFunctionBody)
         {
-            body = localFunctionBody;
-            return true;
+            yield return localFunctionBody;
+            yield break;
         }
 
         if (symbol is not ILocalSymbol { Type.TypeKind: TypeKind.Delegate } local
@@ -260,15 +252,22 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                 Initializer.Value: { } initializer,
             } declarator
             || semanticModel.SyntaxTree != declarator.SyntaxTree
-            || IsWrittenAfterDeclaration(local, declarator, semanticModel, cancellationToken)
-            || UnwrapReceiver(initializer) is not AnonymousFunctionExpressionSyntax anonymous)
+            || IsWrittenAfterDeclaration(local, declarator, semanticModel, cancellationToken))
         {
-            body = null!;
-            return false;
+            yield break;
         }
 
-        body = anonymous.Body;
-        return true;
+        foreach (var part in GetDelegateValueParts(initializer))
+        {
+            foreach (var body in GetStableDelegateExpressionBodies(
+                         part,
+                         semanticModel,
+                         cancellationToken,
+                         visited))
+            {
+                yield return body;
+            }
+        }
     }
 
     private static IEnumerable<ExpressionSyntax> GetDelegateValueParts(

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -1,0 +1,292 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Kevlar.Analyzers;
+
+/// <summary>Moves asynchronous lambdas from synchronous strategy hooks to their async twin.</summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AsyncCallbackCodeFixProvider)), Shared]
+internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
+{
+    private const string Title = "Use the asynchronous callback";
+
+    /// <inheritdoc />
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("KEV013");
+
+    /// <inheritdoc />
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        var assignment = root?
+            .FindNode(context.Span)
+            .FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+        if (assignment?.Right is not AnonymousFunctionExpressionSyntax callback)
+        {
+            return;
+        }
+
+        if (assignment.IsKind(SyntaxKind.AddAssignmentExpression)
+            || assignment.IsKind(SyntaxKind.CoalesceAssignmentExpression))
+        {
+            return;
+        }
+
+        if (callback.AsyncKeyword.IsKind(SyntaxKind.None)
+            && callback.Body is BlockSyntax)
+        {
+            return;
+        }
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        var property = semanticModel?.GetSymbolInfo(assignment.Left, context.CancellationToken).Symbol
+            as IPropertySymbol;
+        if (property is null)
+        {
+            return;
+        }
+
+        if (callback is LambdaExpressionSyntax
+            {
+                AsyncKeyword.RawKind: 0,
+                ExpressionBody: { } expressionBody,
+            }
+            && !HasCompatibleResult(semanticModel!.GetTypeInfo(
+                expressionBody,
+                context.CancellationToken).Type))
+        {
+            return;
+        }
+
+        var asyncProperty = property.ContainingType.GetMembers(property.Name + "Async")
+            .OfType<IPropertySymbol>()
+            .FirstOrDefault();
+        if (asyncProperty is null
+            || IsAlreadyAssigned(assignment, asyncProperty, semanticModel!, context.CancellationToken))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                Title,
+                cancellationToken => RenamePropertyAsync(
+                    context.Document,
+                    assignment,
+                    asyncProperty.Name,
+                    cancellationToken),
+                Title),
+            context.Diagnostics);
+    }
+
+    private static bool IsAlreadyAssigned(
+        AssignmentExpressionSyntax assignment,
+        IPropertySymbol property,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode scope = assignment.FirstAncestorOrSelf<InitializerExpressionSyntax>(
+                static initializer => initializer.IsKind(SyntaxKind.ObjectInitializerExpression))
+            ?? assignment.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>()
+            ?? assignment.FirstAncestorOrSelf<BlockSyntax>()
+            ?? assignment.Parent!;
+        foreach (var candidate in scope.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (ReferenceEquals(candidate, assignment)
+                || assignment.Right.Span.Contains(candidate.Span))
+            {
+                continue;
+            }
+
+            var assignedProperty = semanticModel.GetSymbolInfo(candidate.Left, cancellationToken).Symbol;
+            if (SymbolEqualityComparer.Default.Equals(assignedProperty, property)
+                && HasSameReceiver(assignment.Left, candidate.Left, semanticModel, cancellationToken))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasSameReceiver(
+        ExpressionSyntax first,
+        ExpressionSyntax second,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var firstReceiver = GetReceiver(first);
+        var secondReceiver = GetReceiver(second);
+        if (firstReceiver is null || secondReceiver is null)
+        {
+            return firstReceiver is null && secondReceiver is null;
+        }
+
+        var firstSymbol = semanticModel.GetSymbolInfo(firstReceiver, cancellationToken).Symbol;
+        var secondSymbol = semanticModel.GetSymbolInfo(secondReceiver, cancellationToken).Symbol;
+        if (!TryResolveStableAlias(
+                firstSymbol,
+                semanticModel,
+                cancellationToken,
+                new HashSet<ISymbol>(SymbolEqualityComparer.Default),
+                out firstSymbol)
+            || !TryResolveStableAlias(
+                secondSymbol,
+                semanticModel,
+                cancellationToken,
+                new HashSet<ISymbol>(SymbolEqualityComparer.Default),
+                out secondSymbol))
+        {
+            return true;
+        }
+
+        return SymbolEqualityComparer.Default.Equals(firstSymbol, secondSymbol);
+    }
+
+    private static bool TryResolveStableAlias(
+        ISymbol? symbol,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        HashSet<ISymbol> visited,
+        out ISymbol resolved)
+    {
+        if (symbol is not ILocalSymbol local)
+        {
+            resolved = symbol!;
+            return symbol is not null;
+        }
+
+        var declarations = local.DeclaringSyntaxReferences;
+        if (!visited.Add(local)
+            || declarations.Length != 1
+            || declarations[0].GetSyntax(cancellationToken) is not VariableDeclaratorSyntax
+            {
+                Initializer.Value: { } initializer,
+            } declarator
+            || semanticModel.SyntaxTree != declarator.SyntaxTree
+            || IsWrittenAfterDeclaration(local, declarator, semanticModel, cancellationToken))
+        {
+            resolved = null!;
+            return false;
+        }
+
+        var initializerSymbol = semanticModel.GetSymbolInfo(
+            UnwrapReceiver(initializer),
+            cancellationToken).Symbol;
+        return TryResolveStableAlias(
+            initializerSymbol,
+            semanticModel,
+            cancellationToken,
+            visited,
+            out resolved);
+    }
+
+    private static bool IsWrittenAfterDeclaration(
+        ILocalSymbol local,
+        VariableDeclaratorSyntax declarator,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode scope = declarator.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>()
+            ?? declarator.FirstAncestorOrSelf<BlockSyntax>()
+            ?? declarator.Parent!;
+        foreach (var identifier in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText == local.Name
+                && SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol,
+                    local)
+                && IsWritten(identifier))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsWritten(IdentifierNameSyntax identifier)
+    {
+        foreach (var ancestor in identifier.Ancestors())
+        {
+            switch (ancestor)
+            {
+                case MemberAccessExpressionSyntax memberAccess
+                    when memberAccess.Expression.Span.Contains(identifier.Span):
+                case ElementAccessExpressionSyntax elementAccess
+                    when elementAccess.Expression.Span.Contains(identifier.Span):
+                    return false;
+                case AssignmentExpressionSyntax assignment
+                    when assignment.Left.Span.Contains(identifier.Span):
+                    return true;
+                case PrefixUnaryExpressionSyntax prefix
+                    when prefix.IsKind(SyntaxKind.PreIncrementExpression)
+                        || prefix.IsKind(SyntaxKind.PreDecrementExpression):
+                    return true;
+                case PostfixUnaryExpressionSyntax postfix
+                    when postfix.IsKind(SyntaxKind.PostIncrementExpression)
+                        || postfix.IsKind(SyntaxKind.PostDecrementExpression):
+                    return true;
+                case ArgumentSyntax argument when !argument.RefKindKeyword.IsKind(SyntaxKind.None):
+                    return true;
+                case StatementSyntax:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static ExpressionSyntax UnwrapReceiver(ExpressionSyntax expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    expression = parenthesized.Expression;
+                    continue;
+                case CastExpressionSyntax cast:
+                    expression = cast.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    private static ExpressionSyntax? GetReceiver(ExpressionSyntax expression) =>
+        expression is MemberAccessExpressionSyntax memberAccess ? memberAccess.Expression : null;
+
+    private static bool HasCompatibleResult(ITypeSymbol? type) =>
+        type is INamedTypeSymbol named
+        && named.OriginalDefinition.ToDisplayString() == "System.Threading.Tasks.ValueTask";
+
+    private static async Task<Document> RenamePropertyAsync(
+        Document document,
+        AssignmentExpressionSyntax assignment,
+        string propertyName,
+        CancellationToken cancellationToken)
+    {
+        var replacement = assignment.Left switch
+        {
+            MemberAccessExpressionSyntax memberAccess =>
+                memberAccess.WithName(SyntaxFactory.IdentifierName(propertyName)),
+            IdentifierNameSyntax identifier =>
+                identifier.WithIdentifier(SyntaxFactory.Identifier(propertyName)),
+            _ => assignment.Left,
+        };
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        return document.WithSyntaxRoot(root!.ReplaceNode(
+            assignment.Left,
+            replacement.WithTriviaFrom(assignment.Left)));
+    }
+}

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -169,6 +169,13 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         HashSet<ILocalSymbol> visited,
         out SyntaxNode body)
     {
+        if (UnwrapReceiver(invocation.Expression)
+                is AnonymousFunctionExpressionSyntax immediatelyInvoked)
+        {
+            body = immediatelyInvoked.Body;
+            return true;
+        }
+
         var identifier = invocation.Expression switch
         {
             IdentifierNameSyntax direct => direct,

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -54,6 +54,12 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
             return;
         }
 
+        if (callback.Body is BlockSyntax block
+            && ContainsUnawaitedTaskInvocation(block, semanticModel!, context.CancellationToken))
+        {
+            return;
+        }
+
         if (callback is LambdaExpressionSyntax
             {
                 AsyncKeyword.RawKind: 0,
@@ -86,6 +92,28 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                 Title),
             context.Diagnostics);
     }
+
+    private static bool ContainsUnawaitedTaskInvocation(
+        BlockSyntax block,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken) =>
+        block.DescendantNodes(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax)
+            .OfType<InvocationExpressionSyntax>()
+            .Any(invocation => IsTaskLike(
+                    semanticModel.GetTypeInfo(invocation, cancellationToken).Type)
+                && !invocation.Ancestors()
+                    .TakeWhile(static ancestor => ancestor is not StatementSyntax)
+                    .Any(static ancestor => ancestor is AwaitExpressionSyntax));
+
+    private static bool IsTaskLike(ITypeSymbol? type) =>
+        type is INamedTypeSymbol named
+        && named.OriginalDefinition.ToDisplayString() is
+            "System.Threading.Tasks.Task"
+                or "System.Threading.Tasks.Task<TResult>"
+                or "System.Threading.Tasks.ValueTask"
+                or "System.Threading.Tasks.ValueTask<TResult>";
 
     private static bool IsAlreadyAssigned(
         AssignmentExpressionSyntax assignment,

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -292,6 +292,16 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
                 }
 
                 break;
+            case BaseObjectCreationExpressionSyntax { ArgumentList: { } argumentList }:
+                foreach (var argument in argumentList.Arguments)
+                {
+                    foreach (var part in GetDelegateValueParts(argument.Expression))
+                    {
+                        yield return part;
+                    }
+                }
+
+                break;
             default:
                 yield return expression;
                 break;

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -101,19 +101,22 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        var pendingBodies = new Stack<SyntaxNode>();
-        var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        var pendingBodies = new Stack<(SyntaxNode Body, SemanticModel SemanticModel)>();
+        var visitedMethods = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
         var visitedDelegateLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
-        pendingBodies.Push(body);
+        pendingBodies.Push((body, semanticModel));
         while (pendingBodies.Count > 0)
         {
-            foreach (var invocation in pendingBodies.Pop()
+            var pending = pendingBodies.Pop();
+            foreach (var invocation in pending.Body
                          .DescendantNodesAndSelf(descendIntoChildren: static node =>
                              node is not AnonymousFunctionExpressionSyntax
                                  and not LocalFunctionStatementSyntax)
                          .OfType<InvocationExpressionSyntax>())
             {
-                if (IsTaskLike(semanticModel.GetTypeInfo(invocation, cancellationToken).Type)
+                if (IsTaskLike(pending.SemanticModel.GetTypeInfo(
+                        invocation,
+                        cancellationToken).Type)
                     && !IsDirectlyAwaited(invocation))
                 {
                     return true;
@@ -121,28 +124,38 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
 
                 if (TryGetStableDelegateBody(
                         invocation,
-                        semanticModel,
+                        pending.SemanticModel,
                         cancellationToken,
                         visitedDelegateLocals,
                         out var delegateBody))
                 {
-                    pendingBodies.Push(delegateBody);
+                    pendingBodies.Push((delegateBody, pending.SemanticModel));
                 }
 
-                if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
-                        is not IMethodSymbol { MethodKind: MethodKind.LocalFunction } localFunction
-                    || !visitedLocalFunctions.Add(localFunction))
+                if (pending.SemanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
+                        is not IMethodSymbol
+                        {
+                            MethodKind: MethodKind.LocalFunction or MethodKind.Ordinary,
+                        } method
+                    || !visitedMethods.Add(method))
                 {
                     continue;
                 }
 
-                foreach (var syntaxReference in localFunction.DeclaringSyntaxReferences)
+                foreach (var syntaxReference in method.DeclaringSyntaxReferences)
                 {
-                    if (GetLocalFunctionBody(syntaxReference.GetSyntax(cancellationToken))
-                        is { } localBody)
+                    var declaration = syntaxReference.GetSyntax(cancellationToken);
+                    if (GetSourceMethodBody(declaration) is not { } methodBody)
                     {
-                        pendingBodies.Push(localBody);
+                        continue;
                     }
+
+#pragma warning disable RS1030 // Source-backed helpers may be declared in another tree.
+                    var methodSemanticModel = declaration.SyntaxTree == pending.SemanticModel.SyntaxTree
+                        ? pending.SemanticModel
+                        : pending.SemanticModel.Compilation.GetSemanticModel(declaration.SyntaxTree);
+#pragma warning restore RS1030
+                    pendingBodies.Push((methodBody, methodSemanticModel));
                 }
             }
         }
@@ -208,10 +221,12 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
         return true;
     }
 
-    private static SyntaxNode? GetLocalFunctionBody(SyntaxNode declaration) => declaration switch
+    private static SyntaxNode? GetSourceMethodBody(SyntaxNode declaration) => declaration switch
     {
         LocalFunctionStatementSyntax { Body: { } body } => body,
         LocalFunctionStatementSyntax { ExpressionBody.Expression: { } expression } => expression,
+        MethodDeclarationSyntax { Body: { } body } => body,
+        MethodDeclarationSyntax { ExpressionBody.Expression: { } expression } => expression,
         _ => null,
     };
 

--- a/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
+++ b/src/Kevlar.Analyzers.CodeFixes/AsyncCallbackCodeFixProvider.cs
@@ -96,16 +96,54 @@ internal sealed class AsyncCallbackCodeFixProvider : CodeFixProvider
     private static bool ContainsUnawaitedTaskInvocation(
         BlockSyntax block,
         SemanticModel semanticModel,
-        CancellationToken cancellationToken) =>
-        block.DescendantNodes(descendIntoChildren: static node =>
-                node is not AnonymousFunctionExpressionSyntax
-                    and not LocalFunctionStatementSyntax)
-            .OfType<InvocationExpressionSyntax>()
-            .Any(invocation => IsTaskLike(
-                    semanticModel.GetTypeInfo(invocation, cancellationToken).Type)
-                && !invocation.Ancestors()
-                    .TakeWhile(static ancestor => ancestor is not StatementSyntax)
-                    .Any(static ancestor => ancestor is AwaitExpressionSyntax));
+        CancellationToken cancellationToken)
+    {
+        var pendingBodies = new Stack<SyntaxNode>();
+        var visitedLocalFunctions = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        pendingBodies.Push(block);
+        while (pendingBodies.Count > 0)
+        {
+            foreach (var invocation in pendingBodies.Pop()
+                         .DescendantNodesAndSelf(descendIntoChildren: static node =>
+                             node is not AnonymousFunctionExpressionSyntax
+                                 and not LocalFunctionStatementSyntax)
+                         .OfType<InvocationExpressionSyntax>())
+            {
+                if (IsTaskLike(semanticModel.GetTypeInfo(invocation, cancellationToken).Type)
+                    && !invocation.Ancestors()
+                        .TakeWhile(static ancestor => ancestor is not StatementSyntax)
+                        .Any(static ancestor => ancestor is AwaitExpressionSyntax))
+                {
+                    return true;
+                }
+
+                if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
+                        is not IMethodSymbol { MethodKind: MethodKind.LocalFunction } localFunction
+                    || !visitedLocalFunctions.Add(localFunction))
+                {
+                    continue;
+                }
+
+                foreach (var syntaxReference in localFunction.DeclaringSyntaxReferences)
+                {
+                    if (GetLocalFunctionBody(syntaxReference.GetSyntax(cancellationToken))
+                        is { } localBody)
+                    {
+                        pendingBodies.Push(localBody);
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static SyntaxNode? GetLocalFunctionBody(SyntaxNode declaration) => declaration switch
+    {
+        LocalFunctionStatementSyntax { Body: { } body } => body,
+        LocalFunctionStatementSyntax { ExpressionBody.Expression: { } expression } => expression,
+        _ => null,
+    };
 
     private static bool IsTaskLike(ITypeSymbol? type) =>
         type is INamedTypeSymbol named

--- a/src/Kevlar.Analyzers.CodeFixes/Kevlar.Analyzers.CodeFixes.csproj
+++ b/src/Kevlar.Analyzers.CodeFixes/Kevlar.Analyzers.CodeFixes.csproj
@@ -8,16 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Analyzers.Tests" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
-    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
 </Project>

--- a/src/Kevlar.Analyzers.CodeFixes/PublicAPI.Shipped.txt
+++ b/src/Kevlar.Analyzers.CodeFixes/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Kevlar.Analyzers.CodeFixes/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers.CodeFixes/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Unshipped.md
@@ -17,3 +17,5 @@ KEV009 | Configuration | Info | Strategy inherits a handling clause declared ear
 KEV010 | Configuration | Info | Default-result clause handles a value type's default
 KEV011 | Configuration | Info | Reactive strategy uses implicit default handling
 KEV012 | Reliability | Warning | Asynchronous strategy configuration requires ExecuteAsync
+KEV013 | Reliability | Warning | Asynchronous work is assigned to a synchronous callback
+KEV014 | Reliability | Warning | Pooled event context is captured by deferred work

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -553,9 +553,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         declarator.Initializer?.Value),
                 AssignmentExpressionSyntax assignment
                     when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) =>
-                    (context.SemanticModel.GetSymbolInfo(
+                    (GetAssignedTargetSymbol(
                             assignment.Left,
-                            context.CancellationToken).Symbol,
+                            context.SemanticModel,
+                            context.CancellationToken),
                         GetAssignedName(assignment.Left),
                         assignment.Right),
                 _ => (null, null, null),
@@ -573,7 +574,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     retainedSymbols.Add(target);
                 }
             }
-            else if (IsUnconditionalAliasWrite(alias, anonymous.Body))
+            else if (alias is not AssignmentExpressionSyntax
+                     {
+                         Left: ElementAccessExpressionSyntax,
+                     }
+                     && IsUnconditionalAliasWrite(alias, anonymous.Body))
             {
                 retainedNames.Remove(name);
                 if (target is IFieldSymbol or IPropertySymbol)
@@ -1161,7 +1166,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         declarator.Initializer?.Value),
                 AssignmentExpressionSyntax assignment
                     when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) =>
-                    (semanticModel?.GetSymbolInfo(assignment.Left, cancellationToken).Symbol,
+                    (GetAssignedTargetSymbol(
+                            assignment.Left,
+                            semanticModel,
+                            cancellationToken),
                         GetAssignedName(assignment.Left),
                         assignment.Right),
                 _ => (null, null, null),
@@ -1191,7 +1199,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     AddRetainedSymbolOrigin(retainedSymbolOrigins, target, alias);
                 }
             }
-            else
+            else if (alias is not AssignmentExpressionSyntax
+                     {
+                         Left: ElementAccessExpressionSyntax,
+                     })
             {
                 if (target is not null)
                 {
@@ -2111,8 +2122,25 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     {
         IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
         MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+        ElementAccessExpressionSyntax elementAccess => GetAssignedName(elementAccess.Expression),
         _ => null,
     };
+
+    private static ISymbol? GetAssignedTargetSymbol(
+        ExpressionSyntax expression,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (semanticModel is null)
+        {
+            return null;
+        }
+
+        var target = expression is ElementAccessExpressionSyntax elementAccess
+            ? elementAccess.Expression
+            : expression;
+        return semanticModel.GetSymbolInfo(target, cancellationToken).Symbol;
+    }
 
     private static bool IsRetainedReference(
         IdentifierNameSyntax identifier,
@@ -2323,6 +2351,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 }
 
                 break;
+            case IInvocationOperation invocation when semanticModel is not null:
+                foreach (var argument in invocation.Arguments)
+                {
+                    if (argument.Parameter is { } parameter
+                        && SourceMethodReturnsParameter(
+                            invocation.TargetMethod,
+                            parameter,
+                            semanticModel,
+                            cancellationToken,
+                            visitedMethods))
+                    {
+                        yield return argument.Value;
+                    }
+                }
+
+                break;
             case IWithOperation withOperation:
                 yield return withOperation.Operand;
                 foreach (var initializer in withOperation.Initializer.Initializers)
@@ -2353,6 +2397,68 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 }
 
                 break;
+        }
+    }
+
+    private static bool SourceMethodReturnsParameter(
+        IMethodSymbol method,
+        IParameterSymbol parameter,
+        SemanticModel currentSemanticModel,
+        CancellationToken cancellationToken,
+        HashSet<ISymbol>? visitedMethods)
+    {
+        visitedMethods ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        if (!visitedMethods.Add(method))
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var syntaxReference in method.DeclaringSyntaxReferences)
+            {
+                var syntax = syntaxReference.GetSyntax(cancellationToken);
+                if (GetFunctionBody(syntax) is not { } body)
+                {
+                    continue;
+                }
+
+#pragma warning disable RS1030 // Source-backed helpers may be declared in another tree.
+                var semanticModel = syntax.SyntaxTree == currentSemanticModel.SyntaxTree
+                    ? currentSemanticModel
+                    : currentSemanticModel.Compilation.GetSemanticModel(syntax.SyntaxTree);
+#pragma warning restore RS1030
+                if (semanticModel.GetOperation(body, cancellationToken) is not { } bodyOperation)
+                {
+                    continue;
+                }
+
+                var returnedValues = body is ExpressionSyntax
+                    ? [bodyOperation]
+                    : ExecutableDescendantOperations(bodyOperation)
+                        .OfType<IReturnOperation>()
+                        .Select(static operation => operation.ReturnedValue)
+                        .OfType<IOperation>();
+                if (returnedValues.Any(value => RetainedValueOperations(
+                        value,
+                        semanticModel,
+                        cancellationToken,
+                        visitedMethods)
+                    .Any(candidate =>
+                        Unwrap(candidate) is IParameterReferenceOperation reference
+                        && SymbolEqualityComparer.Default.Equals(
+                            reference.Parameter,
+                            parameter))))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            visitedMethods.Remove(method);
         }
     }
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -436,6 +436,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     return true;
                 }
 
+                if (TryFindPostAwaitMemberContext(
+                    invocation,
+                    context,
+                    knownTypes,
+                    out capturedContext))
+                {
+                    return true;
+                }
+
                 if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
                     && context.SemanticModel.GetSymbolInfo(
                         invocation,
@@ -460,6 +469,75 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         knownTypes,
                         out capturedContext))
                     {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool TryFindPostAwaitMemberContext(
+        InvocationExpressionSyntax invocation,
+        SyntaxNodeAnalysisContext context,
+        KnownTypes knownTypes,
+        out SyntaxNode capturedContext)
+    {
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(
+            invocation,
+            context.CancellationToken);
+        var methods = symbolInfo.Symbol is IMethodSymbol method
+            ? [method]
+            : symbolInfo.CandidateSymbols.OfType<IMethodSymbol>();
+        foreach (var candidate in methods.Where(static method =>
+                     method.DeclaringSyntaxReferences.Length > 0))
+        {
+            foreach (var syntaxReference in candidate.DeclaringSyntaxReferences)
+            {
+                var declaration = syntaxReference.GetSyntax(context.CancellationToken);
+                if (GetFunctionBody(declaration) is not { } body)
+                {
+                    continue;
+                }
+
+#pragma warning disable RS1030 // Source-backed async calls may be declared in another tree.
+                var semanticModel = declaration.SyntaxTree == context.SemanticModel.SyntaxTree
+                    ? context.SemanticModel
+                    : context.SemanticModel.Compilation.GetSemanticModel(declaration.SyntaxTree);
+#pragma warning restore RS1030
+                var nodes = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
+                        node is not AnonymousFunctionExpressionSyntax
+                            and not LocalFunctionStatementSyntax)
+                    .ToArray();
+                var awaits = nodes.OfType<AwaitExpressionSyntax>().ToArray();
+                if (awaits.Length == 0)
+                {
+                    continue;
+                }
+
+                var controlFlowGraph = TryCreateControlFlowGraph(
+                    body,
+                    semanticModel,
+                    context.CancellationToken);
+                foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
+                             .Where(identifier => IsRuntimeValueReference(identifier)))
+                {
+                    var type = semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol
+                        switch
+                        {
+                            IFieldSymbol field => field.Type,
+                            IPropertySymbol property => property.Type,
+                            _ => null,
+                        };
+                    if (ContainsEventContextReference(type, knownTypes)
+                        && awaits.Any(awaitExpression => CanReachAfterSuspension(
+                            awaitExpression,
+                            identifier,
+                            controlFlowGraph)))
+                    {
+                        capturedContext = identifier;
                         return true;
                     }
                 }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3273,7 +3273,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IParameterSymbol parameter,
         SemanticModel? currentSemanticModel,
         CancellationToken cancellationToken,
-        HashSet<ISymbol>? visitedMethods = null)
+        HashSet<ISymbol>? visitedMethods = null,
+        HashSet<ISymbol>? rootedParameters = null)
     {
         if (method is null || currentSemanticModel is null)
         {
@@ -3312,7 +3313,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && ExecutableDescendantOperations(bodyOperation)
                         .OfType<ISimpleAssignmentOperation>()
                         .Any(assignment =>
-                            IsConstructorInstanceMember(assignment.Target)
+                            IsConstructorInstanceMember(assignment.Target, rootedParameters)
                             && RetainedValueOperations(
                                     assignment.Value,
                                     semanticModel,
@@ -3335,7 +3336,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                             parameter,
                             semanticModel,
                             cancellationToken,
-                            visitedMethods)))
+                            visitedMethods,
+                            rootedParameters)))
                 {
                     return true;
                 }
@@ -3366,7 +3368,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                                 delegatedParameter,
                                 semanticModel,
                                 cancellationToken,
-                                visitedMethods))
+                                visitedMethods,
+                                rootedParameters))
                         {
                             return true;
                         }
@@ -3387,11 +3390,26 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IParameterSymbol parameter,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        HashSet<ISymbol> visitedMethods)
+        HashSet<ISymbol> visitedMethods,
+        HashSet<ISymbol>? rootedParameters)
     {
-        var isRootedInstance = IsRootedInCurrentInstance(invocation.Instance);
+        var isRootedInstance = IsRootedInCurrentInstance(
+            invocation.Instance,
+            rootedParameters);
+        var invokedRootedParameters = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter is { } invokedParameter
+                && IsRootedInCurrentInstance(argument.Value, rootedParameters))
+            {
+                invokedRootedParameters.Add(invokedParameter);
+            }
+        }
+
+        var sourceBacked = invocation.TargetMethod.DeclaringSyntaxReferences.Length > 0;
         if (!isRootedInstance
-            && invocation.TargetMethod.MethodKind is not MethodKind.LocalFunction)
+            && invocation.TargetMethod.MethodKind is not MethodKind.LocalFunction
+            && (!sourceBacked || invokedRootedParameters.Count == 0))
         {
             return false;
         }
@@ -3412,13 +3430,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
             if ((isRootedInstance && IsKnownRetainingMutation(invocation.TargetMethod))
                 || (argument.Parameter is { } invokedParameter
-                    && invocation.TargetMethod.DeclaringSyntaxReferences.Length > 0
+                    && sourceBacked
                     && IsInstanceParameterStored(
                         invocation.TargetMethod,
                         invokedParameter,
                         semanticModel,
                         cancellationToken,
-                        visitedMethods)))
+                        visitedMethods,
+                        invokedRootedParameters)))
             {
                 return true;
             }
@@ -3450,7 +3469,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsConstructorInstanceMember(IOperation operation)
+    private static bool IsConstructorInstanceMember(
+        IOperation operation,
+        HashSet<ISymbol>? rootedParameters = null)
     {
         var instance = operation switch
         {
@@ -3459,17 +3480,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             _ => null,
         };
 
-        return IsRootedInCurrentInstance(instance);
+        return IsRootedInCurrentInstance(instance, rootedParameters);
     }
 
-    private static bool IsRootedInCurrentInstance(IOperation? operation) =>
+    private static bool IsRootedInCurrentInstance(
+        IOperation? operation,
+        HashSet<ISymbol>? rootedParameters = null) =>
         Unwrap(operation) switch
         {
             IInstanceReferenceOperation => true,
+            IParameterReferenceOperation parameter =>
+                rootedParameters?.Contains(parameter.Parameter) is true,
             IFieldReferenceOperation { Field.IsStatic: false } field =>
-                IsRootedInCurrentInstance(field.Instance),
+                IsRootedInCurrentInstance(field.Instance, rootedParameters),
             IPropertyReferenceOperation { Property.IsStatic: false } property =>
-                IsRootedInCurrentInstance(property.Instance),
+                IsRootedInCurrentInstance(property.Instance, rootedParameters),
             _ => false,
         };
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -586,6 +586,90 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        var localFunctions = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax)
+            .OfType<LocalFunctionStatementSyntax>()
+            .ToLookup(
+                static function => function.Identifier.ValueText,
+                StringComparer.Ordinal);
+        foreach (var invocation in nodes.OfType<InvocationExpressionSyntax>()
+                     .Where(invocation => invocation.SpanStart > firstAwait))
+        {
+            if (TryFindRetainedContextInLocalFunction(
+                invocation,
+                localFunctions,
+                retainedNames,
+                [],
+                out capturedContext))
+            {
+                return true;
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool TryFindRetainedContextInLocalFunction(
+        InvocationExpressionSyntax invocation,
+        ILookup<string, LocalFunctionStatementSyntax> localFunctions,
+        HashSet<string> retainedNames,
+        HashSet<LocalFunctionStatementSyntax> callPath,
+        out SyntaxNode capturedContext)
+    {
+        if (invocation.Expression is not IdentifierNameSyntax identifier)
+        {
+            capturedContext = null!;
+            return false;
+        }
+
+        foreach (var function in localFunctions[identifier.Identifier.ValueText])
+        {
+            if (function.Parent is not BlockSyntax declaringBlock
+                || !invocation.Ancestors().Contains(declaringBlock)
+                || callPath.Contains(function)
+                || GetFunctionBody(function) is not { } functionBody)
+            {
+                continue;
+            }
+
+            var nestedCallPath = new HashSet<LocalFunctionStatementSyntax>(callPath)
+            {
+                function,
+            };
+            var functionRetainedNames = new HashSet<string>(retainedNames, StringComparer.Ordinal);
+            foreach (var parameter in function.ParameterList.Parameters)
+            {
+                functionRetainedNames.Remove(parameter.Identifier.ValueText);
+            }
+
+            var functionNodes = functionBody.DescendantNodesAndSelf(
+                    descendIntoChildren: static node =>
+                        node is not AnonymousFunctionExpressionSyntax
+                            and not LocalFunctionStatementSyntax)
+                .ToArray();
+            foreach (var retainedIdentifier in functionNodes.OfType<IdentifierNameSyntax>()
+                         .Where(candidate => functionRetainedNames.Contains(
+                             candidate.Identifier.ValueText)))
+            {
+                capturedContext = retainedIdentifier;
+                return true;
+            }
+
+            foreach (var nestedInvocation in functionNodes.OfType<InvocationExpressionSyntax>())
+            {
+                if (TryFindRetainedContextInLocalFunction(
+                    nestedInvocation,
+                    localFunctions,
+                    functionRetainedNames,
+                    nestedCallPath,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
         capturedContext = null!;
         return false;
     }
@@ -855,9 +939,19 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsSynchronouslyObserved(
         InvocationExpressionSyntax invocation,
         SemanticModel semanticModel,
+        CancellationToken cancellationToken) =>
+        IsSynchronouslyObservedCore(invocation, semanticModel, cancellationToken)
+        || IsSynchronouslyObservedThroughLocal(
+            invocation,
+            semanticModel,
+            cancellationToken);
+
+    private static bool IsSynchronouslyObservedCore(
+        SyntaxNode value,
+        SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        SyntaxNode current = invocation;
+        var current = value;
         while (current.Parent is MemberAccessExpressionSyntax memberAccess
                && memberAccess.Expression == current)
         {
@@ -926,6 +1020,55 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 consumerInvocation,
                 semanticModel,
                 cancellationToken);
+    }
+
+    private static bool IsSynchronouslyObservedThroughLocal(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (invocation.Parent is not EqualsValueClauseSyntax
+            {
+                Parent: VariableDeclaratorSyntax declarator,
+            }
+            || semanticModel.GetDeclaredSymbol(
+                declarator,
+                cancellationToken) is not ILocalSymbol local
+            || declarator.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>()?.Parent
+                is not BlockSyntax block)
+        {
+            return false;
+        }
+
+        foreach (var reference in block.DescendantNodes(descendIntoChildren: static node =>
+                     node is not AnonymousFunctionExpressionSyntax
+                         and not LocalFunctionStatementSyntax)
+                 .OfType<IdentifierNameSyntax>()
+                 .Where(reference => reference.SpanStart > declarator.SpanStart
+                     && reference.FirstAncestorOrSelf<StatementSyntax>()?.Parent == block))
+        {
+            if (!SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(reference, cancellationToken).Symbol,
+                    local)
+                || !TryGetStableLocalInitializer(
+                    local,
+                    semanticModel,
+                    cancellationToken,
+                    reference,
+                    out var initializer)
+                || !initializer.Span.Contains(invocation.Span)
+                || !IsSynchronouslyObservedCore(
+                    reference,
+                    semanticModel,
+                    cancellationToken))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsObservationPreservingArgumentPath(
@@ -1608,8 +1751,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         foreach (var operation in DescendantOperations(root))
         {
             if (operation is IPropertyReferenceOperation property
-                && property.Property.Name == "Context"
-                && knownTypes.IsEventContextReference(property.Property.Type))
+                && ContainsEventContextReference(property.Property.Type, knownTypes))
             {
                 capturedContext = property.Syntax;
                 return true;

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -2109,59 +2109,6 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         _ => null,
     };
 
-    private static bool IsRetainedAliasExpression(
-        ExpressionSyntax expression,
-        HashSet<string> retainedNames,
-        HashSet<ISymbol> retainedSymbols,
-        SemanticModel? semanticModel,
-        CancellationToken cancellationToken) => expression switch
-    {
-        IdentifierNameSyntax identifier => IsRetainedReference(
-            identifier,
-            retainedNames,
-            retainedSymbols,
-            semanticModel,
-            cancellationToken),
-        MemberAccessExpressionSyntax { Name: IdentifierNameSyntax identifier }
-            when semanticModel is not null
-                && IsRetainedReference(
-                identifier,
-                retainedNames,
-                retainedSymbols,
-                semanticModel,
-                cancellationToken) => true,
-        MemberAccessExpressionSyntax memberAccess
-            when memberAccess.Name.Identifier.ValueText is "Context" or "Properties" =>
-            IsRetainedAliasExpression(
-                memberAccess.Expression,
-                retainedNames,
-                retainedSymbols,
-                semanticModel,
-                cancellationToken),
-        ParenthesizedExpressionSyntax parenthesized =>
-            IsRetainedAliasExpression(
-                parenthesized.Expression,
-                retainedNames,
-                retainedSymbols,
-                semanticModel,
-                cancellationToken),
-        CastExpressionSyntax cast => IsRetainedAliasExpression(
-            cast.Expression,
-            retainedNames,
-            retainedSymbols,
-            semanticModel,
-            cancellationToken),
-        PostfixUnaryExpressionSyntax postfix
-            when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression) =>
-            IsRetainedAliasExpression(
-                postfix.Operand,
-                retainedNames,
-                retainedSymbols,
-                semanticModel,
-                cancellationToken),
-        _ => false,
-    };
-
     private static bool IsRetainedReference(
         IdentifierNameSyntax identifier,
         HashSet<string> retainedNames,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1327,7 +1327,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         foreach (var argument in objectCreation.Arguments)
         {
             if (argument.Parameter is { } parameter
-                && IsConstructorParameterStored(
+                && IsInstanceParameterStored(
                     objectCreation.Constructor,
                     parameter,
                     semanticModel,
@@ -2123,7 +2123,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IOperation root,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        HashSet<ISymbol>? visitedConstructors = null)
+        HashSet<ISymbol>? visitedMethods = null)
     {
         var stack = new Stack<IOperation>();
         var visitedLocals = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
@@ -2171,7 +2171,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                          current,
                          semanticModel,
                          cancellationToken,
-                         visitedConstructors))
+                         visitedMethods))
             {
                 stack.Push(child);
             }
@@ -2194,7 +2194,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IOperation operation,
         SemanticModel? semanticModel = null,
         CancellationToken cancellationToken = default,
-        HashSet<ISymbol>? visitedConstructors = null)
+        HashSet<ISymbol>? visitedMethods = null)
     {
         switch (operation)
         {
@@ -2238,12 +2238,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         || argument.Parameter is not { } parameter
                         || semanticModel is null
                         || constructor.DeclaringSyntaxReferences.Length == 0
-                        || IsConstructorParameterStored(
+                        || IsInstanceParameterStored(
                             constructor,
                             parameter,
                             semanticModel,
                             cancellationToken,
-                            visitedConstructors))
+                            visitedMethods))
                     {
                         yield return argument.Value;
                     }
@@ -3156,7 +3156,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             foreach (var argument in objectCreation.Arguments)
             {
                 if (argument.Parameter is { } parameter
-                    && IsConstructorParameterStored(
+                    && IsInstanceParameterStored(
                         objectCreation.Constructor,
                         parameter,
                         context.Operation.SemanticModel,
@@ -3268,31 +3268,31 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool IsConstructorParameterStored(
-        IMethodSymbol? constructor,
+    private static bool IsInstanceParameterStored(
+        IMethodSymbol? method,
         IParameterSymbol parameter,
         SemanticModel? currentSemanticModel,
         CancellationToken cancellationToken,
-        HashSet<ISymbol>? visitedConstructors = null)
+        HashSet<ISymbol>? visitedMethods = null)
     {
-        if (constructor is null || currentSemanticModel is null)
+        if (method is null || currentSemanticModel is null)
         {
             return false;
         }
 
-        visitedConstructors ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-        if (!visitedConstructors.Add(constructor))
+        visitedMethods ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        if (!visitedMethods.Add(method))
         {
             return false;
         }
 
         try
         {
-            foreach (var syntaxReference in constructor.DeclaringSyntaxReferences)
+            foreach (var syntaxReference in method.DeclaringSyntaxReferences)
             {
                 var syntax = syntaxReference.GetSyntax(cancellationToken);
                 if (syntax is RecordDeclarationSyntax
-                    && constructor.ContainingType.GetMembers(parameter.Name)
+                    && method.ContainingType.GetMembers(parameter.Name)
                         .OfType<IPropertySymbol>()
                         .Any())
                 {
@@ -3317,12 +3317,25 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                                     assignment.Value,
                                     semanticModel,
                                     cancellationToken,
-                                    visitedConstructors)
+                                    visitedMethods)
                                 .Any(candidate =>
                                     Unwrap(candidate) is IParameterReferenceOperation reference
                                     && SymbolEqualityComparer.Default.Equals(
                                         reference.Parameter,
                                         parameter))))
+                {
+                    return true;
+                }
+
+                if (bodyOperation is not null
+                    && DescendantOperations(bodyOperation)
+                        .OfType<IInvocationOperation>()
+                        .Any(invocation => IsRetainingInstanceInvocation(
+                            invocation,
+                            parameter,
+                            semanticModel,
+                            cancellationToken,
+                            visitedMethods)))
                 {
                     return true;
                 }
@@ -3340,12 +3353,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                             }
                             && Unwrap(value) is IParameterReferenceOperation reference
                             && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)
-                            && IsConstructorParameterStored(
+                            && IsInstanceParameterStored(
                                 delegatedConstructor,
                                 delegatedParameter,
                                 semanticModel,
                                 cancellationToken,
-                                visitedConstructors))
+                                visitedMethods))
                         {
                             return true;
                         }
@@ -3357,9 +3370,57 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
         finally
         {
-            visitedConstructors.Remove(constructor);
+            visitedMethods.Remove(method);
         }
     }
+
+    private static bool IsRetainingInstanceInvocation(
+        IInvocationOperation invocation,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        HashSet<ISymbol> visitedMethods)
+    {
+        if (!IsRootedInCurrentInstance(invocation.Instance))
+        {
+            return false;
+        }
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (!RetainedValueOperations(
+                    argument.Value,
+                    semanticModel,
+                    cancellationToken,
+                    visitedMethods)
+                .Any(candidate =>
+                    Unwrap(candidate) is IParameterReferenceOperation reference
+                    && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)))
+            {
+                continue;
+            }
+
+            if (IsKnownRetainingMutation(invocation.TargetMethod)
+                || argument.Parameter is { } invokedParameter
+                && invocation.TargetMethod.DeclaringSyntaxReferences.Length > 0
+                && IsInstanceParameterStored(
+                    invocation.TargetMethod,
+                    invokedParameter,
+                    semanticModel,
+                    cancellationToken,
+                    visitedMethods))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsKnownRetainingMutation(IMethodSymbol method) =>
+        method.Name is "Add" or "Enqueue" or "Push" or "Insert" or "TryAdd"
+        && method.ContainingNamespace.ToDisplayString() is
+            "System.Collections.Generic" or "System.Collections.Concurrent";
 
     private static bool IsConstructorInstanceMember(IOperation operation)
     {

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -940,6 +940,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             StringComparer.Ordinal);
         var retainedSymbolOrigins = new Dictionary<ISymbol, List<SyntaxNode?>>(
             SymbolEqualityComparer.Default);
+        var retainedNameKills = new Dictionary<string, List<SyntaxNode>>(StringComparer.Ordinal);
+        var retainedSymbolKills = new Dictionary<ISymbol, List<SyntaxNode>>(
+            SymbolEqualityComparer.Default);
         foreach (var symbol in retainedSymbols)
         {
             retainedSymbolOrigins.Add(symbol, [null]);
@@ -975,32 +978,86 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     alias,
                     retainedNameOrigins,
                     retainedSymbolOrigins,
+                    retainedNameKills,
+                    retainedSymbolKills,
                     semanticModel,
                     controlFlowGraph,
                     cancellationToken))
             {
                 retainedNames.Add(name);
-                AddRetainedOrigin(retainedNameOrigins, name, alias);
+                AddRetainedNameOrigin(retainedNameOrigins, name, alias);
                 if (target is not null)
                 {
                     retainedSymbols.Add(target);
-                    AddRetainedOrigin(retainedSymbolOrigins, target, alias);
+                    AddRetainedSymbolOrigin(retainedSymbolOrigins, target, alias);
                 }
             }
-            else if (IsUnconditionalAliasWrite(alias, body))
+            else
             {
                 if (target is not null)
                 {
-                    retainedSymbols.Remove(target);
-                    retainedSymbolOrigins.Remove(target);
+                    AddRetainedSymbolKill(retainedSymbolKills, target, alias);
                 }
                 else
                 {
-                    retainedNames.Remove(name);
-                    retainedNameOrigins.Remove(name);
+                    AddRetainedNameKill(retainedNameKills, name, alias);
+                }
+
+                if (IsUnconditionalAliasWrite(alias, body))
+                {
+                    if (target is not null)
+                    {
+                        retainedSymbols.Remove(target);
+                        retainedSymbolOrigins.Remove(target);
+                    }
+                    else
+                    {
+                        retainedNames.Remove(name);
+                        retainedNameOrigins.Remove(name);
+                    }
                 }
             }
         }
+
+        retainedNames.RemoveWhere(name =>
+        {
+            retainedNameKills.TryGetValue(name, out var kills);
+            return retainedNameOrigins.TryGetValue(name, out var origins)
+                && (!HasReachableOrigin(origins, destination, controlFlowGraph, kills)
+                    || IsClearedOnEveryBranch(kills, destination, body));
+        });
+        retainedSymbols.RemoveWhere(symbol =>
+        {
+            retainedSymbolKills.TryGetValue(symbol, out var kills);
+            return retainedSymbolOrigins.TryGetValue(symbol, out var origins)
+                && (!HasReachableOrigin(origins, destination, controlFlowGraph, kills)
+                    || IsClearedOnEveryBranch(kills, destination, body));
+        });
+    }
+
+    private static bool IsClearedOnEveryBranch(
+        List<SyntaxNode>? kills,
+        SyntaxNode destination,
+        SyntaxNode body)
+    {
+        if (kills is null || kills.Count < 2)
+        {
+            return false;
+        }
+
+        foreach (var conditional in body.DescendantNodes()
+                     .OfType<IfStatementSyntax>()
+                     .Where(candidate => candidate.SpanStart < destination.SpanStart
+                         && candidate.Else is not null))
+        {
+            if (kills.Any(kill => conditional.Statement.Span.Contains(kill.Span))
+                && kills.Any(kill => conditional.Else!.Statement.Span.Contains(kill.Span)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool HasReachableRetainedAlias(
@@ -1008,6 +1065,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         SyntaxNode destination,
         Dictionary<string, List<SyntaxNode?>> retainedNameOrigins,
         Dictionary<ISymbol, List<SyntaxNode?>> retainedSymbolOrigins,
+        Dictionary<string, List<SyntaxNode>> retainedNameKills,
+        Dictionary<ISymbol, List<SyntaxNode>> retainedSymbolKills,
         SemanticModel? semanticModel,
         ControlFlowGraph? controlFlowGraph,
         CancellationToken cancellationToken)
@@ -1015,17 +1074,25 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         if (expression is IdentifierNameSyntax identifier)
         {
             var symbol = semanticModel?.GetSymbolInfo(identifier, cancellationToken).Symbol;
-            return symbol is not null
-                ? HasReachableOrigin(
-                    retainedSymbolOrigins,
-                    symbol,
+            var hasOrigins = symbol is not null
+                ? retainedSymbolOrigins.TryGetValue(symbol, out var origins)
+                : retainedNameOrigins.TryGetValue(identifier.Identifier.ValueText, out origins);
+            List<SyntaxNode>? kills;
+            if (symbol is not null)
+            {
+                retainedSymbolKills.TryGetValue(symbol, out kills);
+            }
+            else
+            {
+                retainedNameKills.TryGetValue(identifier.Identifier.ValueText, out kills);
+            }
+
+            return hasOrigins
+                && HasReachableOrigin(
+                    origins!,
                     destination,
-                    controlFlowGraph)
-                : HasReachableOrigin(
-                    retainedNameOrigins,
-                    identifier.Identifier.ValueText,
-                    destination,
-                    controlFlowGraph);
+                    controlFlowGraph,
+                    kills);
         }
 
         if (expression is MemberAccessExpressionSyntax memberAccess)
@@ -1033,12 +1100,19 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             var symbol = semanticModel?.GetSymbolInfo(
                 memberAccess.Name,
                 cancellationToken).Symbol;
+            List<SyntaxNode>? kills = null;
+            if (symbol is not null)
+            {
+                retainedSymbolKills.TryGetValue(symbol, out kills);
+            }
+
             if (symbol is not null
+                && retainedSymbolOrigins.TryGetValue(symbol, out var origins)
                 && HasReachableOrigin(
-                    retainedSymbolOrigins,
-                    symbol,
+                    origins,
                     destination,
-                    controlFlowGraph))
+                    controlFlowGraph,
+                    kills))
             {
                 return true;
             }
@@ -1049,6 +1123,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     destination,
                     retainedNameOrigins,
                     retainedSymbolOrigins,
+                    retainedNameKills,
+                    retainedSymbolKills,
                     semanticModel,
                     controlFlowGraph,
                     cancellationToken);
@@ -1061,6 +1137,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 destination,
                 retainedNameOrigins,
                 retainedSymbolOrigins,
+                retainedNameKills,
+                retainedSymbolKills,
                 semanticModel,
                 controlFlowGraph,
                 cancellationToken),
@@ -1069,6 +1147,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 destination,
                 retainedNameOrigins,
                 retainedSymbolOrigins,
+                retainedNameKills,
+                retainedSymbolKills,
                 semanticModel,
                 controlFlowGraph,
                 cancellationToken),
@@ -1079,6 +1159,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     destination,
                     retainedNameOrigins,
                     retainedSymbolOrigins,
+                    retainedNameKills,
+                    retainedSymbolKills,
                     semanticModel,
                     controlFlowGraph,
                     cancellationToken),
@@ -1086,28 +1168,148 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    private static bool HasReachableOrigin<TKey>(
-        Dictionary<TKey, List<SyntaxNode?>> retainedOrigins,
-        TKey key,
+    private static bool HasReachableOrigin(
+        List<SyntaxNode?> origins,
         SyntaxNode destination,
-        ControlFlowGraph? controlFlowGraph)
-        where TKey : notnull =>
-        retainedOrigins.TryGetValue(key, out var origins)
-        && origins.Any(origin => origin is null || CanReach(origin, destination, controlFlowGraph));
+        ControlFlowGraph? controlFlowGraph,
+        List<SyntaxNode>? kills = null) =>
+        origins.Any(origin => origin is null
+            || CanReachWithoutKills(origin, destination, kills, controlFlowGraph));
 
-    private static void AddRetainedOrigin<TKey>(
-        Dictionary<TKey, List<SyntaxNode?>> retainedOrigins,
-        TKey key,
-        SyntaxNode origin)
-        where TKey : notnull
+    private static bool CanReachWithoutKills(
+        SyntaxNode source,
+        SyntaxNode target,
+        List<SyntaxNode>? kills,
+        ControlFlowGraph? controlFlowGraph)
     {
-        if (!retainedOrigins.TryGetValue(key, out var origins))
+        if (kills is null || kills.Count == 0 || controlFlowGraph is null)
+        {
+            return CanReach(source, target, controlFlowGraph);
+        }
+
+        var sourceSyntax = source is VariableDeclaratorSyntax
+            ? source.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>() ?? source
+            : source;
+        var sourceBlocks = controlFlowGraph.Blocks
+            .Where(block => block.IsReachable && ContainsOperationSyntax(block, sourceSyntax))
+            .ToArray();
+        var targetBlocks = new HashSet<BasicBlock>(controlFlowGraph.Blocks
+            .Where(block => block.IsReachable && ContainsOperationSyntax(block, target)));
+        if (sourceBlocks.Length == 0 || targetBlocks.Count == 0)
+        {
+            return CanReach(source, target, controlFlowGraph);
+        }
+
+        foreach (var sourceBlock in sourceBlocks)
+        {
+            if (targetBlocks.Contains(sourceBlock)
+                && !ContainsKill(sourceBlock, kills, source.SpanStart, target.SpanStart))
+            {
+                return true;
+            }
+
+            if (ContainsKill(sourceBlock, kills, source.SpanStart, int.MaxValue))
+            {
+                continue;
+            }
+
+            var pending = new Queue<BasicBlock>();
+            var visited = new HashSet<BasicBlock>();
+            EnqueueSuccessor(sourceBlock.FallThroughSuccessor, pending);
+            EnqueueSuccessor(sourceBlock.ConditionalSuccessor, pending);
+            while (pending.Count > 0)
+            {
+                var block = pending.Dequeue();
+                if (!visited.Add(block))
+                {
+                    continue;
+                }
+
+                if (targetBlocks.Contains(block))
+                {
+                    if (!ContainsKill(block, kills, int.MinValue, target.SpanStart))
+                    {
+                        return true;
+                    }
+
+                    continue;
+                }
+
+                if (ContainsKill(block, kills, int.MinValue, int.MaxValue))
+                {
+                    continue;
+                }
+
+                EnqueueSuccessor(block.FallThroughSuccessor, pending);
+                EnqueueSuccessor(block.ConditionalSuccessor, pending);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsKill(
+        BasicBlock block,
+        List<SyntaxNode> kills,
+        int after,
+        int before) => kills.Any(kill => kill.SpanStart > after
+            && kill.SpanStart < before
+            && ContainsOperationSyntax(block, kill));
+
+    private static void AddRetainedNameOrigin(
+        Dictionary<string, List<SyntaxNode?>> retainedOrigins,
+        string name,
+        SyntaxNode origin)
+    {
+        if (!retainedOrigins.TryGetValue(name, out var origins))
         {
             origins = [];
-            retainedOrigins.Add(key, origins);
+            retainedOrigins.Add(name, origins);
         }
 
         origins.Add(origin);
+    }
+
+    private static void AddRetainedSymbolOrigin(
+        Dictionary<ISymbol, List<SyntaxNode?>> retainedOrigins,
+        ISymbol symbol,
+        SyntaxNode origin)
+    {
+        if (!retainedOrigins.TryGetValue(symbol, out var origins))
+        {
+            origins = [];
+            retainedOrigins.Add(symbol, origins);
+        }
+
+        origins.Add(origin);
+    }
+
+    private static void AddRetainedNameKill(
+        Dictionary<string, List<SyntaxNode>> retainedKills,
+        string name,
+        SyntaxNode kill)
+    {
+        if (!retainedKills.TryGetValue(name, out var kills))
+        {
+            kills = [];
+            retainedKills.Add(name, kills);
+        }
+
+        kills.Add(kill);
+    }
+
+    private static void AddRetainedSymbolKill(
+        Dictionary<ISymbol, List<SyntaxNode>> retainedKills,
+        ISymbol symbol,
+        SyntaxNode kill)
+    {
+        if (!retainedKills.TryGetValue(symbol, out var kills))
+        {
+            kills = [];
+            retainedKills.Add(symbol, kills);
+        }
+
+        kills.Add(kill);
     }
 
     private static bool TryFindRetainedContextInLocalFunction(
@@ -2906,7 +3108,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
 
             if (operation is IPropertyReferenceOperation property
-                && ContainsEventContextReference(property.Property.Type, knownTypes))
+                && (knownTypes.IsEventContextReference(property.Property.Type)
+                    || knownTypes.IsEventContextContainer(property.Property.Type)
+                        && IsProvenEventMemberCapture(
+                            property.Property,
+                            property.Syntax,
+                            context,
+                            knownTypes)))
             {
                 capturedContext = property.Syntax;
                 return true;
@@ -2921,7 +3129,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
 
             if (operation is IFieldReferenceOperation fieldReference
-                && knownTypes.IsEventContextReference(fieldReference.Field.Type))
+                && (knownTypes.IsEventContextReference(fieldReference.Field.Type)
+                    || knownTypes.IsEventContextContainer(fieldReference.Field.Type)
+                        && IsProvenEventMemberCapture(
+                            fieldReference.Field,
+                            fieldReference.Syntax,
+                            context,
+                            knownTypes)))
             {
                 capturedContext = fieldReference.Syntax;
                 return true;
@@ -2980,6 +3194,73 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         capturedContext = null!;
         return false;
+    }
+
+    private static bool IsProvenEventMemberCapture(
+        ISymbol member,
+        SyntaxNode reference,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes)
+    {
+        var scheduledDelegate = reference.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>();
+        var callback = scheduledDelegate?.Ancestors()
+            .OfType<AnonymousFunctionExpressionSyntax>()
+            .FirstOrDefault();
+        var semanticModel = context.Operation.SemanticModel;
+        if (callback is null || semanticModel is null)
+        {
+            return false;
+        }
+
+        var callbackAssignment = callback.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+        if (callbackAssignment is null
+            || semanticModel.GetSymbolInfo(
+                    callbackAssignment.Left,
+                    context.CancellationToken).Symbol
+                is not IPropertySymbol callbackProperty
+            || !knownTypes.IsSynchronousCallback(callbackProperty))
+        {
+            return false;
+        }
+
+        var callbackParameterNames = callback switch
+        {
+            SimpleLambdaExpressionSyntax simple => [simple.Parameter.Identifier.ValueText],
+            ParenthesizedLambdaExpressionSyntax parenthesized => parenthesized.ParameterList.Parameters
+                .Select(static parameter => parameter.Identifier.ValueText)
+                .ToArray(),
+            AnonymousMethodExpressionSyntax { ParameterList: { } parameterList } =>
+                parameterList.Parameters
+                    .Select(static parameter => parameter.Identifier.ValueText)
+                    .ToArray(),
+            _ => [],
+        };
+        if (callbackParameterNames.Length == 0)
+        {
+            return false;
+        }
+
+        var assignment = callback.Body
+            .DescendantNodes(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax)
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(candidate => candidate.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                && candidate.SpanStart < scheduledDelegate!.SpanStart
+                && (SymbolEqualityComparer.Default.Equals(
+                        semanticModel.GetSymbolInfo(
+                            candidate.Left,
+                            context.CancellationToken).Symbol,
+                        member)
+                    || GetAssignedName(candidate.Left) == member.Name))
+            .OrderBy(static candidate => candidate.SpanStart)
+            .LastOrDefault();
+        return assignment is not null
+            && assignment.Right.DescendantNodesAndSelf()
+                .OfType<IdentifierNameSyntax>()
+                .Any(identifier => callbackParameterNames.Contains(
+                    identifier.Identifier.ValueText,
+                    StringComparer.Ordinal));
     }
 
     private static bool ContainsReferenceOwnedByNestedAnonymousFunction(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -21,6 +21,37 @@ namespace Kevlar.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 {
+    private static readonly ImmutableHashSet<string> RetainingCollectionNamespaces =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            "System.Collections.Generic",
+            "System.Collections.Concurrent");
+
+    private static readonly ImmutableHashSet<string> RetainingCollectionTypes =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            "List",
+            "Dictionary",
+            "HashSet",
+            "Queue",
+            "Stack",
+            "LinkedList",
+            "SortedSet",
+            "SortedDictionary",
+            "ConcurrentBag",
+            "ConcurrentDictionary",
+            "ConcurrentQueue",
+            "ConcurrentStack");
+
+    private static readonly ImmutableHashSet<string> RetainingMutationNames =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            "Add",
+            "Enqueue",
+            "Push",
+            "Insert",
+            "TryAdd");
+
     /// <summary>The KEV002 rule.</summary>
     public static readonly DiagnosticDescriptor SynchronousHedgeRule = new(
         id: "KEV002",
@@ -538,18 +569,31 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             else if (IsUnconditionalAliasWrite(alias, anonymous.Body))
             {
                 retainedNames.Remove(name);
+                if (target is IFieldSymbol or IPropertySymbol)
+                {
+                    retainedSymbols.Remove(target);
+                }
             }
         }
 
         foreach (var assignment in nodes.OfType<AssignmentExpressionSyntax>()
                      .Where(assignment => assignment.SpanStart < invocation.SpanStart
-                         && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)))
+                         && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+                     .OrderBy(static assignment => assignment.SpanStart))
         {
             var target = context.SemanticModel.GetSymbolInfo(
                 assignment.Left,
                 context.CancellationToken).Symbol;
-            if (target is IFieldSymbol or IPropertySymbol
-                && TryFindEventContextExpression(
+            if (target is not (IFieldSymbol or IPropertySymbol))
+            {
+                continue;
+            }
+
+            if (IsKnownFreshEventContextExpression(assignment.Right))
+            {
+                retainedSymbols.Remove(target);
+            }
+            else if (TryFindEventContextExpression(
                     assignment.Right,
                     context,
                     knownTypes,
@@ -557,10 +601,26 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             {
                 retainedSymbols.Add(target);
             }
+            else if (IsUnconditionalAliasWrite(assignment, anonymous.Body))
+            {
+                retainedSymbols.Remove(target);
+            }
         }
 
         return retainedSymbols;
     }
+
+    private static bool IsKnownFreshEventContextExpression(ExpressionSyntax expression) =>
+        expression switch
+        {
+            DefaultExpressionSyntax => true,
+            LiteralExpressionSyntax literal
+                when literal.IsKind(SyntaxKind.DefaultLiteralExpression) => true,
+            ParenthesizedExpressionSyntax parenthesized =>
+                IsKnownFreshEventContextExpression(parenthesized.Expression),
+            CastExpressionSyntax cast => IsKnownFreshEventContextExpression(cast.Expression),
+            _ => false,
+        };
 
     private static bool IsCallbackRetainedExpression(
         ExpressionSyntax expression,
@@ -3156,11 +3216,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             foreach (var argument in objectCreation.Arguments)
             {
                 if (argument.Parameter is { } parameter
-                    && IsInstanceParameterStored(
-                        objectCreation.Constructor,
-                        parameter,
-                        context.Operation.SemanticModel,
-                        context.CancellationToken)
+                    && (IsInstanceParameterStored(
+                            objectCreation.Constructor,
+                            parameter,
+                            context.Operation.SemanticModel,
+                            context.CancellationToken)
+                        || IsKnownRetainingFrameworkConstructorParameter(
+                            objectCreation.Constructor,
+                            parameter))
                     && TryFindDeferredStateContext(
                         argument.Value,
                         context,
@@ -3447,9 +3510,31 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool IsKnownRetainingMutation(IMethodSymbol method) =>
-        method.Name is "Add" or "Enqueue" or "Push" or "Insert" or "TryAdd"
-        && method.ContainingNamespace.ToDisplayString() is
-            "System.Collections.Generic" or "System.Collections.Concurrent";
+        RetainingMutationNames.Contains(method.Name)
+        && RetainingCollectionNamespaces.Contains(
+            method.ContainingNamespace.ToDisplayString());
+
+    private static bool IsKnownRetainingFrameworkConstructorParameter(
+        IMethodSymbol? constructor,
+        IParameterSymbol parameter)
+    {
+        if (constructor is null
+            || constructor.MethodKind is not MethodKind.Constructor
+            || !RetainingCollectionNamespaces.Contains(
+                constructor.ContainingNamespace.ToDisplayString())
+            || !RetainingCollectionTypes.Contains(constructor.ContainingType.Name))
+        {
+            return false;
+        }
+
+        return parameter.Type is INamedTypeSymbol type
+            && (IsGenericEnumerable(type)
+                || type.AllInterfaces.Any(IsGenericEnumerable));
+    }
+
+    private static bool IsGenericEnumerable(INamedTypeSymbol type) =>
+        type.OriginalDefinition.ToDisplayString() ==
+        "System.Collections.Generic.IEnumerable<T>";
 
     private static IEnumerable<IOperation> ExecutableDescendantOperations(IOperation root)
     {

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1811,12 +1811,6 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         out SyntaxNode capturedContext)
     {
         operation = Unwrap(operation)!;
-        if (ContainsEventContextReference(operation.Type, knownTypes))
-        {
-            capturedContext = operation.Syntax;
-            return true;
-        }
-
         if (operation is IConditionalOperation conditional
             && (TryFindDeferredStateContext(
                     conditional.WhenTrue,
@@ -1873,15 +1867,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
             if (visitedLocals.Add(localReference.Local)
                 && TryGetStableInitializer(localReference, context, out var initializer)
-                && initializer is not null
-                && TryFindDeferredStateContext(
+                && initializer is not null)
+            {
+                if (TryFindDeferredStateContext(
                     initializer,
                     context,
                     knownTypes,
                     visitedLocals,
                     out capturedContext))
-            {
-                return true;
+                {
+                    return true;
+                }
+
+                visitedLocals.Remove(localReference.Local);
+                capturedContext = null!;
+                return false;
             }
 
             visitedLocals.Remove(localReference.Local);
@@ -2030,9 +2030,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        if (IsKnownCompositeState(operation))
+        {
+            capturedContext = null!;
+            return false;
+        }
+
+        if (ContainsEventContextReference(operation.Type, knownTypes))
+        {
+            capturedContext = operation.Syntax;
+            return true;
+        }
+
         capturedContext = null!;
         return false;
     }
+
+    private static bool IsKnownCompositeState(IOperation operation) =>
+        operation is IConditionalOperation
+            or ICoalesceOperation
+            or ISwitchExpressionOperation
+            or IArrayCreationOperation
+            or ITupleOperation
+            or IObjectCreationOperation
+            or IWithOperation
+            or IAnonymousObjectCreationOperation
+        || operation.Syntax is CollectionExpressionSyntax or SpreadElementSyntax;
 
     private static bool ContainsEventContextReference(ITypeSymbol? type, KnownTypes knownTypes) =>
         knownTypes.IsEventContextReference(type)
@@ -2224,6 +2247,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     {
         foreach (var operation in DescendantOperations(root))
         {
+            if (ContainsReferenceOwnedByNestedAnonymousFunction(operation, root))
+            {
+                continue;
+            }
+
             if (operation is IPropertyReferenceOperation property
                 && ContainsEventContextReference(property.Property.Type, knownTypes))
             {
@@ -2296,6 +2324,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         capturedContext = null!;
+        return false;
+    }
+
+    private static bool ContainsReferenceOwnedByNestedAnonymousFunction(
+        IOperation operation,
+        IOperation root)
+    {
+        for (var current = operation; current is not null; current = current.Parent)
+        {
+            if (current is IAnonymousFunctionOperation anonymous
+                && root.Syntax.Span.Contains(anonymous.Syntax.Span))
+            {
+                return ContainsAnonymousOwnedReference(operation, anonymous.Symbol);
+            }
+        }
+
         return false;
     }
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -713,15 +713,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     var symbol = semanticModel.GetSymbolInfo(
                         identifier,
                         context.CancellationToken).Symbol;
-                    var type = symbol switch
-                    {
-                        IFieldSymbol field => field.Type,
-                        IPropertySymbol property => property.Type,
-                        _ => null,
-                    };
                     if (symbol is not null
-                        && callbackRetainedSymbols.Contains(symbol)
-                        && ContainsEventContextReference(type, knownTypes))
+                        && callbackRetainedSymbols.Contains(symbol))
                     {
                         retainedSymbolSeeds.Add(symbol);
                     }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -686,6 +686,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         HashSet<string> retainedNames) => expression switch
     {
         IdentifierNameSyntax identifier => retainedNames.Contains(identifier.Identifier.ValueText),
+        MemberAccessExpressionSyntax memberAccess
+            when memberAccess.Name.Identifier.ValueText is "Context" or "Properties" =>
+            IsRetainedAliasExpression(memberAccess.Expression, retainedNames),
         ParenthesizedExpressionSyntax parenthesized =>
             IsRetainedAliasExpression(parenthesized.Expression, retainedNames),
         CastExpressionSyntax cast => IsRetainedAliasExpression(cast.Expression, retainedNames),
@@ -1034,8 +1037,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             || semanticModel.GetDeclaredSymbol(
                 declarator,
                 cancellationToken) is not ILocalSymbol local
-            || declarator.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>()?.Parent
-                is not BlockSyntax block)
+            || declarator.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>()
+                is not { Parent: BlockSyntax block } declarationStatement)
         {
             return false;
         }
@@ -1044,10 +1047,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                      node is not AnonymousFunctionExpressionSyntax
                          and not LocalFunctionStatementSyntax)
                  .OfType<IdentifierNameSyntax>()
-                 .Where(reference => reference.SpanStart > declarator.SpanStart
-                     && reference.FirstAncestorOrSelf<StatementSyntax>()?.Parent == block))
+                 .Where(reference => reference.SpanStart > declarator.SpanStart))
         {
-            if (!SymbolEqualityComparer.Default.Equals(
+            if (reference.FirstAncestorOrSelf<StatementSyntax>()
+                    is not { Parent: BlockSyntax observationBlock } observationStatement
+                || observationBlock != block
+                || !SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetSymbolInfo(reference, cancellationToken).Symbol,
                     local)
                 || !TryGetStableLocalInitializer(
@@ -1060,7 +1065,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 || !IsSynchronouslyObservedCore(
                     reference,
                     semanticModel,
-                    cancellationToken))
+                    cancellationToken)
+                || semanticModel.AnalyzeControlFlow(
+                        declarationStatement,
+                        observationStatement)
+                    ?.ExitPoints.Any() != false)
             {
                 continue;
             }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -617,7 +617,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 return true;
             }
 
-            if (method.Name is not ("ConfigureAwait" or "GetAwaiter"))
+            if (method.Name is not ("ConfigureAwait" or "GetAwaiter")
+                && (method.Name != "AsTask" || !IsTaskLike(method.ContainingType)))
             {
                 break;
             }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -563,37 +563,78 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             semanticModel,
             cancellationToken);
         var retainedNames = new HashSet<string>(eventParameterNames, StringComparer.Ordinal);
+        var retainedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        if (semanticModel is not null)
+        {
+            foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
+                         .Where(identifier => eventParameterNames.Contains(
+                             identifier.Identifier.ValueText)))
+            {
+                if (semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
+                    is IParameterSymbol parameter)
+                {
+                    retainedSymbols.Add(parameter);
+                }
+            }
+        }
+
         foreach (var alias in nodes
                      .Where(node => node.SpanStart < firstAwait
                          && node is VariableDeclaratorSyntax or AssignmentExpressionSyntax)
                      .OrderBy(static node => node.SpanStart))
         {
-            var (name, value) = alias switch
+            var (target, name, value) = alias switch
             {
                 VariableDeclaratorSyntax declarator =>
-                    (declarator.Identifier.ValueText, declarator.Initializer?.Value),
+                    (semanticModel?.GetDeclaredSymbol(declarator, cancellationToken),
+                        declarator.Identifier.ValueText,
+                        declarator.Initializer?.Value),
                 AssignmentExpressionSyntax assignment
                     when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) =>
-                    (GetAssignedName(assignment.Left), assignment.Right),
-                _ => (null, null),
+                    (semanticModel?.GetSymbolInfo(assignment.Left, cancellationToken).Symbol,
+                        GetAssignedName(assignment.Left),
+                        assignment.Right),
+                _ => (null, null, null),
             };
             if (name is null)
             {
                 continue;
             }
 
-            if (value is not null && IsRetainedAliasExpression(value, retainedNames))
+            if (value is not null
+                && IsRetainedAliasExpression(
+                    value,
+                    retainedNames,
+                    retainedSymbols,
+                    semanticModel,
+                    cancellationToken))
             {
                 retainedNames.Add(name);
+                if (target is not null)
+                {
+                    retainedSymbols.Add(target);
+                }
             }
             else if (IsUnconditionalAliasWrite(alias, body))
             {
-                retainedNames.Remove(name);
+                if (target is not null)
+                {
+                    retainedSymbols.Remove(target);
+                }
+                else
+                {
+                    retainedNames.Remove(name);
+                }
             }
         }
 
         foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
-                     .Where(identifier => retainedNames.Contains(identifier.Identifier.ValueText)
+                     .Where(identifier => IsRetainedReference(
+                             identifier,
+                             retainedNames,
+                             retainedSymbols,
+                             semanticModel,
+                             cancellationToken)
                          && IsRuntimeValueReference(identifier)
                          && awaits.Any(awaitExpression => CanReachAfterSuspension(
                              awaitExpression,
@@ -983,20 +1024,58 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static bool IsRetainedAliasExpression(
         ExpressionSyntax expression,
-        HashSet<string> retainedNames) => expression switch
+        HashSet<string> retainedNames,
+        HashSet<ISymbol> retainedSymbols,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken) => expression switch
     {
-        IdentifierNameSyntax identifier => retainedNames.Contains(identifier.Identifier.ValueText),
+        IdentifierNameSyntax identifier => IsRetainedReference(
+            identifier,
+            retainedNames,
+            retainedSymbols,
+            semanticModel,
+            cancellationToken),
         MemberAccessExpressionSyntax memberAccess
             when memberAccess.Name.Identifier.ValueText is "Context" or "Properties" =>
-            IsRetainedAliasExpression(memberAccess.Expression, retainedNames),
+            IsRetainedAliasExpression(
+                memberAccess.Expression,
+                retainedNames,
+                retainedSymbols,
+                semanticModel,
+                cancellationToken),
         ParenthesizedExpressionSyntax parenthesized =>
-            IsRetainedAliasExpression(parenthesized.Expression, retainedNames),
-        CastExpressionSyntax cast => IsRetainedAliasExpression(cast.Expression, retainedNames),
+            IsRetainedAliasExpression(
+                parenthesized.Expression,
+                retainedNames,
+                retainedSymbols,
+                semanticModel,
+                cancellationToken),
+        CastExpressionSyntax cast => IsRetainedAliasExpression(
+            cast.Expression,
+            retainedNames,
+            retainedSymbols,
+            semanticModel,
+            cancellationToken),
         PostfixUnaryExpressionSyntax postfix
             when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression) =>
-            IsRetainedAliasExpression(postfix.Operand, retainedNames),
+            IsRetainedAliasExpression(
+                postfix.Operand,
+                retainedNames,
+                retainedSymbols,
+                semanticModel,
+                cancellationToken),
         _ => false,
     };
+
+    private static bool IsRetainedReference(
+        IdentifierNameSyntax identifier,
+        HashSet<string> retainedNames,
+        HashSet<ISymbol> retainedSymbols,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken) =>
+        semanticModel?.GetSymbolInfo(identifier, cancellationToken).Symbol is { } symbol
+            ? retainedSymbols.Contains(symbol)
+            : retainedNames.Contains(identifier.Identifier.ValueText);
 
     private static SyntaxNode? GetFunctionBody(SyntaxNode declaration) => declaration switch
     {
@@ -1389,10 +1468,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     reference,
                     semanticModel,
                     cancellationToken)
-                || semanticModel.AnalyzeControlFlow(
-                        declarationStatement,
-                        observationStatement)
-                    ?.ExitPoints.Any() != false)
+                || !IsGuaranteedBeforeFunctionExit(
+                    invocation,
+                    reference,
+                    semanticModel,
+                    cancellationToken))
             {
                 continue;
             }
@@ -1401,6 +1481,68 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool IsGuaranteedBeforeFunctionExit(
+        SyntaxNode start,
+        SyntaxNode observation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var controlFlowGraph = TryCreateControlFlowGraph(
+            start,
+            semanticModel,
+            cancellationToken);
+        if (controlFlowGraph is null)
+        {
+            return false;
+        }
+
+        var observationBlocks = new HashSet<BasicBlock>(controlFlowGraph.Blocks
+            .Where(block => block.IsReachable && ContainsOperationSyntax(block, observation)));
+        if (observationBlocks.Count == 0)
+        {
+            return false;
+        }
+
+        var startBlocks = controlFlowGraph.Blocks
+            .Where(block => block.IsReachable && ContainsOperationSyntax(block, start))
+            .ToArray();
+        if (startBlocks.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var startBlock in startBlocks)
+        {
+            if (observationBlocks.Contains(startBlock))
+            {
+                continue;
+            }
+
+            var pending = new Queue<BasicBlock>();
+            var visited = new HashSet<BasicBlock>();
+            EnqueueSuccessor(startBlock.FallThroughSuccessor, pending);
+            EnqueueSuccessor(startBlock.ConditionalSuccessor, pending);
+            while (pending.Count > 0)
+            {
+                var block = pending.Dequeue();
+                if (!visited.Add(block) || observationBlocks.Contains(block))
+                {
+                    continue;
+                }
+
+                if (block.Kind == BasicBlockKind.Exit)
+                {
+                    return false;
+                }
+
+                EnqueueSuccessor(block.FallThroughSuccessor, pending);
+                EnqueueSuccessor(block.ConditionalSuccessor, pending);
+            }
+        }
+
+        return true;
     }
 
     private static bool IsObservationPreservingArgumentPath(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -43,6 +43,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             "ConcurrentQueue",
             "ConcurrentStack");
 
+    private static readonly ImmutableHashSet<string> RetainingContainerTypes =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            "System.Tuple",
+            "System.ValueTuple",
+            "System.Collections.Generic.KeyValuePair");
+
     private static readonly ImmutableHashSet<string> RetainingMutationNames =
         ImmutableHashSet.Create(
             StringComparer.Ordinal,
@@ -1046,10 +1053,43 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     ContainingType: { } containingType,
                 },
             } => IsKnownCompletedAwaitableType(containingType),
+            IInvocationOperation invocation => IsKnownZeroDurationTaskDelay(invocation),
             IObjectCreationOperation { Constructor: { } constructor } =>
                 IsKnownCompletedValueTaskConstructor(constructor),
             IDefaultValueOperation { Type: INamedTypeSymbol type } =>
                 IsKnownValueTaskType(type),
+            _ => false,
+        };
+    }
+
+    private static bool IsKnownZeroDurationTaskDelay(IInvocationOperation invocation)
+    {
+        if (invocation.TargetMethod is not
+            {
+                IsStatic: true,
+                Name: "Delay",
+                ContainingType: { } containingType,
+            }
+            || containingType.ToDisplayString() != "System.Threading.Tasks.Task")
+        {
+            return false;
+        }
+
+        var duration = Unwrap(invocation.Arguments
+            .FirstOrDefault(static argument => argument.Parameter?.Ordinal == 0)
+            ?.Value);
+        return duration switch
+        {
+            { ConstantValue: { HasValue: true, Value: 0 } } => true,
+            IFieldReferenceOperation
+            {
+                Field:
+                {
+                    IsStatic: true,
+                    Name: "Zero",
+                    ContainingType: { } timeSpanType,
+                },
+            } => timeSpanType.ToDisplayString() == "System.TimeSpan",
             _ => false,
         };
     }
@@ -3519,10 +3559,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IParameterSymbol parameter)
     {
         if (constructor is null
-            || constructor.MethodKind is not MethodKind.Constructor
-            || !RetainingCollectionNamespaces.Contains(
-                constructor.ContainingNamespace.ToDisplayString())
-            || !RetainingCollectionTypes.Contains(constructor.ContainingType.Name))
+            || constructor.MethodKind is not MethodKind.Constructor)
+        {
+            return false;
+        }
+
+        var containingType = constructor.ContainingType;
+        if (RetainingContainerTypes.Contains(
+                $"{containingType.ContainingNamespace}.{containingType.Name}"))
+        {
+            return true;
+        }
+
+        if (!RetainingCollectionNamespaces.Contains(
+                containingType.ContainingNamespace.ToDisplayString())
+            || !RetainingCollectionTypes.Contains(containingType.Name))
         {
             return false;
         }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1162,6 +1162,24 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     cancellationToken);
         }
 
+        var operation = Unwrap(semanticModel?.GetOperation(expression, cancellationToken));
+        if (operation is not null
+            && GetRetainedValueParts(operation).Any(part =>
+                part.Syntax is ExpressionSyntax partExpression
+                && HasReachableRetainedAlias(
+                    partExpression,
+                    destination,
+                    retainedNameOrigins,
+                    retainedSymbolOrigins,
+                    retainedNameKills,
+                    retainedSymbolKills,
+                    semanticModel,
+                    controlFlowGraph,
+                    cancellationToken)))
+        {
+            return true;
+        }
+
         return expression switch
         {
             ParenthesizedExpressionSyntax parenthesized => HasReachableRetainedAlias(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -5353,20 +5353,34 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 _synchronousCallbackTypes.Add(type);
                 foreach (var property in type.GetMembers().OfType<IPropertySymbol>())
                 {
-                    if (property.Type is INamedTypeSymbol
+                    if (property.Type is not INamedTypeSymbol callbackType)
+                    {
+                        continue;
+                    }
+
+                    var isNotification = callbackType is
                         {
                             Name: "Action",
                             Arity: 1,
                             ContainingNamespace.Name: "System",
-                        } callbackType
-                        && callbackType.TypeArguments[0] is INamedTypeSymbol eventType
+                        }
                         && property.Name is "OnRetry"
                             or "OnTimeout"
                             or "OnStateChanged"
                             or "OnHedge"
                             or "OnFallback"
                             or "OnInjected"
-                            or "OnRejected")
+                            or "OnRejected";
+                    var isHandlingPredicate = callbackType is
+                        {
+                            Name: "Func",
+                            Arity: 2,
+                            ContainingNamespace.Name: "System",
+                        }
+                        && callbackType.TypeArguments[1].SpecialType == SpecialType.System_Boolean
+                        && property.Name == "HandlesExceptionWithContext";
+                    if ((isNotification || isHandlingPredicate)
+                        && callbackType.TypeArguments[0] is INamedTypeSymbol eventType)
                     {
                         _eventContextContainerTypes.Add(eventType.OriginalDefinition);
                     }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1215,7 +1215,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         var operation = Unwrap(semanticModel?.GetOperation(expression, cancellationToken));
         if (operation is not null
-            && GetStoredAliasValueParts(operation).Any(part =>
+            && GetStoredAliasValueParts(
+                operation,
+                semanticModel,
+                cancellationToken).Any(part =>
                 part.Syntax is ExpressionSyntax partExpression
                 && HasReachableRetainedAlias(
                     partExpression,
@@ -1269,10 +1272,39 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         };
     }
 
-    private static IEnumerable<IOperation> GetStoredAliasValueParts(IOperation operation) =>
-        operation is IObjectCreationOperation objectCreation
-            ? GetObjectInitializerValues(objectCreation.Initializer)
-            : GetRetainedValueParts(operation);
+    private static IEnumerable<IOperation> GetStoredAliasValueParts(
+        IOperation operation,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (operation is not IObjectCreationOperation objectCreation)
+        {
+            foreach (var part in GetRetainedValueParts(operation))
+            {
+                yield return part;
+            }
+
+            yield break;
+        }
+
+        foreach (var value in GetObjectInitializerValues(objectCreation.Initializer))
+        {
+            yield return value;
+        }
+
+        foreach (var argument in objectCreation.Arguments)
+        {
+            if (argument.Parameter is { } parameter
+                && IsConstructorParameterStored(
+                    objectCreation.Constructor,
+                    parameter,
+                    semanticModel,
+                    cancellationToken))
+            {
+                yield return argument.Value;
+            }
+        }
+    }
 
     private static IEnumerable<IOperation> GetObjectInitializerValues(
         IObjectOrCollectionInitializerOperation? initializer)
@@ -3074,8 +3106,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && IsConstructorParameterStored(
                         objectCreation.Constructor,
                         parameter,
-                        context,
-                        knownTypes)
+                        context.Operation.SemanticModel,
+                        context.CancellationToken)
                     && TryFindDeferredStateContext(
                         argument.Value,
                         context,
@@ -3186,10 +3218,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsConstructorParameterStored(
         IMethodSymbol? constructor,
         IParameterSymbol parameter,
-        OperationAnalysisContext context,
-        KnownTypes knownTypes)
+        SemanticModel? currentSemanticModel,
+        CancellationToken cancellationToken)
     {
-        var currentSemanticModel = context.Operation.SemanticModel;
         if (constructor is null || currentSemanticModel is null)
         {
             return false;
@@ -3197,11 +3228,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         foreach (var syntaxReference in constructor.DeclaringSyntaxReferences)
         {
-            var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+            var syntax = syntaxReference.GetSyntax(cancellationToken);
             if (syntax is RecordDeclarationSyntax
                 && constructor.ContainingType.GetMembers(parameter.Name)
                     .OfType<IPropertySymbol>()
-                    .Any(property => CanRetainDeferredState(property.Type, knownTypes)))
+                    .Any())
             {
                 return true;
             }
@@ -3214,12 +3245,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             var body = GetFunctionBody(syntax);
             var bodyOperation = body is null
                 ? null
-                : semanticModel.GetOperation(body, context.CancellationToken);
+                : semanticModel.GetOperation(body, cancellationToken);
             if (bodyOperation is not null
                 && DescendantOperations(bodyOperation)
                     .OfType<ISimpleAssignmentOperation>()
                     .Any(assignment =>
-                        CanRetainDeferredState(assignment.Target.Type, knownTypes)
+                        assignment.Target is IFieldReferenceOperation { Field.IsStatic: false }
+                            or IPropertyReferenceOperation { Property.IsStatic: false }
                         && Unwrap(assignment.Value) is IParameterReferenceOperation reference
                         && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)))
             {
@@ -3229,9 +3261,6 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         return false;
     }
-
-    private static bool CanRetainDeferredState(ITypeSymbol? type, KnownTypes knownTypes) =>
-        type?.IsReferenceType is true || ContainsEventContextReference(type, knownTypes);
 
     private static bool IsKnownCompositeState(IOperation operation) =>
         operation is IConditionalOperation

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1660,6 +1660,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             var functionRetainedSymbols = new HashSet<ISymbol>(
                 retainedSymbols,
                 SymbolEqualityComparer.Default);
+            if (semanticModel?.GetOperation(invocation, cancellationToken)
+                    is IInvocationOperation invocationOperation)
+            {
+                foreach (var argument in invocationOperation.Arguments)
+                {
+                    if (argument.Parameter is { } parameter
+                        && IsRetainedArgumentValue(
+                            argument.Value,
+                            retainedNames,
+                            retainedSymbols))
+                    {
+                        functionRetainedSymbols.Add(parameter);
+                    }
+                }
+            }
+
             foreach (var parameter in function.ParameterList.Parameters)
             {
                 functionRetainedNames.Remove(parameter.Identifier.ValueText);
@@ -1762,15 +1778,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 foreach (var argument in invocationOperation.Arguments)
                 {
                     if (argument.Parameter is { } parameter
-                        && ContainsEventContextReference(argument.Value.Type, knownTypes)
-                        && argument.Value.Syntax.DescendantNodesAndSelf()
-                            .OfType<IdentifierNameSyntax>()
-                            .Any(identifier => IsRetainedReference(
-                                identifier,
-                                retainedNames,
-                                retainedSymbols,
-                                semanticModel,
-                                cancellationToken)))
+                        && IsRetainedArgumentValue(
+                            argument.Value,
+                            retainedNames,
+                            retainedSymbols))
                     {
                         methodRetainedSymbols.Add(parameter);
                     }
@@ -2151,6 +2162,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         semanticModel?.GetSymbolInfo(identifier, cancellationToken).Symbol is { } symbol
             ? retainedSymbols.Contains(symbol)
             : retainedNames.Contains(identifier.Identifier.ValueText);
+
+    private static bool IsRetainedArgumentValue(
+        IOperation operation,
+        HashSet<string> retainedNames,
+        HashSet<ISymbol> retainedSymbols)
+    {
+        operation = Unwrap(operation)!;
+        return operation switch
+        {
+            ILocalReferenceOperation local => retainedSymbols.Contains(local.Local)
+                || retainedNames.Contains(local.Local.Name),
+            IParameterReferenceOperation parameter =>
+                retainedSymbols.Contains(parameter.Parameter)
+                || retainedNames.Contains(parameter.Parameter.Name),
+            _ => false,
+        };
+    }
 
     private static SyntaxNode? GetFunctionBody(SyntaxNode declaration) => declaration switch
     {

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -986,6 +986,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     ContainingType: { } containingType,
                 },
             } => IsKnownCompletedAwaitableType(containingType),
+            IObjectCreationOperation { Constructor: { } constructor } =>
+                IsKnownCompletedValueTaskConstructor(constructor),
+            IDefaultValueOperation { Type: INamedTypeSymbol type } =>
+                IsKnownValueTaskType(type),
             _ => false,
         };
     }
@@ -993,6 +997,29 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsKnownCompletedAwaitableType(INamedTypeSymbol type) =>
         type.ToDisplayString() is "System.Threading.Tasks.Task"
             or "System.Threading.Tasks.ValueTask";
+
+    private static bool IsKnownCompletedValueTaskConstructor(IMethodSymbol constructor)
+    {
+        if (!IsKnownValueTaskType(constructor.ContainingType))
+        {
+            return false;
+        }
+
+        if (constructor.Parameters.Length == 0)
+        {
+            return true;
+        }
+
+        return constructor.ContainingType is { IsGenericType: true, TypeArguments.Length: 1 } type
+            && constructor.Parameters.Length == 1
+            && SymbolEqualityComparer.Default.Equals(
+                constructor.Parameters[0].Type,
+                type.TypeArguments[0]);
+    }
+
+    private static bool IsKnownValueTaskType(INamedTypeSymbol type) =>
+        type.OriginalDefinition.ToDisplayString() is "System.Threading.Tasks.ValueTask"
+            or "System.Threading.Tasks.ValueTask<TResult>";
 
     private static void CollectRetainedAliases(
         SyntaxNode[] nodes,
@@ -3264,8 +3291,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && DescendantOperations(bodyOperation)
                         .OfType<ISimpleAssignmentOperation>()
                         .Any(assignment =>
-                            assignment.Target is IFieldReferenceOperation { Field.IsStatic: false }
-                                or IPropertyReferenceOperation { Property.IsStatic: false }
+                            IsConstructorInstanceMember(assignment.Target)
                             && Unwrap(assignment.Value) is IParameterReferenceOperation reference
                             && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)))
                 {
@@ -3305,6 +3331,29 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             visitedConstructors.Remove(constructor);
         }
     }
+
+    private static bool IsConstructorInstanceMember(IOperation operation)
+    {
+        var instance = operation switch
+        {
+            IFieldReferenceOperation { Field.IsStatic: false } field => field.Instance,
+            IPropertyReferenceOperation { Property.IsStatic: false } property => property.Instance,
+            _ => null,
+        };
+
+        return IsRootedInCurrentInstance(instance);
+    }
+
+    private static bool IsRootedInCurrentInstance(IOperation? operation) =>
+        Unwrap(operation) switch
+        {
+            IInstanceReferenceOperation => true,
+            IFieldReferenceOperation { Field.IsStatic: false } field =>
+                IsRootedInCurrentInstance(field.Instance),
+            IPropertyReferenceOperation { Property.IsStatic: false } property =>
+                IsRootedInCurrentInstance(property.Instance),
+            _ => false,
+        };
 
     private static bool IsKnownCompositeState(IOperation operation) =>
         operation is IConditionalOperation

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3242,6 +3242,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         var callbackParameters = new HashSet<ISymbol>(
             callbackOperation.Symbol.Parameters,
             SymbolEqualityComparer.Default);
+        var flowTarget = anchor.AncestorsAndSelf()
+            .OfType<AnonymousFunctionExpressionSyntax>()
+            .FirstOrDefault(candidate => candidate != callback
+                && callback.Span.Contains(candidate.Span))
+            ?? anchor;
 
         var assignments = callback.Body
             .DescendantNodes(descendIntoChildren: static node =>
@@ -3281,8 +3286,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             semanticModel,
             context.CancellationToken);
         return origins.Count > 0
-            && HasReachableOrigin(origins, anchor, controlFlowGraph, kills)
-            && !IsClearedOnEveryBranch(origins, kills, anchor, callback.Body);
+            && HasReachableOrigin(origins, flowTarget, controlFlowGraph, kills)
+            && !IsClearedOnEveryBranch(origins, kills, flowTarget, callback.Body);
     }
 
     private static bool ContainsReferenceOwnedByNestedAnonymousFunction(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1386,6 +1386,28 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        var expression = invocation.Expression;
+        while (true)
+        {
+            if (expression is AnonymousFunctionExpressionSyntax anonymous)
+            {
+                initializer = anonymous;
+                return true;
+            }
+
+            var parts = GetCallbackExpressionParts(
+                    expression,
+                    semanticModel,
+                    cancellationToken)
+                .ToArray();
+            if (parts.Length != 1)
+            {
+                break;
+            }
+
+            expression = parts[0];
+        }
+
         initializer = null!;
         return false;
     }
@@ -1503,6 +1525,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             if (reference.FirstAncestorOrSelf<StatementSyntax>()
                     is not { Parent: BlockSyntax observationBlock } observationStatement
                 || observationBlock != block
+                || block.Statements.Any(statement =>
+                    statement.SpanStart > declarationStatement.SpanStart
+                        && statement.SpanStart < observationStatement.SpanStart)
                 || !SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetSymbolInfo(reference, cancellationToken).Symbol,
                     local)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -660,7 +660,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     retainedNames,
                     retainedSymbols,
                     semanticModel,
-                    controlFlowGraph: null,
+                    controlFlowGraph,
                     cancellationToken: context.CancellationToken);
                 foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
                              .Where(identifier => IsRuntimeValueReference(identifier)
@@ -795,8 +795,6 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     and not LocalFunctionStatementSyntax)
             .ToArray();
         var awaits = nodes.OfType<AwaitExpressionSyntax>().ToArray();
-        var firstAwait = awaits.OrderBy(static awaitExpression => awaitExpression.SpanStart)
-            .FirstOrDefault();
         var controlFlowGraph = TryCreateControlFlowGraph(
             body,
             semanticModel,
@@ -819,17 +817,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        if (firstAwait is not null)
+        var retainedNameSeeds = new HashSet<string>(retainedNames, StringComparer.Ordinal);
+        var retainedSymbolSeedsForAwait = new HashSet<ISymbol>(
+            retainedSymbols,
+            SymbolEqualityComparer.Default);
+        foreach (var awaitExpression in awaits.OrderBy(static candidate => candidate.SpanStart))
         {
+            var namesAtAwait = new HashSet<string>(retainedNameSeeds, StringComparer.Ordinal);
+            var symbolsAtAwait = new HashSet<ISymbol>(
+                retainedSymbolSeedsForAwait,
+                SymbolEqualityComparer.Default);
             CollectRetainedAliases(
                 nodes,
-                firstAwait,
+                awaitExpression,
                 body,
-                retainedNames,
-                retainedSymbols,
+                namesAtAwait,
+                symbolsAtAwait,
                 semanticModel,
                 controlFlowGraph,
                 cancellationToken);
+            retainedNames.UnionWith(namesAtAwait);
+            retainedSymbols.UnionWith(symbolsAtAwait);
         }
 
         foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
@@ -1258,9 +1266,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        var sourceSyntax = source is VariableDeclaratorSyntax
+            ? source.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>() ?? source
+            : source;
         var sourceBlocks = controlFlowGraph.Blocks
             .Where(block => block.IsReachable
-                && ContainsOperationSyntax(block, source))
+                && ContainsOperationSyntax(block, sourceSyntax))
             .ToArray();
         var targetBlocks = new HashSet<BasicBlock>(controlFlowGraph.Blocks
             .Where(block => block.IsReachable && ContainsOperationSyntax(block, target)));
@@ -1647,7 +1658,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 context.SemanticModel,
                 context.CancellationToken,
                 out var initializer)
-            && StartsAsynchronousWork(initializer, context))
+            && StartsAsynchronousWork(initializer, context)
+            && !IsSynchronouslyObserved(
+                invocation,
+                context.SemanticModel,
+                context.CancellationToken))
         {
             return true;
         }
@@ -1669,7 +1684,17 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         CancellationToken cancellationToken,
         out ExpressionSyntax initializer)
     {
-        if (invocation.Expression is IdentifierNameSyntax identifier
+        var identifier = invocation.Expression switch
+        {
+            IdentifierNameSyntax direct => direct,
+            MemberAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax receiver,
+                Name.Identifier.ValueText: "Invoke",
+            } => receiver,
+            _ => null,
+        };
+        if (identifier is not null
             && semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
                 is ILocalSymbol { Type.TypeKind: TypeKind.Delegate } local
             && TryGetStableLocalInitializer(
@@ -2742,7 +2767,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
 
             if (operation is IParameterReferenceOperation parameterReference
-                && knownTypes.IsEventContextContainer(parameterReference.Parameter.Type))
+                && (knownTypes.IsEventContextContainer(parameterReference.Parameter.Type)
+                    || knownTypes.IsEventContextReference(parameterReference.Parameter.Type)))
             {
                 capturedContext = parameterReference.Syntax;
                 return true;

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -422,6 +422,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
+                if (TryGetInvokedStableDelegateInitializer(
+                        invocation,
+                        context.SemanticModel,
+                        context.CancellationToken,
+                        out var delegateInitializer)
+                    && TryFindEventContextExpression(
+                        delegateInitializer,
+                        context,
+                        knownTypes,
+                        out capturedContext))
+                {
+                    return true;
+                }
+
                 if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
                     && context.SemanticModel.GetSymbolInfo(
                         invocation,
@@ -1330,16 +1344,51 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static bool IsUnobservedAsyncInvocation(
         InvocationExpressionSyntax invocation,
-        SyntaxNodeAnalysisContext context) =>
-        context.SemanticModel.GetSymbolInfo(
-            invocation,
-            context.CancellationToken).Symbol is IMethodSymbol method
-        && !IsDeferredScheduler(method)
-        && StartsAsynchronousWork(method)
-        && !IsSynchronouslyObserved(
-            invocation,
-            context.SemanticModel,
-            context.CancellationToken);
+        SyntaxNodeAnalysisContext context)
+    {
+        if (TryGetInvokedStableDelegateInitializer(
+                invocation,
+                context.SemanticModel,
+                context.CancellationToken,
+                out var initializer)
+            && StartsAsynchronousWork(initializer, context))
+        {
+            return true;
+        }
+
+        return context.SemanticModel.GetSymbolInfo(
+                invocation,
+                context.CancellationToken).Symbol is IMethodSymbol method
+            && !IsDeferredScheduler(method)
+            && StartsAsynchronousWork(method)
+            && !IsSynchronouslyObserved(
+                invocation,
+                context.SemanticModel,
+                context.CancellationToken);
+    }
+
+    private static bool TryGetInvokedStableDelegateInitializer(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax initializer)
+    {
+        if (invocation.Expression is IdentifierNameSyntax identifier
+            && semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
+                is ILocalSymbol { Type.TypeKind: TypeKind.Delegate } local
+            && TryGetStableLocalInitializer(
+                local,
+                semanticModel,
+                cancellationToken,
+                identifier,
+                out initializer))
+        {
+            return true;
+        }
+
+        initializer = null!;
+        return false;
+    }
 
     private static bool IsSynchronouslyObserved(
         InvocationExpressionSyntax invocation,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1471,6 +1471,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
+        if (IsReturnedTaskWrapper(current, semanticModel, cancellationToken))
+        {
+            return true;
+        }
+
         if (current.Ancestors()
                 .TakeWhile(static node => node is not AnonymousFunctionExpressionSyntax
                     and not StatementSyntax)
@@ -1524,6 +1529,39 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && IsTaskLike(returnType),
             _ => false,
         };
+
+    private static bool IsReturnedTaskWrapper(
+        SyntaxNode value,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var current = value;
+        while (current.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+        {
+            current = current.Parent;
+        }
+
+        if (current.Parent is not ArgumentSyntax
+            {
+                Parent.Parent: BaseObjectCreationExpressionSyntax creation,
+            }
+            || !IsTaskLike(semanticModel.GetTypeInfo(creation, cancellationToken).Type))
+        {
+            return false;
+        }
+
+        current = creation;
+        while (current.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+        {
+            current = current.Parent;
+        }
+
+        return IsTaskReturningFunction(current, semanticModel, cancellationToken)
+            && (current.Parent is ReturnStatementSyntax
+                || current.Parent is ArrowExpressionClauseSyntax
+                || current.Parent is LambdaExpressionSyntax lambda
+                    && lambda.ExpressionBody == current);
+    }
 
     private static bool IsSynchronouslyObservedThroughLocal(
         InvocationExpressionSyntax invocation,
@@ -5286,6 +5324,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             AddSynchronousCallbackType(compilation, "Kevlar.RateLimitOptions");
             AddSynchronousCallbackType(compilation, "Kevlar.ConcurrencyLimitOptions");
             AddSynchronousCallbackType(compilation, "Kevlar.Chaos.ChaosOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.Chaos.ChaosBehaviorOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.Chaos.ChaosFaultOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.Chaos.ChaosLatencyOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.Chaos.ChaosOutcomeOptions`1");
             AddSynchronousCallbackType(compilation, "Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions");
             var assemblyName = compilation.AssemblyName;
             IsTestAssembly = assemblyName is not null
@@ -5376,7 +5418,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        private static bool TryGetSynchronousCallbackEventType(
+        private bool TryGetSynchronousCallbackEventType(
             IPropertySymbol property,
             out INamedTypeSymbol eventType)
         {
@@ -5386,29 +5428,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 return false;
             }
 
-            var isNotification = callbackType is
+            if (callbackType.TypeKind != TypeKind.Delegate
+                || callbackType.TypeArguments.Length == 0
+                || callbackType.TypeArguments[0] is not INamedTypeSymbol callbackEventType
+                || !IsContextBearingCallbackArgument(callbackEventType))
+            {
+                return false;
+            }
+
+            var isSynchronousAction = callbackType is
                 {
                     Name: "Action",
                     Arity: 1,
                     ContainingNamespace.Name: "System",
-                }
-                && property.Name is "OnRetry"
-                    or "OnTimeout"
-                    or "OnStateChanged"
-                    or "OnHedge"
-                    or "OnFallback"
-                    or "OnInjected"
-                    or "OnRejected";
-            var isHandlingPredicate = callbackType is
+                };
+            var isSynchronousFunc = callbackType is
                 {
                     Name: "Func",
-                    Arity: 2,
                     ContainingNamespace.Name: "System",
                 }
-                && callbackType.TypeArguments[1].SpecialType == SpecialType.System_Boolean
-                && property.Name == "HandlesExceptionWithContext";
-            if ((isNotification || isHandlingPredicate)
-                && callbackType.TypeArguments[0] is INamedTypeSymbol callbackEventType)
+                && !IsTaskLike(callbackType.TypeArguments[callbackType.TypeArguments.Length - 1]);
+            if (isSynchronousAction || isSynchronousFunc)
             {
                 eventType = callbackEventType;
                 return true;
@@ -5416,6 +5456,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
             return false;
         }
+
+        private bool IsContextBearingCallbackArgument(INamedTypeSymbol type) =>
+            IsEventContextReference(type)
+            || type.GetMembers("Context")
+                .OfType<IPropertySymbol>()
+                .Any(property => !property.IsStatic && IsEventContextReference(property.Type));
 
         private static bool Is(INamedTypeSymbol type, INamedTypeSymbol? expected) =>
             expected is not null

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -499,13 +499,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             {
                 var declaration = syntaxReference.GetSyntax(context.CancellationToken);
                 var body = GetFunctionBody(declaration);
+#pragma warning disable RS1030 // Cross-tree method-group CFGs require that tree's semantic model.
+                var semanticModel = declaration.SyntaxTree == context.SemanticModel.SyntaxTree
+                    ? context.SemanticModel
+                    : context.SemanticModel.Compilation.GetSemanticModel(declaration.SyntaxTree);
+#pragma warning restore RS1030
                 if (body is not null
                     && TryFindPostAwaitEventContext(
                         body,
                         eventParameterNames,
-                        declaration.SyntaxTree == context.SemanticModel.SyntaxTree
-                            ? context.SemanticModel
-                            : null,
+                        semanticModel,
                         context.CancellationToken,
                         out capturedContext))
                 {
@@ -1592,7 +1595,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 || observationBlock != block
                 || block.Statements.Any(statement =>
                     statement.SpanStart > declarationStatement.SpanStart
-                        && statement.SpanStart < observationStatement.SpanStart)
+                        && statement.SpanStart < observationStatement.SpanStart
+                        && IsPotentiallyThrowingOrBranchingStatement(
+                            statement,
+                            semanticModel,
+                            cancellationToken))
                 || !SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetSymbolInfo(reference, cancellationToken).Symbol,
                     local)
@@ -1621,6 +1628,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         return false;
     }
+
+    private static bool IsPotentiallyThrowingOrBranchingStatement(
+        StatementSyntax statement,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken) =>
+        statement switch
+        {
+            EmptyStatementSyntax => false,
+            LocalDeclarationStatementSyntax declaration => declaration.Declaration.Variables
+                .Any(variable => variable.Initializer is { Value: { } value }
+                    && !semanticModel.GetConstantValue(value, cancellationToken).HasValue
+                    && value is not (DefaultExpressionSyntax or LiteralExpressionSyntax
+                    {
+                        RawKind: (int)SyntaxKind.DefaultLiteralExpression,
+                    })),
+            _ => true,
+        };
 
     private static bool IsGuaranteedBeforeFunctionExit(
         SyntaxNode start,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -934,6 +934,17 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         ControlFlowGraph? controlFlowGraph,
         CancellationToken cancellationToken)
     {
+        var retainedNameOrigins = retainedNames.ToDictionary(
+            static name => name,
+            static _ => new List<SyntaxNode?> { null },
+            StringComparer.Ordinal);
+        var retainedSymbolOrigins = new Dictionary<ISymbol, List<SyntaxNode?>>(
+            SymbolEqualityComparer.Default);
+        foreach (var symbol in retainedSymbols)
+        {
+            retainedSymbolOrigins.Add(symbol, [null]);
+        }
+
         foreach (var alias in nodes
                      .Where(node => node.SpanStart < destination.SpanStart
                          && node is (VariableDeclaratorSyntax or AssignmentExpressionSyntax)
@@ -959,17 +970,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
 
             if (value is not null
-                && IsRetainedAliasExpression(
+                && HasReachableRetainedAlias(
                     value,
-                    retainedNames,
-                    retainedSymbols,
+                    alias,
+                    retainedNameOrigins,
+                    retainedSymbolOrigins,
                     semanticModel,
+                    controlFlowGraph,
                     cancellationToken))
             {
                 retainedNames.Add(name);
+                AddRetainedOrigin(retainedNameOrigins, name, alias);
                 if (target is not null)
                 {
                     retainedSymbols.Add(target);
+                    AddRetainedOrigin(retainedSymbolOrigins, target, alias);
                 }
             }
             else if (IsUnconditionalAliasWrite(alias, body))
@@ -977,13 +992,122 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 if (target is not null)
                 {
                     retainedSymbols.Remove(target);
+                    retainedSymbolOrigins.Remove(target);
                 }
                 else
                 {
                     retainedNames.Remove(name);
+                    retainedNameOrigins.Remove(name);
                 }
             }
         }
+    }
+
+    private static bool HasReachableRetainedAlias(
+        ExpressionSyntax expression,
+        SyntaxNode destination,
+        Dictionary<string, List<SyntaxNode?>> retainedNameOrigins,
+        Dictionary<ISymbol, List<SyntaxNode?>> retainedSymbolOrigins,
+        SemanticModel? semanticModel,
+        ControlFlowGraph? controlFlowGraph,
+        CancellationToken cancellationToken)
+    {
+        if (expression is IdentifierNameSyntax identifier)
+        {
+            var symbol = semanticModel?.GetSymbolInfo(identifier, cancellationToken).Symbol;
+            return symbol is not null
+                ? HasReachableOrigin(
+                    retainedSymbolOrigins,
+                    symbol,
+                    destination,
+                    controlFlowGraph)
+                : HasReachableOrigin(
+                    retainedNameOrigins,
+                    identifier.Identifier.ValueText,
+                    destination,
+                    controlFlowGraph);
+        }
+
+        if (expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            var symbol = semanticModel?.GetSymbolInfo(
+                memberAccess.Name,
+                cancellationToken).Symbol;
+            if (symbol is not null
+                && HasReachableOrigin(
+                    retainedSymbolOrigins,
+                    symbol,
+                    destination,
+                    controlFlowGraph))
+            {
+                return true;
+            }
+
+            return memberAccess.Name.Identifier.ValueText is "Context" or "Properties"
+                && HasReachableRetainedAlias(
+                    memberAccess.Expression,
+                    destination,
+                    retainedNameOrigins,
+                    retainedSymbolOrigins,
+                    semanticModel,
+                    controlFlowGraph,
+                    cancellationToken);
+        }
+
+        return expression switch
+        {
+            ParenthesizedExpressionSyntax parenthesized => HasReachableRetainedAlias(
+                parenthesized.Expression,
+                destination,
+                retainedNameOrigins,
+                retainedSymbolOrigins,
+                semanticModel,
+                controlFlowGraph,
+                cancellationToken),
+            CastExpressionSyntax cast => HasReachableRetainedAlias(
+                cast.Expression,
+                destination,
+                retainedNameOrigins,
+                retainedSymbolOrigins,
+                semanticModel,
+                controlFlowGraph,
+                cancellationToken),
+            PostfixUnaryExpressionSyntax postfix
+                when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression) =>
+                HasReachableRetainedAlias(
+                    postfix.Operand,
+                    destination,
+                    retainedNameOrigins,
+                    retainedSymbolOrigins,
+                    semanticModel,
+                    controlFlowGraph,
+                    cancellationToken),
+            _ => false,
+        };
+    }
+
+    private static bool HasReachableOrigin<TKey>(
+        Dictionary<TKey, List<SyntaxNode?>> retainedOrigins,
+        TKey key,
+        SyntaxNode destination,
+        ControlFlowGraph? controlFlowGraph)
+        where TKey : notnull =>
+        retainedOrigins.TryGetValue(key, out var origins)
+        && origins.Any(origin => origin is null || CanReach(origin, destination, controlFlowGraph));
+
+    private static void AddRetainedOrigin<TKey>(
+        Dictionary<TKey, List<SyntaxNode?>> retainedOrigins,
+        TKey key,
+        SyntaxNode origin)
+        where TKey : notnull
+    {
+        if (!retainedOrigins.TryGetValue(key, out var origins))
+        {
+            origins = [];
+            retainedOrigins.Add(key, origins);
+        }
+
+        origins.Add(origin);
     }
 
     private static bool TryFindRetainedContextInLocalFunction(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1427,11 +1427,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         foreach (var argument in objectCreation.Arguments)
         {
             if (argument.Parameter is { } parameter
-                && IsInstanceParameterStored(
-                    objectCreation.Constructor,
-                    parameter,
-                    semanticModel,
-                    cancellationToken))
+                && (IsInstanceParameterStored(
+                        objectCreation.Constructor,
+                        parameter,
+                        semanticModel,
+                        cancellationToken)
+                    || IsKnownRetainingFrameworkConstructorParameter(
+                        objectCreation.Constructor,
+                        parameter)))
             {
                 yield return argument.Value;
             }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1043,16 +1043,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     ContainingType: { } containingType,
                 },
             } => IsKnownCompletedAwaitableType(containingType),
-            IInvocationOperation
-            {
-                TargetMethod:
-                {
-                    IsStatic: true,
-                    Name: "FromResult",
-                    Parameters.Length: 1,
-                    ContainingType: { } containingType,
-                },
-            } => IsKnownCompletedAwaitableType(containingType),
+            IInvocationOperation invocation
+                when IsKnownCompletedAwaitableFactory(invocation) => true,
             IInvocationOperation invocation => IsKnownZeroDurationTaskDelay(invocation),
             IObjectCreationOperation { Constructor: { } constructor } =>
                 IsKnownCompletedValueTaskConstructor(constructor),
@@ -1061,6 +1053,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             _ => false,
         };
     }
+
+    private static bool IsKnownCompletedAwaitableFactory(IInvocationOperation invocation) =>
+        invocation.TargetMethod is
+        {
+            IsStatic: true,
+            Parameters.Length: 1,
+            ContainingType: { } containingType,
+        } method
+        && method.Name is "FromResult" or "FromException" or "FromCanceled"
+        && IsKnownCompletedAwaitableType(containingType);
 
     private static bool IsKnownZeroDurationTaskDelay(IInvocationOperation invocation)
     {
@@ -2287,13 +2289,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     if (objectCreation.Constructor is not { } constructor
                         || argument.Parameter is not { } parameter
                         || semanticModel is null
-                        || constructor.DeclaringSyntaxReferences.Length == 0
-                        || IsInstanceParameterStored(
-                            constructor,
-                            parameter,
-                            semanticModel,
-                            cancellationToken,
-                            visitedMethods))
+                        || (constructor.DeclaringSyntaxReferences.Length == 0
+                            ? IsKnownRetainingFrameworkConstructorParameter(
+                                constructor,
+                                parameter)
+                            : IsInstanceParameterStored(
+                                constructor,
+                                parameter,
+                                semanticModel,
+                                cancellationToken,
+                                visitedMethods)))
                     {
                         yield return argument.Value;
                     }
@@ -3563,6 +3568,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             IFieldReferenceOperation { Field.IsStatic: false } field => field.Instance,
             IPropertyReferenceOperation { Property.IsStatic: false } property => property.Instance,
+            IArrayElementReferenceOperation arrayElement => arrayElement.ArrayReference,
             _ => null,
         };
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -619,7 +619,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         node is not AnonymousFunctionExpressionSyntax
                             and not LocalFunctionStatementSyntax)
                     .ToArray();
-                var awaits = nodes.OfType<AwaitExpressionSyntax>().ToArray();
+                var awaits = nodes.OfType<AwaitExpressionSyntax>()
+                    .Where(awaitExpression => !IsKnownCompletedAwait(
+                        awaitExpression,
+                        semanticModel,
+                        context.CancellationToken))
+                    .ToArray();
                 if (awaits.Length == 0)
                 {
                     continue;
@@ -3219,47 +3224,86 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IMethodSymbol? constructor,
         IParameterSymbol parameter,
         SemanticModel? currentSemanticModel,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        HashSet<ISymbol>? visitedConstructors = null)
     {
         if (constructor is null || currentSemanticModel is null)
         {
             return false;
         }
 
-        foreach (var syntaxReference in constructor.DeclaringSyntaxReferences)
+        visitedConstructors ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        if (!visitedConstructors.Add(constructor))
         {
-            var syntax = syntaxReference.GetSyntax(cancellationToken);
-            if (syntax is RecordDeclarationSyntax
-                && constructor.ContainingType.GetMembers(parameter.Name)
-                    .OfType<IPropertySymbol>()
-                    .Any())
-            {
-                return true;
-            }
-
-#pragma warning disable RS1030 // Source-backed constructors may be declared in another tree.
-            var semanticModel = syntax.SyntaxTree == currentSemanticModel.SyntaxTree
-                ? currentSemanticModel
-                : currentSemanticModel.Compilation.GetSemanticModel(syntax.SyntaxTree);
-#pragma warning restore RS1030
-            var body = GetFunctionBody(syntax);
-            var bodyOperation = body is null
-                ? null
-                : semanticModel.GetOperation(body, cancellationToken);
-            if (bodyOperation is not null
-                && DescendantOperations(bodyOperation)
-                    .OfType<ISimpleAssignmentOperation>()
-                    .Any(assignment =>
-                        assignment.Target is IFieldReferenceOperation { Field.IsStatic: false }
-                            or IPropertyReferenceOperation { Property.IsStatic: false }
-                        && Unwrap(assignment.Value) is IParameterReferenceOperation reference
-                        && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)))
-            {
-                return true;
-            }
+            return false;
         }
 
-        return false;
+        try
+        {
+            foreach (var syntaxReference in constructor.DeclaringSyntaxReferences)
+            {
+                var syntax = syntaxReference.GetSyntax(cancellationToken);
+                if (syntax is RecordDeclarationSyntax
+                    && constructor.ContainingType.GetMembers(parameter.Name)
+                        .OfType<IPropertySymbol>()
+                        .Any())
+                {
+                    return true;
+                }
+
+#pragma warning disable RS1030 // Source-backed constructors may be declared in another tree.
+                var semanticModel = syntax.SyntaxTree == currentSemanticModel.SyntaxTree
+                    ? currentSemanticModel
+                    : currentSemanticModel.Compilation.GetSemanticModel(syntax.SyntaxTree);
+#pragma warning restore RS1030
+                var body = GetFunctionBody(syntax);
+                var bodyOperation = body is null
+                    ? null
+                    : semanticModel.GetOperation(body, cancellationToken);
+                if (bodyOperation is not null
+                    && DescendantOperations(bodyOperation)
+                        .OfType<ISimpleAssignmentOperation>()
+                        .Any(assignment =>
+                            assignment.Target is IFieldReferenceOperation { Field.IsStatic: false }
+                                or IPropertyReferenceOperation { Property.IsStatic: false }
+                            && Unwrap(assignment.Value) is IParameterReferenceOperation reference
+                            && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)))
+                {
+                    return true;
+                }
+
+                if (syntax is ConstructorDeclarationSyntax { Initializer: { } initializer }
+                    && semanticModel.GetSymbolInfo(initializer, cancellationToken).Symbol
+                        is IMethodSymbol delegatedConstructor)
+                {
+                    foreach (var argument in initializer.ArgumentList.Arguments)
+                    {
+                        if (semanticModel.GetOperation(argument, cancellationToken) is IArgumentOperation
+                            {
+                                Parameter: { } delegatedParameter,
+                                Value: { } value,
+                            }
+                            && Unwrap(value) is IParameterReferenceOperation reference
+                            && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)
+                            && IsConstructorParameterStored(
+                                delegatedConstructor,
+                                delegatedParameter,
+                                semanticModel,
+                                cancellationToken,
+                                visitedConstructors))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            visitedConstructors.Remove(constructor);
+        }
     }
 
     private static bool IsKnownCompositeState(IOperation operation) =>

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -2271,10 +2271,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     visitedLocals,
                     out capturedContext);
             case IMethodReferenceOperation methodReference:
-                if (methodReference.Method.MethodKind == MethodKind.LocalFunction)
+                if (methodReference.Method.MethodKind is MethodKind.LocalFunction or MethodKind.Ordinary
+                    && methodReference.Method.DeclaringSyntaxReferences.Length > 0)
                 {
                     visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-                    if (TryFindCapturedEventContextInLocalFunction(
+                    if (TryFindCapturedEventContextInMethod(
                         methodReference.Method,
                         context,
                         knownTypes,
@@ -2374,7 +2375,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool TryFindCapturedEventContextInLocalFunction(
+    private static bool TryFindCapturedEventContextInMethod(
         IMethodSymbol method,
         OperationAnalysisContext context,
         KnownTypes knownTypes,
@@ -2389,16 +2390,24 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         try
         {
-            var semanticModel = context.Operation.SemanticModel;
-            if (semanticModel is not null)
+            var currentSemanticModel = context.Operation.SemanticModel;
+            if (currentSemanticModel is not null)
             {
                 foreach (var syntaxReference in method.DeclaringSyntaxReferences)
                 {
                     var syntax = syntaxReference.GetSyntax(context.CancellationToken);
-                    if (semanticModel.GetOperation(syntax, context.CancellationToken)
-                            is ILocalFunctionOperation { Body: { } body }
+#pragma warning disable RS1030 // Source-backed method groups may be declared in another tree.
+                    var semanticModel = syntax.SyntaxTree == currentSemanticModel.SyntaxTree
+                        ? currentSemanticModel
+                        : currentSemanticModel.Compilation.GetSemanticModel(syntax.SyntaxTree);
+#pragma warning restore RS1030
+                    var body = GetFunctionBody(syntax);
+                    var bodyOperation = body is null
+                        ? null
+                        : semanticModel.GetOperation(body, context.CancellationToken);
+                    if (bodyOperation is not null
                         && TryFindCapturedEventContextInDelegate(
-                            body,
+                            bodyOperation,
                             context,
                             knownTypes,
                             visitedSymbols,
@@ -2454,10 +2463,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
 
             if (operation is IInvocationOperation invocation
-                && invocation.TargetMethod.MethodKind == MethodKind.LocalFunction)
+                && invocation.TargetMethod.MethodKind is MethodKind.LocalFunction or MethodKind.Ordinary
+                && invocation.TargetMethod.DeclaringSyntaxReferences.Length > 0)
             {
                 visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-                if (TryFindCapturedEventContextInLocalFunction(
+                if (TryFindCapturedEventContextInMethod(
                     invocation.TargetMethod,
                     context,
                     knownTypes,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1024,18 +1024,19 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             retainedNameKills.TryGetValue(name, out var kills);
             return retainedNameOrigins.TryGetValue(name, out var origins)
                 && (!HasReachableOrigin(origins, destination, controlFlowGraph, kills)
-                    || IsClearedOnEveryBranch(kills, destination, body));
+                    || IsClearedOnEveryBranch(origins, kills, destination, body));
         });
         retainedSymbols.RemoveWhere(symbol =>
         {
             retainedSymbolKills.TryGetValue(symbol, out var kills);
             return retainedSymbolOrigins.TryGetValue(symbol, out var origins)
                 && (!HasReachableOrigin(origins, destination, controlFlowGraph, kills)
-                    || IsClearedOnEveryBranch(kills, destination, body));
+                    || IsClearedOnEveryBranch(origins, kills, destination, body));
         });
     }
 
     private static bool IsClearedOnEveryBranch(
+        List<SyntaxNode?> origins,
         List<SyntaxNode>? kills,
         SyntaxNode destination,
         SyntaxNode body)
@@ -1048,7 +1049,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         foreach (var conditional in body.DescendantNodes()
                      .OfType<IfStatementSyntax>()
                      .Where(candidate => candidate.SpanStart < destination.SpanStart
-                         && candidate.Else is not null))
+                         && candidate.Else is not null
+                         && !origins.Any(origin => origin is not null
+                             && origin.SpanStart > candidate.SpanStart
+                             && origin.SpanStart < destination.SpanStart)))
         {
             if (kills.Any(kill => conditional.Statement.Span.Contains(kill.Span))
                 && kills.Any(kill => conditional.Else!.Statement.Span.Contains(kill.Span)))
@@ -2935,6 +2939,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     context,
                     knownTypes,
                     visitedLocals,
+                    provenanceAnchor: null,
                     out capturedContext);
             case IMethodReferenceOperation methodReference:
                 if (methodReference.Method.MethodKind is MethodKind.LocalFunction or MethodKind.Ordinary
@@ -2946,6 +2951,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         context,
                         knownTypes,
                         visitedLocals,
+                        methodReference.Syntax,
                         out capturedContext))
                     {
                         return true;
@@ -3046,6 +3052,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         OperationAnalysisContext context,
         KnownTypes knownTypes,
         HashSet<ISymbol> visitedSymbols,
+        SyntaxNode provenanceAnchor,
         out SyntaxNode capturedContext)
     {
         if (!visitedSymbols.Add(method))
@@ -3077,6 +3084,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                             context,
                             knownTypes,
                             visitedSymbols,
+                            provenanceAnchor,
                             out capturedContext))
                     {
                         return true;
@@ -3098,6 +3106,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         OperationAnalysisContext context,
         KnownTypes knownTypes,
         HashSet<ISymbol>? visitedLocals,
+        SyntaxNode? provenanceAnchor,
         out SyntaxNode capturedContext)
     {
         foreach (var operation in DescendantOperations(root))
@@ -3114,7 +3123,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                             property.Property,
                             property.Syntax,
                             context,
-                            knownTypes)))
+                            knownTypes,
+                            provenanceAnchor)))
             {
                 capturedContext = property.Syntax;
                 return true;
@@ -3135,7 +3145,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                             fieldReference.Field,
                             fieldReference.Syntax,
                             context,
-                            knownTypes)))
+                            knownTypes,
+                            provenanceAnchor)))
             {
                 capturedContext = fieldReference.Syntax;
                 return true;
@@ -3151,6 +3162,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     context,
                     knownTypes,
                     visitedLocals,
+                    provenanceAnchor ?? invocation.Syntax,
                     out _))
                 {
                     capturedContext = invocation.Syntax;
@@ -3200,45 +3212,36 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         ISymbol member,
         SyntaxNode reference,
         OperationAnalysisContext context,
-        KnownTypes knownTypes)
+        KnownTypes knownTypes,
+        SyntaxNode? provenanceAnchor)
     {
-        var scheduledDelegate = reference.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>();
-        var callback = scheduledDelegate?.Ancestors()
-            .OfType<AnonymousFunctionExpressionSyntax>()
-            .FirstOrDefault();
+        var anchor = provenanceAnchor ?? reference;
         var semanticModel = context.Operation.SemanticModel;
-        if (callback is null || semanticModel is null)
+        if (semanticModel is null || semanticModel.SyntaxTree != anchor.SyntaxTree)
         {
             return false;
         }
 
-        var callbackAssignment = callback.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
-        if (callbackAssignment is null
-            || semanticModel.GetSymbolInfo(
-                    callbackAssignment.Left,
-                    context.CancellationToken).Symbol
-                is not IPropertySymbol callbackProperty
-            || !knownTypes.IsSynchronousCallback(callbackProperty))
+        var callback = anchor.AncestorsAndSelf()
+            .OfType<AnonymousFunctionExpressionSyntax>()
+            .FirstOrDefault(candidate => candidate.FirstAncestorOrSelf<AssignmentExpressionSyntax>()
+                    is { } assignment
+                && semanticModel.GetSymbolInfo(
+                        assignment.Left,
+                        context.CancellationToken).Symbol
+                    is IPropertySymbol callbackProperty
+                && knownTypes.IsSynchronousCallback(callbackProperty));
+        if (callback is null
+            || semanticModel.GetOperation(callback, context.CancellationToken)
+                is not IAnonymousFunctionOperation callbackOperation
+            || callbackOperation.Symbol.Parameters.Length == 0)
         {
             return false;
         }
 
-        var callbackParameterNames = callback switch
-        {
-            SimpleLambdaExpressionSyntax simple => [simple.Parameter.Identifier.ValueText],
-            ParenthesizedLambdaExpressionSyntax parenthesized => parenthesized.ParameterList.Parameters
-                .Select(static parameter => parameter.Identifier.ValueText)
-                .ToArray(),
-            AnonymousMethodExpressionSyntax { ParameterList: { } parameterList } =>
-                parameterList.Parameters
-                    .Select(static parameter => parameter.Identifier.ValueText)
-                    .ToArray(),
-            _ => [],
-        };
-        if (callbackParameterNames.Length == 0)
-        {
-            return false;
-        }
+        var callbackParameters = new HashSet<ISymbol>(
+            callbackOperation.Symbol.Parameters,
+            SymbolEqualityComparer.Default);
 
         var assignment = callback.Body
             .DescendantNodes(descendIntoChildren: static node =>
@@ -3246,21 +3249,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     and not LocalFunctionStatementSyntax)
             .OfType<AssignmentExpressionSyntax>()
             .Where(candidate => candidate.IsKind(SyntaxKind.SimpleAssignmentExpression)
-                && candidate.SpanStart < scheduledDelegate!.SpanStart
-                && (SymbolEqualityComparer.Default.Equals(
-                        semanticModel.GetSymbolInfo(
-                            candidate.Left,
-                            context.CancellationToken).Symbol,
-                        member)
-                    || GetAssignedName(candidate.Left) == member.Name))
+                && candidate.SpanStart < anchor.SpanStart
+                && SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(
+                        candidate.Left,
+                        context.CancellationToken).Symbol,
+                    member))
             .OrderBy(static candidate => candidate.SpanStart)
             .LastOrDefault();
         return assignment is not null
             && assignment.Right.DescendantNodesAndSelf()
                 .OfType<IdentifierNameSyntax>()
-                .Any(identifier => callbackParameterNames.Contains(
-                    identifier.Identifier.ValueText,
-                    StringComparer.Ordinal));
+                .Any(identifier => callbackParameters.Contains(
+                    semanticModel.GetSymbolInfo(
+                        identifier,
+                        context.CancellationToken).Symbol!));
     }
 
     private static bool ContainsReferenceOwnedByNestedAnonymousFunction(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -130,6 +130,26 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "Asynchronous callbacks and generators can capture a SynchronizationContext. Kevlar rejects synchronous Execute for statically known asynchronous strategy configuration instead of blocking the calling thread.");
 
+    /// <summary>The KEV013 rule.</summary>
+    public static readonly DiagnosticDescriptor AsyncWorkInSynchronousCallbackRule = new(
+        id: "KEV013",
+        title: "Asynchronous work is assigned to a synchronous callback",
+        messageFormat: "'{0}' is synchronous, so this asynchronous delegate becomes async void or discards its task. Use {1} instead.",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Kevlar's synchronous callback properties cannot await asynchronous work. Async lambdas become async void, and task-returning expression lambdas discard the task, allowing pooled event context to outlive its execution.");
+
+    /// <summary>The KEV014 rule.</summary>
+    public static readonly DiagnosticDescriptor DeferredContextCaptureRule = new(
+        id: "KEV014",
+        title: "Pooled event context is captured by deferred work",
+        messageFormat: "This deferred work captures a pooled event context. Copy the values it needs before scheduling the work.",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Task.Run and ThreadPool work can execute after a strategy callback completes. Capturing an event context there can observe state from a later execution when the pooled context is reused.");
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
@@ -143,7 +163,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             InheritedHandlingClauseRule,
             DefaultResultClauseOnValueTypeRule,
             ImplicitDefaultHandlingRule,
-            AsyncConfigurationWithSynchronousExecuteRule);
+            AsyncConfigurationWithSynchronousExecuteRule,
+            AsyncWorkInSynchronousCallbackRule,
+            DeferredContextCaptureRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -156,12 +178,520 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             compilationContext.RegisterOperationAction(
                 context => AnalyzeInvocation(context, knownTypes),
                 OperationKind.Invocation);
+            compilationContext.RegisterSyntaxNodeAction(
+                context => AnalyzeCallbackAssignment(context, knownTypes),
+                SyntaxKind.SimpleAssignmentExpression,
+                SyntaxKind.AddAssignmentExpression,
+                SyntaxKind.CoalesceAssignmentExpression);
         });
+    }
+
+    private static void AnalyzeCallbackAssignment(
+        SyntaxNodeAnalysisContext context,
+        KnownTypes knownTypes)
+    {
+        var assignment = (AssignmentExpressionSyntax)context.Node;
+        var propertyInfo = context.SemanticModel.GetSymbolInfo(
+            assignment.Left,
+            context.CancellationToken);
+        var property = propertyInfo.Symbol as IPropertySymbol
+            ?? propertyInfo.CandidateSymbols.OfType<IPropertySymbol>().FirstOrDefault();
+        if (property is null || !knownTypes.IsSynchronousCallback(property)
+            || !StartsAsynchronousWork(assignment.Right, context))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            AsyncWorkInSynchronousCallbackRule,
+            assignment.Right.GetLocation(),
+            property.Name,
+            HasAsyncCallback(property)
+                ? $"'{property.Name}Async'"
+                : "a synchronous delegate that completes before returning"));
+
+        if (TryFindDiscardedEventContext(
+                assignment.Right,
+                context,
+                knownTypes,
+                out var capturedContext))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DeferredContextCaptureRule,
+                capturedContext.GetLocation()));
+        }
+    }
+
+    private static bool HasAsyncCallback(IPropertySymbol property) =>
+        property.ContainingType.GetMembers(property.Name + "Async")
+            .OfType<IPropertySymbol>()
+            .Any();
+
+    private static bool StartsAsynchronousWork(
+        ExpressionSyntax expression,
+        SyntaxNodeAnalysisContext context)
+    {
+        if (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            return StartsAsynchronousWork(parenthesized.Expression, context);
+        }
+
+        if (expression is ConditionalExpressionSyntax conditional)
+        {
+            return StartsAsynchronousWork(conditional.WhenTrue, context)
+                || StartsAsynchronousWork(conditional.WhenFalse, context);
+        }
+
+        if (expression is BinaryExpressionSyntax coalesce
+            && coalesce.IsKind(SyntaxKind.CoalesceExpression))
+        {
+            return StartsAsynchronousWork(coalesce.Left, context)
+                || StartsAsynchronousWork(coalesce.Right, context);
+        }
+
+        if (expression is SwitchExpressionSyntax switchExpression)
+        {
+            return switchExpression.Arms.Any(arm =>
+                StartsAsynchronousWork(arm.Expression, context));
+        }
+
+        if (expression is CastExpressionSyntax cast)
+        {
+            return StartsAsynchronousWork(cast.Expression, context);
+        }
+
+        if (expression is PostfixUnaryExpressionSyntax postfix
+            && postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression))
+        {
+            return StartsAsynchronousWork(postfix.Operand, context);
+        }
+
+        if (expression is BaseObjectCreationExpressionSyntax creation
+            && context.SemanticModel.GetTypeInfo(
+                creation,
+                context.CancellationToken).Type?.TypeKind == TypeKind.Delegate
+            && creation.ArgumentList is { } arguments)
+        {
+            return arguments.Arguments.Any(argument =>
+                StartsAsynchronousWork(argument.Expression, context));
+        }
+
+        if (expression is AnonymousFunctionExpressionSyntax anonymous)
+        {
+            if (!anonymous.AsyncKeyword.IsKind(SyntaxKind.None))
+            {
+                return true;
+            }
+
+            if (anonymous is LambdaExpressionSyntax { ExpressionBody: { } body })
+            {
+                return IsTaskLike(context.SemanticModel.GetTypeInfo(
+                    body,
+                    context.CancellationToken).Type)
+                    || GetCallbackInvocations(body)
+                        .Any(invocation => IsUnobservedAsyncInvocation(invocation, context));
+            }
+
+            return anonymous.Body is BlockSyntax block
+                && GetCallbackInvocations(block)
+                    .Any(invocation => IsUnobservedAsyncInvocation(invocation, context));
+        }
+
+        var symbol = context.SemanticModel.GetSymbolInfo(expression, context.CancellationToken);
+        if (symbol.Symbol is ILocalSymbol local
+            && TryGetStableLocalInitializer(
+                local,
+                context.SemanticModel,
+                context.CancellationToken,
+                expression,
+                out var initializer))
+        {
+            return StartsAsynchronousWork(initializer, context);
+        }
+
+        return symbol.Symbol is IMethodSymbol method && StartsAsynchronousWork(method)
+            || symbol.CandidateSymbols
+                .OfType<IMethodSymbol>()
+                .Any(static candidate => StartsAsynchronousWork(candidate));
+    }
+
+    private static bool StartsAsynchronousWork(IMethodSymbol method) =>
+        (method.IsAsync && method.ReturnsVoid) || IsTaskLike(method.ReturnType);
+
+    private static bool TryFindDiscardedEventContext(
+        ExpressionSyntax expression,
+        SyntaxNodeAnalysisContext context,
+        KnownTypes knownTypes,
+        out SyntaxNode capturedContext)
+    {
+        if (context.SemanticModel.GetSymbolInfo(
+                expression,
+                context.CancellationToken).Symbol is ILocalSymbol local
+            && local.Type.TypeKind == TypeKind.Delegate
+            && TryGetStableLocalInitializer(
+                local,
+                context.SemanticModel,
+                context.CancellationToken,
+                expression,
+                out var initializer))
+        {
+            return TryFindDiscardedEventContext(
+                initializer,
+                context,
+                knownTypes,
+                out capturedContext);
+        }
+
+        foreach (var anonymous in expression.DescendantNodesAndSelf()
+                     .OfType<AnonymousFunctionExpressionSyntax>()
+                     .Where(candidate => !candidate.Ancestors()
+                         .OfType<AnonymousFunctionExpressionSyntax>()
+                         .Any(ancestor => expression.Span.Contains(ancestor.Span))))
+        {
+            foreach (var invocation in GetCallbackInvocations(anonymous.Body))
+            {
+                if (!IsUnobservedAsyncInvocation(invocation, context))
+                {
+                    continue;
+                }
+
+                if (invocation.Expression is MemberAccessExpressionSyntax memberAccess
+                    && context.SemanticModel.GetSymbolInfo(
+                        invocation,
+                        context.CancellationToken).Symbol is IMethodSymbol
+                        {
+                            ReducedFrom: not null,
+                        }
+                    && TryFindEventContextExpression(
+                        memberAccess.Expression,
+                        context,
+                        knownTypes,
+                        out capturedContext))
+                {
+                    return true;
+                }
+
+                foreach (var argument in invocation.ArgumentList.Arguments)
+                {
+                    if (TryFindEventContextExpression(
+                        argument.Expression,
+                        context,
+                        knownTypes,
+                        out capturedContext))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool TryFindEventContextExpression(
+        ExpressionSyntax expression,
+        SyntaxNodeAnalysisContext context,
+        KnownTypes knownTypes,
+        out SyntaxNode capturedContext)
+    {
+        var operation = Unwrap(context.SemanticModel.GetOperation(
+            expression,
+            context.CancellationToken));
+        if (operation is not null)
+        {
+            foreach (var candidate in RetainedValueOperations(
+                operation,
+                context.SemanticModel,
+                context.CancellationToken))
+            {
+                var unwrapped = Unwrap(candidate)!;
+                if (ContainsEventContextReference(unwrapped.Type, knownTypes))
+                {
+                    capturedContext = unwrapped.Syntax;
+                    return true;
+                }
+            }
+        }
+        else if (ContainsEventContextReference(
+            context.SemanticModel.GetTypeInfo(expression, context.CancellationToken).Type,
+            knownTypes))
+        {
+            capturedContext = expression;
+            return true;
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static IEnumerable<IOperation> RetainedValueOperations(
+        IOperation root,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var stack = new Stack<IOperation>();
+        var visitedLocals = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var current = Unwrap(stack.Pop())!;
+            yield return current;
+
+            if (current is ILocalReferenceOperation localReference
+                && visitedLocals.Add(localReference.Local)
+                && TryGetStableLocalInitializer(
+                    localReference.Local,
+                    semanticModel,
+                    cancellationToken,
+                    localReference.Syntax,
+                    out var initializer)
+                && semanticModel.GetOperation(initializer, cancellationToken) is { } initializerOperation)
+            {
+                stack.Push(initializerOperation);
+            }
+
+            if (current is IDelegateCreationOperation or IAnonymousFunctionOperation)
+            {
+                foreach (var descendant in DescendantOperations(current).Skip(1))
+                {
+                    stack.Push(descendant);
+                }
+
+                continue;
+            }
+
+            foreach (var child in GetRetainedValueParts(current))
+            {
+                stack.Push(child);
+            }
+        }
+    }
+
+    private static IEnumerable<IOperation> GetRetainedValueParts(IOperation operation)
+    {
+        switch (operation)
+        {
+            case IConditionalOperation conditional:
+                yield return conditional.WhenTrue;
+                if (conditional.WhenFalse is { } whenFalse)
+                {
+                    yield return whenFalse;
+                }
+
+                break;
+            case ICoalesceOperation coalesce:
+                yield return coalesce.Value;
+                yield return coalesce.WhenNull;
+                break;
+            case ISwitchExpressionOperation switchExpression:
+                foreach (var arm in switchExpression.Arms)
+                {
+                    yield return arm.Value;
+                }
+
+                break;
+            case IArrayCreationOperation { Initializer: { } arrayInitializer }:
+                foreach (var element in arrayInitializer.ElementValues)
+                {
+                    yield return element;
+                }
+
+                break;
+            case ITupleOperation tuple:
+                foreach (var element in tuple.Elements)
+                {
+                    yield return element;
+                }
+
+                break;
+            case IObjectCreationOperation objectCreation:
+                foreach (var argument in objectCreation.Arguments)
+                {
+                    yield return argument.Value;
+                }
+
+                if (objectCreation.Initializer is { } objectInitializer)
+                {
+                    foreach (var initializer in objectInitializer.Initializers)
+                    {
+                        if (initializer is ISimpleAssignmentOperation assignment)
+                        {
+                            yield return assignment.Value;
+                        }
+                        else if (initializer is IInvocationOperation invocation)
+                        {
+                            foreach (var argument in invocation.Arguments)
+                            {
+                                yield return argument.Value;
+                            }
+                        }
+                    }
+                }
+
+                break;
+            case IWithOperation withOperation:
+                yield return withOperation.Operand;
+                foreach (var initializer in withOperation.Initializer.Initializers)
+                {
+                    if (initializer is ISimpleAssignmentOperation assignment)
+                    {
+                        yield return assignment.Value;
+                    }
+                }
+
+                break;
+            case IAnonymousObjectCreationOperation anonymousObjectCreation:
+                foreach (var initializer in anonymousObjectCreation.Initializers)
+                {
+                    yield return initializer is ISimpleAssignmentOperation assignment
+                        ? assignment.Value
+                        : initializer;
+                }
+
+                break;
+            default:
+                if (operation.Syntax is CollectionExpressionSyntax or SpreadElementSyntax)
+                {
+                    foreach (var child in operation.ChildOperations)
+                    {
+                        yield return child;
+                    }
+                }
+
+                break;
+        }
+    }
+
+    private static IEnumerable<InvocationExpressionSyntax> GetCallbackInvocations(
+        SyntaxNode body) =>
+        body.DescendantNodesAndSelf(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax)
+            .OfType<InvocationExpressionSyntax>();
+
+    private static bool IsUnobservedAsyncInvocation(
+        InvocationExpressionSyntax invocation,
+        SyntaxNodeAnalysisContext context) =>
+        context.SemanticModel.GetSymbolInfo(
+            invocation,
+            context.CancellationToken).Symbol is IMethodSymbol method
+        && !IsDeferredScheduler(method)
+        && StartsAsynchronousWork(method)
+        && !IsSynchronouslyObserved(
+            invocation,
+            context.SemanticModel,
+            context.CancellationToken);
+
+    private static bool IsSynchronouslyObserved(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode current = invocation;
+        while (current.Parent is MemberAccessExpressionSyntax memberAccess
+               && memberAccess.Expression == current)
+        {
+            if (memberAccess.Parent is not InvocationExpressionSyntax consumer
+                || semanticModel.GetSymbolInfo(
+                    consumer,
+                    cancellationToken).Symbol is not IMethodSymbol method)
+            {
+                return semanticModel.GetSymbolInfo(
+                        memberAccess,
+                        cancellationToken).Symbol is IPropertySymbol
+                    {
+                        Name: "Result",
+                        ContainingType: { } resultContainingType,
+                    }
+                    && IsTaskLike(resultContainingType);
+            }
+
+            if ((method.Name == "GetResult"
+                    && consumer.ArgumentList.Arguments.Count == 0)
+                || (method.Name == "Wait"
+                    && consumer.ArgumentList.Arguments.Count == 0
+                    && method.ContainingType is { } waitContainingType
+                    && IsTaskLike(waitContainingType)))
+            {
+                return true;
+            }
+
+            if (method.Name is not ("ConfigureAwait" or "GetAwaiter"))
+            {
+                break;
+            }
+
+            current = consumer;
+        }
+
+        if (current.Ancestors()
+                .TakeWhile(static node => node is not AnonymousFunctionExpressionSyntax
+                    and not StatementSyntax)
+                .OfType<ArgumentSyntax>()
+                .FirstOrDefault() is not { } argument
+            || argument.Parent?.Parent is not InvocationExpressionSyntax consumerInvocation
+            || semanticModel.GetSymbolInfo(
+                consumerInvocation,
+                cancellationToken).Symbol is not IMethodSymbol consumerMethod
+            || !IsTaskLike(consumerMethod.ContainingType))
+        {
+            return false;
+        }
+
+        if (consumerMethod.Name == "WaitAll"
+            && consumerMethod.Parameters.Length == 1
+            && consumerMethod.Parameters[0].Type is IArrayTypeSymbol
+            {
+                ElementType: { } elementType,
+            }
+            && IsTaskLike(elementType))
+        {
+            return true;
+        }
+
+        return consumerMethod.Name == "WhenAll"
+            && IsSynchronouslyObserved(
+                consumerInvocation,
+                semanticModel,
+                cancellationToken);
+    }
+
+    private static bool IsTaskLike(ITypeSymbol? type)
+    {
+        if (type is not INamedTypeSymbol named)
+        {
+            return false;
+        }
+
+        var definition = named.OriginalDefinition.ToDisplayString();
+        return definition is "System.Threading.Tasks.Task"
+            or "System.Threading.Tasks.Task<TResult>"
+            or "System.Threading.Tasks.ValueTask"
+            or "System.Threading.Tasks.ValueTask<TResult>";
     }
 
     private static void AnalyzeInvocation(OperationAnalysisContext context, KnownTypes knownTypes)
     {
         var invocation = (IInvocationOperation)context.Operation;
+
+        if (IsDeferredScheduler(invocation.TargetMethod)
+            && (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax
+                || context.Operation.SemanticModel is not { } semanticModel
+                || !IsSynchronouslyObserved(
+                    invocationSyntax,
+                    semanticModel,
+                    context.CancellationToken))
+            && TryFindCapturedEventContext(
+                invocation,
+                context,
+                knownTypes,
+                out var capturedContext))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DeferredContextCaptureRule,
+                capturedContext.GetLocation()));
+        }
 
         if (IsSynchronousExecute(invocation.TargetMethod, knownTypes))
         {
@@ -301,6 +831,559 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 ImplicitDefaultHandlingRule,
                 GetMethodNameLocation(invocation),
                 Normalize(invocation.TargetMethod).Name));
+        }
+    }
+
+    private static bool IsDeferredScheduler(IMethodSymbol method) =>
+        method.Name == "Run"
+            && method.ContainingType.ToDisplayString() == "System.Threading.Tasks.Task"
+        || method.Name is "QueueUserWorkItem" or "UnsafeQueueUserWorkItem"
+            && method.ContainingType.ToDisplayString() == "System.Threading.ThreadPool";
+
+    private static bool TryFindCapturedEventContext(
+        IInvocationOperation invocation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        out SyntaxNode capturedContext)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Type.TypeKind == TypeKind.Delegate)
+            {
+                if (TryFindCapturedEventContext(
+                        argument.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals: null,
+                        out capturedContext))
+                {
+                    return true;
+                }
+            }
+            else if (TryFindDeferredStateContext(
+                argument.Value,
+                context,
+                knownTypes,
+                visitedLocals: null,
+                out capturedContext))
+            {
+                return true;
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool TryFindDeferredStateContext(
+        IOperation operation,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals,
+        out SyntaxNode capturedContext)
+    {
+        operation = Unwrap(operation)!;
+        if (ContainsEventContextReference(operation.Type, knownTypes))
+        {
+            capturedContext = operation.Syntax;
+            return true;
+        }
+
+        if (operation is IConditionalOperation conditional
+            && (TryFindDeferredStateContext(
+                    conditional.WhenTrue,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext)
+                || conditional.WhenFalse is { } whenFalse
+                    && TryFindDeferredStateContext(
+                        whenFalse,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext)))
+        {
+            return true;
+        }
+
+        if (operation is ICoalesceOperation coalesce
+            && (TryFindDeferredStateContext(
+                    coalesce.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext)
+                || TryFindDeferredStateContext(
+                    coalesce.WhenNull,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext)))
+        {
+            return true;
+        }
+
+        if (operation is ISwitchExpressionOperation switchExpression)
+        {
+            foreach (var arm in switchExpression.Arms)
+            {
+                if (TryFindDeferredStateContext(
+                    arm.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (visitedLocals.Add(localReference.Local)
+                && TryGetStableInitializer(localReference, context, out var initializer)
+                && initializer is not null
+                && TryFindDeferredStateContext(
+                    initializer,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+            {
+                return true;
+            }
+
+            visitedLocals.Remove(localReference.Local);
+        }
+
+        if (operation is IArrayCreationOperation { Initializer: { } arrayInitializer })
+        {
+            foreach (var element in arrayInitializer.ElementValues)
+            {
+                if (TryFindDeferredStateContext(
+                    element,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (operation is ITupleOperation tuple)
+        {
+            foreach (var element in tuple.Elements)
+            {
+                if (TryFindDeferredStateContext(
+                    element,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (operation.Syntax is CollectionExpressionSyntax or SpreadElementSyntax)
+        {
+            foreach (var child in operation.ChildOperations)
+            {
+                if (TryFindDeferredStateContext(
+                    child,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (operation is IObjectCreationOperation objectCreation)
+        {
+            foreach (var argument in objectCreation.Arguments)
+            {
+                if (TryFindDeferredStateContext(
+                    argument.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+
+            if (objectCreation.Initializer is { } objectInitializer)
+            {
+                foreach (var initializer in objectInitializer.Initializers)
+                {
+                    if (initializer is ISimpleAssignmentOperation assignment
+                        && TryFindDeferredStateContext(
+                            assignment.Value,
+                            context,
+                            knownTypes,
+                            visitedLocals,
+                            out capturedContext))
+                    {
+                        return true;
+                    }
+
+                    if (initializer is IInvocationOperation invocation)
+                    {
+                        foreach (var argument in invocation.Arguments)
+                        {
+                            if (TryFindDeferredStateContext(
+                                argument.Value,
+                                context,
+                                knownTypes,
+                                visitedLocals,
+                                out capturedContext))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (operation is IWithOperation withOperation)
+        {
+            if (TryFindDeferredStateContext(
+                withOperation.Operand,
+                context,
+                knownTypes,
+                visitedLocals,
+                out capturedContext))
+            {
+                return true;
+            }
+
+            foreach (var initializer in withOperation.Initializer.Initializers)
+            {
+                if (initializer is ISimpleAssignmentOperation assignment
+                    && TryFindDeferredStateContext(
+                        assignment.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (operation is IAnonymousObjectCreationOperation anonymousObjectCreation)
+        {
+            foreach (var initializer in anonymousObjectCreation.Initializers)
+            {
+                var value = initializer is ISimpleAssignmentOperation assignment
+                    ? assignment.Value
+                    : initializer;
+                if (TryFindDeferredStateContext(
+                    value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool ContainsEventContextReference(ITypeSymbol? type, KnownTypes knownTypes) =>
+        knownTypes.IsEventContextReference(type)
+        || knownTypes.IsEventContextContainer(type)
+        || type is IArrayTypeSymbol array
+            && ContainsEventContextReference(array.ElementType, knownTypes)
+        || type is INamedTypeSymbol named
+            && named.TypeArguments.Any(argument =>
+                ContainsEventContextReference(argument, knownTypes));
+
+    private static bool TryFindCapturedEventContext(
+        IOperation root,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals,
+        out SyntaxNode capturedContext)
+    {
+        root = Unwrap(root)!;
+        switch (root)
+        {
+            case IDelegateCreationOperation delegateCreation:
+                return TryFindCapturedEventContext(
+                    delegateCreation.Target,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext);
+            case IAnonymousFunctionOperation:
+                return TryFindCapturedEventContextInDelegate(
+                    root,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext);
+            case IMethodReferenceOperation methodReference:
+                if (methodReference.Method.MethodKind == MethodKind.LocalFunction)
+                {
+                    visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                    if (TryFindCapturedEventContextInLocalFunction(
+                        methodReference.Method,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
+                    {
+                        return true;
+                    }
+                }
+
+                if (methodReference.Instance is { } receiver)
+                {
+                    return TryFindDeferredStateContext(
+                        receiver,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext);
+                }
+
+                break;
+            case ILocalReferenceOperation localReference
+                when localReference.Local.Type.TypeKind == TypeKind.Delegate:
+                visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                if (visitedLocals.Add(localReference.Local)
+                    && TryGetStableInitializer(localReference, context, out var initializer)
+                    && initializer is not null
+                    && TryFindCapturedEventContext(
+                        initializer,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out _))
+                {
+                    capturedContext = localReference.Syntax;
+                    return true;
+                }
+
+                visitedLocals.Remove(localReference.Local);
+                break;
+            case IConditionalOperation conditional:
+                if (TryFindCapturedEventContext(
+                        conditional.WhenTrue,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext)
+                    || conditional.WhenFalse is { } whenFalse
+                        && TryFindCapturedEventContext(
+                            whenFalse,
+                            context,
+                            knownTypes,
+                            visitedLocals,
+                            out capturedContext))
+                {
+                    return true;
+                }
+
+                break;
+            case ICoalesceOperation coalesce:
+                if (TryFindCapturedEventContext(
+                        coalesce.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext)
+                    || coalesce.WhenNull is { } whenNull
+                        && TryFindCapturedEventContext(
+                            whenNull,
+                            context,
+                            knownTypes,
+                            visitedLocals,
+                            out capturedContext))
+                {
+                    return true;
+                }
+
+                break;
+            case ISwitchExpressionOperation switchExpression:
+                foreach (var arm in switchExpression.Arms)
+                {
+                    if (TryFindCapturedEventContext(
+                        arm.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
+                    {
+                        return true;
+                    }
+                }
+
+                break;
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool TryFindCapturedEventContextInLocalFunction(
+        IMethodSymbol method,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol> visitedSymbols,
+        out SyntaxNode capturedContext)
+    {
+        if (!visitedSymbols.Add(method))
+        {
+            capturedContext = null!;
+            return false;
+        }
+
+        try
+        {
+            var semanticModel = context.Operation.SemanticModel;
+            if (semanticModel is not null)
+            {
+                foreach (var syntaxReference in method.DeclaringSyntaxReferences)
+                {
+                    var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+                    if (semanticModel.GetOperation(syntax, context.CancellationToken)
+                            is ILocalFunctionOperation { Body: { } body }
+                        && TryFindCapturedEventContextInDelegate(
+                            body,
+                            context,
+                            knownTypes,
+                            visitedSymbols,
+                            out capturedContext))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            capturedContext = null!;
+            return false;
+        }
+        finally
+        {
+            visitedSymbols.Remove(method);
+        }
+    }
+
+    private static bool TryFindCapturedEventContextInDelegate(
+        IOperation root,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol>? visitedLocals,
+        out SyntaxNode capturedContext)
+    {
+        foreach (var operation in DescendantOperations(root))
+        {
+            if (operation is IPropertyReferenceOperation property
+                && property.Property.Name == "Context"
+                && knownTypes.IsEventContextReference(property.Property.Type))
+            {
+                capturedContext = property.Syntax;
+                return true;
+            }
+
+            if (operation is IParameterReferenceOperation parameterReference
+                && knownTypes.IsEventContextContainer(parameterReference.Parameter.Type))
+            {
+                capturedContext = parameterReference.Syntax;
+                return true;
+            }
+
+            if (operation is IFieldReferenceOperation fieldReference
+                && knownTypes.IsEventContextReference(fieldReference.Field.Type))
+            {
+                capturedContext = fieldReference.Syntax;
+                return true;
+            }
+
+            if (operation is IInvocationOperation invocation
+                && invocation.TargetMethod.MethodKind == MethodKind.LocalFunction)
+            {
+                visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                if (TryFindCapturedEventContextInLocalFunction(
+                    invocation.TargetMethod,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out _))
+                {
+                    capturedContext = invocation.Syntax;
+                    return true;
+                }
+            }
+
+            if (operation is not ILocalReferenceOperation localReference)
+            {
+                continue;
+            }
+
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (!visitedLocals.Add(localReference.Local))
+            {
+                continue;
+            }
+
+            if (TryGetStableInitializer(localReference, context, out var initializer)
+                && initializer is not null
+                && (localReference.Local.Type.TypeKind == TypeKind.Delegate
+                    ? TryFindCapturedEventContext(
+                        initializer,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out _)
+                    : TryFindDeferredStateContext(
+                        initializer,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out _)))
+            {
+                capturedContext = localReference.Syntax;
+                return true;
+            }
+
+            visitedLocals.Remove(localReference.Local);
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static IEnumerable<IOperation> DescendantOperations(IOperation root)
+    {
+        var stack = new Stack<IOperation>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            yield return current;
+            foreach (var child in current.ChildOperations)
+            {
+                stack.Push(child);
+            }
         }
     }
 
@@ -1729,6 +2812,44 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             allowMemberMutation: true,
             out initializer);
 
+    private static bool TryGetStableLocalInitializer(
+        ILocalSymbol local,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        SyntaxNode? reference,
+        out ExpressionSyntax initializer)
+    {
+        var declarations = local.DeclaringSyntaxReferences;
+        if (declarations.Length != 1
+            || declarations[0].GetSyntax(cancellationToken) is not VariableDeclaratorSyntax
+            {
+                Initializer.Value: { } initializerSyntax,
+            } declarator
+            || semanticModel.SyntaxTree != declarator.SyntaxTree)
+        {
+            initializer = null!;
+            return false;
+        }
+
+        var declarationScope = GetExecutableScope(declarator, cancellationToken);
+        foreach (var identifier in declarationScope.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Identifier.ValueText == local.Name
+                && SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol,
+                    local)
+                && (reference is null || identifier.SpanStart < reference.SpanStart)
+                && IsWritten(identifier))
+            {
+                initializer = null!;
+                return false;
+            }
+        }
+
+        initializer = initializerSyntax;
+        return true;
+    }
+
     private static bool TryGetSingleUseInitializer(
         ILocalReferenceOperation localReference,
         OperationAnalysisContext context,
@@ -3020,6 +4141,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         private readonly INamedTypeSymbol? _chaosShield;
         private readonly INamedTypeSymbol? _chaosBehaviorOptions;
         private readonly INamedTypeSymbol? _rateLimiterAdapterOptions;
+        private readonly INamedTypeSymbol? _kevlarContext;
+        private readonly INamedTypeSymbol? _kevlarProperties;
+        private readonly HashSet<INamedTypeSymbol> _synchronousCallbackTypes;
+        private readonly HashSet<INamedTypeSymbol> _eventContextContainerTypes;
 
         internal KnownTypes(Compilation compilation)
         {
@@ -3056,6 +4181,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 "Kevlar.Chaos.ChaosBehaviorOptions");
             _rateLimiterAdapterOptions = _shieldRateLimiterExtensions?.ContainingAssembly.GetTypeByMetadataName(
                 "Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions");
+            _kevlarContext = kevlarAssembly?.GetTypeByMetadataName("Kevlar.KevlarContext");
+            _kevlarProperties = kevlarAssembly?.GetTypeByMetadataName("Kevlar.KevlarProperties");
+            _synchronousCallbackTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            _eventContextContainerTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            AddSynchronousCallbackType(compilation, "Kevlar.RetryOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.RetryOptions`1");
+            AddSynchronousCallbackType(compilation, "Kevlar.TimeoutOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.CircuitBreakerOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.CircuitBreakerOptions`1");
+            AddSynchronousCallbackType(compilation, "Kevlar.HedgeOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.HedgeOptions`1");
+            AddSynchronousCallbackType(compilation, "Kevlar.FallbackOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.FallbackOptions`1");
+            AddSynchronousCallbackType(compilation, "Kevlar.RateLimitOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.ConcurrencyLimitOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.Chaos.ChaosOptions");
+            AddSynchronousCallbackType(compilation, "Kevlar.Extensions.RateLimiting.RateLimiterAdapterOptions");
             var assemblyName = compilation.AssemblyName;
             IsTestAssembly = assemblyName is not null
                 && (assemblyName.EndsWith(".Test", StringComparison.OrdinalIgnoreCase)
@@ -3063,6 +4205,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         internal bool IsTestAssembly { get; }
+
+        internal bool IsSynchronousCallback(IPropertySymbol property) =>
+            property.Type is INamedTypeSymbol
+            {
+                Name: "Action",
+                Arity: 1,
+                ContainingNamespace.Name: "System",
+            }
+            && _synchronousCallbackTypes.Contains(property.ContainingType.OriginalDefinition)
+            && property.Name is "OnRetry"
+                or "OnTimeout"
+                or "OnStateChanged"
+                or "OnHedge"
+                or "OnFallback"
+                or "OnInjected"
+                or "OnRejected";
 
         internal bool IsShield(INamedTypeSymbol type) =>
             Is(type, _shield) || Is(type, _shieldOfT);
@@ -3109,6 +4267,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             };
         }
 
+        internal bool IsEventContextReference(ITypeSymbol? type) =>
+            type is INamedTypeSymbol namedType
+            && (Is(namedType, _kevlarContext)
+                || Is(namedType, _kevlarProperties));
+
+        internal bool IsEventContextContainer(ITypeSymbol? type) =>
+            type is INamedTypeSymbol namedType
+            && _eventContextContainerTypes.Contains(namedType.OriginalDefinition);
+
         internal bool IsNonGenericExecutionResult(ITypeSymbol type) =>
             type is INamedTypeSymbol namedType
             && (Is(namedType, _outcome)
@@ -3116,6 +4283,34 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 || Is(namedType, _valueTask)
                 || ((Is(namedType, _taskOfT) || Is(namedType, _valueTaskOfT))
                     && IsNonGenericExecutionResult(namedType.TypeArguments[0])));
+
+        private void AddSynchronousCallbackType(Compilation compilation, string metadataName)
+        {
+            if (compilation.GetTypeByMetadataName(metadataName) is { } type)
+            {
+                _synchronousCallbackTypes.Add(type);
+                foreach (var property in type.GetMembers().OfType<IPropertySymbol>())
+                {
+                    if (property.Type is INamedTypeSymbol
+                        {
+                            Name: "Action",
+                            Arity: 1,
+                            ContainingNamespace.Name: "System",
+                        } callbackType
+                        && callbackType.TypeArguments[0] is INamedTypeSymbol eventType
+                        && property.Name is "OnRetry"
+                            or "OnTimeout"
+                            or "OnStateChanged"
+                            or "OnHedge"
+                            or "OnFallback"
+                            or "OnInjected"
+                            or "OnRejected")
+                    {
+                        _eventContextContainerTypes.Add(eventType.OriginalDefinition);
+                    }
+                }
+            }
+        }
 
         private static bool Is(INamedTypeSymbol type, INamedTypeSymbol? expected) =>
             expected is not null

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -365,6 +365,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                          .OfType<AnonymousFunctionExpressionSyntax>()
                          .Any(ancestor => expression.Span.Contains(ancestor.Span))))
         {
+            if (!anonymous.AsyncKeyword.IsKind(SyntaxKind.None)
+                && TryFindAsyncAnonymousFunctionContext(
+                    anonymous,
+                    context,
+                    knownTypes,
+                    out capturedContext))
+            {
+                return true;
+            }
+
             foreach (var invocation in GetCallbackInvocations(
                          anonymous.Body,
                          context.SemanticModel,
@@ -439,40 +449,87 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             {
                 var declaration = syntaxReference.GetSyntax(context.CancellationToken);
                 var body = GetFunctionBody(declaration);
-                if (body is null)
+                if (body is not null
+                    && TryFindPostAwaitEventContext(
+                        body,
+                        eventParameterNames,
+                        out capturedContext))
                 {
-                    continue;
-                }
-
-                var nodes = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
-                        node is not AnonymousFunctionExpressionSyntax
-                            and not LocalFunctionStatementSyntax)
-                    .ToArray();
-                var firstAwait = nodes.OfType<AwaitExpressionSyntax>()
-                    .Select(static awaitExpression => awaitExpression.SpanStart)
-                    .DefaultIfEmpty(int.MaxValue)
-                    .Min();
-                var retainedNames = new HashSet<string>(eventParameterNames, StringComparer.Ordinal);
-                foreach (var declarator in nodes.OfType<VariableDeclaratorSyntax>()
-                             .Where(declarator => declarator.SpanStart < firstAwait)
-                             .OrderBy(static declarator => declarator.SpanStart))
-                {
-                    if (declarator.Initializer?.Value is { } initializer
-                        && IsRetainedAliasExpression(initializer, retainedNames))
-                    {
-                        retainedNames.Add(declarator.Identifier.ValueText);
-                    }
-                }
-
-                foreach (var identifier in nodes
-                             .OfType<IdentifierNameSyntax>()
-                             .Where(identifier => identifier.SpanStart > firstAwait
-                                 && retainedNames.Contains(identifier.Identifier.ValueText)))
-                {
-                    capturedContext = identifier;
                     return true;
                 }
             }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool TryFindAsyncAnonymousFunctionContext(
+        AnonymousFunctionExpressionSyntax anonymous,
+        SyntaxNodeAnalysisContext context,
+        KnownTypes knownTypes,
+        out SyntaxNode capturedContext)
+    {
+        var parameters = (anonymous switch
+        {
+            SimpleLambdaExpressionSyntax simple => (IEnumerable<ParameterSyntax>)[simple.Parameter],
+            ParenthesizedLambdaExpressionSyntax parenthesized => parenthesized.ParameterList.Parameters,
+            AnonymousMethodExpressionSyntax { ParameterList: { } parameterList } => parameterList.Parameters,
+            _ => [],
+        }).ToArray();
+        var delegateParameters = (context.SemanticModel.GetTypeInfo(
+                anonymous,
+                context.CancellationToken).ConvertedType as INamedTypeSymbol)
+            ?.DelegateInvokeMethod?.Parameters;
+        var eventParameterNames = new HashSet<string>(StringComparer.Ordinal);
+        if (delegateParameters is { } symbols)
+        {
+            for (var index = 0; index < Math.Min(parameters.Length, symbols.Length); index++)
+            {
+                if (ContainsEventContextReference(symbols[index].Type, knownTypes))
+                {
+                    eventParameterNames.Add(parameters[index].Identifier.ValueText);
+                }
+            }
+        }
+
+        return TryFindPostAwaitEventContext(
+            anonymous.Body,
+            eventParameterNames,
+            out capturedContext);
+    }
+
+    private static bool TryFindPostAwaitEventContext(
+        SyntaxNode body,
+        HashSet<string> eventParameterNames,
+        out SyntaxNode capturedContext)
+    {
+        var nodes = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax)
+            .ToArray();
+        var firstAwait = nodes.OfType<AwaitExpressionSyntax>()
+            .Select(static awaitExpression => awaitExpression.SpanStart)
+            .DefaultIfEmpty(int.MaxValue)
+            .Min();
+        var retainedNames = new HashSet<string>(eventParameterNames, StringComparer.Ordinal);
+        foreach (var declarator in nodes.OfType<VariableDeclaratorSyntax>()
+                     .Where(declarator => declarator.SpanStart < firstAwait)
+                     .OrderBy(static declarator => declarator.SpanStart))
+        {
+            if (declarator.Initializer?.Value is { } initializer
+                && IsRetainedAliasExpression(initializer, retainedNames))
+            {
+                retainedNames.Add(declarator.Identifier.ValueText);
+            }
+        }
+
+        foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
+                     .Where(identifier => identifier.SpanStart > firstAwait
+                         && retainedNames.Contains(identifier.Identifier.ValueText)))
+        {
+            capturedContext = identifier;
+            return true;
         }
 
         capturedContext = null!;

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -438,6 +438,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
                 if (TryFindPostAwaitMemberContext(
                     invocation,
+                    GetRetainedCallbackSymbols(
+                        invocation.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>()
+                            ?? anonymous,
+                        invocation,
+                        context,
+                        knownTypes),
                     context,
                     knownTypes,
                     out capturedContext))
@@ -479,12 +485,114 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
+    private static HashSet<ISymbol> GetRetainedCallbackSymbols(
+        AnonymousFunctionExpressionSyntax anonymous,
+        InvocationExpressionSyntax invocation,
+        SyntaxNodeAnalysisContext context,
+        KnownTypes knownTypes)
+    {
+        var retainedNames = new HashSet<string>(
+            GetAnonymousFunctionParameters(anonymous)
+                .Select(static parameter => parameter.Identifier.ValueText),
+            StringComparer.Ordinal);
+        var retainedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var nodes = anonymous.Body.DescendantNodesAndSelf(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax)
+            .ToArray();
+        foreach (var alias in nodes
+                     .Where(node => node.SpanStart < invocation.SpanStart
+                         && node is (VariableDeclaratorSyntax or AssignmentExpressionSyntax))
+                     .OrderBy(static node => node.SpanStart))
+        {
+            var (target, name, value) = alias switch
+            {
+                VariableDeclaratorSyntax declarator =>
+                    (context.SemanticModel.GetDeclaredSymbol(
+                            declarator,
+                            context.CancellationToken),
+                        declarator.Identifier.ValueText,
+                        declarator.Initializer?.Value),
+                AssignmentExpressionSyntax assignment
+                    when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) =>
+                    (context.SemanticModel.GetSymbolInfo(
+                            assignment.Left,
+                            context.CancellationToken).Symbol,
+                        GetAssignedName(assignment.Left),
+                        assignment.Right),
+                _ => (null, null, null),
+            };
+            if (name is null)
+            {
+                continue;
+            }
+
+            if (value is not null && IsCallbackRetainedExpression(value, retainedNames))
+            {
+                retainedNames.Add(name);
+                if (target is IFieldSymbol or IPropertySymbol)
+                {
+                    retainedSymbols.Add(target);
+                }
+            }
+            else if (IsUnconditionalAliasWrite(alias, anonymous.Body))
+            {
+                retainedNames.Remove(name);
+            }
+        }
+
+        foreach (var assignment in nodes.OfType<AssignmentExpressionSyntax>()
+                     .Where(assignment => assignment.SpanStart < invocation.SpanStart
+                         && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)))
+        {
+            var target = context.SemanticModel.GetSymbolInfo(
+                assignment.Left,
+                context.CancellationToken).Symbol;
+            if (target is IFieldSymbol or IPropertySymbol
+                && TryFindEventContextExpression(
+                    assignment.Right,
+                    context,
+                    knownTypes,
+                    out _))
+            {
+                retainedSymbols.Add(target);
+            }
+        }
+
+        return retainedSymbols;
+    }
+
+    private static bool IsCallbackRetainedExpression(
+        ExpressionSyntax expression,
+        HashSet<string> retainedNames) => expression switch
+    {
+        IdentifierNameSyntax identifier => retainedNames.Contains(
+            identifier.Identifier.ValueText),
+        MemberAccessExpressionSyntax memberAccess
+            when memberAccess.Name.Identifier.ValueText is "Context" or "Properties" =>
+            IsCallbackRetainedExpression(memberAccess.Expression, retainedNames),
+        ParenthesizedExpressionSyntax parenthesized =>
+            IsCallbackRetainedExpression(parenthesized.Expression, retainedNames),
+        CastExpressionSyntax cast => IsCallbackRetainedExpression(cast.Expression, retainedNames),
+        PostfixUnaryExpressionSyntax postfix
+            when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression) =>
+            IsCallbackRetainedExpression(postfix.Operand, retainedNames),
+        _ => false,
+    };
+
     private static bool TryFindPostAwaitMemberContext(
         InvocationExpressionSyntax invocation,
+        HashSet<ISymbol> callbackRetainedSymbols,
         SyntaxNodeAnalysisContext context,
         KnownTypes knownTypes,
         out SyntaxNode capturedContext)
     {
+        if (callbackRetainedSymbols.Count == 0)
+        {
+            capturedContext = null!;
+            return false;
+        }
+
         var symbolInfo = context.SemanticModel.GetSymbolInfo(
             invocation,
             context.CancellationToken);
@@ -521,7 +629,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     body,
                     semanticModel,
                     context.CancellationToken);
-                var firstAwait = awaits.Min(static awaitExpression => awaitExpression.SpanStart);
+                var firstAwait = awaits.OrderBy(static awaitExpression => awaitExpression.SpanStart)
+                    .First();
                 var retainedNames = new HashSet<string>(StringComparer.Ordinal);
                 var retainedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                 foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
@@ -536,7 +645,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         IPropertySymbol property => property.Type,
                         _ => null,
                     };
-                    if (symbol is not null && ContainsEventContextReference(type, knownTypes))
+                    if (symbol is not null
+                        && callbackRetainedSymbols.Contains(symbol)
+                        && ContainsEventContextReference(type, knownTypes))
                     {
                         retainedSymbols.Add(symbol);
                     }
@@ -549,7 +660,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     retainedNames,
                     retainedSymbols,
                     semanticModel,
-                    context.CancellationToken);
+                    controlFlowGraph: null,
+                    cancellationToken: context.CancellationToken);
                 foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
                              .Where(identifier => IsRuntimeValueReference(identifier)
                                  && IsRetainedReference(
@@ -642,6 +754,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 context.CancellationToken).ConvertedType as INamedTypeSymbol)
             ?.DelegateInvokeMethod?.Parameters;
         var eventParameterNames = new HashSet<string>(StringComparer.Ordinal);
+        var eventParameterSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         if (delegateParameters is { } symbols)
         {
             for (var index = 0; index < Math.Min(parameters.Length, symbols.Length); index++)
@@ -649,6 +762,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 if (ContainsEventContextReference(symbols[index].Type, knownTypes))
                 {
                     eventParameterNames.Add(parameters[index].Identifier.ValueText);
+                    if (context.SemanticModel.GetDeclaredSymbol(
+                            parameters[index],
+                            context.CancellationToken) is { } parameterSymbol)
+                    {
+                        eventParameterSymbols.Add(parameterSymbol);
+                    }
                 }
             }
         }
@@ -658,7 +777,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             eventParameterNames,
             context.SemanticModel,
             context.CancellationToken,
-            out capturedContext);
+            out capturedContext,
+            retainedSymbolSeeds: eventParameterSymbols);
     }
 
     private static bool TryFindPostAwaitEventContext(
@@ -667,23 +787,24 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         SemanticModel? semanticModel,
         CancellationToken cancellationToken,
         out SyntaxNode capturedContext,
-        HashSet<LocalFunctionStatementSyntax>? callPath = null)
+        HashSet<LocalFunctionStatementSyntax>? callPath = null,
+        HashSet<ISymbol>? retainedSymbolSeeds = null)
     {
         var nodes = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
                 node is not AnonymousFunctionExpressionSyntax
                     and not LocalFunctionStatementSyntax)
             .ToArray();
         var awaits = nodes.OfType<AwaitExpressionSyntax>().ToArray();
-        var firstAwait = awaits
-            .Select(static awaitExpression => awaitExpression.SpanStart)
-            .DefaultIfEmpty(int.MaxValue)
-            .Min();
+        var firstAwait = awaits.OrderBy(static awaitExpression => awaitExpression.SpanStart)
+            .FirstOrDefault();
         var controlFlowGraph = TryCreateControlFlowGraph(
             body,
             semanticModel,
             cancellationToken);
         var retainedNames = new HashSet<string>(eventParameterNames, StringComparer.Ordinal);
-        var retainedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var retainedSymbols = retainedSymbolSeeds is null
+            ? new HashSet<ISymbol>(SymbolEqualityComparer.Default)
+            : new HashSet<ISymbol>(retainedSymbolSeeds, SymbolEqualityComparer.Default);
         if (semanticModel is not null)
         {
             foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
@@ -698,14 +819,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        CollectRetainedAliases(
-            nodes,
-            firstAwait,
-            body,
-            retainedNames,
-            retainedSymbols,
-            semanticModel,
-            cancellationToken);
+        if (firstAwait is not null)
+        {
+            CollectRetainedAliases(
+                nodes,
+                firstAwait,
+                body,
+                retainedNames,
+                retainedSymbols,
+                semanticModel,
+                controlFlowGraph,
+                cancellationToken);
+        }
 
         foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
                      .Where(identifier => IsRetainedReference(
@@ -742,6 +867,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 invocation,
                 localFunctions,
                 retainedNames,
+                retainedSymbols,
                 invokedAfterSuspension,
                 semanticModel,
                 cancellationToken,
@@ -755,6 +881,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && TryFindRetainedContextInInvokedDelegate(
                     invocation,
                     retainedNames,
+                    retainedSymbols,
                     semanticModel,
                     cancellationToken,
                     out capturedContext))
@@ -769,16 +896,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static void CollectRetainedAliases(
         SyntaxNode[] nodes,
-        int firstAwait,
+        SyntaxNode destination,
         SyntaxNode body,
         HashSet<string> retainedNames,
         HashSet<ISymbol> retainedSymbols,
         SemanticModel? semanticModel,
+        ControlFlowGraph? controlFlowGraph,
         CancellationToken cancellationToken)
     {
         foreach (var alias in nodes
-                     .Where(node => node.SpanStart < firstAwait
-                         && node is VariableDeclaratorSyntax or AssignmentExpressionSyntax)
+                     .Where(node => node.SpanStart < destination.SpanStart
+                         && node is (VariableDeclaratorSyntax or AssignmentExpressionSyntax)
+                         && CanReach(node, destination, controlFlowGraph))
                      .OrderBy(static node => node.SpanStart))
         {
             var (target, name, value) = alias switch
@@ -831,6 +960,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         InvocationExpressionSyntax invocation,
         ILookup<string, LocalFunctionStatementSyntax> localFunctions,
         HashSet<string> retainedNames,
+        HashSet<ISymbol> retainedSymbols,
         bool invokedAfterSuspension,
         SemanticModel? semanticModel,
         CancellationToken cancellationToken,
@@ -858,6 +988,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 function,
             };
             var functionRetainedNames = new HashSet<string>(retainedNames, StringComparer.Ordinal);
+            var functionRetainedSymbols = new HashSet<ISymbol>(
+                retainedSymbols,
+                SymbolEqualityComparer.Default);
             foreach (var parameter in function.ParameterList.Parameters)
             {
                 functionRetainedNames.Remove(parameter.Identifier.ValueText);
@@ -872,7 +1005,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         semanticModel,
                         cancellationToken,
                         out capturedContext,
-                        nestedCallPath))
+                        nestedCallPath,
+                        functionRetainedSymbols))
                 {
                     return true;
                 }
@@ -886,8 +1020,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                             and not LocalFunctionStatementSyntax)
                 .ToArray();
             foreach (var retainedIdentifier in functionNodes.OfType<IdentifierNameSyntax>()
-                         .Where(candidate => functionRetainedNames.Contains(
-                                 candidate.Identifier.ValueText)
+                         .Where(candidate => IsRetainedReference(
+                                 candidate,
+                                 functionRetainedNames,
+                                 functionRetainedSymbols,
+                                 semanticModel,
+                                 cancellationToken)
                              && IsRuntimeValueReference(candidate)))
             {
                 capturedContext = retainedIdentifier;
@@ -900,6 +1038,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     nestedInvocation,
                     localFunctions,
                     functionRetainedNames,
+                    functionRetainedSymbols,
                     invokedAfterSuspension: true,
                     semanticModel,
                     cancellationToken,
@@ -918,6 +1057,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool TryFindRetainedContextInInvokedDelegate(
         InvocationExpressionSyntax invocation,
         HashSet<string> retainedNames,
+        HashSet<ISymbol> retainedSymbols,
         SemanticModel? semanticModel,
         CancellationToken cancellationToken,
         out SyntaxNode capturedContext)
@@ -951,7 +1091,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                              node is not AnonymousFunctionExpressionSyntax
                                  and not LocalFunctionStatementSyntax)
                          .OfType<IdentifierNameSyntax>()
-                         .Where(candidate => capturedNames.Contains(candidate.Identifier.ValueText)
+                         .Where(candidate => IsRetainedReference(
+                                 candidate,
+                                 capturedNames,
+                                 retainedSymbols,
+                                 semanticModel,
+                                 cancellationToken)
                              && IsRuntimeValueReference(candidate)))
             {
                 capturedContext = capturedIdentifier;
@@ -1100,23 +1245,41 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
-        var awaitBlocks = controlFlowGraph.Blocks
-            .Where(block => block.IsReachable
-                && ContainsOperationSyntax(block, awaitExpression))
-            .ToArray();
-        var candidateBlocks = new HashSet<BasicBlock>(controlFlowGraph.Blocks
-            .Where(block => block.IsReachable && ContainsOperationSyntax(block, candidate)));
-        foreach (var awaitBlock in awaitBlocks)
+        return CanReach(awaitExpression, candidate, controlFlowGraph);
+    }
+
+    private static bool CanReach(
+        SyntaxNode source,
+        SyntaxNode target,
+        ControlFlowGraph? controlFlowGraph)
+    {
+        if (controlFlowGraph is null)
         {
-            if (candidateBlocks.Contains(awaitBlock))
+            return true;
+        }
+
+        var sourceBlocks = controlFlowGraph.Blocks
+            .Where(block => block.IsReachable
+                && ContainsOperationSyntax(block, source))
+            .ToArray();
+        var targetBlocks = new HashSet<BasicBlock>(controlFlowGraph.Blocks
+            .Where(block => block.IsReachable && ContainsOperationSyntax(block, target)));
+        if (sourceBlocks.Length == 0 || targetBlocks.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (var sourceBlock in sourceBlocks)
+        {
+            if (targetBlocks.Contains(sourceBlock))
             {
                 return true;
             }
 
             var pending = new Queue<BasicBlock>();
             var visited = new HashSet<BasicBlock>();
-            EnqueueSuccessor(awaitBlock.FallThroughSuccessor, pending);
-            EnqueueSuccessor(awaitBlock.ConditionalSuccessor, pending);
+            EnqueueSuccessor(sourceBlock.FallThroughSuccessor, pending);
+            EnqueueSuccessor(sourceBlock.ConditionalSuccessor, pending);
             while (pending.Count > 0)
             {
                 var block = pending.Dequeue();
@@ -1125,7 +1288,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                if (candidateBlocks.Contains(block))
+                if (targetBlocks.Contains(block))
                 {
                     return true;
                 }
@@ -1175,7 +1338,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             semanticModel,
             cancellationToken),
         MemberAccessExpressionSyntax { Name: IdentifierNameSyntax identifier }
-            when IsRetainedReference(
+            when semanticModel is not null
+                && IsRetainedReference(
                 identifier,
                 retainedNames,
                 retainedSymbols,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -960,18 +960,34 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             operation = Unwrap(instance);
         }
 
-        return operation is IPropertyReferenceOperation
+        return operation switch
         {
-            Property:
+            IPropertyReferenceOperation
             {
-                IsStatic: true,
-                Name: "CompletedTask",
-                ContainingType: { } containingType,
-            },
-        }
-            && containingType.ToDisplayString() is "System.Threading.Tasks.Task"
-                or "System.Threading.Tasks.ValueTask";
+                Property:
+                {
+                    IsStatic: true,
+                    Name: "CompletedTask",
+                    ContainingType: { } containingType,
+                },
+            } => IsKnownCompletedAwaitableType(containingType),
+            IInvocationOperation
+            {
+                TargetMethod:
+                {
+                    IsStatic: true,
+                    Name: "FromResult",
+                    Parameters.Length: 1,
+                    ContainingType: { } containingType,
+                },
+            } => IsKnownCompletedAwaitableType(containingType),
+            _ => false,
+        };
     }
+
+    private static bool IsKnownCompletedAwaitableType(INamedTypeSymbol type) =>
+        type.ToDisplayString() is "System.Threading.Tasks.Task"
+            or "System.Threading.Tasks.ValueTask";
 
     private static void CollectRetainedAliases(
         SyntaxNode[] nodes,
@@ -1998,6 +2014,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         MethodDeclarationSyntax { ExpressionBody.Expression: { } expression } => expression,
         LocalFunctionStatementSyntax { Body: { } block } => block,
         LocalFunctionStatementSyntax { ExpressionBody.Expression: { } expression } => expression,
+        ConstructorDeclarationSyntax { Body: { } block } => block,
+        ConstructorDeclarationSyntax { ExpressionBody.Expression: { } expression } => expression,
         _ => null,
     };
 
@@ -3052,12 +3070,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             foreach (var argument in objectCreation.Arguments)
             {
-                if (TryFindDeferredStateContext(
-                    argument.Value,
-                    context,
-                    knownTypes,
-                    visitedLocals,
-                    out capturedContext))
+                if (argument.Parameter is { } parameter
+                    && IsConstructorParameterStored(
+                        objectCreation.Constructor,
+                        parameter,
+                        context,
+                        knownTypes)
+                    && TryFindDeferredStateContext(
+                        argument.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
                 {
                     return true;
                 }
@@ -3158,6 +3182,56 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         capturedContext = null!;
         return false;
     }
+
+    private static bool IsConstructorParameterStored(
+        IMethodSymbol? constructor,
+        IParameterSymbol parameter,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes)
+    {
+        var currentSemanticModel = context.Operation.SemanticModel;
+        if (constructor is null || currentSemanticModel is null)
+        {
+            return false;
+        }
+
+        foreach (var syntaxReference in constructor.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxReference.GetSyntax(context.CancellationToken);
+            if (syntax is RecordDeclarationSyntax
+                && constructor.ContainingType.GetMembers(parameter.Name)
+                    .OfType<IPropertySymbol>()
+                    .Any(property => CanRetainDeferredState(property.Type, knownTypes)))
+            {
+                return true;
+            }
+
+#pragma warning disable RS1030 // Source-backed constructors may be declared in another tree.
+            var semanticModel = syntax.SyntaxTree == currentSemanticModel.SyntaxTree
+                ? currentSemanticModel
+                : currentSemanticModel.Compilation.GetSemanticModel(syntax.SyntaxTree);
+#pragma warning restore RS1030
+            var body = GetFunctionBody(syntax);
+            var bodyOperation = body is null
+                ? null
+                : semanticModel.GetOperation(body, context.CancellationToken);
+            if (bodyOperation is not null
+                && DescendantOperations(bodyOperation)
+                    .OfType<ISimpleAssignmentOperation>()
+                    .Any(assignment =>
+                        CanRetainDeferredState(assignment.Target.Type, knownTypes)
+                        && Unwrap(assignment.Value) is IParameterReferenceOperation reference
+                        && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool CanRetainDeferredState(ITypeSymbol? type, KnownTypes knownTypes) =>
+        type?.IsReferenceType is true || ContainsEventContextReference(type, knownTypes);
 
     private static bool IsKnownCompositeState(IOperation operation) =>
         operation is IConditionalOperation

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -801,7 +801,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 node is not AnonymousFunctionExpressionSyntax
                     and not LocalFunctionStatementSyntax)
             .ToArray();
-        var awaits = nodes.OfType<AwaitExpressionSyntax>().ToArray();
+        var awaits = nodes.OfType<AwaitExpressionSyntax>()
+            .Where(awaitExpression => !IsKnownCompletedAwait(
+                awaitExpression,
+                semanticModel,
+                cancellationToken))
+            .ToArray();
         var controlFlowGraph = TryCreateControlFlowGraph(
             body,
             semanticModel,
@@ -936,6 +941,36 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         capturedContext = null!;
         return false;
+    }
+
+    private static bool IsKnownCompletedAwait(
+        AwaitExpressionSyntax awaitExpression,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var operation = Unwrap(semanticModel?.GetOperation(
+            awaitExpression.Expression,
+            cancellationToken));
+        if (operation is IInvocationOperation
+            {
+                TargetMethod.Name: "ConfigureAwait",
+                Instance: { } instance,
+            })
+        {
+            operation = Unwrap(instance);
+        }
+
+        return operation is IPropertyReferenceOperation
+        {
+            Property:
+            {
+                IsStatic: true,
+                Name: "CompletedTask",
+                ContainingType: { } containingType,
+            },
+        }
+            && containingType.ToDisplayString() is "System.Threading.Tasks.Task"
+                or "System.Threading.Tasks.ValueTask";
     }
 
     private static void CollectRetainedAliases(
@@ -2909,7 +2944,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        if (operation is IInvocationOperation invocationOperation)
+        if (operation is IInvocationOperation invocationOperation
+            && ContainsEventContextReference(operation.Type, knownTypes))
         {
             if (invocationOperation.Instance is { } instance
                 && TryFindDeferredStateContext(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1811,6 +1811,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         out SyntaxNode capturedContext)
     {
         operation = Unwrap(operation)!;
+        if (operation is IDefaultValueOperation
+            || operation.ConstantValue is { HasValue: true, Value: null })
+        {
+            capturedContext = null!;
+            return false;
+        }
+
         if (operation is IConditionalOperation conditional
             && (TryFindDeferredStateContext(
                     conditional.WhenTrue,
@@ -2055,7 +2062,17 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             or IObjectCreationOperation
             or IWithOperation
             or IAnonymousObjectCreationOperation
-        || operation.Syntax is CollectionExpressionSyntax or SpreadElementSyntax;
+        || operation.Syntax is CollectionExpressionSyntax or SpreadElementSyntax
+        || operation is IInvocationOperation
+        {
+            TargetMethod:
+            {
+                Name: "Empty",
+                Parameters.Length: 0,
+                ContainingType: { } containingType,
+            },
+        }
+            && containingType.ToDisplayString() is "System.Array" or "System.Linq.Enumerable";
 
     private static bool ContainsEventContextReference(ITypeSymbol? type, KnownTypes knownTypes) =>
         knownTypes.IsEventContextReference(type)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1054,8 +1054,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                              && origin.SpanStart > candidate.SpanStart
                              && origin.SpanStart < destination.SpanStart)))
         {
-            if (kills.Any(kill => conditional.Statement.Span.Contains(kill.Span))
-                && kills.Any(kill => conditional.Else!.Statement.Span.Contains(kill.Span)))
+            if (IsClearedOnEveryPath(conditional.Statement, kills)
+                && IsClearedOnEveryPath(conditional.Else!.Statement, kills))
             {
                 return true;
             }
@@ -1063,6 +1063,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         return false;
     }
+
+    private static bool IsClearedOnEveryPath(
+        StatementSyntax statement,
+        List<SyntaxNode> kills) => statement switch
+    {
+        ExpressionStatementSyntax expressionStatement =>
+            kills.Any(kill => expressionStatement.Span.Contains(kill.Span)),
+        BlockSyntax block => block.Statements.Any(child =>
+            IsClearedOnEveryPath(child, kills)),
+        IfStatementSyntax { Else: { } elseClause } conditional =>
+            IsClearedOnEveryPath(conditional.Statement, kills)
+            && IsClearedOnEveryPath(elseClause.Statement, kills),
+        _ => false,
+    };
 
     private static bool HasReachableRetainedAlias(
         ExpressionSyntax expression,
@@ -3266,12 +3280,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         var kills = new List<SyntaxNode>();
         foreach (var assignment in assignments)
         {
-            if (assignment.Right.DescendantNodesAndSelf()
-                .OfType<IdentifierNameSyntax>()
-                .Any(identifier => callbackParameters.Contains(
-                    semanticModel.GetSymbolInfo(
-                        identifier,
-                        context.CancellationToken).Symbol!)))
+            var value = semanticModel.GetOperation(
+                assignment.Right,
+                context.CancellationToken);
+            if (value is not null
+                && ContainsCallbackParameterInRetainedValue(
+                    value,
+                    callbackParameters,
+                    knownTypes))
             {
                 origins.Add(assignment);
             }
@@ -3288,6 +3304,47 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return origins.Count > 0
             && HasReachableOrigin(origins, flowTarget, controlFlowGraph, kills)
             && !IsClearedOnEveryBranch(origins, kills, flowTarget, callback.Body);
+    }
+
+    private static bool ContainsCallbackParameterInRetainedValue(
+        IOperation operation,
+        HashSet<ISymbol> callbackParameters,
+        KnownTypes knownTypes)
+    {
+        operation = Unwrap(operation)!;
+        if (operation is IParameterReferenceOperation parameterReference)
+        {
+            return callbackParameters.Contains(parameterReference.Parameter);
+        }
+
+        var retainedParts = GetRetainedValueParts(operation).ToArray();
+        if (retainedParts.Length > 0)
+        {
+            return retainedParts.Any(part => ContainsCallbackParameterInRetainedValue(
+                part,
+                callbackParameters,
+                knownTypes));
+        }
+
+        if (operation is IInvocationOperation invocation)
+        {
+            return invocation.Arguments.Any(argument =>
+                ContainsCallbackParameterInRetainedValue(
+                    argument.Value,
+                    callbackParameters,
+                    knownTypes));
+        }
+
+        if (!ContainsEventContextReference(operation.Type, knownTypes))
+        {
+            return false;
+        }
+
+        return operation.ChildOperations.Any(child =>
+            ContainsCallbackParameterInRetainedValue(
+                child,
+                callbackParameters,
+                knownTypes));
     }
 
     private static bool ContainsReferenceOwnedByNestedAnonymousFunction(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -521,25 +521,50 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     body,
                     semanticModel,
                     context.CancellationToken);
+                var firstAwait = awaits.Min(static awaitExpression => awaitExpression.SpanStart);
+                var retainedNames = new HashSet<string>(StringComparer.Ordinal);
+                var retainedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                 foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
                              .Where(identifier => IsRuntimeValueReference(identifier)))
                 {
-                    var type = semanticModel.GetSymbolInfo(identifier, context.CancellationToken).Symbol
-                        switch
-                        {
-                            IFieldSymbol field => field.Type,
-                            IPropertySymbol property => property.Type,
-                            _ => null,
-                        };
-                    if (ContainsEventContextReference(type, knownTypes)
-                        && awaits.Any(awaitExpression => CanReachAfterSuspension(
-                            awaitExpression,
-                            identifier,
-                            controlFlowGraph)))
+                    var symbol = semanticModel.GetSymbolInfo(
+                        identifier,
+                        context.CancellationToken).Symbol;
+                    var type = symbol switch
                     {
-                        capturedContext = identifier;
-                        return true;
+                        IFieldSymbol field => field.Type,
+                        IPropertySymbol property => property.Type,
+                        _ => null,
+                    };
+                    if (symbol is not null && ContainsEventContextReference(type, knownTypes))
+                    {
+                        retainedSymbols.Add(symbol);
                     }
+                }
+
+                CollectRetainedAliases(
+                    nodes,
+                    firstAwait,
+                    body,
+                    retainedNames,
+                    retainedSymbols,
+                    semanticModel,
+                    context.CancellationToken);
+                foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
+                             .Where(identifier => IsRuntimeValueReference(identifier)
+                                 && IsRetainedReference(
+                                     identifier,
+                                     retainedNames,
+                                     retainedSymbols,
+                                     semanticModel,
+                                     context.CancellationToken)
+                                 && awaits.Any(awaitExpression => CanReachAfterSuspension(
+                                     awaitExpression,
+                                     identifier,
+                                     controlFlowGraph))))
+                {
+                    capturedContext = identifier;
+                    return true;
                 }
             }
         }
@@ -673,55 +698,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        foreach (var alias in nodes
-                     .Where(node => node.SpanStart < firstAwait
-                         && node is VariableDeclaratorSyntax or AssignmentExpressionSyntax)
-                     .OrderBy(static node => node.SpanStart))
-        {
-            var (target, name, value) = alias switch
-            {
-                VariableDeclaratorSyntax declarator =>
-                    (semanticModel?.GetDeclaredSymbol(declarator, cancellationToken),
-                        declarator.Identifier.ValueText,
-                        declarator.Initializer?.Value),
-                AssignmentExpressionSyntax assignment
-                    when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) =>
-                    (semanticModel?.GetSymbolInfo(assignment.Left, cancellationToken).Symbol,
-                        GetAssignedName(assignment.Left),
-                        assignment.Right),
-                _ => (null, null, null),
-            };
-            if (name is null)
-            {
-                continue;
-            }
-
-            if (value is not null
-                && IsRetainedAliasExpression(
-                    value,
-                    retainedNames,
-                    retainedSymbols,
-                    semanticModel,
-                    cancellationToken))
-            {
-                retainedNames.Add(name);
-                if (target is not null)
-                {
-                    retainedSymbols.Add(target);
-                }
-            }
-            else if (IsUnconditionalAliasWrite(alias, body))
-            {
-                if (target is not null)
-                {
-                    retainedSymbols.Remove(target);
-                }
-                else
-                {
-                    retainedNames.Remove(name);
-                }
-            }
-        }
+        CollectRetainedAliases(
+            nodes,
+            firstAwait,
+            body,
+            retainedNames,
+            retainedSymbols,
+            semanticModel,
+            cancellationToken);
 
         foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
                      .Where(identifier => IsRetainedReference(
@@ -781,6 +765,66 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         capturedContext = null!;
         return false;
+    }
+
+    private static void CollectRetainedAliases(
+        SyntaxNode[] nodes,
+        int firstAwait,
+        SyntaxNode body,
+        HashSet<string> retainedNames,
+        HashSet<ISymbol> retainedSymbols,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken)
+    {
+        foreach (var alias in nodes
+                     .Where(node => node.SpanStart < firstAwait
+                         && node is VariableDeclaratorSyntax or AssignmentExpressionSyntax)
+                     .OrderBy(static node => node.SpanStart))
+        {
+            var (target, name, value) = alias switch
+            {
+                VariableDeclaratorSyntax declarator =>
+                    (semanticModel?.GetDeclaredSymbol(declarator, cancellationToken),
+                        declarator.Identifier.ValueText,
+                        declarator.Initializer?.Value),
+                AssignmentExpressionSyntax assignment
+                    when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) =>
+                    (semanticModel?.GetSymbolInfo(assignment.Left, cancellationToken).Symbol,
+                        GetAssignedName(assignment.Left),
+                        assignment.Right),
+                _ => (null, null, null),
+            };
+            if (name is null)
+            {
+                continue;
+            }
+
+            if (value is not null
+                && IsRetainedAliasExpression(
+                    value,
+                    retainedNames,
+                    retainedSymbols,
+                    semanticModel,
+                    cancellationToken))
+            {
+                retainedNames.Add(name);
+                if (target is not null)
+                {
+                    retainedSymbols.Add(target);
+                }
+            }
+            else if (IsUnconditionalAliasWrite(alias, body))
+            {
+                if (target is not null)
+                {
+                    retainedSymbols.Remove(target);
+                }
+                else
+                {
+                    retainedNames.Remove(name);
+                }
+            }
+        }
     }
 
     private static bool TryFindRetainedContextInLocalFunction(
@@ -1130,6 +1174,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             retainedSymbols,
             semanticModel,
             cancellationToken),
+        MemberAccessExpressionSyntax { Name: IdentifierNameSyntax identifier }
+            when IsRetainedReference(
+                identifier,
+                retainedNames,
+                retainedSymbols,
+                semanticModel,
+                cancellationToken) => true,
         MemberAccessExpressionSyntax memberAccess
             when memberAccess.Name.Identifier.ValueText is "Context" or "Properties" =>
             IsRetainedAliasExpression(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -2122,7 +2122,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static IEnumerable<IOperation> RetainedValueOperations(
         IOperation root,
         SemanticModel semanticModel,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        HashSet<ISymbol>? visitedConstructors = null)
     {
         var stack = new Stack<IOperation>();
         var visitedLocals = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
@@ -2166,7 +2167,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var child in GetRetainedValueParts(current))
+            foreach (var child in GetRetainedValueParts(
+                         current,
+                         semanticModel,
+                         cancellationToken,
+                         visitedConstructors))
             {
                 stack.Push(child);
             }
@@ -2185,7 +2190,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     localReference.Local.ContainingSymbol,
                     anonymousSymbol)));
 
-    private static IEnumerable<IOperation> GetRetainedValueParts(IOperation operation)
+    private static IEnumerable<IOperation> GetRetainedValueParts(
+        IOperation operation,
+        SemanticModel? semanticModel = null,
+        CancellationToken cancellationToken = default,
+        HashSet<ISymbol>? visitedConstructors = null)
     {
         switch (operation)
         {
@@ -2225,7 +2234,19 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             case IObjectCreationOperation objectCreation:
                 foreach (var argument in objectCreation.Arguments)
                 {
-                    yield return argument.Value;
+                    if (objectCreation.Constructor is not { } constructor
+                        || argument.Parameter is not { } parameter
+                        || semanticModel is null
+                        || constructor.DeclaringSyntaxReferences.Length == 0
+                        || IsConstructorParameterStored(
+                            constructor,
+                            parameter,
+                            semanticModel,
+                            cancellationToken,
+                            visitedConstructors))
+                    {
+                        yield return argument.Value;
+                    }
                 }
 
                 if (objectCreation.Initializer is { } objectInitializer)
@@ -3292,8 +3313,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         .OfType<ISimpleAssignmentOperation>()
                         .Any(assignment =>
                             IsConstructorInstanceMember(assignment.Target)
-                            && Unwrap(assignment.Value) is IParameterReferenceOperation reference
-                            && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)))
+                            && RetainedValueOperations(
+                                    assignment.Value,
+                                    semanticModel,
+                                    cancellationToken,
+                                    visitedConstructors)
+                                .Any(candidate =>
+                                    Unwrap(candidate) is IParameterReferenceOperation reference
+                                    && SymbolEqualityComparer.Default.Equals(
+                                        reference.Parameter,
+                                        parameter))))
                 {
                     return true;
                 }

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -342,6 +342,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 out capturedContext);
         }
 
+        if (TryFindAsyncVoidMethodGroupContext(
+                expression,
+                context,
+                knownTypes,
+                out capturedContext))
+        {
+            return true;
+        }
+
         foreach (var anonymous in expression.DescendantNodesAndSelf()
                      .OfType<AnonymousFunctionExpressionSyntax>()
                      .Where(candidate => !candidate.Ancestors()
@@ -381,6 +390,49 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     {
                         return true;
                     }
+                }
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool TryFindAsyncVoidMethodGroupContext(
+        ExpressionSyntax expression,
+        SyntaxNodeAnalysisContext context,
+        KnownTypes knownTypes,
+        out SyntaxNode capturedContext)
+    {
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(
+            expression,
+            context.CancellationToken);
+        var methods = symbolInfo.Symbol is IMethodSymbol method
+            ? [method]
+            : symbolInfo.CandidateSymbols.OfType<IMethodSymbol>();
+
+        foreach (var candidate in methods.Where(static method => method.IsAsync && method.ReturnsVoid))
+        {
+            foreach (var syntaxReference in candidate.DeclaringSyntaxReferences)
+            {
+                var declaration = syntaxReference.GetSyntax(context.CancellationToken);
+                if (!declaration.DescendantNodes().OfType<AwaitExpressionSyntax>().Any())
+                {
+                    continue;
+                }
+
+                var eventParameterNames = new HashSet<string>(
+                    candidate.Parameters
+                        .Where(parameter => ContainsEventContextReference(parameter.Type, knownTypes))
+                        .Select(static parameter => parameter.Name),
+                    StringComparer.Ordinal);
+                foreach (var identifier in declaration.DescendantNodes()
+                             .OfType<IdentifierNameSyntax>()
+                             .Where(identifier => eventParameterNames.Contains(
+                                 identifier.Identifier.ValueText)))
+                {
+                    capturedContext = identifier;
+                    return true;
                 }
             }
         }
@@ -607,7 +659,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && IsTaskLike(resultContainingType);
             }
 
-            if ((method.Name == "GetResult"
+            if ((IsFrameworkAwaiterGetResult(method)
                     && consumer.ArgumentList.Arguments.Count == 0)
                 || (method.Name == "Wait"
                     && consumer.ArgumentList.Arguments.Count == 0
@@ -656,6 +708,24 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 consumerInvocation,
                 semanticModel,
                 cancellationToken);
+    }
+
+    private static bool IsFrameworkAwaiterGetResult(IMethodSymbol method)
+    {
+        if (method.Name != "GetResult")
+        {
+            return false;
+        }
+
+        var definition = method.ContainingType.OriginalDefinition.ToDisplayString();
+        return definition is "System.Runtime.CompilerServices.TaskAwaiter"
+            or "System.Runtime.CompilerServices.TaskAwaiter<TResult>"
+            or "System.Runtime.CompilerServices.ValueTaskAwaiter<TResult>"
+            or "System.Runtime.CompilerServices.ValueTaskAwaiter"
+            or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter"
+            or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter"
+            or "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter"
+            or "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter";
     }
 
     private static bool IsTaskLike(ITypeSymbol? type)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Kevlar.Analyzers;
@@ -401,12 +402,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                          .OfType<AnonymousFunctionExpressionSyntax>()
                          .Any(ancestor => expression.Span.Contains(ancestor.Span))))
         {
-            if (!anonymous.AsyncKeyword.IsKind(SyntaxKind.None)
-                && TryFindAsyncAnonymousFunctionContext(
-                    anonymous,
-                    context,
-                    knownTypes,
-                    out capturedContext))
+            if (TryFindAnonymousFunctionContext(
+                anonymous,
+                context,
+                knownTypes,
+                out capturedContext))
             {
                 return true;
             }
@@ -489,6 +489,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && TryFindPostAwaitEventContext(
                         body,
                         eventParameterNames,
+                        declaration.SyntaxTree == context.SemanticModel.SyntaxTree
+                            ? context.SemanticModel
+                            : null,
+                        context.CancellationToken,
                         out capturedContext))
                 {
                     return true;
@@ -500,7 +504,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool TryFindAsyncAnonymousFunctionContext(
+    private static bool TryFindAnonymousFunctionContext(
         AnonymousFunctionExpressionSyntax anonymous,
         SyntaxNodeAnalysisContext context,
         KnownTypes knownTypes,
@@ -532,22 +536,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return TryFindPostAwaitEventContext(
             anonymous.Body,
             eventParameterNames,
+            context.SemanticModel,
+            context.CancellationToken,
             out capturedContext);
     }
 
     private static bool TryFindPostAwaitEventContext(
         SyntaxNode body,
         HashSet<string> eventParameterNames,
-        out SyntaxNode capturedContext)
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken,
+        out SyntaxNode capturedContext,
+        HashSet<LocalFunctionStatementSyntax>? callPath = null)
     {
         var nodes = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
                 node is not AnonymousFunctionExpressionSyntax
                     and not LocalFunctionStatementSyntax)
             .ToArray();
-        var firstAwait = nodes.OfType<AwaitExpressionSyntax>()
+        var awaits = nodes.OfType<AwaitExpressionSyntax>().ToArray();
+        var firstAwait = awaits
             .Select(static awaitExpression => awaitExpression.SpanStart)
             .DefaultIfEmpty(int.MaxValue)
             .Min();
+        var controlFlowGraph = TryCreateControlFlowGraph(
+            body,
+            semanticModel,
+            cancellationToken);
         var retainedNames = new HashSet<string>(eventParameterNames, StringComparer.Ordinal);
         foreach (var alias in nodes
                      .Where(node => node.SpanStart < firstAwait
@@ -572,15 +586,19 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             {
                 retainedNames.Add(name);
             }
-            else
+            else if (IsUnconditionalAliasWrite(alias, body))
             {
                 retainedNames.Remove(name);
             }
         }
 
         foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
-                     .Where(identifier => identifier.SpanStart > firstAwait
-                         && retainedNames.Contains(identifier.Identifier.ValueText)))
+                     .Where(identifier => retainedNames.Contains(identifier.Identifier.ValueText)
+                         && IsRuntimeValueReference(identifier)
+                         && awaits.Any(awaitExpression => CanReachAfterSuspension(
+                             awaitExpression,
+                             identifier,
+                             controlFlowGraph))))
         {
             capturedContext = identifier;
             return true;
@@ -592,15 +610,34 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             .ToLookup(
                 static function => function.Identifier.ValueText,
                 StringComparer.Ordinal);
-        foreach (var invocation in nodes.OfType<InvocationExpressionSyntax>()
-                     .Where(invocation => invocation.SpanStart > firstAwait))
+        callPath ??= [];
+        foreach (var invocation in nodes.OfType<InvocationExpressionSyntax>())
         {
+            var invokedAfterSuspension = awaits.Any(awaitExpression =>
+                CanReachAfterSuspension(
+                    awaitExpression,
+                    invocation,
+                    controlFlowGraph));
             if (TryFindRetainedContextInLocalFunction(
                 invocation,
                 localFunctions,
                 retainedNames,
-                [],
+                invokedAfterSuspension,
+                semanticModel,
+                cancellationToken,
+                callPath,
                 out capturedContext))
+            {
+                return true;
+            }
+
+            if (invokedAfterSuspension
+                && TryFindRetainedContextInInvokedDelegate(
+                    invocation,
+                    retainedNames,
+                    semanticModel,
+                    cancellationToken,
+                    out capturedContext))
             {
                 return true;
             }
@@ -614,6 +651,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         InvocationExpressionSyntax invocation,
         ILookup<string, LocalFunctionStatementSyntax> localFunctions,
         HashSet<string> retainedNames,
+        bool invokedAfterSuspension,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken,
         HashSet<LocalFunctionStatementSyntax> callPath,
         out SyntaxNode capturedContext)
     {
@@ -643,6 +683,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 functionRetainedNames.Remove(parameter.Identifier.ValueText);
             }
 
+            if (!invokedAfterSuspension)
+            {
+                if (function.Modifiers.Any(SyntaxKind.AsyncKeyword)
+                    && TryFindPostAwaitEventContext(
+                        functionBody,
+                        functionRetainedNames,
+                        semanticModel,
+                        cancellationToken,
+                        out capturedContext,
+                        nestedCallPath))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
             var functionNodes = functionBody.DescendantNodesAndSelf(
                     descendIntoChildren: static node =>
                         node is not AnonymousFunctionExpressionSyntax
@@ -650,7 +707,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 .ToArray();
             foreach (var retainedIdentifier in functionNodes.OfType<IdentifierNameSyntax>()
                          .Where(candidate => functionRetainedNames.Contains(
-                             candidate.Identifier.ValueText)))
+                                 candidate.Identifier.ValueText)
+                             && IsRuntimeValueReference(candidate)))
             {
                 capturedContext = retainedIdentifier;
                 return true;
@@ -662,6 +720,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     nestedInvocation,
                     localFunctions,
                     functionRetainedNames,
+                    invokedAfterSuspension: true,
+                    semanticModel,
+                    cancellationToken,
                     nestedCallPath,
                     out capturedContext))
                 {
@@ -673,6 +734,245 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         capturedContext = null!;
         return false;
     }
+
+    private static bool TryFindRetainedContextInInvokedDelegate(
+        InvocationExpressionSyntax invocation,
+        HashSet<string> retainedNames,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken,
+        out SyntaxNode capturedContext)
+    {
+        if (semanticModel is null
+            || invocation.Expression is not IdentifierNameSyntax identifier
+            || semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
+                is not ILocalSymbol local
+            || !TryGetStableLocalInitializer(
+                local,
+                semanticModel,
+                cancellationToken,
+                identifier,
+                out var initializer))
+        {
+            capturedContext = null!;
+            return false;
+        }
+
+        foreach (var anonymous in initializer.DescendantNodesAndSelf()
+                     .OfType<AnonymousFunctionExpressionSyntax>())
+        {
+            var capturedNames = new HashSet<string>(retainedNames, StringComparer.Ordinal);
+            foreach (var parameter in GetAnonymousFunctionParameters(anonymous))
+            {
+                capturedNames.Remove(parameter.Identifier.ValueText);
+            }
+
+            foreach (var capturedIdentifier in anonymous.Body
+                         .DescendantNodesAndSelf(descendIntoChildren: static node =>
+                             node is not AnonymousFunctionExpressionSyntax
+                                 and not LocalFunctionStatementSyntax)
+                         .OfType<IdentifierNameSyntax>()
+                         .Where(candidate => capturedNames.Contains(candidate.Identifier.ValueText)
+                             && IsRuntimeValueReference(candidate)))
+            {
+                capturedContext = capturedIdentifier;
+                return true;
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static IEnumerable<ParameterSyntax> GetAnonymousFunctionParameters(
+        AnonymousFunctionExpressionSyntax anonymous) => anonymous switch
+    {
+        SimpleLambdaExpressionSyntax simple => [simple.Parameter],
+        ParenthesizedLambdaExpressionSyntax parenthesized => parenthesized.ParameterList.Parameters,
+        AnonymousMethodExpressionSyntax { ParameterList: { } parameterList } =>
+            parameterList.Parameters,
+        _ => [],
+    };
+
+    private static bool IsRuntimeValueReference(IdentifierNameSyntax identifier) =>
+        !identifier.Ancestors().OfType<InvocationExpressionSyntax>().Any(invocation =>
+            invocation.Expression is IdentifierNameSyntax name
+            && name.Identifier.ValueText == "nameof"
+            && invocation.ArgumentList.Span.Contains(identifier.Span));
+
+    private static bool IsUnconditionalAliasWrite(SyntaxNode alias, SyntaxNode body)
+    {
+        for (var current = alias.Parent; current is not null && current != body; current = current.Parent)
+        {
+            if (current is IfStatementSyntax
+                or ElseClauseSyntax
+                or SwitchStatementSyntax
+                or SwitchExpressionSyntax
+                or ConditionalExpressionSyntax
+                or ForStatementSyntax
+                or ForEachStatementSyntax
+                or WhileStatementSyntax
+                or DoStatementSyntax
+                or TryStatementSyntax
+                or CatchClauseSyntax)
+            {
+                return false;
+            }
+        }
+
+        return body.Span.Contains(alias.Span);
+    }
+
+    private static ControlFlowGraph? TryCreateControlFlowGraph(
+        SyntaxNode body,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (semanticModel is null || semanticModel.SyntaxTree != body.SyntaxTree)
+        {
+            return null;
+        }
+
+        try
+        {
+            return GetContainingFunction(body) is { } function
+                ? TryCreateFunctionControlFlowGraph(
+                    function,
+                    semanticModel,
+                    cancellationToken)
+                : null;
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static ControlFlowGraph? TryCreateFunctionControlFlowGraph(
+        SyntaxNode function,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (function is BaseMethodDeclarationSyntax or AccessorDeclarationSyntax)
+        {
+            return ControlFlowGraph.Create(function, semanticModel, cancellationToken);
+        }
+
+        if (GetContainingFunction(function.Parent) is not { } containingFunction
+            || TryCreateFunctionControlFlowGraph(
+                containingFunction,
+                semanticModel,
+                cancellationToken) is not { } containingGraph)
+        {
+            return null;
+        }
+
+        if (function is LocalFunctionStatementSyntax localFunction
+            && semanticModel.GetDeclaredSymbol(localFunction, cancellationToken)
+                is IMethodSymbol symbol)
+        {
+            return containingGraph.GetLocalFunctionControlFlowGraph(symbol, cancellationToken);
+        }
+
+        if (function is AnonymousFunctionExpressionSyntax anonymous)
+        {
+            foreach (var block in containingGraph.Blocks)
+            {
+                foreach (var operation in block.Operations
+                             .Concat(block.BranchValue is { } branchValue
+                                 ? [branchValue]
+                                 : []))
+                {
+                    var flowAnonymous = DescendantOperations(operation)
+                        .OfType<IFlowAnonymousFunctionOperation>()
+                        .FirstOrDefault(candidate => candidate.Syntax == anonymous);
+                    if (flowAnonymous is not null)
+                    {
+                        return containingGraph.GetAnonymousFunctionControlFlowGraph(
+                            flowAnonymous,
+                            cancellationToken);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static SyntaxNode? GetContainingFunction(SyntaxNode? node) =>
+        node?.AncestorsAndSelf().FirstOrDefault(static candidate =>
+            candidate is BaseMethodDeclarationSyntax
+                or AccessorDeclarationSyntax
+                or LocalFunctionStatementSyntax
+                or AnonymousFunctionExpressionSyntax);
+
+    private static bool CanReachAfterSuspension(
+        AwaitExpressionSyntax awaitExpression,
+        SyntaxNode candidate,
+        ControlFlowGraph? controlFlowGraph)
+    {
+        if (awaitExpression.SpanStart >= candidate.SpanStart)
+        {
+            return false;
+        }
+
+        if (controlFlowGraph is null)
+        {
+            return true;
+        }
+
+        var awaitBlocks = controlFlowGraph.Blocks
+            .Where(block => block.IsReachable
+                && ContainsOperationSyntax(block, awaitExpression))
+            .ToArray();
+        var candidateBlocks = new HashSet<BasicBlock>(controlFlowGraph.Blocks
+            .Where(block => block.IsReachable && ContainsOperationSyntax(block, candidate)));
+        foreach (var awaitBlock in awaitBlocks)
+        {
+            if (candidateBlocks.Contains(awaitBlock))
+            {
+                return true;
+            }
+
+            var pending = new Queue<BasicBlock>();
+            var visited = new HashSet<BasicBlock>();
+            EnqueueSuccessor(awaitBlock.FallThroughSuccessor, pending);
+            EnqueueSuccessor(awaitBlock.ConditionalSuccessor, pending);
+            while (pending.Count > 0)
+            {
+                var block = pending.Dequeue();
+                if (!visited.Add(block))
+                {
+                    continue;
+                }
+
+                if (candidateBlocks.Contains(block))
+                {
+                    return true;
+                }
+
+                EnqueueSuccessor(block.FallThroughSuccessor, pending);
+                EnqueueSuccessor(block.ConditionalSuccessor, pending);
+            }
+        }
+
+        return false;
+    }
+
+    private static void EnqueueSuccessor(
+        ControlFlowBranch? branch,
+        Queue<BasicBlock> pending)
+    {
+        if (branch?.Destination is { IsReachable: true } destination)
+        {
+            pending.Enqueue(destination);
+        }
+    }
+
+    private static bool ContainsOperationSyntax(BasicBlock block, SyntaxNode syntax) =>
+        block.Operations.Any(operation => DescendantOperations(operation)
+            .Any(candidate => candidate.Syntax == syntax))
+        || block.BranchValue is { } branchValue
+            && DescendantOperations(branchValue).Any(candidate => candidate.Syntax == syntax);
 
     private static string? GetAssignedName(ExpressionSyntax expression) => expression switch
     {
@@ -769,13 +1069,24 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 stack.Push(initializerOperation);
             }
 
-            if (current is IDelegateCreationOperation or IAnonymousFunctionOperation)
+            if (current is IAnonymousFunctionOperation anonymous)
             {
-                foreach (var descendant in DescendantOperations(current).Skip(1))
+                foreach (var descendant in DescendantOperations(anonymous).Skip(1))
                 {
+                    if (ContainsAnonymousOwnedReference(descendant, anonymous.Symbol))
+                    {
+                        continue;
+                    }
+
                     stack.Push(descendant);
                 }
 
+                continue;
+            }
+
+            if (current is IDelegateCreationOperation delegateCreation)
+            {
+                stack.Push(delegateCreation.Target);
                 continue;
             }
 
@@ -785,6 +1096,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
         }
     }
+
+    private static bool ContainsAnonymousOwnedReference(
+        IOperation operation,
+        IMethodSymbol anonymousSymbol) => DescendantOperations(operation).Any(candidate =>
+            (candidate is IParameterReferenceOperation parameterReference
+                && SymbolEqualityComparer.Default.Equals(
+                    parameterReference.Parameter.ContainingSymbol,
+                    anonymousSymbol))
+            || (candidate is ILocalReferenceOperation localReference
+                && SymbolEqualityComparer.Default.Equals(
+                    localReference.Local.ContainingSymbol,
+                    anonymousSymbol)));
 
     private static IEnumerable<IOperation> GetRetainedValueParts(IOperation operation)
     {

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -291,7 +291,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     || GetCallbackInvocations(
                             body,
                             context.SemanticModel,
-                            context.CancellationToken)
+                            context.CancellationToken,
+                            followTaskReturningLocalFunctions: false)
                         .Any(invocation => IsUnobservedAsyncInvocation(invocation, context));
             }
 
@@ -299,7 +300,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && GetCallbackInvocations(
                         block,
                         context.SemanticModel,
-                        context.CancellationToken)
+                        context.CancellationToken,
+                        followTaskReturningLocalFunctions: false)
                     .Any(invocation => IsUnobservedAsyncInvocation(invocation, context));
         }
 
@@ -366,7 +368,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             foreach (var invocation in GetCallbackInvocations(
                          anonymous.Body,
                          context.SemanticModel,
-                         context.CancellationToken))
+                         context.CancellationToken,
+                         followTaskReturningLocalFunctions: true))
             {
                 if (!IsUnobservedAsyncInvocation(invocation, context))
                 {
@@ -449,10 +452,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     .Select(static awaitExpression => awaitExpression.SpanStart)
                     .DefaultIfEmpty(int.MaxValue)
                     .Min();
+                var retainedNames = new HashSet<string>(eventParameterNames, StringComparer.Ordinal);
+                foreach (var declarator in nodes.OfType<VariableDeclaratorSyntax>()
+                             .Where(declarator => declarator.SpanStart < firstAwait)
+                             .OrderBy(static declarator => declarator.SpanStart))
+                {
+                    if (declarator.Initializer?.Value is { } initializer
+                        && IsRetainedAliasExpression(initializer, retainedNames))
+                    {
+                        retainedNames.Add(declarator.Identifier.ValueText);
+                    }
+                }
+
                 foreach (var identifier in nodes
                              .OfType<IdentifierNameSyntax>()
                              .Where(identifier => identifier.SpanStart > firstAwait
-                                 && eventParameterNames.Contains(identifier.Identifier.ValueText)))
+                                 && retainedNames.Contains(identifier.Identifier.ValueText)))
                 {
                     capturedContext = identifier;
                     return true;
@@ -463,6 +478,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         capturedContext = null!;
         return false;
     }
+
+    private static bool IsRetainedAliasExpression(
+        ExpressionSyntax expression,
+        HashSet<string> retainedNames) => expression switch
+    {
+        IdentifierNameSyntax identifier => retainedNames.Contains(identifier.Identifier.ValueText),
+        ParenthesizedExpressionSyntax parenthesized =>
+            IsRetainedAliasExpression(parenthesized.Expression, retainedNames),
+        CastExpressionSyntax cast => IsRetainedAliasExpression(cast.Expression, retainedNames),
+        PostfixUnaryExpressionSyntax postfix
+            when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression) =>
+            IsRetainedAliasExpression(postfix.Operand, retainedNames),
+        _ => false,
+    };
 
     private static SyntaxNode? GetFunctionBody(SyntaxNode declaration) => declaration switch
     {
@@ -650,7 +679,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static IEnumerable<InvocationExpressionSyntax> GetCallbackInvocations(
         SyntaxNode body,
         SemanticModel semanticModel,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool followTaskReturningLocalFunctions)
     {
         var pendingBodies = new Stack<SyntaxNode>();
         var visitedLocalFunctions = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
@@ -669,8 +699,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         cancellationToken).Symbol is not IMethodSymbol
                     {
                         MethodKind: MethodKind.LocalFunction,
-                        ReturnsVoid: true,
                     } localFunction
+                    || !localFunction.ReturnsVoid
+                        && (!followTaskReturningLocalFunctions
+                            || !StartsAsynchronousWork(localFunction))
                     || !visitedLocalFunctions.Add(localFunction))
                 {
                     continue;
@@ -750,6 +782,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     and not StatementSyntax)
                 .OfType<ArgumentSyntax>()
                 .FirstOrDefault() is not { } argument
+            || !IsObservationPreservingArgumentPath(current, argument)
             || argument.Parent?.Parent is not InvocationExpressionSyntax consumerInvocation
             || semanticModel.GetSymbolInfo(
                 consumerInvocation,
@@ -775,6 +808,28 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 consumerInvocation,
                 semanticModel,
                 cancellationToken);
+    }
+
+    private static bool IsObservationPreservingArgumentPath(
+        SyntaxNode value,
+        ArgumentSyntax argument)
+    {
+        for (var current = value.Parent; current != argument; current = current?.Parent)
+        {
+            if (current is null
+                || current is not (InitializerExpressionSyntax
+                    or ArrayCreationExpressionSyntax
+                    or ImplicitArrayCreationExpressionSyntax
+                    or CollectionExpressionSyntax
+                    or ParenthesizedExpressionSyntax
+                    or CastExpressionSyntax
+                    or PostfixUnaryExpressionSyntax))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool IsFrameworkAwaiterGetResult(IMethodSymbol method)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -629,10 +629,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     body,
                     semanticModel,
                     context.CancellationToken);
-                var firstAwait = awaits.OrderBy(static awaitExpression => awaitExpression.SpanStart)
-                    .First();
-                var retainedNames = new HashSet<string>(StringComparer.Ordinal);
-                var retainedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+                var retainedSymbolSeeds = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
                 foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
                              .Where(identifier => IsRuntimeValueReference(identifier)))
                 {
@@ -649,34 +646,41 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         && callbackRetainedSymbols.Contains(symbol)
                         && ContainsEventContextReference(type, knownTypes))
                     {
-                        retainedSymbols.Add(symbol);
+                        retainedSymbolSeeds.Add(symbol);
                     }
                 }
 
-                CollectRetainedAliases(
-                    nodes,
-                    firstAwait,
-                    body,
-                    retainedNames,
-                    retainedSymbols,
-                    semanticModel,
-                    controlFlowGraph,
-                    cancellationToken: context.CancellationToken);
-                foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
-                             .Where(identifier => IsRuntimeValueReference(identifier)
-                                 && IsRetainedReference(
-                                     identifier,
-                                     retainedNames,
-                                     retainedSymbols,
-                                     semanticModel,
-                                     context.CancellationToken)
-                                 && awaits.Any(awaitExpression => CanReachAfterSuspension(
-                                     awaitExpression,
-                                     identifier,
-                                     controlFlowGraph))))
+                foreach (var awaitExpression in awaits)
                 {
-                    capturedContext = identifier;
-                    return true;
+                    var retainedNames = new HashSet<string>(StringComparer.Ordinal);
+                    var retainedSymbols = new HashSet<ISymbol>(
+                        retainedSymbolSeeds,
+                        SymbolEqualityComparer.Default);
+                    CollectRetainedAliases(
+                        nodes,
+                        awaitExpression,
+                        body,
+                        retainedNames,
+                        retainedSymbols,
+                        semanticModel,
+                        controlFlowGraph,
+                        cancellationToken: context.CancellationToken);
+                    foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
+                                 .Where(identifier => IsRuntimeValueReference(identifier)
+                                     && IsRetainedReference(
+                                         identifier,
+                                         retainedNames,
+                                         retainedSymbols,
+                                         semanticModel,
+                                         context.CancellationToken)
+                                     && CanReachAfterSuspension(
+                                         awaitExpression,
+                                         identifier,
+                                         controlFlowGraph)))
+                    {
+                        capturedContext = identifier;
+                        return true;
+                    }
                 }
             }
         }
@@ -821,6 +825,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         var retainedSymbolSeedsForAwait = new HashSet<ISymbol>(
             retainedSymbols,
             SymbolEqualityComparer.Default);
+        var retainedStates = new List<(
+            AwaitExpressionSyntax AwaitExpression,
+            HashSet<string> Names,
+            HashSet<ISymbol> Symbols)>();
         foreach (var awaitExpression in awaits.OrderBy(static candidate => candidate.SpanStart))
         {
             var namesAtAwait = new HashSet<string>(retainedNameSeeds, StringComparer.Ordinal);
@@ -836,22 +844,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 semanticModel,
                 controlFlowGraph,
                 cancellationToken);
-            retainedNames.UnionWith(namesAtAwait);
-            retainedSymbols.UnionWith(symbolsAtAwait);
+            retainedStates.Add((awaitExpression, namesAtAwait, symbolsAtAwait));
         }
 
         foreach (var identifier in nodes.OfType<IdentifierNameSyntax>()
-                     .Where(identifier => IsRetainedReference(
-                             identifier,
-                             retainedNames,
-                             retainedSymbols,
-                             semanticModel,
-                             cancellationToken)
-                         && IsRuntimeValueReference(identifier)
-                         && awaits.Any(awaitExpression => CanReachAfterSuspension(
-                             awaitExpression,
-                             identifier,
-                             controlFlowGraph))))
+                     .Where(identifier => IsRuntimeValueReference(identifier)
+                         && retainedStates.Any(state =>
+                             IsRetainedReference(
+                                 identifier,
+                                 state.Names,
+                                 state.Symbols,
+                                 semanticModel,
+                                 cancellationToken)
+                             && CanReachAfterSuspension(
+                                 state.AwaitExpression,
+                                 identifier,
+                                 controlFlowGraph))))
         {
             capturedContext = identifier;
             return true;
@@ -866,35 +874,49 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         callPath ??= [];
         foreach (var invocation in nodes.OfType<InvocationExpressionSyntax>())
         {
-            var invokedAfterSuspension = awaits.Any(awaitExpression =>
-                CanReachAfterSuspension(
-                    awaitExpression,
+            var reachingStates = retainedStates
+                .Where(state => CanReachAfterSuspension(
+                    state.AwaitExpression,
                     invocation,
-                    controlFlowGraph));
-            if (TryFindRetainedContextInLocalFunction(
-                invocation,
-                localFunctions,
-                retainedNames,
-                retainedSymbols,
-                invokedAfterSuspension,
-                semanticModel,
-                cancellationToken,
-                callPath,
-                out capturedContext))
+                    controlFlowGraph))
+                .ToArray();
+            if (reachingStates.Length == 0
+                && TryFindRetainedContextInLocalFunction(
+                    invocation,
+                    localFunctions,
+                    retainedNameSeeds,
+                    retainedSymbolSeedsForAwait,
+                    invokedAfterSuspension: false,
+                    semanticModel,
+                    cancellationToken,
+                    callPath,
+                    out capturedContext))
             {
                 return true;
             }
 
-            if (invokedAfterSuspension
-                && TryFindRetainedContextInInvokedDelegate(
-                    invocation,
-                    retainedNames,
-                    retainedSymbols,
-                    semanticModel,
-                    cancellationToken,
-                    out capturedContext))
+            foreach (var state in reachingStates)
             {
-                return true;
+                if (TryFindRetainedContextInLocalFunction(
+                        invocation,
+                        localFunctions,
+                        state.Names,
+                        state.Symbols,
+                        invokedAfterSuspension: true,
+                        semanticModel,
+                        cancellationToken,
+                        callPath,
+                        out capturedContext)
+                    || TryFindRetainedContextInInvokedDelegate(
+                        invocation,
+                        state.Names,
+                        state.Symbols,
+                        semanticModel,
+                        cancellationToken,
+                        out capturedContext))
+                {
+                    return true;
+                }
             }
         }
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -2044,23 +2044,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         SyntaxNode candidate,
         ControlFlowGraph? controlFlowGraph)
     {
-        if (awaitExpression.SpanStart >= candidate.SpanStart)
-        {
-            return false;
-        }
-
         if (controlFlowGraph is null)
         {
-            return true;
+            return awaitExpression.SpanStart < candidate.SpanStart;
         }
 
-        return CanReach(awaitExpression, candidate, controlFlowGraph);
+        return CanReach(
+            awaitExpression,
+            candidate,
+            controlFlowGraph,
+            requireTraversal: awaitExpression.SpanStart >= candidate.SpanStart);
     }
 
     private static bool CanReach(
         SyntaxNode source,
         SyntaxNode target,
-        ControlFlowGraph? controlFlowGraph)
+        ControlFlowGraph? controlFlowGraph,
+        bool requireTraversal = false)
     {
         if (controlFlowGraph is null)
         {
@@ -2083,7 +2083,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         foreach (var sourceBlock in sourceBlocks)
         {
-            if (targetBlocks.Contains(sourceBlock))
+            if (!requireTraversal && targetBlocks.Contains(sourceBlock))
             {
                 return true;
             }
@@ -4144,7 +4144,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && ContainsCallbackParameterInRetainedValue(
                     value,
                     callbackParameters,
-                    knownTypes))
+                    knownTypes,
+                    semanticModel,
+                    context.CancellationToken))
             {
                 origins.Add(write.Syntax);
             }
@@ -4166,7 +4168,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool ContainsCallbackParameterInRetainedValue(
         IOperation operation,
         HashSet<ISymbol> callbackParameters,
-        KnownTypes knownTypes)
+        KnownTypes knownTypes,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         operation = Unwrap(operation)!;
         if (operation is IParameterReferenceOperation parameterReference)
@@ -4174,22 +4178,31 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             return callbackParameters.Contains(parameterReference.Parameter);
         }
 
-        var retainedParts = GetRetainedValueParts(operation).ToArray();
+        var retainedParts = GetRetainedValueParts(
+                operation,
+                semanticModel,
+                cancellationToken)
+            .ToArray();
         if (retainedParts.Length > 0)
         {
             return retainedParts.Any(part => ContainsCallbackParameterInRetainedValue(
                 part,
                 callbackParameters,
-                knownTypes));
+                knownTypes,
+                semanticModel,
+                cancellationToken));
         }
 
         if (operation is IInvocationOperation invocation)
         {
-            return invocation.Arguments.Any(argument =>
+            return invocation.TargetMethod.DeclaringSyntaxReferences.Length == 0
+                && invocation.Arguments.Any(argument =>
                 ContainsCallbackParameterInRetainedValue(
                     argument.Value,
                     callbackParameters,
-                    knownTypes));
+                    knownTypes,
+                    semanticModel,
+                    cancellationToken));
         }
 
         if (!ContainsEventContextReference(operation.Type, knownTypes))
@@ -4201,7 +4214,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             ContainsCallbackParameterInRetainedValue(
                 child,
                 callbackParameters,
-                knownTypes));
+                knownTypes,
+                semanticModel,
+                cancellationToken));
     }
 
     private static bool ContainsReferenceOwnedByNestedAnonymousFunction(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1465,7 +1465,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             current = consumer;
         }
 
-        if (current.Parent is AwaitExpressionSyntax)
+        if (current.Parent is AwaitExpressionSyntax
+            && IsTaskReturningFunction(current, semanticModel, cancellationToken))
         {
             return true;
         }
@@ -1502,6 +1503,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 semanticModel,
                 cancellationToken);
     }
+
+    private static bool IsTaskReturningFunction(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken) =>
+        GetContainingFunction(node) switch
+        {
+            AnonymousFunctionExpressionSyntax anonymous =>
+                semanticModel.GetTypeInfo(anonymous, cancellationToken).ConvertedType
+                    is INamedTypeSymbol { DelegateInvokeMethod.ReturnType: { } returnType }
+                && IsTaskLike(returnType),
+            LocalFunctionStatementSyntax localFunction =>
+                semanticModel.GetDeclaredSymbol(localFunction, cancellationToken)
+                    is IMethodSymbol { ReturnType: { } returnType }
+                && IsTaskLike(returnType),
+            BaseMethodDeclarationSyntax method =>
+                semanticModel.GetDeclaredSymbol(method, cancellationToken)
+                    is IMethodSymbol { ReturnType: { } returnType }
+                && IsTaskLike(returnType),
+            _ => false,
+        };
 
     private static bool IsSynchronouslyObservedThroughLocal(
         InvocationExpressionSyntax invocation,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3290,7 +3290,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
             if (operation is IParameterReferenceOperation parameterReference
                 && (knownTypes.IsEventContextContainer(parameterReference.Parameter.Type)
-                    || knownTypes.IsEventContextReference(parameterReference.Parameter.Type)))
+                    || knownTypes.IsEventContextReference(parameterReference.Parameter.Type))
+                && root is IAnonymousFunctionOperation anonymous
+                && !SymbolEqualityComparer.Default.Equals(
+                    parameterReference.Parameter.ContainingSymbol,
+                    anonymous.Symbol))
             {
                 capturedContext = parameterReference.Syntax;
                 return true;

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -288,12 +288,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 return IsTaskLike(context.SemanticModel.GetTypeInfo(
                     body,
                     context.CancellationToken).Type)
-                    || GetCallbackInvocations(body)
+                    || GetCallbackInvocations(
+                            body,
+                            context.SemanticModel,
+                            context.CancellationToken)
                         .Any(invocation => IsUnobservedAsyncInvocation(invocation, context));
             }
 
             return anonymous.Body is BlockSyntax block
-                && GetCallbackInvocations(block)
+                && GetCallbackInvocations(
+                        block,
+                        context.SemanticModel,
+                        context.CancellationToken)
                     .Any(invocation => IsUnobservedAsyncInvocation(invocation, context));
         }
 
@@ -357,7 +363,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                          .OfType<AnonymousFunctionExpressionSyntax>()
                          .Any(ancestor => expression.Span.Contains(ancestor.Span))))
         {
-            foreach (var invocation in GetCallbackInvocations(anonymous.Body))
+            foreach (var invocation in GetCallbackInvocations(
+                         anonymous.Body,
+                         context.SemanticModel,
+                         context.CancellationToken))
             {
                 if (!IsUnobservedAsyncInvocation(invocation, context))
                 {
@@ -426,14 +435,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             foreach (var syntaxReference in candidate.DeclaringSyntaxReferences)
             {
                 var declaration = syntaxReference.GetSyntax(context.CancellationToken);
-                SyntaxNode? body = declaration switch
-                {
-                    MethodDeclarationSyntax { Body: { } block } => block,
-                    MethodDeclarationSyntax { ExpressionBody.Expression: { } bodyExpression } => bodyExpression,
-                    LocalFunctionStatementSyntax { Body: { } block } => block,
-                    LocalFunctionStatementSyntax { ExpressionBody.Expression: { } bodyExpression } => bodyExpression,
-                    _ => null,
-                };
+                var body = GetFunctionBody(declaration);
                 if (body is null)
                 {
                     continue;
@@ -461,6 +463,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         capturedContext = null!;
         return false;
     }
+
+    private static SyntaxNode? GetFunctionBody(SyntaxNode declaration) => declaration switch
+    {
+        MethodDeclarationSyntax { Body: { } block } => block,
+        MethodDeclarationSyntax { ExpressionBody.Expression: { } expression } => expression,
+        LocalFunctionStatementSyntax { Body: { } block } => block,
+        LocalFunctionStatementSyntax { ExpressionBody.Expression: { } expression } => expression,
+        _ => null,
+    };
 
     private static bool TryFindEventContextExpression(
         ExpressionSyntax expression,
@@ -637,11 +648,46 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     }
 
     private static IEnumerable<InvocationExpressionSyntax> GetCallbackInvocations(
-        SyntaxNode body) =>
-        body.DescendantNodesAndSelf(descendIntoChildren: static node =>
-                node is not AnonymousFunctionExpressionSyntax
-                    and not LocalFunctionStatementSyntax)
-            .OfType<InvocationExpressionSyntax>();
+        SyntaxNode body,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var pendingBodies = new Stack<SyntaxNode>();
+        var visitedLocalFunctions = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        pendingBodies.Push(body);
+        while (pendingBodies.Count > 0)
+        {
+            foreach (var invocation in pendingBodies.Pop()
+                         .DescendantNodesAndSelf(descendIntoChildren: static node =>
+                             node is not AnonymousFunctionExpressionSyntax
+                                 and not LocalFunctionStatementSyntax)
+                         .OfType<InvocationExpressionSyntax>())
+            {
+                yield return invocation;
+                if (semanticModel.GetSymbolInfo(
+                        invocation,
+                        cancellationToken).Symbol is not IMethodSymbol
+                    {
+                        MethodKind: MethodKind.LocalFunction,
+                        ReturnsVoid: true,
+                    } localFunction
+                    || !visitedLocalFunctions.Add(localFunction))
+                {
+                    continue;
+                }
+
+                foreach (var syntaxReference in localFunction.DeclaringSyntaxReferences)
+                {
+                    var declaration = syntaxReference.GetSyntax(cancellationToken);
+                    var localBody = GetFunctionBody(declaration);
+                    if (localBody is not null)
+                    {
+                        pendingBodies.Push(localBody);
+                    }
+                }
+            }
+        }
+    }
 
     private static bool IsUnobservedAsyncInvocation(
         InvocationExpressionSyntax invocation,
@@ -1404,7 +1450,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
 
             if (operation is IFieldReferenceOperation fieldReference
-                && knownTypes.IsEventContextReference(fieldReference.Field.Type))
+                && ContainsEventContextReference(fieldReference.Field.Type, knownTypes))
             {
                 capturedContext = fieldReference.Syntax;
                 return true;

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -413,23 +413,44 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         foreach (var candidate in methods.Where(static method => method.IsAsync && method.ReturnsVoid))
         {
+            var eventParameterNames = new HashSet<string>(
+                candidate.Parameters
+                    .Where(parameter => ContainsEventContextReference(parameter.Type, knownTypes))
+                    .Select(static parameter => parameter.Name),
+                StringComparer.Ordinal);
+            if (eventParameterNames.Count == 0)
+            {
+                continue;
+            }
+
             foreach (var syntaxReference in candidate.DeclaringSyntaxReferences)
             {
                 var declaration = syntaxReference.GetSyntax(context.CancellationToken);
-                if (!declaration.DescendantNodes().OfType<AwaitExpressionSyntax>().Any())
+                SyntaxNode? body = declaration switch
+                {
+                    MethodDeclarationSyntax { Body: { } block } => block,
+                    MethodDeclarationSyntax { ExpressionBody.Expression: { } bodyExpression } => bodyExpression,
+                    LocalFunctionStatementSyntax { Body: { } block } => block,
+                    LocalFunctionStatementSyntax { ExpressionBody.Expression: { } bodyExpression } => bodyExpression,
+                    _ => null,
+                };
+                if (body is null)
                 {
                     continue;
                 }
 
-                var eventParameterNames = new HashSet<string>(
-                    candidate.Parameters
-                        .Where(parameter => ContainsEventContextReference(parameter.Type, knownTypes))
-                        .Select(static parameter => parameter.Name),
-                    StringComparer.Ordinal);
-                foreach (var identifier in declaration.DescendantNodes()
+                var nodes = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
+                        node is not AnonymousFunctionExpressionSyntax
+                            and not LocalFunctionStatementSyntax)
+                    .ToArray();
+                var firstAwait = nodes.OfType<AwaitExpressionSyntax>()
+                    .Select(static awaitExpression => awaitExpression.SpanStart)
+                    .DefaultIfEmpty(int.MaxValue)
+                    .Min();
+                foreach (var identifier in nodes
                              .OfType<IdentifierNameSyntax>()
-                             .Where(identifier => eventParameterNames.Contains(
-                                 identifier.Identifier.ValueText)))
+                             .Where(identifier => identifier.SpanStart > firstAwait
+                                 && eventParameterNames.Contains(identifier.Identifier.ValueText)))
                 {
                     capturedContext = identifier;
                     return true;

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3243,7 +3243,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             callbackOperation.Symbol.Parameters,
             SymbolEqualityComparer.Default);
 
-        var assignment = callback.Body
+        var assignments = callback.Body
             .DescendantNodes(descendIntoChildren: static node =>
                 node is not AnonymousFunctionExpressionSyntax
                     and not LocalFunctionStatementSyntax)
@@ -3256,14 +3256,33 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         context.CancellationToken).Symbol,
                     member))
             .OrderBy(static candidate => candidate.SpanStart)
-            .LastOrDefault();
-        return assignment is not null
-            && assignment.Right.DescendantNodesAndSelf()
+            .ToArray();
+        var origins = new List<SyntaxNode?>();
+        var kills = new List<SyntaxNode>();
+        foreach (var assignment in assignments)
+        {
+            if (assignment.Right.DescendantNodesAndSelf()
                 .OfType<IdentifierNameSyntax>()
                 .Any(identifier => callbackParameters.Contains(
                     semanticModel.GetSymbolInfo(
                         identifier,
-                        context.CancellationToken).Symbol!));
+                        context.CancellationToken).Symbol!)))
+            {
+                origins.Add(assignment);
+            }
+            else
+            {
+                kills.Add(assignment);
+            }
+        }
+
+        var controlFlowGraph = TryCreateControlFlowGraph(
+            callback.Body,
+            semanticModel,
+            context.CancellationToken);
+        return origins.Count > 0
+            && HasReachableOrigin(origins, anchor, controlFlowGraph, kills)
+            && !IsClearedOnEveryBranch(origins, kills, anchor, callback.Body);
     }
 
     private static bool ContainsReferenceOwnedByNestedAnonymousFunction(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1164,7 +1164,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         var operation = Unwrap(semanticModel?.GetOperation(expression, cancellationToken));
         if (operation is not null
-            && GetRetainedValueParts(operation).Any(part =>
+            && GetStoredAliasValueParts(operation).Any(part =>
                 part.Syntax is ExpressionSyntax partExpression
                 && HasReachableRetainedAlias(
                     partExpression,
@@ -1216,6 +1216,37 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     cancellationToken),
             _ => false,
         };
+    }
+
+    private static IEnumerable<IOperation> GetStoredAliasValueParts(IOperation operation) =>
+        operation is IObjectCreationOperation objectCreation
+            ? GetObjectInitializerValues(objectCreation.Initializer)
+            : GetRetainedValueParts(operation);
+
+    private static IEnumerable<IOperation> GetObjectInitializerValues(
+        IObjectOrCollectionInitializerOperation? initializer)
+    {
+        if (initializer is null)
+        {
+            yield break;
+        }
+
+        foreach (var item in initializer.Initializers)
+        {
+            if (item is ISimpleAssignmentOperation assignment)
+            {
+                yield return assignment.Value;
+                continue;
+            }
+
+            if (item is IInvocationOperation invocation)
+            {
+                foreach (var argument in invocation.Arguments)
+                {
+                    yield return argument.Value;
+                }
+            }
+        }
     }
 
     private static bool HasReachableOrigin(
@@ -2876,6 +2907,36 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     return true;
                 }
             }
+        }
+
+        if (operation is IInvocationOperation invocationOperation)
+        {
+            if (invocationOperation.Instance is { } instance
+                && TryFindDeferredStateContext(
+                    instance,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+            {
+                return true;
+            }
+
+            foreach (var argument in invocationOperation.Arguments)
+            {
+                if (TryFindDeferredStateContext(
+                    argument.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+
+            capturedContext = null!;
+            return false;
         }
 
         if (operation is ILocalReferenceOperation localReference)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -2797,7 +2797,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             }
 
             if (operation is IFieldReferenceOperation fieldReference
-                && ContainsEventContextReference(fieldReference.Field.Type, knownTypes))
+                && knownTypes.IsEventContextReference(fieldReference.Field.Type))
             {
                 capturedContext = fieldReference.Syntax;
                 return true;

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1465,6 +1465,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             current = consumer;
         }
 
+        if (current.Parent is AwaitExpressionSyntax)
+        {
+            return true;
+        }
+
         if (current.Ancestors()
                 .TakeWhile(static node => node is not AnonymousFunctionExpressionSyntax
                     and not StatementSyntax)
@@ -5269,20 +5274,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         internal bool IsTestAssembly { get; }
 
         internal bool IsSynchronousCallback(IPropertySymbol property) =>
-            property.Type is INamedTypeSymbol
-            {
-                Name: "Action",
-                Arity: 1,
-                ContainingNamespace.Name: "System",
-            }
-            && _synchronousCallbackTypes.Contains(property.ContainingType.OriginalDefinition)
-            && property.Name is "OnRetry"
-                or "OnTimeout"
-                or "OnStateChanged"
-                or "OnHedge"
-                or "OnFallback"
-                or "OnInjected"
-                or "OnRejected";
+            _synchronousCallbackTypes.Contains(property.ContainingType.OriginalDefinition)
+            && TryGetSynchronousCallbackEventType(property, out _);
 
         internal bool IsShield(INamedTypeSymbol type) =>
             Is(type, _shield) || Is(type, _shieldOfT);
@@ -5353,39 +5346,53 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 _synchronousCallbackTypes.Add(type);
                 foreach (var property in type.GetMembers().OfType<IPropertySymbol>())
                 {
-                    if (property.Type is not INamedTypeSymbol callbackType)
-                    {
-                        continue;
-                    }
-
-                    var isNotification = callbackType is
-                        {
-                            Name: "Action",
-                            Arity: 1,
-                            ContainingNamespace.Name: "System",
-                        }
-                        && property.Name is "OnRetry"
-                            or "OnTimeout"
-                            or "OnStateChanged"
-                            or "OnHedge"
-                            or "OnFallback"
-                            or "OnInjected"
-                            or "OnRejected";
-                    var isHandlingPredicate = callbackType is
-                        {
-                            Name: "Func",
-                            Arity: 2,
-                            ContainingNamespace.Name: "System",
-                        }
-                        && callbackType.TypeArguments[1].SpecialType == SpecialType.System_Boolean
-                        && property.Name == "HandlesExceptionWithContext";
-                    if ((isNotification || isHandlingPredicate)
-                        && callbackType.TypeArguments[0] is INamedTypeSymbol eventType)
+                    if (TryGetSynchronousCallbackEventType(property, out var eventType))
                     {
                         _eventContextContainerTypes.Add(eventType.OriginalDefinition);
                     }
                 }
             }
+        }
+
+        private static bool TryGetSynchronousCallbackEventType(
+            IPropertySymbol property,
+            out INamedTypeSymbol eventType)
+        {
+            eventType = null!;
+            if (property.Type is not INamedTypeSymbol callbackType)
+            {
+                return false;
+            }
+
+            var isNotification = callbackType is
+                {
+                    Name: "Action",
+                    Arity: 1,
+                    ContainingNamespace.Name: "System",
+                }
+                && property.Name is "OnRetry"
+                    or "OnTimeout"
+                    or "OnStateChanged"
+                    or "OnHedge"
+                    or "OnFallback"
+                    or "OnInjected"
+                    or "OnRejected";
+            var isHandlingPredicate = callbackType is
+                {
+                    Name: "Func",
+                    Arity: 2,
+                    ContainingNamespace.Name: "System",
+                }
+                && callbackType.TypeArguments[1].SpecialType == SpecialType.System_Boolean
+                && property.Name == "HandlesExceptionWithContext";
+            if ((isNotification || isHandlingPredicate)
+                && callbackType.TypeArguments[0] is INamedTypeSymbol callbackEventType)
+            {
+                eventType = callbackEventType;
+                return true;
+            }
+
+            return false;
         }
 
         private static bool Is(INamedTypeSymbol type, INamedTypeSymbol? expected) =>

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -728,6 +728,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         body,
                         eventParameterNames,
                         semanticModel,
+                        knownTypes,
                         context.CancellationToken,
                         out capturedContext))
                 {
@@ -780,6 +781,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             anonymous.Body,
             eventParameterNames,
             context.SemanticModel,
+            knownTypes,
             context.CancellationToken,
             out capturedContext,
             retainedSymbolSeeds: eventParameterSymbols);
@@ -789,6 +791,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         SyntaxNode body,
         HashSet<string> eventParameterNames,
         SemanticModel? semanticModel,
+        KnownTypes knownTypes,
         CancellationToken cancellationToken,
         out SyntaxNode capturedContext,
         HashSet<LocalFunctionStatementSyntax>? callPath = null,
@@ -888,6 +891,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     retainedSymbolSeedsForAwait,
                     invokedAfterSuspension: false,
                     semanticModel,
+                    knownTypes,
                     cancellationToken,
                     callPath,
                     out capturedContext))
@@ -904,6 +908,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         state.Symbols,
                         invokedAfterSuspension: true,
                         semanticModel,
+                        knownTypes,
                         cancellationToken,
                         callPath,
                         out capturedContext)
@@ -913,6 +918,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         state.Symbols,
                         semanticModel,
                         cancellationToken,
+                        out capturedContext)
+                    || TryFindRetainedContextInSourceMethod(
+                        invocation,
+                        state.Names,
+                        state.Symbols,
+                        semanticModel,
+                        knownTypes,
+                        cancellationToken,
+                        null,
                         out capturedContext))
                 {
                     return true;
@@ -1337,6 +1351,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         HashSet<ISymbol> retainedSymbols,
         bool invokedAfterSuspension,
         SemanticModel? semanticModel,
+        KnownTypes knownTypes,
         CancellationToken cancellationToken,
         HashSet<LocalFunctionStatementSyntax> callPath,
         out SyntaxNode capturedContext)
@@ -1377,6 +1392,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         functionBody,
                         functionRetainedNames,
                         semanticModel,
+                        knownTypes,
                         cancellationToken,
                         out capturedContext,
                         nestedCallPath,
@@ -1415,6 +1431,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     functionRetainedSymbols,
                     invokedAfterSuspension: true,
                     semanticModel,
+                    knownTypes,
                     cancellationToken,
                     nestedCallPath,
                     out capturedContext))
@@ -1428,6 +1445,123 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
+    private static bool TryFindRetainedContextInSourceMethod(
+        InvocationExpressionSyntax invocation,
+        HashSet<string> retainedNames,
+        HashSet<ISymbol> retainedSymbols,
+        SemanticModel? semanticModel,
+        KnownTypes knownTypes,
+        CancellationToken cancellationToken,
+        HashSet<IMethodSymbol>? visitedMethods,
+        out SyntaxNode capturedContext)
+    {
+        if (semanticModel is null
+            || semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
+                is not IMethodSymbol { MethodKind: MethodKind.Ordinary } method
+            || method.DeclaringSyntaxReferences.Length == 0)
+        {
+            capturedContext = null!;
+            return false;
+        }
+
+        visitedMethods ??= new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        if (!visitedMethods.Add(method))
+        {
+            capturedContext = null!;
+            return false;
+        }
+
+        try
+        {
+            var methodRetainedSymbols = new HashSet<ISymbol>(
+                retainedSymbols,
+                SymbolEqualityComparer.Default);
+            if (semanticModel.GetOperation(invocation, cancellationToken)
+                    is IInvocationOperation invocationOperation)
+            {
+                foreach (var argument in invocationOperation.Arguments)
+                {
+                    if (argument.Parameter is { } parameter
+                        && ContainsEventContextReference(argument.Value.Type, knownTypes)
+                        && argument.Value.Syntax.DescendantNodesAndSelf()
+                            .OfType<IdentifierNameSyntax>()
+                            .Any(identifier => IsRetainedReference(
+                                identifier,
+                                retainedNames,
+                                retainedSymbols,
+                                semanticModel,
+                                cancellationToken)))
+                    {
+                        methodRetainedSymbols.Add(parameter);
+                    }
+                }
+            }
+
+            foreach (var syntaxReference in method.DeclaringSyntaxReferences)
+            {
+                var declaration = syntaxReference.GetSyntax(cancellationToken);
+                if (GetFunctionBody(declaration) is not { } methodBody)
+                {
+                    continue;
+                }
+
+#pragma warning disable RS1030 // Source-backed helpers may be declared in another tree.
+                var methodSemanticModel = declaration.SyntaxTree == semanticModel.SyntaxTree
+                    ? semanticModel
+                    : semanticModel.Compilation.GetSemanticModel(declaration.SyntaxTree);
+#pragma warning restore RS1030
+                var methodRetainedNames = new HashSet<string>(
+                    retainedNames,
+                    StringComparer.Ordinal);
+                foreach (var parameter in method.Parameters)
+                {
+                    methodRetainedNames.Remove(parameter.Name);
+                }
+
+                var methodNodes = methodBody.DescendantNodesAndSelf(
+                        descendIntoChildren: static node =>
+                            node is not AnonymousFunctionExpressionSyntax
+                                and not LocalFunctionStatementSyntax)
+                    .ToArray();
+                foreach (var retainedIdentifier in methodNodes.OfType<IdentifierNameSyntax>()
+                             .Where(candidate => IsRetainedReference(
+                                     candidate,
+                                     methodRetainedNames,
+                                     methodRetainedSymbols,
+                                     methodSemanticModel,
+                                     cancellationToken)
+                                 && IsRuntimeValueReference(candidate)))
+                {
+                    capturedContext = retainedIdentifier;
+                    return true;
+                }
+
+                foreach (var nestedInvocation in methodNodes.OfType<InvocationExpressionSyntax>())
+                {
+                    if (TryFindRetainedContextInSourceMethod(
+                        nestedInvocation,
+                        methodRetainedNames,
+                        methodRetainedSymbols,
+                        methodSemanticModel,
+                        knownTypes,
+                        cancellationToken,
+                        visitedMethods,
+                        out capturedContext))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            capturedContext = null!;
+            return false;
+        }
+        finally
+        {
+            visitedMethods.Remove(method);
+        }
+    }
+
     private static bool TryFindRetainedContextInInvokedDelegate(
         InvocationExpressionSyntax invocation,
         HashSet<string> retainedNames,
@@ -1436,8 +1570,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         CancellationToken cancellationToken,
         out SyntaxNode capturedContext)
     {
+        var identifier = invocation.Expression switch
+        {
+            IdentifierNameSyntax direct => direct,
+            MemberAccessExpressionSyntax
+            {
+                Expression: IdentifierNameSyntax receiver,
+                Name.Identifier.ValueText: "Invoke",
+            } => receiver,
+            _ => null,
+        };
         if (semanticModel is null
-            || invocation.Expression is not IdentifierNameSyntax identifier
+            || identifier is null
             || semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol
                 is not ILocalSymbol local
             || !TryGetStableLocalInitializer(
@@ -3133,7 +3277,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             if (operation is IPropertyReferenceOperation property
                 && (knownTypes.IsEventContextReference(property.Property.Type)
                     || knownTypes.IsEventContextContainer(property.Property.Type)
-                        && IsProvenEventMemberCapture(
+                        && IsProvenEventSymbolCapture(
                             property.Property,
                             property.Syntax,
                             context,
@@ -3155,7 +3299,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             if (operation is IFieldReferenceOperation fieldReference
                 && (knownTypes.IsEventContextReference(fieldReference.Field.Type)
                     || knownTypes.IsEventContextContainer(fieldReference.Field.Type)
-                        && IsProvenEventMemberCapture(
+                        && IsProvenEventSymbolCapture(
                             fieldReference.Field,
                             fieldReference.Syntax,
                             context,
@@ -3215,6 +3359,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 return true;
             }
 
+            if (ContainsEventContextReference(localReference.Local.Type, knownTypes)
+                && IsProvenEventSymbolCapture(
+                    localReference.Local,
+                    localReference.Syntax,
+                    context,
+                    knownTypes,
+                    provenanceAnchor))
+            {
+                capturedContext = localReference.Syntax;
+                return true;
+            }
+
             visitedLocals.Remove(localReference.Local);
         }
 
@@ -3222,8 +3378,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool IsProvenEventMemberCapture(
-        ISymbol member,
+    private static bool IsProvenEventSymbolCapture(
+        ISymbol retainedSymbol,
         SyntaxNode reference,
         OperationAnalysisContext context,
         KnownTypes knownTypes,
@@ -3262,26 +3418,43 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && callback.Span.Contains(candidate.Span))
             ?? anchor;
 
-        var assignments = callback.Body
-            .DescendantNodes(descendIntoChildren: static node =>
+        var writes = new List<(SyntaxNode Syntax, ExpressionSyntax Value)>();
+        foreach (var candidate in callback.Body
+                     .DescendantNodes(descendIntoChildren: static node =>
                 node is not AnonymousFunctionExpressionSyntax
                     and not LocalFunctionStatementSyntax)
-            .OfType<AssignmentExpressionSyntax>()
-            .Where(candidate => candidate.IsKind(SyntaxKind.SimpleAssignmentExpression)
-                && candidate.SpanStart < anchor.SpanStart
+                     .Where(candidate => candidate.SpanStart < anchor.SpanStart))
+        {
+            if (candidate is AssignmentExpressionSyntax assignment
+                && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
                 && SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetSymbolInfo(
-                        candidate.Left,
+                        assignment.Left,
                         context.CancellationToken).Symbol,
-                    member))
-            .OrderBy(static candidate => candidate.SpanStart)
-            .ToArray();
+                    retainedSymbol))
+            {
+                writes.Add((assignment, assignment.Right));
+            }
+            else if (candidate is VariableDeclaratorSyntax
+                     {
+                         Initializer.Value: { } value,
+                     } declarator
+                && SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetDeclaredSymbol(
+                        declarator,
+                        context.CancellationToken),
+                    retainedSymbol))
+            {
+                writes.Add((declarator, value));
+            }
+        }
+
         var origins = new List<SyntaxNode?>();
         var kills = new List<SyntaxNode>();
-        foreach (var assignment in assignments)
+        foreach (var write in writes.OrderBy(static candidate => candidate.Syntax.SpanStart))
         {
             var value = semanticModel.GetOperation(
-                assignment.Right,
+                write.Value,
                 context.CancellationToken);
             if (value is not null
                 && ContainsCallbackParameterInRetainedValue(
@@ -3289,11 +3462,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     callbackParameters,
                     knownTypes))
             {
-                origins.Add(assignment);
+                origins.Add(write.Syntax);
             }
             else
             {
-                kills.Add(assignment);
+                kills.Add(write.Syntax);
             }
         }
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -231,49 +231,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         ExpressionSyntax expression,
         SyntaxNodeAnalysisContext context)
     {
-        if (expression is ParenthesizedExpressionSyntax parenthesized)
+        var parts = GetCallbackExpressionParts(
+                expression,
+                context.SemanticModel,
+                context.CancellationToken)
+            .ToArray();
+        if (parts.Length > 0)
         {
-            return StartsAsynchronousWork(parenthesized.Expression, context);
-        }
-
-        if (expression is ConditionalExpressionSyntax conditional)
-        {
-            return StartsAsynchronousWork(conditional.WhenTrue, context)
-                || StartsAsynchronousWork(conditional.WhenFalse, context);
-        }
-
-        if (expression is BinaryExpressionSyntax coalesce
-            && coalesce.IsKind(SyntaxKind.CoalesceExpression))
-        {
-            return StartsAsynchronousWork(coalesce.Left, context)
-                || StartsAsynchronousWork(coalesce.Right, context);
-        }
-
-        if (expression is SwitchExpressionSyntax switchExpression)
-        {
-            return switchExpression.Arms.Any(arm =>
-                StartsAsynchronousWork(arm.Expression, context));
-        }
-
-        if (expression is CastExpressionSyntax cast)
-        {
-            return StartsAsynchronousWork(cast.Expression, context);
-        }
-
-        if (expression is PostfixUnaryExpressionSyntax postfix
-            && postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression))
-        {
-            return StartsAsynchronousWork(postfix.Operand, context);
-        }
-
-        if (expression is BaseObjectCreationExpressionSyntax creation
-            && context.SemanticModel.GetTypeInfo(
-                creation,
-                context.CancellationToken).Type?.TypeKind == TypeKind.Delegate
-            && creation.ArgumentList is { } arguments)
-        {
-            return arguments.Arguments.Any(argument =>
-                StartsAsynchronousWork(argument.Expression, context));
+            return parts.Any(part => StartsAsynchronousWork(part, context));
         }
 
         if (expression is AnonymousFunctionExpressionSyntax anonymous)
@@ -323,6 +288,54 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 .Any(static candidate => StartsAsynchronousWork(candidate));
     }
 
+    private static IEnumerable<ExpressionSyntax> GetCallbackExpressionParts(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        switch (expression)
+        {
+            case ParenthesizedExpressionSyntax parenthesized:
+                yield return parenthesized.Expression;
+                break;
+            case ConditionalExpressionSyntax conditional:
+                yield return conditional.WhenTrue;
+                yield return conditional.WhenFalse;
+                break;
+            case BinaryExpressionSyntax binary
+                when binary.IsKind(SyntaxKind.CoalesceExpression)
+                    || semanticModel.GetTypeInfo(binary, cancellationToken).Type?.TypeKind
+                        == TypeKind.Delegate:
+                yield return binary.Left;
+                yield return binary.Right;
+                break;
+            case SwitchExpressionSyntax switchExpression:
+                foreach (var arm in switchExpression.Arms)
+                {
+                    yield return arm.Expression;
+                }
+
+                break;
+            case CastExpressionSyntax cast:
+                yield return cast.Expression;
+                break;
+            case PostfixUnaryExpressionSyntax postfix
+                when postfix.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                yield return postfix.Operand;
+                break;
+            case BaseObjectCreationExpressionSyntax creation
+                when semanticModel.GetTypeInfo(creation, cancellationToken).Type?.TypeKind
+                    == TypeKind.Delegate
+                && creation.ArgumentList is { } arguments:
+                foreach (var argument in arguments.Arguments)
+                {
+                    yield return argument.Expression;
+                }
+
+                break;
+        }
+    }
+
     private static bool StartsAsynchronousWork(IMethodSymbol method) =>
         (method.IsAsync && method.ReturnsVoid) || IsTaskLike(method.ReturnType);
 
@@ -348,6 +361,29 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 context,
                 knownTypes,
                 out capturedContext);
+        }
+
+        var parts = GetCallbackExpressionParts(
+                expression,
+                context.SemanticModel,
+                context.CancellationToken)
+            .ToArray();
+        if (parts.Length > 0)
+        {
+            foreach (var part in parts)
+            {
+                if (TryFindDiscardedEventContext(
+                    part,
+                    context,
+                    knownTypes,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+
+            capturedContext = null!;
+            return false;
         }
 
         if (TryFindAsyncVoidMethodGroupContext(
@@ -513,14 +549,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             .DefaultIfEmpty(int.MaxValue)
             .Min();
         var retainedNames = new HashSet<string>(eventParameterNames, StringComparer.Ordinal);
-        foreach (var declarator in nodes.OfType<VariableDeclaratorSyntax>()
-                     .Where(declarator => declarator.SpanStart < firstAwait)
-                     .OrderBy(static declarator => declarator.SpanStart))
+        foreach (var alias in nodes
+                     .Where(node => node.SpanStart < firstAwait
+                         && node is VariableDeclaratorSyntax or AssignmentExpressionSyntax)
+                     .OrderBy(static node => node.SpanStart))
         {
-            if (declarator.Initializer?.Value is { } initializer
-                && IsRetainedAliasExpression(initializer, retainedNames))
+            var (name, value) = alias switch
             {
-                retainedNames.Add(declarator.Identifier.ValueText);
+                VariableDeclaratorSyntax declarator =>
+                    (declarator.Identifier.ValueText, declarator.Initializer?.Value),
+                AssignmentExpressionSyntax assignment
+                    when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) =>
+                    (GetAssignedName(assignment.Left), assignment.Right),
+                _ => (null, null),
+            };
+            if (name is null)
+            {
+                continue;
+            }
+
+            if (value is not null && IsRetainedAliasExpression(value, retainedNames))
+            {
+                retainedNames.Add(name);
+            }
+            else
+            {
+                retainedNames.Remove(name);
             }
         }
 
@@ -535,6 +589,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         capturedContext = null!;
         return false;
     }
+
+    private static string? GetAssignedName(ExpressionSyntax expression) => expression switch
+    {
+        IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+        MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+        _ => null,
+    };
 
     private static bool IsRetainedAliasExpression(
         ExpressionSyntax expression,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3309,7 +3309,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     ? null
                     : semanticModel.GetOperation(body, cancellationToken);
                 if (bodyOperation is not null
-                    && DescendantOperations(bodyOperation)
+                    && ExecutableDescendantOperations(bodyOperation)
                         .OfType<ISimpleAssignmentOperation>()
                         .Any(assignment =>
                             IsConstructorInstanceMember(assignment.Target)
@@ -3328,7 +3328,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 }
 
                 if (bodyOperation is not null
-                    && DescendantOperations(bodyOperation)
+                    && ExecutableDescendantOperations(bodyOperation)
                         .OfType<IInvocationOperation>()
                         .Any(invocation => IsRetainingInstanceInvocation(
                             invocation,
@@ -3351,8 +3351,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                                 Parameter: { } delegatedParameter,
                                 Value: { } value,
                             }
-                            && Unwrap(value) is IParameterReferenceOperation reference
-                            && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter)
+                            && RetainedValueOperations(
+                                    value,
+                                    semanticModel,
+                                    cancellationToken,
+                                    visitedMethods)
+                                .Any(candidate =>
+                                    Unwrap(candidate) is IParameterReferenceOperation reference
+                                    && SymbolEqualityComparer.Default.Equals(
+                                        reference.Parameter,
+                                        parameter))
                             && IsInstanceParameterStored(
                                 delegatedConstructor,
                                 delegatedParameter,
@@ -3381,7 +3389,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         CancellationToken cancellationToken,
         HashSet<ISymbol> visitedMethods)
     {
-        if (!IsRootedInCurrentInstance(invocation.Instance))
+        var isRootedInstance = IsRootedInCurrentInstance(invocation.Instance);
+        if (!isRootedInstance
+            && invocation.TargetMethod.MethodKind is not MethodKind.LocalFunction)
         {
             return false;
         }
@@ -3400,15 +3410,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (IsKnownRetainingMutation(invocation.TargetMethod)
-                || argument.Parameter is { } invokedParameter
-                && invocation.TargetMethod.DeclaringSyntaxReferences.Length > 0
-                && IsInstanceParameterStored(
-                    invocation.TargetMethod,
-                    invokedParameter,
-                    semanticModel,
-                    cancellationToken,
-                    visitedMethods))
+            if ((isRootedInstance && IsKnownRetainingMutation(invocation.TargetMethod))
+                || (argument.Parameter is { } invokedParameter
+                    && invocation.TargetMethod.DeclaringSyntaxReferences.Length > 0
+                    && IsInstanceParameterStored(
+                        invocation.TargetMethod,
+                        invokedParameter,
+                        semanticModel,
+                        cancellationToken,
+                        visitedMethods)))
             {
                 return true;
             }
@@ -3421,6 +3431,24 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         method.Name is "Add" or "Enqueue" or "Push" or "Insert" or "TryAdd"
         && method.ContainingNamespace.ToDisplayString() is
             "System.Collections.Generic" or "System.Collections.Concurrent";
+
+    private static IEnumerable<IOperation> ExecutableDescendantOperations(IOperation root)
+    {
+        var stack = new Stack<IOperation>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            yield return current;
+            foreach (var child in current.ChildOperations)
+            {
+                if (child is not IAnonymousFunctionOperation and not ILocalFunctionOperation)
+                {
+                    stack.Push(child);
+                }
+            }
+        }
+    }
 
     private static bool IsConstructorInstanceMember(IOperation operation)
     {

--- a/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Analyzers/PublicAPI.Unshipped.txt
@@ -7,6 +7,8 @@ static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.EphemeralStatefulShieldR
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.InheritedHandlingClauseRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.ImplicitDefaultHandlingRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.AsyncConfigurationWithSynchronousExecuteRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.AsyncWorkInSynchronousCallbackRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
+static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.DeferredContextCaptureRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!
 override Kevlar.Analyzers.PipelineHazardAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Kevlar.Analyzers.PipelineHazardAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 static readonly Kevlar.Analyzers.PipelineHazardAnalyzer.SynchronousHedgeRule -> Microsoft.CodeAnalysis.DiagnosticDescriptor!

--- a/src/Kevlar.Chaos/Kevlar.Chaos.csproj
+++ b/src/Kevlar.Chaos/Kevlar.Chaos.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" PrivateAssets="Build" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
+++ b/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />
-    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" PrivateAssets="Build" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Primitives" />

--- a/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
+++ b/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" PrivateAssets="Build" />
     <ProjectReference Include="..\Kevlar.Extensions.DependencyInjection\Kevlar.Extensions.DependencyInjection.csproj" />
     <PackageReference Include="Grpc.Core.Api" />
     <PackageReference Include="Grpc.Net.ClientFactory" />

--- a/src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj
+++ b/src/Kevlar.Extensions.Http/Kevlar.Extensions.Http.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />
-    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" PrivateAssets="Build" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Primitives" />

--- a/src/Kevlar.Extensions.Logging/Kevlar.Extensions.Logging.csproj
+++ b/src/Kevlar.Extensions.Logging/Kevlar.Extensions.Logging.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" PrivateAssets="Build" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>

--- a/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
+++ b/src/Kevlar.Extensions.RateLimiting/Kevlar.Extensions.RateLimiting.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" PrivateAssets="Build" />
     <PackageReference Include="System.Threading.RateLimiting" />
   </ItemGroup>
 

--- a/src/Kevlar.Testing/Kevlar.Testing.csproj
+++ b/src/Kevlar.Testing/Kevlar.Testing.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Kevlar\Kevlar.csproj" />
+    <ProjectReference Include="..\Kevlar\Kevlar.csproj" PrivateAssets="Build" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -20,6 +20,34 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Kevlar.Analyzers\Kevlar.Analyzers.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+    <ProjectReference Include="..\Kevlar.Analyzers.CodeFixes\Kevlar.Analyzers.CodeFixes.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(ArtifactsPath)\bin\Kevlar.Analyzers\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(ArtifactsPath)\bin\Kevlar.Analyzers\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.pdb"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(ArtifactsPath)\bin\Kevlar.Analyzers.CodeFixes\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.CodeFixes.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(ArtifactsPath)\bin\Kevlar.Analyzers.CodeFixes\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.CodeFixes.pdb"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />
     <InternalsVisibleTo Include="Kevlar.Testing" />
     <InternalsVisibleTo Include="Kevlar.Extensions.Http" />

--- a/tests/Kevlar.Analyzers.Tests/AnalyzerMetadataTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/AnalyzerMetadataTests.cs
@@ -6,6 +6,17 @@ namespace Kevlar.Analyzers.Tests;
 public class AnalyzerMetadataTests
 {
     [Test]
+    public async Task Compiler_Analyzer_Assembly_Does_Not_Reference_Workspaces()
+    {
+        var references = typeof(PipelineHazardAnalyzer).Assembly.GetReferencedAssemblies();
+
+        await Assert.That(references.Any(static reference =>
+            reference.Name?.Contains("Workspaces", StringComparison.Ordinal) == true)).IsFalse();
+        await Assert.That(typeof(AsyncCallbackCodeFixProvider).Assembly)
+            .IsNotEqualTo(typeof(PipelineHazardAnalyzer).Assembly);
+    }
+
+    [Test]
     public async Task Supported_Diagnostics_Expose_Every_Public_Rule_Exactly_Once()
     {
         var cancellationRules = new IgnoredCancellationTokenAnalyzer().SupportedDiagnostics;
@@ -14,7 +25,7 @@ public class AnalyzerMetadataTests
         await Assert.That(cancellationRules.Select(static rule => rule.Id).SequenceEqual(["KEV001"]))
             .IsTrue();
         await Assert.That(pipelineRules.Select(static rule => rule.Id).SequenceEqual(
-            ["KEV002", "KEV003", "KEV004", "KEV005", "KEV006", "KEV007", "KEV008", "KEV009", "KEV010", "KEV011", "KEV012"]))
+            ["KEV002", "KEV003", "KEV004", "KEV005", "KEV006", "KEV007", "KEV008", "KEV009", "KEV010", "KEV011", "KEV012", "KEV013", "KEV014"]))
             .IsTrue();
 
         var allRules = cancellationRules.Concat(pipelineRules).ToArray();
@@ -29,7 +40,7 @@ public class AnalyzerMetadataTests
             .Concat(new PipelineHazardAnalyzer().SupportedDiagnostics)
             .ToDictionary(static rule => rule.Id, StringComparer.Ordinal);
 
-        foreach (var reliabilityRule in new[] { "KEV001", "KEV002", "KEV004", "KEV006", "KEV012" })
+        foreach (var reliabilityRule in new[] { "KEV001", "KEV002", "KEV004", "KEV006", "KEV012", "KEV013", "KEV014" })
         {
             await Assert.That(rules[reliabilityRule].Category).IsEqualTo("Reliability");
             await Assert.That(rules[reliabilityRule].DefaultSeverity).IsEqualTo(DiagnosticSeverity.Warning);

--- a/tests/Kevlar.Analyzers.Tests/Kevlar.Analyzers.Tests.csproj
+++ b/tests/Kevlar.Analyzers.Tests/Kevlar.Analyzers.Tests.csproj
@@ -9,11 +9,13 @@
   <ItemGroup>
     <PackageReference Include="TUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Kevlar\Kevlar.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Analyzers\Kevlar.Analyzers.csproj" />
+    <ProjectReference Include="..\..\src\Kevlar.Analyzers.CodeFixes\Kevlar.Analyzers.CodeFixes.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Chaos\Kevlar.Chaos.csproj" />
     <ProjectReference Include="..\..\src\Kevlar.Extensions.RateLimiting\Kevlar.Extensions.RateLimiting.csproj" />
   </ItemGroup>

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -178,6 +178,28 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Explicit_Delegate_Invoke_Calls()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                Action work = async () =>
+                {
+                    await Task.Yield();
+                    Console.WriteLine(item.Context.ShieldName);
+                };
+                work.Invoke();
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Immediately_Invoked_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -272,6 +294,31 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Aliases_At_Later_Reachable_Awaits()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                if (Environment.TickCount == 0)
+                {
+                    await Task.Yield();
+                    return;
+                }
+
+                var retained = item;
+                await Task.Yield();
+                Console.WriteLine(retained.Context.ShieldName);
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -739,6 +786,23 @@ public class PipelineHazardAnalyzerTests
                 "KEV014",
                 DiagnosticSeverity.Warning);
         }
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Direct_Context_Captured_By_Scheduled_Work()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = ChaosShield.Latency(options => options.Predicate = context =>
+            {
+                _ = Task.Run(() => Consume(context));
+                return true;
+            });
+
+            static void Consume(KevlarContext context) =>
+                Console.WriteLine(context.ShieldName);
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -1311,6 +1375,24 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Synchronously_Joined_Delegate_Locals()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                Func<Task> work = async () =>
+                {
+                    await Task.Yield();
+                    Console.WriteLine(item.Context.ShieldName);
+                };
+                work().GetAwaiter().GetResult();
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Ignores_Awaited_TaskRun()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1530,6 +1612,39 @@ public class PipelineHazardAnalyzerTests
                 {
                     await Task.Yield();
                     Console.WriteLine(_unrelated.RetryNumber);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Async_Method_Aliases_On_Exiting_Paths()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = AuditAsync(Environment.TickCount == 0);
+                    });
+
+                private async Task AuditAsync(bool stop)
+                {
+                    RetryEvent retained = default;
+                    if (stop)
+                    {
+                        retained = _event;
+                        return;
+                    }
+
+                    await Task.Yield();
+                    Console.WriteLine(retained.RetryNumber);
                 }
             }
             """);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -172,6 +172,27 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Maps_PostAwait_Local_Function_Parameters()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                Read(item);
+
+                static void Read(RetryEvent value) =>
+                    Console.WriteLine(value.Context.ShieldName);
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Follows_PostAwait_Source_Method_Calls()
     {
         var diagnostics = await AnalyzeSourceAsync("""
@@ -235,6 +256,42 @@ public class PipelineHazardAnalyzerTests
             "KEV014",
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(scalarParameter, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Maps_Retained_Wrappers_To_Source_Parameters()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Read(holder);
+                    });
+
+                private static void Read(Holder value) =>
+                    Console.WriteLine(value.Event.Context.ShieldName);
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Event = item;
+                    }
+
+                    public RetryEvent Event { get; }
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -705,6 +705,25 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Framework_Collections_In_PostAwait_Aliases()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>(new[] { item });
+                await Task.Yield();
+                Console.WriteLine(events[0].Context.ShieldName);
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Follows_Nested_PostAwait_Local_Function_Calls()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -344,6 +344,31 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Keeps_Alias_Propagation_On_One_Control_Flow_Path()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                RetryEvent first = default;
+                RetryEvent retained = default;
+                if (Environment.TickCount == 0)
+                {
+                    first = item;
+                }
+                else
+                {
+                    retained = first;
+                }
+
+                await Task.Yield();
+                Console.WriteLine(retained.RetryNumber);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Combined_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1120,6 +1145,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV013_Rejects_Task_Local_Joins_Of_Unrelated_Composite_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var pending = (AuditAsync(item), Task.CompletedTask).Item2;
+                pending.GetAwaiter().GetResult();
+            });
+
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Rejects_Filtered_WhenAll_Collections()
     {
         var diagnostics = await AnalyzeSourceAsync("""
@@ -1278,6 +1323,21 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleLocalFunctionDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Start();
+                        await Task.Yield();
+
+                        void Start() => _ = AuditAsync(item);
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleTimedWait = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -1372,6 +1432,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleDiscardingBlock.ChangedText).IsNull();
         await Assert.That(incompatibleAsyncDiscardingBlock.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleAsyncDiscardingBlock.ChangedText).IsNull();
+        await Assert.That(incompatibleLocalFunctionDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleLocalFunctionDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleTimedWait.ChangedText).IsNull();
         await Assert.That(incompatibleCollectionAdd.ActionCount).IsEqualTo(0);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -61,6 +61,11 @@ public class PipelineHazardAnalyzerTests
             "Task.CompletedTask.ConfigureAwait(false)",
             "Task.FromResult(0)",
             "Task.FromResult(0).ConfigureAwait(false)",
+            "Task.Delay(0)",
+            "Task.Delay(0).ConfigureAwait(false)",
+            "Task.Delay(TimeSpan.Zero)",
+            "Task.Delay(0, CancellationToken.None)",
+            "Task.Delay(TimeSpan.Zero, CancellationToken.None)",
             "ValueTask.CompletedTask",
             "ValueTask.CompletedTask.ConfigureAwait(false)",
             "ValueTask.FromResult(0)",
@@ -90,6 +95,7 @@ public class PipelineHazardAnalyzerTests
     {
         var awaitExpressions = new[]
         {
+            "Task.Delay(1)",
             "new ValueTask(Task.Delay(1))",
             "new ValueTask<int>(Task.Run(() => 1))",
         };
@@ -2145,6 +2151,21 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleLocalFunctionMethodGroup = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Array.ForEach(new[] { 0 }, Work);
+                        await Task.Yield();
+
+                        void Work(int _) => _ = AuditAsync(item);
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleConstructedDelegateDiscard = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -2330,6 +2351,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleForwardedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleOpaqueDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleOpaqueDelegateDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleLocalFunctionMethodGroup.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleLocalFunctionMethodGroup.ChangedText).IsNull();
         await Assert.That(incompatibleConstructedDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleConstructedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleConditionalDelegateDiscard.ActionCount).IsEqualTo(0);
@@ -3842,6 +3865,21 @@ public class PipelineHazardAnalyzerTests
                     static (System.Collections.Generic.List<RetryEvent> state) =>
                         Console.WriteLine(state[0].Context.ShieldName),
                     new System.Collections.Generic.List<RetryEvent>(new[] { item }),
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Metadata_Container_State_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static (System.Collections.Generic.KeyValuePair<int, RetryEvent> state) =>
+                        Console.WriteLine(state.Value.Context.ShieldName),
+                    new System.Collections.Generic.KeyValuePair<int, RetryEvent>(0, item),
                     preferLocal: false));
             """);
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -369,6 +369,36 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Uses_Declaration_Tree_Control_Flow_For_Method_Groups()
+    {
+        var diagnostics = await AnalyzeSourcesAsync(
+            """
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = CallbackHost.OnRetry);
+            }
+            """,
+            """
+            public static class CallbackHost
+            {
+                public static async void OnRetry(RetryEvent item)
+                {
+                    if (Environment.TickCount == 0)
+                    {
+                        await Task.Yield();
+                        return;
+                    }
+
+                    _ = item.Context.ShieldName;
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Constructed_Async_Void_Method_Groups()
     {
         var diagnostics = await AnalyzeSourceAsync("""
@@ -1230,6 +1260,25 @@ public class PipelineHazardAnalyzerTests
         var diagnostics = await AnalyzeBodyAsync("""
             _ = Shield.Retry(options => options.OnRetryAsync = async item =>
                 await Task.Run(() => Consume(item.Context)));
+
+            static void Consume(KevlarContext context) =>
+                Console.WriteLine(context.ShieldName);
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Task_Locals_Joined_After_Constant_Declarations()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetryAsync = async item =>
+            {
+                var pending = Task.Run(() => Consume(item.Context));
+                var marker = 0;
+                await pending;
+                _ = marker;
+            });
 
             static void Consume(KevlarContext context) =>
                 Console.WriteLine(context.ShieldName);
@@ -3662,6 +3711,28 @@ public class PipelineHazardAnalyzerTests
         if (!allowCompilationErrors && errors.Length > 0)
         {
             throw new InvalidOperationException("Test source does not compile: " + string.Join("; ", errors.Select(static error => error.ToString())));
+        }
+
+        return await GetAnalyzerDiagnosticsAsync(compilation);
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeSourcesAsync(
+        params string[] declarations)
+    {
+        var compilation = CSharpCompilation.Create(
+            "PipelineHazardAnalyzerTestSubject",
+            declarations.Select(declaration =>
+                CSharpSyntaxTree.ParseText(CreateSource(declaration))),
+            GetMetadataReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var errors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        if (errors.Length > 0)
+        {
+            throw new InvalidOperationException(
+                "Test source does not compile: "
+                + string.Join("; ", errors.Select(static error => error.ToString())));
         }
 
         return await GetAnalyzerDiagnosticsAsync(compilation);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -466,6 +466,30 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var compositeConstructorStore = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Events[0].Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Events = new[] { item };
+                    }
+
+                    public RetryEvent[] Events { get; }
+                }
+            }
+            """);
         var collectionWrapper = await AnalyzeSourceAsync("""
             public sealed class TestSubject
             {
@@ -505,6 +529,11 @@ public class PipelineHazardAnalyzerTests
         await AssertRuleAsync(Without(nestedConstructorStore, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(nestedConstructorStore, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(Without(compositeConstructorStore, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(compositeConstructorStore, "KEV013"),
             "KEV014",
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(Without(collectionWrapper, "KEV014"), "KEV013");
@@ -1267,6 +1296,33 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Scalar_Constructor_Snapshots_In_Discarded_Tasks()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                        _ = AuditAsync(new RetrySnapshot(item)));
+
+                private static Task AuditAsync(RetrySnapshot snapshot) => Task.CompletedTask;
+
+                private sealed class RetrySnapshot
+                {
+                    public RetrySnapshot(RetryEvent item)
+                    {
+                        RetryNumber = item.RetryNumber;
+                    }
+
+                    public int RetryNumber { get; }
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV013_Inspects_Unobserved_Task_Calls_In_Handling_Predicates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1905,6 +1961,22 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleForwardedDelegateDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Action start = () => _ = AuditAsync(item);
+                        Run(() => Console.WriteLine(item.RetryNumber));
+                        Run(start);
+                        await Task.Yield();
+                    });
+
+                private static void Run(Action action) => action();
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleAwaitWrapper = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -2023,6 +2095,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleImmediatelyInvokedDelegateInvoke.ChangedText).IsNull();
         await Assert.That(incompatibleSourceMethodDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleSourceMethodDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleForwardedDelegateDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleForwardedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleAwaitWrapper.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleAwaitWrapper.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1874,6 +1874,47 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Event_Member_Provenance_Across_Sequential_Writes()
+    {
+        var cleared = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _event = default;
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+        var reintroduced = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _event = default;
+                        _event = item;
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+
+        await Assert.That(cleared).IsEmpty();
+        await AssertRuleAsync(reintroduced, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Ignores_Unproven_Member_Assignments_In_Scheduled_Work()
     {
         var unrelatedCallback = await AnalyzeSourceAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -627,6 +627,50 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV013_Inspects_Context_Bearing_Synchronous_Funcs()
+    {
+        var cases = new[]
+        {
+            """
+            _ = Shield.For<int>().Retry(options => options.HandlesResultWithContext = item =>
+            {
+                _ = AuditAsync(item.Context);
+                return true;
+            });
+            """,
+            """
+            _ = Shield.Retry(options => options.DelayGenerator = item =>
+            {
+                _ = AuditAsync(item.Context);
+                return TimeSpan.Zero;
+            });
+            """,
+            """
+            _ = ChaosShield.Latency(options => options.Predicate = context =>
+            {
+                _ = AuditAsync(context);
+                return true;
+            });
+            """,
+        };
+
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                {{body}}
+
+                static Task AuditAsync(KevlarContext context) => Task.CompletedTask;
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
     public async Task KEV013_Inspects_Unobserved_Task_Calls_In_Expression_Lambdas()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1186,6 +1230,20 @@ public class PipelineHazardAnalyzerTests
         var diagnostics = await AnalyzeBodyAsync("""
             _ = Shield.Retry(options => options.OnRetryAsync = async item =>
                 await Task.Run(() => Consume(item.Context)));
+
+            static void Consume(KevlarContext context) =>
+                Console.WriteLine(context.ShieldName);
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Returned_ValueTask_Wrappers()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetryAsync = item =>
+                new ValueTask(Task.Run(() => Consume(item.Context))));
 
             static void Consume(KevlarContext context) =>
                 Console.WriteLine(context.ShieldName);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1868,9 +1868,40 @@ public class PipelineHazardAnalyzerTests
                 private static void Consume(RetryEvent item) { }
             }
             """);
+        var partiallyClearedNestedBranch = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        if (Environment.TickCount == 0)
+                        {
+                            if (Environment.TickCount == 1)
+                            {
+                                _event = default;
+                            }
+                        }
+                        else
+                        {
+                            _event = default;
+                        }
+
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
 
         await AssertRuleAsync(retainedOnOneBranch, "KEV014", DiagnosticSeverity.Warning);
         await Assert.That(clearedOnEveryBranch).IsEmpty();
+        await AssertRuleAsync(
+            partiallyClearedNestedBranch,
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -1979,11 +2010,29 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var conditionOnlyReference = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item.RetryNumber > 0
+                            ? default(RetryEvent)
+                            : default(RetryEvent);
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
 
         await Assert.That(unrelatedCallback).IsEmpty();
         await Assert.That(parameterlessCallback).IsEmpty();
         await Assert.That(shadowedField).IsEmpty();
         await Assert.That(memberNameCollision).IsEmpty();
+        await Assert.That(conditionOnlyReference).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -490,6 +490,59 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var mutatingConstructorStore = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Events[0].Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Events.Add(item);
+                    }
+
+                    public System.Collections.Generic.List<RetryEvent> Events { get; } = new();
+                }
+            }
+            """);
+        var helperConstructorStore = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Event.Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Store(item);
+                    }
+
+                    public RetryEvent Event { get; private set; }
+
+                    private void Store(RetryEvent item)
+                    {
+                        Event = item;
+                    }
+                }
+            }
+            """);
         var collectionWrapper = await AnalyzeSourceAsync("""
             public sealed class TestSubject
             {
@@ -534,6 +587,16 @@ public class PipelineHazardAnalyzerTests
         await AssertRuleAsync(Without(compositeConstructorStore, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(compositeConstructorStore, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(Without(mutatingConstructorStore, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(mutatingConstructorStore, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(Without(helperConstructorStore, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(helperConstructorStore, "KEV013"),
             "KEV014",
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(Without(collectionWrapper, "KEV014"), "KEV013");
@@ -1977,6 +2040,19 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleOpaqueDelegateDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Array.ForEach(new[] { 0 }, _ => _ = AuditAsync(item));
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleAwaitWrapper = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -2097,6 +2173,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleSourceMethodDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleForwardedDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleForwardedDelegateDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleOpaqueDelegateDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleOpaqueDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleAwaitWrapper.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleAwaitWrapper.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -106,6 +106,30 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Async_Void_Method_Group_After_Await()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = RetryAsyncVoid);
+
+                private static async void RetryAsyncVoid(RetryEvent item)
+                {
+                    await Task.Yield();
+                    _ = item.Context.ShieldName;
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Follows_Stable_Callback_Local_Initializers()
     {
         var trailingStatements = new[] { "", "callback = _ => { };" };
@@ -288,12 +312,14 @@ public class PipelineHazardAnalyzerTests
         var statements = new[]
         {
             "AuditAsync(item).GetAwaiter().GetResult();",
+            "AuditAsync(item).ConfigureAwait(false).GetAwaiter().GetResult();",
             "AuditAsync(item).Wait();",
             "_ = AuditAsync(item).Result;",
             "Task.WaitAll(AuditAsync(item));",
             "Task.WhenAll(AuditAsync(item), FlushAsync()).GetAwaiter().GetResult();",
             "Task.WhenAll(new[] { AuditAsync(item), FlushAsync() }).GetAwaiter().GetResult();",
             "AuditValueAsync(item).AsTask().GetAwaiter().GetResult();",
+            "AuditValueAsync(item).ConfigureAwait(false).GetAwaiter().GetResult();",
             "AuditValueAsync(item).AsTask().Wait();",
         };
         foreach (var statement in statements)
@@ -312,6 +338,32 @@ public class PipelineHazardAnalyzerTests
 
             await Assert.That(diagnostics).IsEmpty();
         }
+    }
+
+    [Test]
+    public async Task KEV013_Rejects_Unrelated_GetResult_Extensions()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public static class TaskExtensions
+            {
+                public static void GetResult(this Task task) { }
+            }
+
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                        AuditAsync(item).GetResult());
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -543,6 +543,34 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var staticHelperConstructorStore = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Events[0].Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Store(Events, item);
+                    }
+
+                    public System.Collections.Generic.List<RetryEvent> Events { get; } = new();
+
+                    private static void Store(
+                        System.Collections.Generic.List<RetryEvent> events,
+                        RetryEvent item) => events.Add(item);
+                }
+            }
+            """);
         var compositeDelegatedConstructor = await AnalyzeSourceAsync("""
             public sealed class TestSubject
             {
@@ -650,6 +678,11 @@ public class PipelineHazardAnalyzerTests
         await AssertRuleAsync(Without(helperConstructorStore, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(helperConstructorStore, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(Without(staticHelperConstructorStore, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(staticHelperConstructorStore, "KEV013"),
             "KEV014",
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(Without(compositeDelegatedConstructor, "KEV014"), "KEV013");
@@ -2112,6 +2145,21 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleConstructedDelegateDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Array.ForEach(
+                            new[] { 0 },
+                            new Action<int>(_ => _ = AuditAsync(item)));
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleConditionalDelegateDiscard = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -2282,6 +2330,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleForwardedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleOpaqueDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleOpaqueDelegateDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleConstructedDelegateDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleConstructedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleConditionalDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleConditionalDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleSwitchDelegateDiscard.ActionCount).IsEqualTo(0);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -73,6 +73,91 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_PostAwait_Source_Method_Calls()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        _event = item;
+                        await Task.Yield();
+                        Read();
+                    });
+
+                private void Read() => Consume(_event);
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+        var parameterFlow = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        await Task.Yield();
+                        Read(item);
+                    });
+
+                private static void Read(RetryEvent item)
+                {
+                    ReadNested(item);
+                }
+
+                private static void ReadNested(RetryEvent item) => Consume(item);
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+        var scalarParameter = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        await Task.Yield();
+                        Read(42);
+                    });
+
+                private static void Read(int retryNumber) => Console.WriteLine(retryNumber);
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(Without(parameterFlow, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(parameterFlow, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(scalarParameter, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Follows_PostAwait_Explicit_Delegate_Invoke()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                Action use = () => Console.WriteLine(item.Context.ShieldName);
+                use.Invoke();
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Follows_Nested_PostAwait_Local_Function_Calls()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1431,6 +1516,25 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleSourceMethodDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Start(item);
+                        await Task.Yield();
+                    });
+
+                private static void Start(RetryEvent item)
+                {
+                    StartCore(item);
+                }
+
+                private static void StartCore(RetryEvent item) => _ = AuditAsync(item);
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleAwaitWrapper = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -1545,6 +1649,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleDelegateLocalDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleImmediatelyInvokedDelegate.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleImmediatelyInvokedDelegate.ChangedText).IsNull();
+        await Assert.That(incompatibleSourceMethodDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleSourceMethodDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleAwaitWrapper.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleAwaitWrapper.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);
@@ -1943,6 +2049,31 @@ public class PipelineHazardAnalyzerTests
 
         await Assert.That(cleared).IsEmpty();
         await AssertRuleAsync(reintroduced, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Conditionally_Assigned_Captured_Locals()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        RetryEvent retained = default;
+                        if (Environment.TickCount == 0)
+                        {
+                            retained = item;
+                        }
+
+                        _ = Task.Run(() => Consume(retained));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -607,6 +607,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV013_Inspects_Unobserved_Task_Calls_In_Handling_Predicates()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.HandlesExceptionWithContext = item =>
+            {
+                _ = AuditAsync(item);
+                return true;
+            });
+
+            static Task AuditAsync(HandlingEvent item) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Inspects_Unobserved_Task_Calls_In_Expression_Lambdas()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1158,6 +1178,20 @@ public class PipelineHazardAnalyzerTests
 
             await Assert.That(diagnostics).IsEmpty();
         }
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Awaited_TaskRun()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetryAsync = async item =>
+                await Task.Run(() => Consume(item.Context)));
+
+            static void Consume(KevlarContext context) =>
+                Console.WriteLine(context.ShieldName);
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -59,8 +59,12 @@ public class PipelineHazardAnalyzerTests
         {
             "Task.CompletedTask",
             "Task.CompletedTask.ConfigureAwait(false)",
+            "Task.FromResult(0)",
+            "Task.FromResult(0).ConfigureAwait(false)",
             "ValueTask.CompletedTask",
             "ValueTask.CompletedTask.ConfigureAwait(false)",
+            "ValueTask.FromResult(0)",
+            "ValueTask.FromResult(0).ConfigureAwait(false)",
         };
         foreach (var awaitExpression in awaitExpressions)
         {
@@ -3225,6 +3229,35 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Constructor_Snapshots_In_Deferred_State()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class RetrySnapshot
+            {
+                public RetrySnapshot(RetryEvent item)
+                {
+                    RetryNumber = item.RetryNumber;
+                }
+
+                public int RetryNumber { get; }
+            }
+
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                        ThreadPool.QueueUserWorkItem(
+                            static (RetrySnapshot snapshot) =>
+                                Console.WriteLine(snapshot.RetryNumber),
+                            new RetrySnapshot(item),
+                            preferLocal: false));
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1647,16 +1647,26 @@ public class PipelineHazardAnalyzerTests
     [Test]
     public async Task KEV014_Ignores_Provably_Empty_Deferred_State()
     {
-        var diagnostics = await AnalyzeBodyAsync("""
-            _ = Shield.Retry(options => options.OnRetry = item =>
-            {
-                ThreadPool.QueueUserWorkItem(
-                    static _ => { },
-                    new RetryEvent[0]);
-            });
-            """);
+        var states = new[]
+        {
+            "new RetryEvent[0]",
+            "Array.Empty<RetryEvent>()",
+            "new System.Collections.Generic.List<RetryEvent>()",
+            "default(RetryEvent)",
+        };
+        foreach (var state in states)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    ThreadPool.QueueUserWorkItem(
+                        static _ => { },
+                        {{state}});
+                });
+                """);
 
-        await Assert.That(diagnostics).IsEmpty();
+            await Assert.That(diagnostics).IsEmpty();
+        }
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -186,6 +186,32 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Completed_Awaits_In_Source_Methods()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = AuditAsync();
+                    });
+
+                private async Task AuditAsync()
+                {
+                    await Task.CompletedTask;
+                    Console.WriteLine(_event.Context.ShieldName);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV014_Tracks_PostAwait_Event_Values_In_Wrapper_Locals()
     {
         var diagnostics = await AnalyzeSourceAsync("""
@@ -270,6 +296,35 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var delegatedConstructor = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Event.Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                        : this(item, 0)
+                    {
+                    }
+
+                    private Holder(RetryEvent item, int _)
+                    {
+                        Event = item;
+                    }
+
+                    public RetryEvent Event { get; }
+                }
+            }
+            """);
         var collectionWrapper = await AnalyzeSourceAsync("""
             public sealed class TestSubject
             {
@@ -295,6 +350,11 @@ public class PipelineHazardAnalyzerTests
             "KEV014",
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(emptyInitializer, "KEV013");
+        await AssertRuleAsync(Without(delegatedConstructor, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(delegatedConstructor, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
         await AssertRuleAsync(Without(collectionWrapper, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(collectionWrapper, "KEV013"),

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -35,6 +35,24 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Flags_Async_Lambda_Event_Use_After_Await()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                _ = item.Context.ShieldName;
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Allows_Awaited_And_Synchronous_Callbacks()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -322,6 +322,28 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Keeps_Aliases_On_Their_Suspension_Path()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                RetryEvent retained = default;
+                if (Environment.TickCount == 0)
+                {
+                    retained = item;
+                    await Task.Yield();
+                    return;
+                }
+
+                await Task.Yield();
+                Console.WriteLine(retained.RetryNumber);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Combined_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1650,6 +1672,43 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Async_Method_Aliases_At_Later_Awaits()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = AuditAsync(Environment.TickCount == 0);
+                    });
+
+                private async Task AuditAsync(bool skip)
+                {
+                    if (skip)
+                    {
+                        await Task.Yield();
+                        return;
+                    }
+
+                    var retained = _event;
+                    await Task.Yield();
+                    Console.WriteLine(retained.Context.ShieldName);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1622,6 +1622,44 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Nested_Scheduler_Delegate_Parameters()
+    {
+        var selectors = new[]
+        {
+            "(RetryEvent other) => other.RetryNumber",
+            "(RetryEvent other) => { var copy = other; return copy.RetryNumber; }",
+        };
+        foreach (var selector in selectors)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    _ = Task.Run(() => Consume({{selector}}));
+                });
+
+                static void Consume(Func<RetryEvent, int> selector) { }
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Provably_Empty_Deferred_State()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                ThreadPool.QueueUserWorkItem(
+                    static _ => { },
+                    new RetryEvent[0]);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Erased_Collection_Expression_Values()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -327,6 +327,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV013_Follows_Invoked_Local_Functions()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                void Start() => _ = AuditAsync(item);
+                Start();
+            });
+
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Ignores_Synchronously_Observed_Task_Calls()
     {
         var statements = new[]
@@ -650,6 +670,26 @@ public class PipelineHazardAnalyzerTests
                     {
                         _context = item.Context;
                         _ = Task.Run(() => Console.WriteLine(_context.ShieldName));
+                    });
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Pooled_Event_Field_In_Deferred_Work()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = Task.Run(() => Console.WriteLine(_event.Context.ShieldName));
                     });
             }
             """);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1374,6 +1374,29 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Scheduled_Instance_Method_Bodies()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = Task.Run(ProcessStored);
+                    });
+
+                private void ProcessStored() =>
+                    Console.WriteLine(_event.Context.ShieldName);
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Flags_Pooled_Event_Property_In_Deferred_Work()
     {
         var diagnostics = await AnalyzeSourceAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -2,14 +2,1116 @@ using System.Collections.Immutable;
 using Kevlar.Analyzers;
 using Kevlar.Chaos;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using System.Reflection;
 
 namespace Kevlar.Analyzers.Tests;
 
 public class PipelineHazardAnalyzerTests
 {
+    [Test]
+    public async Task KEV013_Flags_Async_Work_Assigned_To_Synchronous_Callbacks()
+    {
+        var cases = new[]
+        {
+            "_ = Shield.Retry(o => o.OnRetry = async _ => await Task.Yield());",
+            "_ = Shield.Retry(o => o.OnRetry ??= async _ => await Task.Yield());",
+            "_ = Shield.Timeout(o => o.OnTimeout = async _ => await Task.Yield());",
+            "_ = Shield.CircuitBreaker(o => o.OnStateChanged = async _ => await Task.Yield());",
+            "_ = Shield.Hedge(o => o.OnHedge = _ => Task.Delay(1));",
+            "_ = Shield.Fallback(_ => ValueTask.CompletedTask, o => o.OnFallback = async _ => await Task.Yield());",
+            "_ = Shield.RateLimit(o => o.OnRejected = async _ => await Task.Yield());",
+            "_ = Shield.ConcurrencyLimit(o => o.OnRejected = async _ => await Task.Yield());",
+            "_ = ChaosShield.Latency(o => o.OnInjected = async _ => await Task.Yield());",
+            "_ = Shield.Empty.UseRateLimiter((System.Threading.RateLimiting.RateLimiter)null!, o => o.OnRejected = async _ => await Task.Yield());",
+            "_ = Shield.Retry(o => o.OnRetry = new Action<RetryEvent>(async _ => await Task.Yield()));",
+        };
+
+        await AssertEachAsync(cases, "KEV013", "KEV006");
+    }
+
+    [Test]
+    public async Task KEV013_Allows_Awaited_And_Synchronous_Callbacks()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(o =>
+            {
+                o.OnRetry = _ => { };
+                o.OnRetryAsync = async _ => await Task.Yield();
+            });
+            _ = Shield.Timeout(o => o.OnTimeoutAsync = _ => ValueTask.CompletedTask);
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV013_Ignores_Similarly_Named_Application_Callbacks()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            namespace KevlarApplication;
+
+            public sealed class RetryOptions
+            {
+                public Action<Kevlar.RetryEvent>? OnRetry { get; set; }
+            }
+
+            public sealed class TestSubject
+            {
+                public void Configure()
+                {
+                    var options = new RetryOptions();
+                    options.OnRetry = async _ => await Task.Yield();
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV013_Flags_Task_Returning_Method_Group_On_Synchronous_Callback()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = RetryAsync);
+
+                private static Task RetryAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """, allowCompilationErrors: true);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV013_Flags_Async_Void_Method_Group_On_Synchronous_Callback()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = RetryAsyncVoid);
+
+                private static async void RetryAsyncVoid(RetryEvent item) => await Task.Yield();
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV013_Follows_Stable_Callback_Local_Initializers()
+    {
+        var trailingStatements = new[] { "", "callback = _ => { };" };
+        foreach (var trailingStatement in trailingStatements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                Action<RetryEvent> callback = item => AuditAsync(item);
+                _ = Shield.Retry(options => options.OnRetry = callback);
+                {{trailingStatement}}
+
+                static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV013_Inspects_Unobserved_Task_Calls_In_Block_Lambdas()
+    {
+        var cases = new[]
+        {
+            (Setup: "", Statement: "_ = AuditAsync(item);"),
+            (Setup: "", Statement: "AuditAsync(item);"),
+            (Setup: "", Statement: "var pending = AuditAsync(item);"),
+            (Setup: "", Statement: "AuditAsync(item).Wait(0);"),
+            (Setup: "", Statement: "Task.WaitAll(new[] { AuditAsync(item) }, 0);"),
+            (
+                Setup: "",
+                Statement: "Task.WaitAll(new[] { AuditAsync(item) }, CancellationToken.None);"),
+            (Setup: "Task? pending = null;", Statement: "pending = AuditAsync(item);"),
+            (Setup: "var enabled = true;", Statement: "if (enabled) _ = AuditAsync(item);"),
+            (
+                Setup: "var pendingTasks = new System.Collections.Generic.List<Task>();",
+                Statement: "pendingTasks.Add(AuditAsync(item));"),
+        };
+        foreach (var (setup, statement) in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                {{setup}}
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{statement}}
+                });
+
+                static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV013_Inspects_Unobserved_Task_Calls_In_Expression_Lambdas()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item => AuditAsync(item).Wait(0));
+
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Reduced_Extension_Receivers()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public static class AuditExtensions
+            {
+                public static Task AuditAsync(this RetryEvent item) => Task.CompletedTask;
+            }
+
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item => item.AuditAsync());
+            }
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Converted_Arguments()
+    {
+        var arguments = new[] { "(object)item", "new object[] { item }" };
+        foreach (var argument in arguments)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item => ProcessAsync({{argument}}));
+
+                static Task ProcessAsync(object item) => Task.CompletedTask;
+                """);
+
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Follows_Retained_Locals_And_Delegates()
+    {
+        var statements = new[]
+        {
+            "object state = item; ProcessObjectAsync(state);",
+            "object state = item; ProcessObjectAsync(state); state = null!;",
+            "ProcessDelegateAsync(() => item.Context.ShieldName);",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{statement}}
+                });
+
+                static Task ProcessObjectAsync(object state) => Task.CompletedTask;
+                static Task ProcessDelegateAsync(Func<string?> state) => Task.CompletedTask;
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Detached_Argument_Projections()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ProcessAsync(item.Context.ShieldName));
+
+            static Task ProcessAsync(string shieldName) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+        await Assert.That(Without(diagnostics, "KEV013")).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV013_Ignores_Uninvoked_Nested_Functions()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                void Local() => _ = AuditAsync(item);
+                Action nested = () => _ = AuditAsync(item);
+            });
+
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV013_Ignores_Synchronously_Observed_Task_Calls()
+    {
+        var statements = new[]
+        {
+            "AuditAsync(item).GetAwaiter().GetResult();",
+            "AuditAsync(item).Wait();",
+            "_ = AuditAsync(item).Result;",
+            "Task.WaitAll(AuditAsync(item));",
+            "Task.WhenAll(AuditAsync(item), FlushAsync()).GetAwaiter().GetResult();",
+            "Task.WhenAll(new[] { AuditAsync(item), FlushAsync() }).GetAwaiter().GetResult();",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{statement}}
+                });
+
+                static Task<RetryEvent> AuditAsync(RetryEvent item) => Task.FromResult(item);
+                static Task FlushAsync() => Task.CompletedTask;
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Every_Task_In_A_Combinator()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            var pendingTasks = new System.Collections.Generic.List<Task>();
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                pendingTasks.Add(Task.WhenAll(FlushAsync(), AuditAsync(item)));
+            });
+
+            static Task FlushAsync() => Task.CompletedTask;
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV013_Inspects_Conditional_Callback_Branches()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            var enabled = true;
+            _ = Shield.Retry(options => options.OnRetry = enabled
+                ? async item => await Task.Yield()
+                : _ => { });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV006"), "KEV013");
+    }
+
+    [Test]
+    public async Task KEV013_Inspects_Coalesced_Callback_Operands()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            Action<RetryEvent>? existing = null;
+            _ = Shield.Retry(options => options.OnRetry = existing
+                ?? (async item => await Task.Yield()));
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV006"), "KEV013");
+    }
+
+    [Test]
+    public async Task KEV013_Inspects_Switch_Expression_Callback_Arms()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            var mode = 0;
+            _ = Shield.Retry(options => options.OnRetry = mode switch
+            {
+                0 => async item => await Task.Yield(),
+                _ => _ => { },
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV006"), "KEV013");
+    }
+
+    [Test]
+    public async Task KEV013_Code_Fix_Only_Renames_Compatible_Lambdas()
+    {
+        var compatible = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async _ => await Task.Yield());
+            }
+            """);
+        var compatibleValueTask = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = _ => AuditAsync());
+
+                private static ValueTask AuditAsync() => ValueTask.CompletedTask;
+            }
+            """);
+        var incompatible = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Hedge(options => options.OnHedge = _ => Task.Delay(1));
+            }
+            """);
+        var incompatibleGenericValueTask = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = _ => GetValueAsync());
+
+                private static ValueTask<int> GetValueAsync() => ValueTask.FromResult(1);
+            }
+            """);
+        var incompatibleAdditiveAssignment = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry += async _ => await Task.Yield());
+            }
+            """);
+        var incompatibleCoalescingAssignment = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry ??= async _ => await Task.Yield());
+            }
+            """);
+        var incompatibleDiscardingBlock = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _ = AuditAsync(item);
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+        var incompatibleTimedWait = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item => AuditAsync(item).Wait(0));
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+        var incompatibleCollectionAdd = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                private readonly System.Collections.Generic.List<Task> _pending = new();
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item => _pending.Add(AuditAsync(item)));
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+        var alreadyAssignedAsyncTwin = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options =>
+                    {
+                        options.OnRetryAsync = _ => ValueTask.CompletedTask;
+                        options.OnRetry = async _ => await Task.Yield();
+                    });
+            }
+            """);
+
+        var alreadyAssignedInHelperBlock = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure(RetryOptions options)
+                {
+                    options.OnRetryAsync = _ => ValueTask.CompletedTask;
+                    options.OnRetry = async _ => await Task.Yield();
+                }
+            }
+            """);
+        var assignedOnDifferentReceiver = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure(RetryOptions first, RetryOptions second)
+                {
+                    first.OnRetryAsync = _ => ValueTask.CompletedTask;
+                    second.OnRetry = async _ => await Task.Yield();
+                }
+            }
+            """);
+        var alreadyAssignedThroughAlias = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure(RetryOptions options)
+                {
+                    var alias = options;
+                    options.OnRetryAsync = _ => ValueTask.CompletedTask;
+                    alias.OnRetry = async _ => await Task.Yield();
+                }
+            }
+            """);
+
+        await Assert.That(compatible.ActionCount).IsEqualTo(1);
+        await Assert.That(compatible.ChangedText).Contains("options.OnRetryAsync = async");
+        await Assert.That(compatibleValueTask.ActionCount).IsEqualTo(1);
+        await Assert.That(compatibleValueTask.ChangedText)
+            .Contains("options.OnRetryAsync = _ => AuditAsync()");
+        await Assert.That(incompatible.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatible.ChangedText).IsNull();
+        await Assert.That(incompatibleGenericValueTask.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleGenericValueTask.ChangedText).IsNull();
+        await Assert.That(incompatibleAdditiveAssignment.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleAdditiveAssignment.ChangedText).IsNull();
+        await Assert.That(incompatibleCoalescingAssignment.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleCoalescingAssignment.ChangedText).IsNull();
+        await Assert.That(incompatibleDiscardingBlock.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleDiscardingBlock.ChangedText).IsNull();
+        await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleTimedWait.ChangedText).IsNull();
+        await Assert.That(incompatibleCollectionAdd.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleCollectionAdd.ChangedText).IsNull();
+        await Assert.That(alreadyAssignedAsyncTwin.ActionCount).IsEqualTo(0);
+        await Assert.That(alreadyAssignedAsyncTwin.ChangedText).IsNull();
+        await Assert.That(alreadyAssignedInHelperBlock.ActionCount).IsEqualTo(0);
+        await Assert.That(alreadyAssignedInHelperBlock.ChangedText).IsNull();
+        await Assert.That(assignedOnDifferentReceiver.ActionCount).IsEqualTo(1);
+        await Assert.That(assignedOnDifferentReceiver.ChangedText)
+            .Contains("second.OnRetryAsync = async");
+        await Assert.That(alreadyAssignedThroughAlias.ActionCount).IsEqualTo(0);
+        await Assert.That(alreadyAssignedThroughAlias.ChangedText).IsNull();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Synchronously_Joined_TaskRun()
+    {
+        var statements = new[]
+        {
+            "Task.Run(() => item.Context.ShieldName).GetAwaiter().GetResult();",
+            "Task.Run(() => item.Context.ShieldName).Wait();",
+            "_ = Task.Run(() => item.Context.ShieldName).Result;",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{statement}}
+                });
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Event_Context_Captured_By_Deferred_Work()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                Task.Run(() => Console.WriteLine(item.Context.ShieldName)));
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Pooled_Context_Field_In_Deferred_Work()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private KevlarContext _context;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _context = item.Context;
+                        _ = Task.Run(() => Console.WriteLine(_context.ShieldName));
+                    });
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Event_Forwarded_To_Deferred_Helper()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                Task.Run(() => Process(item)));
+
+            static void Process(RetryEvent item) =>
+                Console.WriteLine(item.Context.ShieldName);
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Sibling_Assembly_Events_Forwarded_To_Deferred_Work()
+    {
+        var chaosDiagnostics = await AnalyzeBodyAsync("""
+            _ = ChaosShield.Latency(options => options.OnInjected = item =>
+                Task.Run(() => Process(item)));
+
+            static void Process(ChaosEvent item) =>
+                Console.WriteLine(item.Context.ShieldName);
+            """);
+        var rateLimiterDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Empty.UseRateLimiter(
+                (System.Threading.RateLimiting.RateLimiter)null!,
+                options => options.OnRejected = item =>
+                    Task.Run(() => Process(item)));
+
+            static void Process(RateLimiterAdapterRejectedEvent item) =>
+                Console.WriteLine(item.Context.ShieldName);
+            """);
+
+        await AssertRuleAsync(
+            Without(chaosDiagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            Without(rateLimiterDiagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Follows_Erased_Event_Local_Captured_By_Deferred_Work()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                object boxed = item;
+                _ = Task.Run(() => Process((RetryEvent)boxed));
+            });
+
+            static void Process(RetryEvent item) =>
+                Console.WriteLine(item.Context.ShieldName);
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Captured_Local_Function_Method_Groups()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                void Work() => Console.WriteLine(item.Context.ShieldName);
+                _ = Task.Run(Work);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Follows_Local_Function_Calls_From_Scheduled_Work()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                void Inner() => Console.WriteLine(item.Context.ShieldName);
+                void Work() => Inner();
+                _ = Task.Run(Work);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Allows_Copied_Context_Values_In_Deferred_Work()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var shieldName = item.Context.ShieldName;
+                _ = Task.Run(() => Console.WriteLine(shieldName));
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Allows_Context_Value_Passed_To_Eager_Delegate_Factory()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            Action CreateWork(string value) => () => Console.WriteLine(value);
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                _ = Task.Run(CreateWork(item.Context.ShieldName));
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Allows_Context_Value_Used_To_Construct_Method_Group_Receiver()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class Worker(string value)
+            {
+                public void Run() => Console.WriteLine(value);
+            }
+
+            public sealed class TestSubject
+            {
+                public void Observe(RetryEvent item)
+                {
+                    _ = Task.Run(new Worker(item.Context.ShieldName).Run);
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Allows_Context_Value_Passed_As_Eager_State()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static value => Console.WriteLine(value),
+                    item.Context.ShieldName));
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Follows_Event_Context_Local_Aliases()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var context = item.Context;
+                _ = Task.Run(() => Console.WriteLine(context.ShieldName));
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Similarly_Named_Application_Context_Types()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            namespace Foo.Kevlar
+            {
+                public sealed class KevlarContext
+                {
+                    public string ShieldName => "application";
+                }
+            }
+
+            public sealed class ApplicationEvent
+            {
+                public Foo.Kevlar.KevlarContext Context { get; } = new();
+            }
+
+            public sealed class TestSubject
+            {
+                public void Observe(ApplicationEvent item) =>
+                    _ = Task.Run(() => Console.WriteLine(item.Context.ShieldName));
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Static_Event_Context_Properties()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class ApplicationEvent
+            {
+                public static KevlarContext Context => default;
+            }
+
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = retryEvent =>
+                    {
+                        var item = new ApplicationEvent();
+                        _ = Task.Run(() => Use(item));
+                    });
+
+                private static void Use(ApplicationEvent item) { }
+            }
+            """);
+
+        await Assert.That(Without(diagnostics, "KEV006")).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Computed_Event_Context_Properties()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class ApplicationEvent
+            {
+                public KevlarContext Context => default;
+            }
+
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = retryEvent =>
+                    {
+                        var item = new ApplicationEvent();
+                        _ = Task.Run(() => Use(item));
+                    });
+
+                private static void Use(ApplicationEvent item) { }
+            }
+            """);
+
+        await Assert.That(Without(diagnostics, "KEV006")).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Event_Context_Passed_As_Deferred_State()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static (KevlarContext context) => Console.WriteLine(context.ShieldName),
+                    item.Context,
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Event_Context_Nested_In_Deferred_State()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static ((KevlarContext Context, int Value) state) =>
+                        Console.WriteLine(state.Context.ShieldName),
+                    (Context: item.Context, Value: 1),
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Event_Context_In_NonGeneric_Deferred_State()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class WorkState
+            {
+                public KevlarContext Context { get; set; } = null!;
+            }
+
+            public sealed class TestSubject
+            {
+                public void Observe(RetryEvent item)
+                {
+                    var state = new WorkState { Context = item.Context };
+                    ThreadPool.QueueUserWorkItem(
+                        static value => Console.WriteLine(value.Context.ShieldName),
+                        state,
+                        preferLocal: false);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Constructor_Arguments_In_Deferred_State()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class WorkState
+            {
+                public WorkState(KevlarContext context) => Context = context;
+
+                public KevlarContext Context { get; }
+            }
+
+            public sealed class TestSubject
+            {
+                public void Observe(RetryEvent item) =>
+                    ThreadPool.QueueUserWorkItem(
+                        static state => Console.WriteLine(state.Context.ShieldName),
+                        new WorkState(item.Context),
+                        preferLocal: false);
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Erased_Array_State_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static (object[] state) =>
+                        Console.WriteLine(((KevlarContext)state[0]).ShieldName),
+                    new object[] { item.Context },
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Object_Erased_Tuple_State_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static state =>
+                        Console.WriteLine(((KevlarContext)state.Context).ShieldName),
+                    (Context: (object)item.Context, Other: 0),
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Conditionally_Selected_Erased_State()
+    {
+        var cases = new[]
+        {
+            "enabled ? (object)item.Context : new object()",
+            "(object?)item.Context ?? new object()",
+            "enabled switch { true => (object)item.Context, false => new object() }",
+        };
+
+        foreach (var state in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                var enabled = true;
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                    ThreadPool.QueueUserWorkItem(
+                        static (object value) => Console.WriteLine(value),
+                        {{state}},
+                        preferLocal: false));
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Erased_Collection_Expression_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static (object[] state) =>
+                        Console.WriteLine(((KevlarContext)state[0]).ShieldName),
+                    [item.Context],
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Erased_Object_Initializer_Values()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class WorkState
+            {
+                public object? Context { get; set; }
+            }
+
+            public sealed class TestSubject
+            {
+                public void Observe(RetryEvent item)
+                {
+                    var state = new WorkState { Context = (object)item.Context };
+                    ThreadPool.QueueUserWorkItem(
+                        static value => Console.WriteLine(((KevlarContext)value.Context!).ShieldName),
+                        state,
+                        preferLocal: false);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Erased_Anonymous_Object_State_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static state =>
+                        Console.WriteLine(((KevlarContext)state.State).ShieldName),
+                    new { State = (object)item.Context },
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Erased_Record_With_State_Values()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed record WorkState(object? State);
+
+            public sealed class TestSubject
+            {
+                public void Observe(RetryEvent item)
+                {
+                    var template = new WorkState(null);
+                    ThreadPool.QueueUserWorkItem(
+                        static state =>
+                            Console.WriteLine(((KevlarContext)state.State!).ShieldName),
+                        template with { State = (object)item.Context },
+                        preferLocal: false);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Copied_Record_State_Values()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed record WorkState(object? State, int Flag);
+
+            public sealed class TestSubject
+            {
+                public void Observe(RetryEvent item)
+                {
+                    var template = new WorkState((object)item.Context, 0);
+                    ThreadPool.QueueUserWorkItem(
+                        static state =>
+                            Console.WriteLine(((KevlarContext)state.State!).ShieldName),
+                        template with { Flag = 1 },
+                        preferLocal: false);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Erased_Collection_Initializer_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static (System.Collections.Generic.List<object> state) =>
+                        Console.WriteLine(((KevlarContext)state[0]).ShieldName),
+                    new System.Collections.Generic.List<object> { item.Context },
+                    preferLocal: false));
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Follows_Stable_Deferred_Delegate_Initializers()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                Action work = () => Console.WriteLine(item.Context.ShieldName);
+                _ = Task.Run(work);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Switch_Selected_Deferred_Delegates()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            var mode = 0;
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                Task.Run(mode switch
+                {
+                    0 => (Action)(() => Console.WriteLine(item.Context.ShieldName)),
+                    _ => () => { },
+                }));
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
     [Test]
     public async Task Public_Surface_Uses_One_Hedge_Stem()
     {
@@ -115,7 +1217,7 @@ public class PipelineHazardAnalyzerTests
             "await Shield.For<int>().ConcurrencyLimit(2).ExecuteOutcomeAsync(1, (state, _) => new ValueTask<int>(state));",
         };
 
-        await AssertEachAsync(cases, "KEV004", "KEV012");
+        await AssertEachAsync(cases, "KEV004", "KEV012", "KEV013");
     }
 
     [Test]
@@ -407,7 +1509,7 @@ public class PipelineHazardAnalyzerTests
             "_ = await Shield.Empty.Fallback(static _ => ValueTask.CompletedTask).ExecuteOutcomeAsync(static _ => Task.FromResult(1));",
         };
 
-        await AssertEachAsync(cases, "KEV005", "KEV012");
+        await AssertEachAsync(cases, "KEV005", "KEV012", "KEV013");
     }
 
     [Test]
@@ -423,7 +1525,7 @@ public class PipelineHazardAnalyzerTests
             "var fallback = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask); _ = Shield.Compose(Shield.Empty, fallback).Execute(static _ => 1);",
         };
 
-        await AssertEachAsync(cases, "KEV005", "KEV012");
+        await AssertEachAsync(cases, "KEV005", "KEV012", "KEV013");
     }
 
     [Test]
@@ -433,7 +1535,7 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask)" +
             ".UseRateLimiter((System.Threading.RateLimiting.RateLimiter)null!).Execute(static _ => 1);");
 
-        await AssertRuleAsync(Without(diagnostics, "KEV004", "KEV012"), "KEV005");
+        await AssertRuleAsync(Without(diagnostics, "KEV004", "KEV012", "KEV013"), "KEV005");
     }
 
     [Test]
@@ -457,7 +1559,7 @@ public class PipelineHazardAnalyzerTests
         foreach (var body in cases)
         {
             var diagnostics = await AnalyzeBodyAsync(body);
-            await Assert.That(Without(diagnostics, "KEV012")).IsEmpty();
+            await Assert.That(Without(diagnostics, "KEV012", "KEV013")).IsEmpty();
         }
     }
 
@@ -481,7 +1583,7 @@ public class PipelineHazardAnalyzerTests
             "Fallback on a non-generic Shield applies only to void executions. " +
             "For executions that return a value, build a result-aware shield with " +
             "Shield.For<T>() and use its Fallback overloads.");
-        await Assert.That(Without(suppressed, "KEV012")).IsEmpty();
+        await Assert.That(Without(suppressed, "KEV012", "KEV013")).IsEmpty();
     }
 
     [Test]
@@ -1564,6 +2666,45 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(diagnostics[0].Severity).IsEqualTo(expectedSeverity);
     }
 
+    private static async Task<(int ActionCount, string? ChangedText)> GetCodeFixAsync(
+        string declarations)
+    {
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "CodeFixTest",
+            "CodeFixTest",
+            LanguageNames.CSharp,
+            compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            parseOptions: new CSharpParseOptions(),
+            metadataReferences: GetMetadataReferences()));
+        var document = workspace.AddDocument(
+            project.Id,
+            "Test.cs",
+            SourceText.From(CreateSource(declarations)));
+        var compilation = (CSharpCompilation)(await document.Project.GetCompilationAsync())!;
+        var diagnostic = (await GetAnalyzerDiagnosticsAsync(compilation))
+            .Single(static item => item.Id == "KEV013");
+        var actions = new List<CodeAction>();
+        var provider = new AsyncCallbackCodeFixProvider();
+
+        await provider.RegisterCodeFixesAsync(new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None));
+        if (actions.Count != 1)
+        {
+            return (actions.Count, null);
+        }
+
+        var operations = await actions[0].GetOperationsAsync(CancellationToken.None);
+        var changedSolution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+        var changedText = await changedSolution.GetDocument(document.Id)!.GetTextAsync();
+        return (actions.Count, changedText.ToString());
+    }
+
     private static Task<ImmutableArray<Diagnostic>> AnalyzeBodyAsync(
         string body,
         string members = "",
@@ -1621,19 +2762,21 @@ public class PipelineHazardAnalyzerTests
         string source,
         string assemblyName = "PipelineHazardAnalyzerTestSubject")
     {
-        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
-            .Split(Path.PathSeparator)
-            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
-            .Append(MetadataReference.CreateFromFile(typeof(Shield).Assembly.Location))
-            .Append(MetadataReference.CreateFromFile(typeof(ChaosShield).Assembly.Location))
-            .Append(MetadataReference.CreateFromFile(
-                typeof(Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions).Assembly.Location));
         return CSharpCompilation.Create(
             assemblyName,
             [CSharpSyntaxTree.ParseText(source)],
-            references,
+            GetMetadataReferences(),
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
     }
+
+    private static IEnumerable<MetadataReference> GetMetadataReferences() =>
+        ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .Append(MetadataReference.CreateFromFile(typeof(Shield).Assembly.Location))
+            .Append(MetadataReference.CreateFromFile(typeof(Kevlar.Chaos.ChaosShield).Assembly.Location))
+            .Append(MetadataReference.CreateFromFile(
+                typeof(Kevlar.Extensions.RateLimiting.ShieldRateLimiterExtensions).Assembly.Location));
 
     private static Task<ImmutableArray<Diagnostic>> GetAnalyzerDiagnosticsAsync(CSharpCompilation compilation) =>
         compilation

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1195,6 +1195,24 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Flags_Awaited_TaskRun_In_Async_Void_Callbacks()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+                await Task.Run(() => Consume(item.Context)));
+
+            static void Consume(KevlarContext context) =>
+                Console.WriteLine(context.ShieldName);
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Flags_Event_Context_Captured_By_Deferred_Work()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -53,6 +53,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Combined_Async_Delegates()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            Action<RetryEvent> existing = _ => { };
+            _ = Shield.Retry(options => options.OnRetry = existing
+                + (Action<RetryEvent>)(async item =>
+                {
+                    await Task.Yield();
+                    _ = item.Context.ShieldName;
+                }));
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Allows_Awaited_And_Synchronous_Callbacks()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -168,6 +188,31 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Constructed_Async_Void_Method_Groups()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry =
+                        new Action<RetryEvent>(RetryAsyncVoid));
+
+                private static async void RetryAsyncVoid(RetryEvent item)
+                {
+                    await Task.Yield();
+                    _ = item.Context.ShieldName;
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Follows_Async_Void_Event_Aliases_After_Await()
     {
         var diagnostics = await AnalyzeSourceAsync("""
@@ -182,6 +227,31 @@ public class PipelineHazardAnalyzerTests
                     await Task.Yield();
                     _ = retained.Context.ShieldName;
                 }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Follows_Assigned_Event_Fields_After_Await()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        _event = item;
+                        await Task.Yield();
+                        _ = _event.Context.ShieldName;
+                    });
             }
             """);
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1320,6 +1320,19 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var alreadyAssignedInOuterBlock = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure(RetryOptions options, bool enabled)
+                {
+                    options.OnRetryAsync = _ => ValueTask.CompletedTask;
+                    if (enabled)
+                    {
+                        options.OnRetry = async _ => await Task.Yield();
+                    }
+                }
+            }
+            """);
         var assignedOnDifferentReceiver = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -1367,6 +1380,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(alreadyAssignedAsyncTwin.ChangedText).IsNull();
         await Assert.That(alreadyAssignedInHelperBlock.ActionCount).IsEqualTo(0);
         await Assert.That(alreadyAssignedInHelperBlock.ChangedText).IsNull();
+        await Assert.That(alreadyAssignedInOuterBlock.ActionCount).IsEqualTo(0);
+        await Assert.That(alreadyAssignedInOuterBlock.ChangedText).IsNull();
         await Assert.That(assignedOnDifferentReceiver.ActionCount).IsEqualTo(1);
         await Assert.That(assignedOnDifferentReceiver.ChangedText)
             .Contains("second.OnRetryAsync = async");
@@ -1531,6 +1546,25 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Unproven_Event_Fields_In_Scheduled_Work()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Schedule()
+                {
+                    _event = default;
+                    _ = Task.Run(() => Console.WriteLine(_event.RetryNumber));
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1125,6 +1125,27 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Uses_Reached_Through_Loop_BackEdges()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                while (Environment.TickCount >= 0)
+                {
+                    Console.WriteLine(item.Context.ShieldName);
+                    await Task.Yield();
+                }
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Keeps_Aliases_On_Their_Suspension_Path()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -3157,6 +3178,29 @@ public class PipelineHazardAnalyzerTests
                 }
 
                 private static RetryEvent CreateDefault() => default;
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Member_Defaults_From_Source_Helpers()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = CreateDefault(item);
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static RetryEvent CreateDefault(RetryEvent ignored) => default;
+                private static void Consume(RetryEvent item) { }
             }
             """);
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -158,6 +158,36 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_PostAwait_Event_Values_In_Wrapper_Locals()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder { Event = item };
+                        await Task.Yield();
+                        Consume(holder.Event.Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public RetryEvent Event { get; set; }
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Follows_Nested_PostAwait_Local_Function_Calls()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1516,6 +1546,19 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleImmediatelyInvokedDelegateInvoke = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        ((Action)(() => _ = AuditAsync(item))).Invoke();
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleSourceMethodDiscard = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -1649,6 +1692,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleDelegateLocalDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleImmediatelyInvokedDelegate.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleImmediatelyInvokedDelegate.ChangedText).IsNull();
+        await Assert.That(incompatibleImmediatelyInvokedDelegateInvoke.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleImmediatelyInvokedDelegateInvoke.ChangedText).IsNull();
         await Assert.That(incompatibleSourceMethodDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleSourceMethodDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleAwaitWrapper.ActionCount).IsEqualTo(0);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -139,6 +139,28 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Invoked_Async_Delegate_Locals()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                Action start = async () =>
+                {
+                    await Task.Yield();
+                    _ = item.Context.ShieldName;
+                };
+                start();
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Invoked_Delegates_After_Await()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -116,6 +116,81 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Invoked_Async_Local_Functions()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                async void Start()
+                {
+                    await Task.Yield();
+                    _ = item.Context.ShieldName;
+                }
+
+                Start();
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Invoked_Delegates_After_Await()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                Action use = () => Console.WriteLine(item.Context.ShieldName);
+                use();
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Nameof_After_Await()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                _ = nameof(item);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Requires_Reachable_Suspension_Before_Event_Use()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                if (Environment.TickCount == 0)
+                {
+                    await Task.Yield();
+                    return;
+                }
+
+                _ = item.Context.ShieldName;
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Combined_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -334,17 +409,21 @@ public class PipelineHazardAnalyzerTests
     [Test]
     public async Task KEV014_Ignores_Reassigned_Async_Event_Aliases()
     {
-        var diagnostics = await AnalyzeBodyAsync("""
-            _ = Shield.Retry(options => options.OnRetry = async item =>
-            {
-                var retained = item;
-                retained = default;
-                await Task.Yield();
-                _ = retained.Context.ShieldName;
-            });
-            """);
+        var assignments = new[] { "retained = default;", "{ retained = default; }" };
+        foreach (var assignment in assignments)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = async item =>
+                {
+                    var retained = item;
+                    {{assignment}}
+                    await Task.Yield();
+                    _ = retained.Context.ShieldName;
+                });
+                """);
 
-        await AssertRuleAsync(diagnostics, "KEV013");
+            await AssertRuleAsync(diagnostics, "KEV013");
+        }
     }
 
     [Test]
@@ -359,6 +438,37 @@ public class PipelineHazardAnalyzerTests
                     _ = Shield.Retry(options => options.OnRetry = async item =>
                     {
                         _event = item;
+                        await Task.Yield();
+                        _ = _event.Context.ShieldName;
+                    });
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Follows_Event_Fields_On_Paths_Reaching_Await()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        _event = item;
+                        if (Environment.TickCount == 0)
+                        {
+                            _event = default;
+                            return;
+                        }
+
                         await Task.Yield();
                         _ = _event.Context.ShieldName;
                     });
@@ -1445,6 +1555,28 @@ public class PipelineHazardAnalyzerTests
                 Without(diagnostics, "KEV013"),
                 "KEV014",
                 DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Nested_Delegate_Event_Parameters()
+    {
+        var selectors = new[]
+        {
+            "(RetryEvent other) => other.RetryNumber",
+            "(RetryEvent other) => other.Context.ShieldName.Length",
+            "(RetryEvent other) => { var copy = other; return copy.RetryNumber; }",
+        };
+        foreach (var selector in selectors)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                    ProcessAsync({{selector}}));
+
+                static Task ProcessAsync(Func<RetryEvent, int> selector) => Task.CompletedTask;
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV013");
         }
     }
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -161,6 +161,27 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Immediately_Invoked_Async_Delegates()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                ((Action)(async () =>
+                {
+                    await Task.Yield();
+                    _ = item.Context.ShieldName;
+                }))();
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Invoked_Delegates_After_Await()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -846,6 +867,28 @@ public class PipelineHazardAnalyzerTests
             });
 
             static Task<int> AuditAsync(RetryEvent item) => Task.FromResult(0);
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV013_Rejects_Task_Local_Joins_After_Throwing_Work()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var pending = AuditAsync(item);
+                MightThrow();
+                pending.GetAwaiter().GetResult();
+            });
+
+            static void MightThrow() => throw new InvalidOperationException();
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             """);
 
         await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1252,6 +1252,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Flags_Handling_Event_Captured_By_Deferred_Work()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.HandlesExceptionWithContext = item =>
+            {
+                _ = Task.Run(() => Consume(item));
+                return true;
+            });
+
+            static void Consume(HandlingEvent item) =>
+                Console.WriteLine(item.Context.ShieldName);
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Flags_Sibling_Assembly_Events_Forwarded_To_Deferred_Work()
     {
         var chaosDiagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -2709,7 +2709,8 @@ public class PipelineHazardAnalyzerTests
                     _ = Shield.Retry(options => options.OnRetry = item =>
                     {
                         _event = item;
-                        _event = default;
+                        _event = (RetryEvent)default;
+                        _event = (default(RetryEvent));
                         _ = Task.Run(() => Consume(_event));
                     });
 
@@ -3058,6 +3059,33 @@ public class PipelineHazardAnalyzerTests
                 {
                     await Task.Yield();
                     Console.WriteLine(_unrelated.RetryNumber);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Honors_Cleared_Event_Members_In_Async_Instance_Methods()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _event = default;
+                        _ = AuditStoredAsync();
+                    });
+
+                private async Task AuditStoredAsync()
+                {
+                    await Task.Yield();
+                    Console.WriteLine(_event.RetryNumber);
                 }
             }
             """);
@@ -3800,6 +3828,21 @@ public class PipelineHazardAnalyzerTests
                 Action work = () => Console.WriteLine(item.Context.ShieldName);
                 _ = Task.Run(work);
             });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Framework_Constructor_State_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static (System.Collections.Generic.List<RetryEvent> state) =>
+                        Console.WriteLine(state[0].Context.ShieldName),
+                    new System.Collections.Generic.List<RetryEvent>(new[] { item }),
+                    preferLocal: false));
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -293,6 +293,8 @@ public class PipelineHazardAnalyzerTests
             "Task.WaitAll(AuditAsync(item));",
             "Task.WhenAll(AuditAsync(item), FlushAsync()).GetAwaiter().GetResult();",
             "Task.WhenAll(new[] { AuditAsync(item), FlushAsync() }).GetAwaiter().GetResult();",
+            "AuditValueAsync(item).AsTask().GetAwaiter().GetResult();",
+            "AuditValueAsync(item).AsTask().Wait();",
         };
         foreach (var statement in statements)
         {
@@ -303,6 +305,8 @@ public class PipelineHazardAnalyzerTests
                 });
 
                 static Task<RetryEvent> AuditAsync(RetryEvent item) => Task.FromResult(item);
+                static ValueTask<RetryEvent> AuditValueAsync(RetryEvent item) =>
+                    ValueTask.FromResult(item);
                 static Task FlushAsync() => Task.CompletedTask;
                 """);
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -61,6 +61,12 @@ public class PipelineHazardAnalyzerTests
             "Task.CompletedTask.ConfigureAwait(false)",
             "Task.FromResult(0)",
             "Task.FromResult(0).ConfigureAwait(false)",
+            "Task.FromException(new InvalidOperationException())",
+            "Task.FromException(new InvalidOperationException()).ConfigureAwait(false)",
+            "Task.FromException<int>(new InvalidOperationException())",
+            "Task.FromCanceled(new CancellationToken(canceled: true))",
+            "Task.FromCanceled(new CancellationToken(canceled: true)).ConfigureAwait(false)",
+            "Task.FromCanceled<int>(new CancellationToken(canceled: true))",
             "Task.Delay(0)",
             "Task.Delay(0).ConfigureAwait(false)",
             "Task.Delay(TimeSpan.Zero)",
@@ -714,6 +720,40 @@ public class PipelineHazardAnalyzerTests
                 await Task.Yield();
                 Console.WriteLine(events[0].Context.ShieldName);
             });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Instance_Array_Stores_In_Constructors()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Console.WriteLine(holder.Events[0].Context.ShieldName);
+                    });
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Events = new RetryEvent[1];
+                        Events[0] = item;
+                    }
+
+                    public RetryEvent[] Events { get; }
+                }
+            }
             """);
 
         await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
@@ -1498,6 +1538,34 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Metadata_Scalar_Constructor_Snapshots()
+    {
+        var snapshotReference = CreateMetadataReference("""
+            public sealed class RetrySnapshot
+            {
+                public RetrySnapshot(RetryEvent item)
+                {
+                    RetryNumber = item.RetryNumber;
+                }
+
+                public int RetryNumber { get; }
+            }
+            """);
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                        _ = AuditAsync(new RetrySnapshot(item)));
+
+                private static Task AuditAsync(RetrySnapshot snapshot) => Task.CompletedTask;
+            }
+            """, additionalReference: snapshotReference);
 
         await AssertRuleAsync(diagnostics, "KEV013");
     }
@@ -5647,10 +5715,11 @@ public class PipelineHazardAnalyzerTests
         bool isGenerated = false,
         bool allowCompilationErrors = false,
         string assemblyName = "PipelineHazardAnalyzerTestSubject",
-        bool enableImplicitDefaultHandlingRule = false)
+        bool enableImplicitDefaultHandlingRule = false,
+        MetadataReference? additionalReference = null)
     {
         var source = CreateSource(declarations, isGenerated, enableImplicitDefaultHandlingRule);
-        var compilation = CreateCompilation(source, assemblyName);
+        var compilation = CreateCompilation(source, assemblyName, additionalReference);
         var errors = compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
         if (!allowCompilationErrors && errors.Length > 0)
         {
@@ -5701,13 +5770,37 @@ public class PipelineHazardAnalyzerTests
 
     private static CSharpCompilation CreateCompilation(
         string source,
-        string assemblyName = "PipelineHazardAnalyzerTestSubject")
+        string assemblyName = "PipelineHazardAnalyzerTestSubject",
+        MetadataReference? additionalReference = null)
     {
+        var references = GetMetadataReferences();
+        if (additionalReference is not null)
+        {
+            references = references.Append(additionalReference);
+        }
+
         return CSharpCompilation.Create(
             assemblyName,
             [CSharpSyntaxTree.ParseText(source)],
-            GetMetadataReferences(),
+            references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static MetadataReference CreateMetadataReference(string declarations)
+    {
+        var compilation = CreateCompilation(
+            CreateSource(declarations),
+            "PipelineHazardAnalyzerExternalTestSubject");
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(
+                "Metadata test source does not compile: "
+                + string.Join("; ", result.Diagnostics.Select(static error => error.ToString())));
+        }
+
+        return MetadataReference.CreateFromImage(stream.ToArray());
     }
 
     private static IEnumerable<MetadataReference> GetMetadataReferences() =>

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -3727,6 +3727,21 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Framework_Collection_Capacity_State()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+                ThreadPool.QueueUserWorkItem(
+                    static (System.Collections.Generic.List<RetryEvent> state) =>
+                        Console.WriteLine(state.Count),
+                    new System.Collections.Generic.List<RetryEvent>(capacity: 1),
+                    preferLocal: false));
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Erased_Collection_Expression_Values()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -5287,6 +5302,25 @@ public class PipelineHazardAnalyzerTests
         };
 
         await AssertEachAsync(cases, "KEV012", "KEV004", "KEV011");
+
+        var additionalOptionShapes = new[]
+        {
+            "_ = Shield.For<int>().Retry(options => options.OnRetryAsync = static _ => ValueTask.CompletedTask).Execute(_ => 1);",
+            "_ = Shield.For<int>().Retry(options => options.DelayGeneratorAsync = static _ => new ValueTask<TimeSpan?>(TimeSpan.Zero)).Execute(_ => 1);",
+            "_ = Shield.Hedge(options => options.DelayGeneratorAsync = static _ => new ValueTask<TimeSpan>(TimeSpan.Zero)).Execute(_ => 1);",
+            "_ = Shield.For<int>().Hedge(options => options.DelayGeneratorAsync = static _ => new ValueTask<TimeSpan>(TimeSpan.Zero)).Execute(_ => 1);",
+            "_ = Shield.Timeout(options => options.OnTimeoutAsync = static _ => ValueTask.CompletedTask).Execute(_ => 1);",
+            "_ = Shield.CircuitBreaker(options => options.OnStateChangedAsync = static _ => ValueTask.CompletedTask).Execute(_ => 1);",
+            "_ = Shield.For<int>().CircuitBreaker(options => { options.ConsecutiveFailures = 1; options.BreakDurationGenerator = static _ => new ValueTask<TimeSpan>(TimeSpan.FromSeconds(1)); }).Execute(_ => 1);",
+            "_ = Shield.For<int>().CircuitBreaker(options => options.OnStateChangedAsync = static _ => ValueTask.CompletedTask).Execute(_ => 1);",
+            "Shield.Fallback(static _ => ValueTask.CompletedTask, options => options.OnFallbackAsync = static _ => ValueTask.CompletedTask).Execute(static _ => { });",
+        };
+        foreach (var body in additionalOptionShapes)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body);
+            await Assert.That(diagnostics.Any(static diagnostic => diagnostic.Id == "KEV012"))
+                .IsTrue();
+        }
     }
 
     [Test]
@@ -5384,6 +5418,14 @@ public class PipelineHazardAnalyzerTests
                 public sealed class CustomOptions
                 {
                     public Func<int, ValueTask>? OnRetryAsync { get; set; }
+                    public Func<int, ValueTask<TimeSpan?>>? DelayGeneratorAsync { get; set; }
+                    public Func<int, ValueTask>? OnTimeoutAsync { get; set; }
+                    public Func<int, ValueTask<TimeSpan>>? TimeoutGenerator { get; set; }
+                    public Func<int, ValueTask>? OnFallbackAsync { get; set; }
+                    public Func<int, ValueTask>? OnStateChangedAsync { get; set; }
+                    public Func<int, ValueTask<TimeSpan>>? BreakDurationGenerator { get; set; }
+                    public Func<int, ValueTask>? OnRejectedAsync { get; set; }
+                    public Func<int, ValueTask>? Behavior { get; set; }
                 }
 
                 public static class CustomShieldExtensions
@@ -5398,7 +5440,18 @@ public class PipelineHazardAnalyzerTests
                 public sealed class TestSubject
                 {
                     public int Run() => Shield.Empty
-                        .Custom(options => options.OnRetryAsync = static _ => ValueTask.CompletedTask)
+                        .Custom(options =>
+                        {
+                            options.OnRetryAsync = static _ => ValueTask.CompletedTask;
+                            options.DelayGeneratorAsync = static _ => ValueTask.FromResult<TimeSpan?>(TimeSpan.Zero);
+                            options.OnTimeoutAsync = static _ => ValueTask.CompletedTask;
+                            options.TimeoutGenerator = static _ => ValueTask.FromResult(TimeSpan.Zero);
+                            options.OnFallbackAsync = static _ => ValueTask.CompletedTask;
+                            options.OnStateChangedAsync = static _ => ValueTask.CompletedTask;
+                            options.BreakDurationGenerator = static _ => ValueTask.FromResult(TimeSpan.Zero);
+                            options.OnRejectedAsync = static _ => ValueTask.CompletedTask;
+                            options.Behavior = static _ => ValueTask.CompletedTask;
+                        })
                         .Execute(_ => 1);
                 }
             }

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1442,6 +1442,36 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Inspects_Member_Aliases_In_Async_Instance_Methods()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = AuditStoredAsync();
+                    });
+
+                private async Task AuditStoredAsync()
+                {
+                    var retained = this._event;
+                    await Task.Yield();
+                    Console.WriteLine(retained.Context.ShieldName);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Flags_Pooled_Event_Property_In_Deferred_Work()
     {
         var diagnostics = await AnalyzeSourceAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -179,10 +179,50 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var snapshot = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var snapshot = new RetrySnapshot(item);
+                        await Task.Yield();
+                        Console.WriteLine(snapshot.RetryNumber);
+                    });
+
+                private sealed class RetrySnapshot
+                {
+                    public RetrySnapshot(RetryEvent item)
+                    {
+                        RetryNumber = item.RetryNumber;
+                    }
+
+                    public int RetryNumber { get; }
+                }
+            }
+            """);
+        var collectionWrapper = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var events = new System.Collections.Generic.List<RetryEvent> { default, item };
+                        await Task.Yield();
+                        Console.WriteLine(events[1].RetryNumber);
+                    });
+            }
+            """);
 
         await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(snapshot, "KEV013");
+        await AssertRuleAsync(Without(collectionWrapper, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(collectionWrapper, "KEV013"),
             "KEV014",
             DiagnosticSeverity.Warning);
     }
@@ -2277,6 +2317,45 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Factory_Produced_Event_Defaults()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Schedule()
+                {
+                    var unrelated = CreateDefault();
+                    _ = Task.Run(() => Console.WriteLine(unrelated.RetryNumber));
+                }
+
+                private static RetryEvent CreateDefault() => default;
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Factory_Results_From_Event_Arguments()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        var retained = Identity(item);
+                        _ = Task.Run(() => Console.WriteLine(retained.RetryNumber));
+                    });
+
+                private static RetryEvent Identity(RetryEvent item) => item;
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -53,6 +53,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_PostAwait_Local_Function_Calls()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                ReadContext();
+
+                void ReadContext() => Console.WriteLine(item.Context.ShieldName);
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Combined_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -494,6 +514,9 @@ public class PipelineHazardAnalyzerTests
             "AuditValueAsync(item).AsTask().GetAwaiter().GetResult();",
             "AuditValueAsync(item).ConfigureAwait(false).GetAwaiter().GetResult();",
             "AuditValueAsync(item).AsTask().Wait();",
+            "var pending = AuditAsync(item); pending.GetAwaiter().GetResult();",
+            "var pending = AuditAsync(item); pending.Wait();",
+            "var pending = AuditAsync(item); _ = pending.Result;",
         };
         foreach (var statement in statements)
         {
@@ -848,6 +871,26 @@ public class PipelineHazardAnalyzerTests
                     {
                         _event = item;
                         _ = Task.Run(() => Console.WriteLine(_event.Context.ShieldName));
+                    });
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Pooled_Event_Property_In_Deferred_Work()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent StoredEvent { get; set; }
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        StoredEvent = item;
+                        _ = Task.Run(() => Console.WriteLine(StoredEvent.Context.ShieldName));
                     });
             }
             """);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -764,6 +764,61 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_PostAwait_Array_Element_Writes()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                var events = new RetryEvent[1];
+                events[0] = item;
+                await Task.Yield();
+                Console.WriteLine(events[0].Context.ShieldName);
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Constructor_Stores_From_Helper_Results()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Console.WriteLine(holder.Event.Context.ShieldName);
+                    });
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Event = Identity(item);
+                    }
+
+                    public RetryEvent Event { get; }
+
+                    private static RetryEvent Identity(RetryEvent item) => item;
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Follows_Nested_PostAwait_Local_Function_Calls()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -94,6 +94,23 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Unrelated_Member_Names_In_Local_Functions()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            var holder = (item: 42, other: 0);
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                Read();
+
+                void Read() => Console.WriteLine(holder.item);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Async_Anonymous_Function_Syntaxes()
     {
         var callbacks = new[]
@@ -227,6 +244,30 @@ public class PipelineHazardAnalyzerTests
                 }
 
                 _ = item.Context.ShieldName;
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Aliases_On_Paths_That_Exit_Before_Await()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                KevlarContext? retained = null;
+                if (Environment.TickCount == 0)
+                {
+                    retained = item.Context;
+                    return;
+                }
+
+                await Task.Yield();
+                if (retained is not null)
+                {
+                    Console.WriteLine(retained.ShieldName);
+                }
             });
             """);
 
@@ -1469,6 +1510,31 @@ public class PipelineHazardAnalyzerTests
             Without(diagnostics, "KEV013"),
             "KEV014",
             DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Unrelated_Event_Members_In_Async_Instance_Methods()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _unrelated;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _ = AuditAsync();
+                    });
+
+                private async Task AuditAsync()
+                {
+                    await Task.Yield();
+                    Console.WriteLine(_unrelated.RetryNumber);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -53,6 +53,30 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Known_Completed_Awaitables()
+    {
+        var awaitExpressions = new[]
+        {
+            "Task.CompletedTask",
+            "Task.CompletedTask.ConfigureAwait(false)",
+            "ValueTask.CompletedTask",
+            "ValueTask.CompletedTask.ConfigureAwait(false)",
+        };
+        foreach (var awaitExpression in awaitExpressions)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = async item =>
+                {
+                    await {{awaitExpression}};
+                    Console.WriteLine(item.Context.ShieldName);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV013");
+        }
+    }
+
+    [Test]
     public async Task KEV014_Follows_PostAwait_Local_Function_Calls()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -2356,6 +2380,26 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Scalar_Factory_Results_From_Event_Arguments()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        var retryNumber = GetRetryNumber(item);
+                        _ = Task.Run(() => Console.WriteLine(retryNumber));
+                    });
+
+                private static int GetRetryNumber(RetryEvent item) => item.RetryNumber;
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -258,6 +258,33 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_Async_Event_Context_Aliases_After_Await()
+    {
+        var expressions = new[]
+        {
+            (Initializer: "item.Context", Use: "retained.ShieldName"),
+            (Initializer: "item.Context.Properties", Use: "retained.Count"),
+        };
+        foreach (var (initializer, use) in expressions)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = async item =>
+                {
+                    var retained = {{initializer}};
+                    await Task.Yield();
+                    _ = {{use}};
+                });
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
     public async Task KEV014_Follows_Assigned_Event_Fields_After_Await()
     {
         var diagnostics = await AnalyzeSourceAsync("""
@@ -553,6 +580,31 @@ public class PipelineHazardAnalyzerTests
 
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV013_Rejects_Task_Local_Joins_After_Early_Returns()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var pending = AuditAsync(item);
+                if (Environment.TickCount == 0)
+                {
+                    return;
+                }
+
+                pending.GetAwaiter().GetResult();
+            });
+
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             """);
 
         await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -150,6 +150,31 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_Async_Void_Event_Aliases_After_Await()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = RetryAsyncVoid);
+
+                private static async void RetryAsyncVoid(RetryEvent item)
+                {
+                    var retained = item;
+                    await Task.Yield();
+                    _ = retained.Context.ShieldName;
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Follows_Stable_Callback_Local_Initializers()
     {
         var trailingStatements = new[] { "", "callback = _ => { };" };
@@ -347,6 +372,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_Task_Returning_Local_Functions()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                Task Start() => AuditAsync(item);
+                _ = Start();
+            });
+
+            static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV013_Ignores_Synchronously_Observed_Task_Calls()
     {
         var statements = new[]
@@ -394,6 +439,31 @@ public class PipelineHazardAnalyzerTests
                 public void Configure() =>
                     _ = Shield.Retry(options => options.OnRetry = item =>
                         AuditAsync(item).GetResult());
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV013_Rejects_Filtered_WhenAll_Collections()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            using System.Linq;
+
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                        Task.WhenAll(new[] { AuditAsync(item) }.Where(_ => false))
+                            .GetAwaiter()
+                            .GetResult());
 
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -65,6 +65,11 @@ public class PipelineHazardAnalyzerTests
             "ValueTask.CompletedTask.ConfigureAwait(false)",
             "ValueTask.FromResult(0)",
             "ValueTask.FromResult(0).ConfigureAwait(false)",
+            "new ValueTask()",
+            "new ValueTask().ConfigureAwait(false)",
+            "new ValueTask<int>(0)",
+            "default(ValueTask)",
+            "default(ValueTask<int>)",
         };
         foreach (var awaitExpression in awaitExpressions)
         {
@@ -78,6 +83,60 @@ public class PipelineHazardAnalyzerTests
 
             await AssertRuleAsync(diagnostics, "KEV013");
         }
+    }
+
+    [Test]
+    public async Task KEV014_Flags_ValueTask_Constructed_From_Pending_Task()
+    {
+        var awaitExpressions = new[]
+        {
+            "new ValueTask(Task.Delay(1))",
+            "new ValueTask<int>(Task.Run(() => 1))",
+        };
+        foreach (var awaitExpression in awaitExpressions)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = async item =>
+                {
+                    await {{awaitExpression}};
+                    Console.WriteLine(item.Context.ShieldName);
+                });
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Unknown_Object_Creation_Awaitables()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        await new PendingAwaitable();
+                        Console.WriteLine(item.Context.ShieldName);
+                    });
+
+                private readonly struct PendingAwaitable
+                {
+                    public System.Runtime.CompilerServices.TaskAwaiter GetAwaiter() =>
+                        Task.Delay(1).GetAwaiter();
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -325,6 +384,88 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var unrelatedConstructorStore = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Console.WriteLine(holder.Value);
+                    });
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        new Sink().Event = item;
+                    }
+
+                    public int Value { get; }
+                }
+
+                private sealed class Sink
+                {
+                    public RetryEvent Event { get; set; }
+                }
+            }
+            """);
+        var fieldConstructorWrapper = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Event.Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    private readonly RetryEvent _event;
+
+                    public Holder(RetryEvent item)
+                    {
+                        _event = item;
+                    }
+
+                    public RetryEvent Event => _event;
+                }
+            }
+            """);
+        var nestedConstructorStore = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.State.Event.Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        State.Event = item;
+                    }
+
+                    public State State { get; } = new();
+                }
+
+                private sealed class State
+                {
+                    public RetryEvent Event { get; set; }
+                }
+            }
+            """);
         var collectionWrapper = await AnalyzeSourceAsync("""
             public sealed class TestSubject
             {
@@ -353,6 +494,17 @@ public class PipelineHazardAnalyzerTests
         await AssertRuleAsync(Without(delegatedConstructor, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(delegatedConstructor, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(unrelatedConstructorStore, "KEV013");
+        await AssertRuleAsync(Without(fieldConstructorWrapper, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(fieldConstructorWrapper, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(Without(nestedConstructorStore, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(nestedConstructorStore, "KEV013"),
             "KEV014",
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(Without(collectionWrapper, "KEV014"), "KEV013");

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -2416,6 +2416,22 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleConditionalDelegateLocalDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure(bool enabled) =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Action<int> work = enabled
+                            ? _ => _ = AuditAsync(item)
+                            : _ => { };
+                        Array.ForEach(new[] { 0 }, work);
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleSwitchDelegateDiscard = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -2577,6 +2593,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleConstructedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleConditionalDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleConditionalDelegateDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleConditionalDelegateLocalDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleConditionalDelegateLocalDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleSwitchDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleSwitchDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleCoalescedDelegateDiscard.ActionCount).IsEqualTo(0);
@@ -3271,6 +3289,45 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Retained_Wrappers_In_Async_Instance_Methods()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private Holder _holder = null!;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _holder = new Holder(item);
+                        _ = AuditStoredAsync();
+                    });
+
+                private async Task AuditStoredAsync()
+                {
+                    await Task.Yield();
+                    Console.WriteLine(_holder.Event.Context.ShieldName);
+                }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Event = item;
+                    }
+
+                    public RetryEvent Event { get; }
+                }
+            }
+            """);
+
         await AssertRuleAsync(
             Without(diagnostics, "KEV013"),
             "KEV014",

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -369,6 +369,30 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Removes_Aliases_Cleared_On_Every_Incoming_Path()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                var retained = item;
+                if (Environment.TickCount == 0)
+                {
+                    retained = default;
+                }
+                else
+                {
+                    retained = default;
+                }
+
+                await Task.Yield();
+                Console.WriteLine(retained.RetryNumber);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Combined_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1310,6 +1334,19 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var compatibleLocalFunction = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async _ =>
+                    {
+                        Log();
+                        await Task.Yield();
+
+                        static void Log() => Console.WriteLine("retrying");
+                    });
+            }
+            """);
         var incompatibleAsyncDiscardingBlock = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -1336,6 +1373,31 @@ public class PipelineHazardAnalyzerTests
                     });
 
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+        var incompatibleDelegateLocalDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Action start = () => _ = AuditAsync(item);
+                        start();
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+        var incompatibleAwaitWrapper = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                        await Forward(AuditAsync(item)));
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+                private static ValueTask Forward(Task ignored) => ValueTask.CompletedTask;
             }
             """);
         var incompatibleTimedWait = await GetCodeFixAsync("""
@@ -1420,6 +1482,9 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(compatibleValueTask.ActionCount).IsEqualTo(1);
         await Assert.That(compatibleValueTask.ChangedText)
             .Contains("options.OnRetryAsync = _ => AuditAsync()");
+        await Assert.That(compatibleLocalFunction.ActionCount).IsEqualTo(1);
+        await Assert.That(compatibleLocalFunction.ChangedText)
+            .Contains("options.OnRetryAsync = async");
         await Assert.That(incompatible.ActionCount).IsEqualTo(0);
         await Assert.That(incompatible.ChangedText).IsNull();
         await Assert.That(incompatibleGenericValueTask.ActionCount).IsEqualTo(0);
@@ -1434,6 +1499,10 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleAsyncDiscardingBlock.ChangedText).IsNull();
         await Assert.That(incompatibleLocalFunctionDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleLocalFunctionDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleDelegateLocalDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleDelegateLocalDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleAwaitWrapper.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleAwaitWrapper.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleTimedWait.ChangedText).IsNull();
         await Assert.That(incompatibleCollectionAdd.ActionCount).IsEqualTo(0);
@@ -1627,6 +1696,116 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Unproven_Event_Properties_In_Scheduled_Work()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent Unrelated => default;
+
+                public void Schedule() =>
+                    _ = Task.Run(() => Console.WriteLine(Unrelated.RetryNumber));
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Flags_Proven_Event_Fields_In_Scheduled_Work()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Event_Members_From_Explicit_Callback_Forms()
+    {
+        var parenthesized = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent Stored { get; set; }
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = (RetryEvent item) =>
+                    {
+                        Stored = item;
+                        _ = Task.Run(() => Consume(Stored));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+        var anonymousMethod = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = delegate(RetryEvent item)
+                    {
+                        _event = item;
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+
+        await AssertRuleAsync(parenthesized, "KEV014", DiagnosticSeverity.Warning);
+        await AssertRuleAsync(anonymousMethod, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Unproven_Member_Assignments_In_Scheduled_Work()
+    {
+        var unrelatedCallback = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+                public Action<RetryEvent>? Callback { get; set; }
+
+                public void Configure() => Callback = item =>
+                {
+                    _event = item;
+                    _ = Task.Run(() => Console.WriteLine(_event.RetryNumber));
+                };
+            }
+            """);
+        var parameterlessCallback = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure(RetryEvent initial) =>
+                    _ = Shield.Retry(options => options.OnRetry = delegate
+                    {
+                        _event = initial;
+                        _ = Task.Run(() => Console.WriteLine(_event.RetryNumber));
+                    });
+            }
+            """);
+
+        await Assert.That(unrelatedCallback).IsEmpty();
+        await Assert.That(parameterlessCallback).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -543,6 +543,59 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var compositeDelegatedConstructor = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Events[0].Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                        : this(new[] { item })
+                    {
+                    }
+
+                    private Holder(RetryEvent[] events)
+                    {
+                        Events = events;
+                    }
+
+                    public RetryEvent[] Events { get; }
+                }
+            }
+            """);
+        var uninvokedNestedStores = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Console.WriteLine(holder.Value);
+                    });
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        void Store() => Events.Add(item);
+                        Action store = () => Events.Add(item);
+                    }
+
+                    public System.Collections.Generic.List<RetryEvent> Events { get; } = new();
+                    public int Value { get; }
+                }
+            }
+            """);
         var collectionWrapper = await AnalyzeSourceAsync("""
             public sealed class TestSubject
             {
@@ -599,6 +652,12 @@ public class PipelineHazardAnalyzerTests
             Without(helperConstructorStore, "KEV013"),
             "KEV014",
             DiagnosticSeverity.Warning);
+        await AssertRuleAsync(Without(compositeDelegatedConstructor, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(compositeDelegatedConstructor, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(uninvokedNestedStores, "KEV013");
         await AssertRuleAsync(Without(collectionWrapper, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(collectionWrapper, "KEV013"),
@@ -2053,6 +2112,54 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleConditionalDelegateDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure(bool enabled) =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Array.ForEach(
+                            new[] { 0 },
+                            enabled ? _ => _ = AuditAsync(item) : _ => { });
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+        var incompatibleSwitchDelegateDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure(int mode) =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Array.ForEach(
+                            new[] { 0 },
+                            mode switch
+                            {
+                                0 => _ => _ = AuditAsync(item),
+                                _ => _ => { },
+                            });
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
+        var incompatibleCoalescedDelegateDiscard = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        Action<int>? audit = _ => _ = AuditAsync(item);
+                        Array.ForEach(new[] { 0 }, audit ?? (_ => { }));
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleAwaitWrapper = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -2175,6 +2282,12 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleForwardedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleOpaqueDelegateDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleOpaqueDelegateDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleConditionalDelegateDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleConditionalDelegateDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleSwitchDelegateDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleSwitchDelegateDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleCoalescedDelegateDiscard.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleCoalescedDelegateDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleAwaitWrapper.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleAwaitWrapper.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -393,6 +393,35 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Keeps_Aliases_Reintroduced_After_Exhaustive_Clears()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                var retained = item;
+                if (Environment.TickCount == 0)
+                {
+                    retained = default;
+                }
+                else
+                {
+                    retained = default;
+                }
+
+                retained = item;
+                await Task.Yield();
+                Console.WriteLine(retained.RetryNumber);
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Combined_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -1389,6 +1418,19 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleImmediatelyInvokedDelegate = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        ((Action)(() => _ = AuditAsync(item)))();
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleAwaitWrapper = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -1501,6 +1543,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleLocalFunctionDiscard.ChangedText).IsNull();
         await Assert.That(incompatibleDelegateLocalDiscard.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleDelegateLocalDiscard.ChangedText).IsNull();
+        await Assert.That(incompatibleImmediatelyInvokedDelegate.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleImmediatelyInvokedDelegate.ChangedText).IsNull();
         await Assert.That(incompatibleAwaitWrapper.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleAwaitWrapper.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);
@@ -1803,9 +1847,47 @@ public class PipelineHazardAnalyzerTests
                     });
             }
             """);
+        var shadowedField = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        RetryEvent _event = item;
+                        _ = Task.Run(() => Consume(this._event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+        var memberNameCollision = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private readonly Holder _holder = new();
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = _holder.item;
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+
+                private sealed class Holder
+                {
+                    public RetryEvent item;
+                }
+            }
+            """);
 
         await Assert.That(unrelatedCallback).IsEmpty();
         await Assert.That(parameterlessCallback).IsEmpty();
+        await Assert.That(shadowedField).IsEmpty();
+        await Assert.That(memberNameCollision).IsEmpty();
     }
 
     [Test]
@@ -1825,6 +1907,29 @@ public class PipelineHazardAnalyzerTests
 
                 private void ProcessStored() =>
                     Console.WriteLine(_event.Context.ShieldName);
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Proven_Event_Fields_Into_Scheduled_Methods()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = Task.Run(ProcessStored);
+                    });
+
+                private void ProcessStored() => Consume(_event);
+                private static void Consume(RetryEvent item) { }
             }
             """);
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -2213,6 +2213,28 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Fresh_Defaults_Passed_To_Scheduled_Helpers()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Schedule()
+                {
+                    _ = Task.Run(() => Consume(default(RetryEvent)));
+                    ThreadPool.QueueUserWorkItem<RetryEvent>(
+                        Consume,
+                        default,
+                        preferLocal: false);
+                }
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Unobserved_Async_Instance_Method_Bodies()
     {
         var diagnostics = await AnalyzeSourceAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -229,6 +229,47 @@ public class PipelineHazardAnalyzerTests
                 }
             }
             """);
+        var constructorWrapper = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder(item);
+                        await Task.Yield();
+                        Consume(holder.Event.Context);
+                    });
+
+                private static void Consume(KevlarContext context) { }
+
+                private sealed class Holder
+                {
+                    public Holder(RetryEvent item)
+                    {
+                        Event = item;
+                    }
+
+                    public RetryEvent Event { get; }
+                }
+            }
+            """);
+        var emptyInitializer = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        var holder = new Holder { };
+                        await Task.Yield();
+                        Console.WriteLine(holder.Value);
+                    });
+
+                private sealed class Holder
+                {
+                    public int Value { get; set; }
+                }
+            }
+            """);
         var collectionWrapper = await AnalyzeSourceAsync("""
             public sealed class TestSubject
             {
@@ -248,6 +289,12 @@ public class PipelineHazardAnalyzerTests
             "KEV014",
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(snapshot, "KEV013");
+        await AssertRuleAsync(Without(constructorWrapper, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(constructorWrapper, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(emptyInitializer, "KEV013");
         await AssertRuleAsync(Without(collectionWrapper, "KEV014"), "KEV013");
         await AssertRuleAsync(
             Without(collectionWrapper, "KEV013"),

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1138,6 +1138,19 @@ public class PipelineHazardAnalyzerTests
                 private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
             }
             """);
+        var incompatibleAsyncDiscardingBlock = await GetCodeFixAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = async item =>
+                    {
+                        _ = AuditAsync(item);
+                        await Task.Yield();
+                    });
+
+                private static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            }
+            """);
         var incompatibleTimedWait = await GetCodeFixAsync("""
             public class TestSubject
             {
@@ -1217,6 +1230,8 @@ public class PipelineHazardAnalyzerTests
         await Assert.That(incompatibleCoalescingAssignment.ChangedText).IsNull();
         await Assert.That(incompatibleDiscardingBlock.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleDiscardingBlock.ChangedText).IsNull();
+        await Assert.That(incompatibleAsyncDiscardingBlock.ActionCount).IsEqualTo(0);
+        await Assert.That(incompatibleAsyncDiscardingBlock.ChangedText).IsNull();
         await Assert.That(incompatibleTimedWait.ActionCount).IsEqualTo(0);
         await Assert.That(incompatibleTimedWait.ChangedText).IsNull();
         await Assert.That(incompatibleCollectionAdd.ActionCount).IsEqualTo(0);
@@ -1394,6 +1409,36 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Unobserved_Async_Instance_Method_Bodies()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        _ = AuditStoredAsync();
+                    });
+
+                private async Task AuditStoredAsync()
+                {
+                    await Task.Yield();
+                    Console.WriteLine(_event.Context.ShieldName);
+                }
+            }
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -130,6 +130,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Ignores_Async_Void_Event_Use_Before_Await()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = RetryAsyncVoid);
+
+                private static async void RetryAsyncVoid(RetryEvent item)
+                {
+                    _ = item.Context.ShieldName;
+                    await Task.Yield();
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
+    }
+
+    [Test]
     public async Task KEV013_Follows_Stable_Callback_Local_Initializers()
     {
         var trailingStatements = new[] { "", "callback = _ => { };" };

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -1819,6 +1819,61 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Event_Member_Provenance_Across_Branches()
+    {
+        var retainedOnOneBranch = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        if (Environment.TickCount == 0)
+                        {
+                            _event = item;
+                        }
+                        else
+                        {
+                            _event = default;
+                        }
+
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+        var clearedOnEveryBranch = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                private RetryEvent _event;
+
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        _event = item;
+                        if (Environment.TickCount == 0)
+                        {
+                            _event = default;
+                        }
+                        else
+                        {
+                            _event = default;
+                        }
+
+                        _ = Task.Run(() => Consume(_event));
+                    });
+
+                private static void Consume(RetryEvent item) { }
+            }
+            """);
+
+        await AssertRuleAsync(retainedOnOneBranch, "KEV014", DiagnosticSeverity.Warning);
+        await Assert.That(clearedOnEveryBranch).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Ignores_Unproven_Member_Assignments_In_Scheduled_Work()
     {
         var unrelatedCallback = await AnalyzeSourceAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -427,6 +427,26 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Distinguishes_Member_And_Parameter_Names()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            var holder = (item: default(RetryEvent), other: 0);
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                holder.item = default;
+                await Task.Yield();
+                _ = item.Context.ShieldName;
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Follows_Assigned_Event_Fields_After_Await()
     {
         var diagnostics = await AnalyzeSourceAsync("""
@@ -783,6 +803,27 @@ public class PipelineHazardAnalyzerTests
             });
 
             static Task AuditAsync(RetryEvent item) => Task.CompletedTask;
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV013_Rejects_Conditional_Task_Local_Joins()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            var skip = Environment.TickCount == 0;
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var pending = AuditAsync(item);
+                _ = skip ? 0 : pending.GetAwaiter().GetResult();
+            });
+
+            static Task<int> AuditAsync(RetryEvent item) => Task.FromResult(0);
             """);
 
         await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -73,6 +73,49 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_Nested_PostAwait_Local_Function_Calls()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                await Task.Yield();
+                ReadContext();
+
+                void ReadContext() => ReadInner();
+                void ReadInner() => Console.WriteLine(item.Context.ShieldName);
+            });
+            """);
+
+        await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+        await AssertRuleAsync(
+            Without(diagnostics, "KEV013"),
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Async_Anonymous_Function_Syntaxes()
+    {
+        var callbacks = new[]
+        {
+            "async (RetryEvent item) => { await Task.Yield(); _ = item.Context.ShieldName; }",
+            "async delegate(RetryEvent item) { await Task.Yield(); _ = item.Context.ShieldName; }",
+        };
+        foreach (var callback in callbacks)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = {{callback}});
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
     public async Task KEV014_Inspects_Combined_Async_Delegates()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -262,6 +305,10 @@ public class PipelineHazardAnalyzerTests
     {
         var expressions = new[]
         {
+            (Initializer: "item", Use: "retained.Context.ShieldName"),
+            (Initializer: "(RetryEvent)item", Use: "retained.Context.ShieldName"),
+            (Initializer: "(item)", Use: "retained.Context.ShieldName"),
+            (Initializer: "item!", Use: "retained.Context.ShieldName"),
             (Initializer: "item.Context", Use: "retained.ShieldName"),
             (Initializer: "item.Context.Properties", Use: "retained.Count"),
         };
@@ -282,6 +329,22 @@ public class PipelineHazardAnalyzerTests
                 "KEV014",
                 DiagnosticSeverity.Warning);
         }
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Reassigned_Async_Event_Aliases()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = async item =>
+            {
+                var retained = item;
+                retained = default;
+                await Task.Yield();
+                _ = retained.Context.ShieldName;
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV013");
     }
 
     [Test]
@@ -541,6 +604,10 @@ public class PipelineHazardAnalyzerTests
             "AuditValueAsync(item).AsTask().GetAwaiter().GetResult();",
             "AuditValueAsync(item).ConfigureAwait(false).GetAwaiter().GetResult();",
             "AuditValueAsync(item).AsTask().Wait();",
+            "FlushAsync().GetAwaiter().GetResult();",
+            "FlushAsync().ConfigureAwait(false).GetAwaiter().GetResult();",
+            "FlushValueAsync().GetAwaiter().GetResult();",
+            "FlushValueAsync().ConfigureAwait(false).GetAwaiter().GetResult();",
             "var pending = AuditAsync(item); pending.GetAwaiter().GetResult();",
             "var pending = AuditAsync(item); pending.Wait();",
             "var pending = AuditAsync(item); _ = pending.Result;",
@@ -557,6 +624,7 @@ public class PipelineHazardAnalyzerTests
                 static ValueTask<RetryEvent> AuditValueAsync(RetryEvent item) =>
                     ValueTask.FromResult(item);
                 static Task FlushAsync() => Task.CompletedTask;
+                static ValueTask FlushValueAsync() => ValueTask.CompletedTask;
                 """);
 
             await Assert.That(diagnostics).IsEmpty();
@@ -1313,7 +1381,9 @@ public class PipelineHazardAnalyzerTests
         var cases = new[]
         {
             "enabled ? (object)item.Context : new object()",
+            "enabled ? new object() : (object)item.Context",
             "(object?)item.Context ?? new object()",
+            "(object?)null ?? item.Context",
             "enabled switch { true => (object)item.Context, false => new object() }",
         };
 
@@ -1329,6 +1399,52 @@ public class PipelineHazardAnalyzerTests
                 """);
 
             await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Retained_Composite_Task_Arguments()
+    {
+        var statements = new[]
+        {
+            "_ = AuditAsync(enabled ? (object)item : new object());",
+            "_ = AuditAsync((object?)item ?? new object());",
+            "_ = AuditAsync(enabled switch { true => (object)item, false => new object() });",
+            "_ = AuditAsync(new object[] { item });",
+            "_ = AuditAsync(((object)item, 0));",
+            "_ = AuditAsync(new WorkState((object)item));",
+            "_ = AuditAsync(new WorkState(new object()) { Value = (object)item });",
+            "_ = AuditAsync(new System.Collections.Generic.List<object> { item });",
+            "var template = new WorkState(new object()); _ = AuditAsync(template with { Value = (object)item });",
+            "_ = AuditAsync(new { Value = (object)item });",
+            "_ = AuditArrayAsync([item]);",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeSourceAsync($$"""
+                public sealed record WorkState(object Value);
+
+                public sealed class TestSubject
+                {
+                    public void Configure()
+                    {
+                        var enabled = true;
+                        _ = Shield.Retry(options => options.OnRetry = item =>
+                        {
+                            {{statement}}
+                        });
+                    }
+
+                    private static Task AuditAsync(object state) => Task.CompletedTask;
+                    private static Task AuditArrayAsync(object[] state) => Task.CompletedTask;
+                }
+                """);
+
+            await AssertRuleAsync(Without(diagnostics, "KEV014"), "KEV013");
+            await AssertRuleAsync(
+                Without(diagnostics, "KEV013"),
+                "KEV014",
+                DiagnosticSeverity.Warning);
         }
     }
 
@@ -1460,6 +1576,31 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Inspects_Conditional_Deferred_Delegate_Initializers()
+    {
+        var initializers = new[]
+        {
+            "enabled ? (Action)(() => Console.WriteLine(item.Context.ShieldName)) : () => { }",
+            "enabled ? (Action)(() => { }) : () => Console.WriteLine(item.Context.ShieldName)",
+            "existing ?? (() => Console.WriteLine(item.Context.ShieldName))",
+        };
+        foreach (var initializer in initializers)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                var enabled = true;
+                Action? existing = null;
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    Action work = {{initializer}};
+                    _ = Task.Run(work);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
     }
 
     [Test]

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Kevlar" VersionOverride="$(KevlarPackageVersion)" />
-    <PackageReference Include="Kevlar.Analyzers" VersionOverride="$(KevlarPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Kevlar.Chaos" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.Grpc" VersionOverride="$(KevlarPackageVersion)" />


### PR DESCRIPTION
## Summary

- add KEV013 for asynchronous work assigned to synchronous callbacks, with a code fix
- add KEV014 as a warning for pooled event/context values retained by deferred work
- bundle analyzer and code-fix assemblies into the `Kevlar` package under `analyzers/dotnet/cs`
- stop producing a separate `Kevlar.Analyzers` package
- leave runtime source, public API, and hot-path execution unchanged

## Motivation

Runtime context lease guards added overhead to every execution. This uses build-time diagnostics instead, so safe code pays no runtime cost and consumers receive the analyzers automatically by referencing `Kevlar`.

Closes #222

## Validation

- `dotnet build Kevlar.slnx -c Release -p:Version=0.0.0-local`
- analyzer tests: 144 passed
- package verification: layout, symbols, determinism, SourceLink, consumers, publish compatibility, and analyzer auto-loading passed
- documentation snippets: 188 compiled and executed for .NET 8 and .NET 10