### PR TITLE
perf(metrics): publish observable state gauges

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/StateMetricsContentionBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/StateMetricsContentionBenchmarks.cs
@@ -1,0 +1,62 @@
+using System.Diagnostics.Metrics;
+using BenchmarkDotNet.Attributes;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>
+/// Measures stateful strategy execution with state instruments subscribed while one or many
+/// workers contend for the same strategy instance.
+/// </summary>
+[MemoryDiagnoser]
+[ThreadingDiagnoser]
+public class StateMetricsContentionBenchmarks
+{
+    private static readonly Shield CircuitBreaker =
+        Shield.CircuitBreaker(1_000_000, TimeSpan.FromMinutes(1)).WithName("contention");
+    private static readonly Shield ConcurrencyLimit =
+        Shield.ConcurrencyLimit(1024).WithName("contention");
+    private static readonly Shield RateLimit =
+        Shield.RateLimit(1_000_000_000, TimeSpan.FromSeconds(1)).WithName("contention");
+
+    private MeterListener? _listener;
+
+    [Params(1, 16)]
+    public int WorkerCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == KevlarDiagnostics.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        _listener.SetMeasurementEventCallback<long>(static (_, _, _, _) => { });
+        _listener.SetMeasurementEventCallback<double>(static (_, _, _, _) => { });
+        _listener.Start();
+
+        CircuitBreaker.Execute(static _ => { });
+        ConcurrencyLimit.Execute(static _ => { });
+        RateLimit.Execute(static _ => { });
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _listener?.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public void CircuitBreakerExecution() =>
+        Parallel.For(0, WorkerCount, static _ => CircuitBreaker.Execute(static _ => { }));
+
+    [Benchmark]
+    public void ConcurrencyLimitExecution() =>
+        Parallel.For(0, WorkerCount, static _ => ConcurrencyLimit.Execute(static _ => { }));
+
+    [Benchmark]
+    public void RateLimitExecution() =>
+        Parallel.For(0, WorkerCount, static _ => RateLimit.Execute(static _ => { }));
+}

--- a/benchmarks/Kevlar.Benchmarks/TelemetryBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/TelemetryBenchmarks.cs
@@ -5,7 +5,7 @@ namespace Kevlar.Benchmarks;
 
 /// <summary>
 /// Telemetry overhead on representative synchronously-completing happy paths. The disabled
-/// parameter measures the normal no-listener path; the enabled parameter records every
+/// parameter measures the normal no-listener path; the enabled parameter subscribes every
 /// instrument through a minimal <see cref="MeterListener"/>.
 /// </summary>
 [MemoryDiagnoser]

--- a/docs/api/Kevlar.Testing.TelemetryRecorder.yml
+++ b/docs/api/Kevlar.Testing.TelemetryRecorder.yml
@@ -353,7 +353,10 @@ items:
   assemblies:
   - Kevlar.Testing
   namespace: Kevlar.Testing
-  summary: Waits until at least <code class="paramref">count</code> metrics have been captured.
+  summary: >-
+    Waits until at least <code class="paramref">count</code> metrics have been captured, collecting
+
+    observable instruments while waiting.
   example: []
   syntax:
     content: public Task WaitForMetricCountAsync(int count, CancellationToken cancellationToken = default)

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -78,12 +78,12 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics
 | `kevlar.execution.duration` | Histogram | `s` | `net8.0` | completed public execution duration | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
 | `kevlar.strategy.events` | Counter | `{event}` | `net8.0` | built-in strategy and caller-recorded events | `kevlar.shield.name`, `kevlar.strategy.index`, `kevlar.strategy.name`, `kevlar.event.name`, `kevlar.event.severity`, `kevlar.attempt.number`, optional `exception.type`, optional `kevlar.operation.key` |
 | `kevlar.attempt.duration` | Histogram | `ms` | `net8.0` | retry attempt duration, including the initial attempt | `kevlar.shield.name`, `kevlar.strategy.index`, `kevlar.strategy.name`, `kevlar.event.name`, `kevlar.event.severity`, `kevlar.attempt.number`, optional `exception.type`, optional `kevlar.operation.key` |
-| `kevlar.circuit_breaker.state` | Gauge | `{state}` | `net10.0` | last observed circuit state: closed `0`, open `1`, half-open `2`, isolated `3` | `kevlar.shield.name`, `kevlar.strategy.index` |
-| `kevlar.concurrency_limit.inflight` | Gauge | `{execution}` | `net10.0` | executions holding a permit | `kevlar.shield.name`, `kevlar.strategy.index` |
-| `kevlar.concurrency_limit.queued` | Gauge | `{execution}` | `net10.0` | executions waiting for a permit | `kevlar.shield.name`, `kevlar.strategy.index` |
-| `kevlar.concurrency_limit.capacity` | Gauge | `{execution}` | `net10.0` | configured concurrency permit capacity | `kevlar.shield.name`, `kevlar.strategy.index` |
-| `kevlar.rate_limit.available` | Gauge | `{permit}` | `net10.0` | immediately available burst permits at the last limiter operation | `kevlar.shield.name`, `kevlar.strategy.index` |
-| `kevlar.rate_limit.queued` | Gauge | `{execution}` | `net10.0` | executions waiting for a rate-limit permit | `kevlar.shield.name`, `kevlar.strategy.index` |
+| `kevlar.circuit_breaker.state` | ObservableGauge | `{state}` | `net10.0` | current circuit state: closed `0`, open `1`, half-open `2`, isolated `3` | `kevlar.shield.name`, `kevlar.strategy.index` |
+| `kevlar.concurrency_limit.inflight` | ObservableGauge | `{execution}` | `net10.0` | executions holding a permit | `kevlar.shield.name`, `kevlar.strategy.index` |
+| `kevlar.concurrency_limit.queued` | ObservableGauge | `{execution}` | `net10.0` | executions waiting for a permit | `kevlar.shield.name`, `kevlar.strategy.index` |
+| `kevlar.concurrency_limit.capacity` | ObservableGauge | `{execution}` | `net10.0` | configured concurrency permit capacity | `kevlar.shield.name`, `kevlar.strategy.index` |
+| `kevlar.rate_limit.available` | ObservableGauge | `{permit}` | `net10.0` | immediately available burst permits at collection time | `kevlar.shield.name`, `kevlar.strategy.index` |
+| `kevlar.rate_limit.queued` | ObservableGauge | `{execution}` | `net10.0` | executions waiting for a rate-limit permit | `kevlar.shield.name`, `kevlar.strategy.index` |
 | `kevlar.chaos.injections` | Counter | `{injection}` | `net8.0` | chaos injections applied | `kevlar.chaos.kind`, `kevlar.shield.name`, `kevlar.chaos.operation`, `kevlar.chaos.environment` |
 
 Each public execution call records exactly one `kevlar.executions` measurement after its final outcome: recovery through fallback is `success`; exceptions, caller cancellation, timeout, and strategy rejection are `failure`. Retry and hedge attempts do not add execution measurements of their own.
@@ -133,7 +133,7 @@ its `Events` property and `WaitForEventCountAsync`. Kevlar intentionally does no
 `ActivitySource` spans: use the metrics and listener hook to enrich the tracing system already owned
 by the application or transport.
 
-The gauges are synchronous last-value measurements emitted when strategy state changes. They aggregate by shield name and carry a bounded `kevlar.strategy.index` attribute (the strategy's zero-based pipeline position), so independent stateful strategies in one named pipeline remain distinct. Shared strategies update up to 64 observed name/index aliases; additional aliases omit state-gauge measurements to bound memory, transition work, and series growth. The gauges do not use observable callbacks or global strategy registries, so telemetry never keeps an abandoned shield alive.
+The state gauges are observable instruments sampled only when the metrics reader collects them. They read the strategies' existing synchronized state instead of publishing from execution paths, so enabling state metrics adds no state-publication locks or listener callbacks to each execution. Listener failures therefore remain confined to collection. Gauges aggregate by shield name and carry a bounded `kevlar.strategy.index` attribute (the strategy's zero-based pipeline position), so independent stateful strategies in one named pipeline remain distinct. Shared strategies expose up to 64 observed name/index aliases; additional aliases are omitted to bound memory and series growth. Registrations hold strategy instances weakly and discard collected registrations during observation, so telemetry does not keep an abandoned shield alive.
 
 This executable example verifies a completed execution with `MeterListener`:
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -179,7 +179,7 @@ Exporter naming rules vary; inspect the exported names if your backend applies a
 
 ### Telemetry overhead
 
-Telemetry cost depends on the runtime, pipeline, listener, exporter, and deployment hardware. See [Benchmarks](benchmarks.md) for the current methodology and generated results. Run `TelemetryBenchmarks` on deployment-class hardware to measure the cost in your environment.
+Telemetry cost depends on the runtime, pipeline, listener, exporter, and deployment hardware. State-gauge collection may take strategy-internal synchronization while it reads a snapshot, but shield execution never takes a telemetry publication lock. See [Benchmarks](benchmarks.md) for the current methodology and generated results. Run `TelemetryBenchmarks` and `StateMetricsContentionBenchmarks` on deployment-class hardware to measure the cost in your environment.
 
 ## Compile-time checks
 

--- a/docs/docs/strategies/concurrency-limit.md
+++ b/docs/docs/strategies/concurrency-limit.md
@@ -37,9 +37,10 @@ and identify the options type, property, and offending value.
 
 Total capacity is `MaxConcurrency + QueueLimit`. Anything beyond that fails **immediately** with `ConcurrencyLimitExceededException` — the overflow check happens before any waiting, so rejection is instant and allocation-light.
 
-For an actual rejection, Kevlar publishes current limiter state and rejection metrics, invokes
-`OnRejected`, awaits `OnRejectedAsync`, then surfaces `ConcurrencyLimitExceededException`. The
-event includes the configured concurrency/queue limits, strategy index, and `KevlarContext`.
+For an actual rejection, Kevlar records the rejection counter, invokes `OnRejected`, awaits
+`OnRejectedAsync`, then surfaces `ConcurrencyLimitExceededException`. Observable limiter gauges
+report the current state at the next metrics collection. The event includes the configured
+concurrency/queue limits, strategy index, and `KevlarContext`.
 Callback failures are reported through `KevlarDiagnostics.OnCallbackError`; both callbacks still
 run and `ConcurrencyLimitExceededException` remains the rejection outcome.
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -194,7 +194,8 @@ if (retry.Kind != CallbackKind.Retry || retry.RetryNumber != 1 || retry.ShieldNa
 Callback recording works from the `netstandard2.0` asset. Metric capture needs the .NET 8 or
 .NET 10 `Kevlar.Testing` asset because `MeterListener` is unavailable in the compatibility asset.
 Use `captureMetrics: false` for callback-only tests, and always dispose the recorder to detach its
-listener. `WaitForMetricCountAsync` and `WaitForCallbackCountAsync` avoid polling concurrent tests.
+listener. Reading `Metrics` collects observable state gauges before returning the immutable
+snapshot. `WaitForMetricCountAsync` and `WaitForCallbackCountAsync` avoid polling concurrent tests.
 
 ## Testing HTTP shields
 

--- a/src/Kevlar.Testing/TelemetryRecorder.cs
+++ b/src/Kevlar.Testing/TelemetryRecorder.cs
@@ -199,7 +199,11 @@ public sealed class TelemetryRecorder : IDisposable, IKevlarTelemetryListener
 
     /// <summary>Waits until at least <paramref name="count"/> telemetry events have been captured.</summary>
     public Task WaitForEventCountAsync(int count, CancellationToken cancellationToken = default) =>
-        WaitForCountAsync(static recorder => recorder._events.Count, count, cancellationToken);
+        WaitForCountAsync(
+            static recorder => recorder._events.Count,
+            count,
+            collectObservableMetrics: false,
+            cancellationToken);
 
     /// <inheritdoc />
     void IKevlarTelemetryListener.OnEvent(in KevlarTelemetryEvent telemetryEvent)

--- a/src/Kevlar.Testing/TelemetryRecorder.cs
+++ b/src/Kevlar.Testing/TelemetryRecorder.cs
@@ -178,13 +178,24 @@ public sealed class TelemetryRecorder : IDisposable, IKevlarTelemetryListener
             item.ConsecutiveFailures,
             breakDuration);
 
-    /// <summary>Waits until at least <paramref name="count"/> metrics have been captured.</summary>
+    /// <summary>
+    /// Waits until at least <paramref name="count"/> metrics have been captured, collecting
+    /// observable instruments while waiting.
+    /// </summary>
     public Task WaitForMetricCountAsync(int count, CancellationToken cancellationToken = default) =>
-        WaitForCountAsync(static recorder => recorder._metrics.Count, count, cancellationToken);
+        WaitForCountAsync(
+            static recorder => recorder._metrics.Count,
+            count,
+            collectObservableMetrics: true,
+            cancellationToken);
 
     /// <summary>Waits until at least <paramref name="count"/> callbacks have been captured.</summary>
     public Task WaitForCallbackCountAsync(int count, CancellationToken cancellationToken = default) =>
-        WaitForCountAsync(static recorder => recorder._callbacks.Count, count, cancellationToken);
+        WaitForCountAsync(
+            static recorder => recorder._callbacks.Count,
+            count,
+            collectObservableMetrics: false,
+            cancellationToken);
 
     /// <summary>Waits until at least <paramref name="count"/> telemetry events have been captured.</summary>
     public Task WaitForEventCountAsync(int count, CancellationToken cancellationToken = default) =>
@@ -315,6 +326,7 @@ public sealed class TelemetryRecorder : IDisposable, IKevlarTelemetryListener
     private async Task WaitForCountAsync(
         Func<TelemetryRecorder, int> getCount,
         int count,
+        bool collectObservableMetrics,
         CancellationToken cancellationToken)
     {
         if (count < 0)
@@ -324,6 +336,13 @@ public sealed class TelemetryRecorder : IDisposable, IKevlarTelemetryListener
 
         while (true)
         {
+            if (collectObservableMetrics)
+            {
+#if NET8_0_OR_GREATER
+                _listener?.RecordObservableInstruments();
+#endif
+            }
+
             Task signal;
             lock (_gate)
             {
@@ -340,7 +359,16 @@ public sealed class TelemetryRecorder : IDisposable, IKevlarTelemetryListener
                 signal = _changed.Task;
             }
 
-            await WaitWithCancellationAsync(signal, cancellationToken).ConfigureAwait(false);
+            if (collectObservableMetrics)
+            {
+                var pollingDelay = Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
+                var completed = await Task.WhenAny(signal, pollingDelay).ConfigureAwait(false);
+                await completed.ConfigureAwait(false);
+            }
+            else
+            {
+                await WaitWithCancellationAsync(signal, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/src/Kevlar.Testing/TelemetryRecorder.cs
+++ b/src/Kevlar.Testing/TelemetryRecorder.cs
@@ -81,6 +81,9 @@ public sealed class TelemetryRecorder : IDisposable, IKevlarTelemetryListener
     {
         get
         {
+#if NET8_0_OR_GREATER
+            _listener?.RecordObservableInstruments();
+#endif
             lock (_gate)
             {
                 return _metrics.ToArray();

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -20,6 +20,9 @@ internal static class KevlarMetrics
     private const int _minimumCachedStrategyIndex = -1;
     private const int _maximumCachedStrategyIndex = 63;
     private static readonly object[] _boxedStrategyIndexes = CreateBoxedStrategyIndexes();
+#endif
+
+#if NET9_0_OR_GREATER
     private static readonly StateMetricRegistry<CircuitBreakerStrategy> CircuitStates = new();
     private static readonly StateMetricRegistry<ConcurrencyLimitStrategy> ConcurrencyStates = new();
     private static readonly StateMetricRegistry<RateLimitStrategy> RateStates = new();
@@ -375,12 +378,6 @@ internal static class KevlarMetrics
 #endif
     }
 
-    public static void RecordCircuitState(
-        string? shieldName,
-        int strategyIndex,
-        CircuitState state)
-    {
-#if NET9_0_OR_GREATER
     public static StateMetricRegistration<CircuitBreakerStrategy> RegisterCircuitStateSource(
         CircuitBreakerStrategy strategy) =>
 #if NET9_0_OR_GREATER
@@ -467,6 +464,263 @@ internal static class KevlarMetrics
         KevlarTelemetrySeverity.Error => "error",
         _ => "information",
     };
+
+#if NET9_0_OR_GREATER
+    internal sealed class StateMetricRegistration<TStrategy>
+        where TStrategy : class
+    {
+        private readonly Lock _gate = new();
+        private readonly StateMetricRegistry<TStrategy> _registry;
+        private readonly WeakReference<TStrategy> _strategy;
+        private StateMetricObservation[] _observations = [];
+        private int _published;
+
+        public StateMetricRegistration(
+            TStrategy strategy,
+            StateMetricRegistry<TStrategy> registry)
+        {
+            _strategy = new WeakReference<TStrategy>(strategy);
+            _registry = registry;
+        }
+
+        public StateMetricObservation[] Observations => Volatile.Read(ref _observations);
+
+        public bool HasObservations => Observations.Length != 0;
+
+        public bool TryGetStrategy(out TStrategy? strategy) => _strategy.TryGetTarget(out strategy);
+
+        public void Add(StrategyMetricAlias alias, TimeProvider? timeProvider = null)
+        {
+            var observations = Volatile.Read(ref _observations);
+            if (HasCurrentObservation(observations, alias, timeProvider))
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                observations = _observations;
+                if (TryUpdate(observations, alias, timeProvider))
+                {
+                    return;
+                }
+
+                if (observations.Length >= MaxTrackedStrategyAliases)
+                {
+                    var live = WithoutCollectedObservations(observations);
+                    if (!ReferenceEquals(live, observations))
+                    {
+                        observations = live;
+                        Volatile.Write(ref _observations, observations);
+                    }
+
+                    if (observations.Length >= MaxTrackedStrategyAliases)
+                    {
+                        return;
+                    }
+                }
+
+                var updated = new StateMetricObservation[observations.Length + 1];
+                observations.CopyTo(updated, 0);
+                updated[^1] = new StateMetricObservation(alias, timeProvider);
+                Volatile.Write(ref _observations, updated);
+            }
+
+            if (observations.Length == 0
+                && Interlocked.Exchange(ref _published, 1) == 0)
+            {
+                _registry.Publish(this);
+            }
+        }
+
+        public void RemoveCollectedObservations()
+        {
+            lock (_gate)
+            {
+                var observations = _observations;
+                var live = WithoutCollectedObservations(observations);
+                if (!ReferenceEquals(live, observations))
+                {
+                    Volatile.Write(ref _observations, live);
+                }
+            }
+        }
+
+        private static bool HasCurrentObservation(
+            StateMetricObservation[] observations,
+            StrategyMetricAlias alias,
+            TimeProvider? timeProvider)
+        {
+            foreach (var observation in observations)
+            {
+                if (observation.Alias == alias)
+                {
+                    return observation.TryGetTimeProvider(out var currentTimeProvider)
+                        && ReferenceEquals(currentTimeProvider, timeProvider);
+                }
+            }
+
+            return false;
+        }
+
+        private static StateMetricObservation[] WithoutCollectedObservations(
+            StateMetricObservation[] observations)
+        {
+            var firstCollected = -1;
+            for (var index = 0; index < observations.Length; index++)
+            {
+                if (!observations[index].TryGetTimeProvider(out _))
+                {
+                    firstCollected = index;
+                    break;
+                }
+            }
+
+            if (firstCollected < 0)
+            {
+                return observations;
+            }
+
+            var live = new StateMetricObservation[observations.Length - 1];
+            Array.Copy(observations, live, firstCollected);
+            var count = firstCollected;
+            for (var index = firstCollected + 1; index < observations.Length; index++)
+            {
+                var observation = observations[index];
+                if (observation.TryGetTimeProvider(out _))
+                {
+                    live[count++] = observation;
+                }
+            }
+
+            Array.Resize(ref live, count);
+            return live;
+        }
+
+        private static bool TryUpdate(
+            StateMetricObservation[] observations,
+            StrategyMetricAlias alias,
+            TimeProvider? timeProvider)
+        {
+            foreach (var observation in observations)
+            {
+                if (observation.Alias == alias)
+                {
+                    if (!observation.TryGetTimeProvider(out var currentTimeProvider)
+                        || !ReferenceEquals(currentTimeProvider, timeProvider))
+                    {
+                        observation.SetTimeProvider(timeProvider);
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    internal sealed class StateMetricRegistry<TStrategy>
+        where TStrategy : class
+    {
+        private readonly Lock _gate = new();
+        private WeakReference<StateMetricRegistration<TStrategy>>[] _registrations = [];
+
+        public StateMetricRegistration<TStrategy> Register(TStrategy strategy) => new(strategy, this);
+
+        public void Publish(StateMetricRegistration<TStrategy> registration)
+        {
+            lock (_gate)
+            {
+                var registrations = _registrations;
+                var updated = new WeakReference<StateMetricRegistration<TStrategy>>[registrations.Length + 1];
+                var count = 0;
+                foreach (var reference in registrations)
+                {
+                    if (reference is not null && reference.TryGetTarget(out _))
+                    {
+                        updated[count++] = reference;
+                    }
+                }
+
+                updated[count++] = new WeakReference<StateMetricRegistration<TStrategy>>(registration);
+                if (count != updated.Length)
+                {
+                    Array.Resize(ref updated, count);
+                }
+
+                Volatile.Write(ref _registrations, updated);
+            }
+        }
+
+        public IEnumerable<Measurement<long>> Observe(Func<TStrategy, TimeProvider?, long> observe)
+        {
+            var registrations = Volatile.Read(ref _registrations);
+            var hasCollectedRegistration = false;
+            foreach (var reference in registrations)
+            {
+                if (reference is null
+                    || !reference.TryGetTarget(out var registration)
+                    || !registration.TryGetStrategy(out var strategy))
+                {
+                    hasCollectedRegistration = true;
+                    continue;
+                }
+
+                var hasCollectedObservation = false;
+                foreach (var observation in registration.Observations)
+                {
+                    if (!observation.TryGetTimeProvider(out var timeProvider))
+                    {
+                        hasCollectedObservation = true;
+                        continue;
+                    }
+
+                    yield return new Measurement<long>(
+                        observe(strategy!, timeProvider),
+                        StateTags(observation.Alias.ShieldName, observation.Alias.StrategyIndex));
+                }
+
+                if (hasCollectedObservation)
+                {
+                    registration.RemoveCollectedObservations();
+                }
+            }
+
+            if (hasCollectedRegistration)
+            {
+                RemoveCollectedRegistrations();
+            }
+        }
+
+        private void RemoveCollectedRegistrations()
+        {
+            lock (_gate)
+            {
+                var registrations = _registrations;
+                var live = new WeakReference<StateMetricRegistration<TStrategy>>[registrations.Length];
+                var count = 0;
+                foreach (var reference in registrations)
+                {
+                    if (reference is not null
+                        && reference.TryGetTarget(out var registration)
+                        && registration.TryGetStrategy(out _))
+                    {
+                        live[count++] = reference;
+                    }
+                }
+
+                if (count == registrations.Length)
+                {
+                    return;
+                }
+
+                Array.Resize(ref live, count);
+                Volatile.Write(ref _registrations, live);
+            }
+        }
+    }
+#endif
 #endif
 
     private static string StateName(CircuitState state) => state switch
@@ -518,6 +772,20 @@ internal static class KevlarMetrics
         "concurrency_limit" => "ConcurrencyLimit",
         _ => "Rejection",
     };
+
+#if !NET9_0_OR_GREATER
+    internal sealed class StateMetricRegistration<TStrategy>
+        where TStrategy : class
+    {
+        public static StateMetricRegistration<TStrategy> Disabled { get; } = new();
+
+        public bool HasObservations => false;
+
+        public void Add(StrategyMetricAlias alias, TimeProvider? timeProvider = null)
+        {
+        }
+    }
+#endif
 }
 
 internal readonly record struct StrategyMetricAlias(string? ShieldName, int StrategyIndex);

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -525,19 +525,31 @@ internal readonly record struct StrategyMetricAlias(string? ShieldName, int Stra
 #if NET9_0_OR_GREATER
 internal sealed class StateMetricObservation
 {
-    private TimeProvider? _timeProvider;
+    private WeakReference<TimeProvider>? _timeProvider;
 
     public StateMetricObservation(StrategyMetricAlias alias, TimeProvider? timeProvider)
     {
         Alias = alias;
-        _timeProvider = timeProvider;
+        SetTimeProvider(timeProvider);
     }
 
     public StrategyMetricAlias Alias { get; }
 
-    public TimeProvider? TimeProvider => Volatile.Read(ref _timeProvider);
+    public bool TryGetTimeProvider(out TimeProvider? timeProvider)
+    {
+        var reference = Volatile.Read(ref _timeProvider);
+        if (reference is null)
+        {
+            timeProvider = null;
+            return true;
+        }
+
+        return reference.TryGetTarget(out timeProvider);
+    }
 
     public void SetTimeProvider(TimeProvider? timeProvider) =>
-        Volatile.Write(ref _timeProvider, timeProvider);
+        Volatile.Write(
+            ref _timeProvider,
+            timeProvider is null ? null : new WeakReference<TimeProvider>(timeProvider));
 }
 #endif

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -383,16 +383,29 @@ internal static class KevlarMetrics
 #if NET9_0_OR_GREATER
     public static StateMetricRegistration<CircuitBreakerStrategy> RegisterCircuitStateSource(
         CircuitBreakerStrategy strategy) =>
+#if NET9_0_OR_GREATER
         CircuitStates.Register(strategy);
+#else
+        StateMetricRegistration<CircuitBreakerStrategy>.Disabled;
+#endif
 
     public static StateMetricRegistration<ConcurrencyLimitStrategy> RegisterConcurrencyStateSource(
         ConcurrencyLimitStrategy strategy) =>
+#if NET9_0_OR_GREATER
         ConcurrencyStates.Register(strategy);
+#else
+        StateMetricRegistration<ConcurrencyLimitStrategy>.Disabled;
+#endif
 
     public static StateMetricRegistration<RateLimitStrategy> RegisterRateStateSource(
         RateLimitStrategy strategy) =>
+#if NET9_0_OR_GREATER
         RateStates.Register(strategy);
+#else
+        StateMetricRegistration<RateLimitStrategy>.Disabled;
+#endif
 
+#if NET9_0_OR_GREATER
     private static IEnumerable<Measurement<long>> ObserveCircuitStates() =>
         CircuitStates.Observe(static (strategy, _) => StateValue(strategy.Core.State));
 

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -20,6 +20,9 @@ internal static class KevlarMetrics
     private const int _minimumCachedStrategyIndex = -1;
     private const int _maximumCachedStrategyIndex = 63;
     private static readonly object[] _boxedStrategyIndexes = CreateBoxedStrategyIndexes();
+    private static readonly StateMetricRegistry<CircuitBreakerStrategy> CircuitStates = new();
+    private static readonly StateMetricRegistry<ConcurrencyLimitStrategy> ConcurrencyStates = new();
+    private static readonly StateMetricRegistry<RateLimitStrategy> RateStates = new();
 #endif
 
 #if NET8_0_OR_GREATER
@@ -75,28 +78,34 @@ internal static class KevlarMetrics
 #endif
 
 #if NET9_0_OR_GREATER
-    private static readonly Gauge<long> CircuitStateGauge = Meter.CreateGauge<long>(
+    private static readonly ObservableGauge<long> CircuitStateGauge = Meter.CreateObservableGauge(
         "kevlar.circuit_breaker.state",
+        ObserveCircuitStates,
         "{state}",
         "Current circuit-breaker state: closed=0, open=1, half-open=2, isolated=3.");
-    private static readonly Gauge<long> ConcurrencyInflight = Meter.CreateGauge<long>(
+    private static readonly ObservableGauge<long> ConcurrencyInflight = Meter.CreateObservableGauge(
         "kevlar.concurrency_limit.inflight",
+        ObserveConcurrencyInflight,
         "{execution}",
         "Executions currently holding a concurrency permit.");
-    private static readonly Gauge<long> ConcurrencyQueued = Meter.CreateGauge<long>(
+    private static readonly ObservableGauge<long> ConcurrencyQueued = Meter.CreateObservableGauge(
         "kevlar.concurrency_limit.queued",
+        ObserveConcurrencyQueued,
         "{execution}",
         "Executions currently waiting for a concurrency permit.");
-    private static readonly Gauge<long> ConcurrencyCapacity = Meter.CreateGauge<long>(
+    private static readonly ObservableGauge<long> ConcurrencyCapacity = Meter.CreateObservableGauge(
         "kevlar.concurrency_limit.capacity",
+        ObserveConcurrencyCapacity,
         "{execution}",
         "Configured concurrency permit capacity.");
-    private static readonly Gauge<long> RateAvailable = Meter.CreateGauge<long>(
+    private static readonly ObservableGauge<long> RateAvailable = Meter.CreateObservableGauge(
         "kevlar.rate_limit.available",
+        ObserveRateAvailable,
         "{permit}",
         "Immediately available rate-limit permits.");
-    private static readonly Gauge<long> RateQueued = Meter.CreateGauge<long>(
+    private static readonly ObservableGauge<long> RateQueued = Meter.CreateObservableGauge(
         "kevlar.rate_limit.queued",
+        ObserveRateQueued,
         "{execution}",
         "Executions currently waiting for a rate-limit permit.");
 #endif
@@ -372,60 +381,36 @@ internal static class KevlarMetrics
         CircuitState state)
     {
 #if NET9_0_OR_GREATER
-        if (CircuitStateGauge.Enabled)
-        {
-            CircuitStateGauge.Record(
-                StateValue(state),
-                StateTags(shieldName, strategyIndex));
-        }
+    public static StateMetricRegistration<CircuitBreakerStrategy> RegisterCircuitStateSource(
+        CircuitBreakerStrategy strategy) =>
+        CircuitStates.Register(strategy);
+
+    public static StateMetricRegistration<ConcurrencyLimitStrategy> RegisterConcurrencyStateSource(
+        ConcurrencyLimitStrategy strategy) =>
+        ConcurrencyStates.Register(strategy);
+
+    public static StateMetricRegistration<RateLimitStrategy> RegisterRateStateSource(
+        RateLimitStrategy strategy) =>
+        RateStates.Register(strategy);
+
+    private static IEnumerable<Measurement<long>> ObserveCircuitStates() =>
+        CircuitStates.Observe(static (strategy, _) => StateValue(strategy.Core.State));
+
+    private static IEnumerable<Measurement<long>> ObserveConcurrencyInflight() =>
+        ConcurrencyStates.Observe(static (strategy, _) => strategy.CaptureState().Running);
+
+    private static IEnumerable<Measurement<long>> ObserveConcurrencyQueued() =>
+        ConcurrencyStates.Observe(static (strategy, _) => strategy.CaptureState().Queued);
+
+    private static IEnumerable<Measurement<long>> ObserveConcurrencyCapacity() =>
+        ConcurrencyStates.Observe(static (strategy, _) => strategy.MaxConcurrency);
+
+    private static IEnumerable<Measurement<long>> ObserveRateAvailable() =>
+        RateStates.Observe(static (strategy, timeProvider) => strategy.CaptureState(timeProvider!).Available);
+
+    private static IEnumerable<Measurement<long>> ObserveRateQueued() =>
+        RateStates.Observe(static (strategy, timeProvider) => strategy.CaptureState(timeProvider!).Queued);
 #endif
-    }
-
-    public static void RecordConcurrencyState(
-        string? shieldName,
-        int strategyIndex,
-        long inflight,
-        long queued,
-        long capacity)
-    {
-#if NET9_0_OR_GREATER
-        var tags = StateTags(shieldName, strategyIndex);
-        if (ConcurrencyInflight.Enabled)
-        {
-            ConcurrencyInflight.Record(inflight, tags);
-        }
-
-        if (ConcurrencyQueued.Enabled)
-        {
-            ConcurrencyQueued.Record(queued, tags);
-        }
-
-        if (ConcurrencyCapacity.Enabled)
-        {
-            ConcurrencyCapacity.Record(capacity, tags);
-        }
-#endif
-    }
-
-    public static void RecordRateState(
-        string? shieldName,
-        int strategyIndex,
-        long available,
-        long queued)
-    {
-#if NET9_0_OR_GREATER
-        var tags = StateTags(shieldName, strategyIndex);
-        if (RateAvailable.Enabled)
-        {
-            RateAvailable.Record(available, tags);
-        }
-
-        if (RateQueued.Enabled)
-        {
-            RateQueued.Record(queued, tags);
-        }
-#endif
-    }
 
 #if NET8_0_OR_GREATER
     private static TagList NameTags(string? shieldName)
@@ -523,3 +508,23 @@ internal static class KevlarMetrics
 }
 
 internal readonly record struct StrategyMetricAlias(string? ShieldName, int StrategyIndex);
+
+#if NET9_0_OR_GREATER
+internal sealed class StateMetricObservation
+{
+    private TimeProvider? _timeProvider;
+
+    public StateMetricObservation(StrategyMetricAlias alias, TimeProvider? timeProvider)
+    {
+        Alias = alias;
+        _timeProvider = timeProvider;
+    }
+
+    public StrategyMetricAlias Alias { get; }
+
+    public TimeProvider? TimeProvider => Volatile.Read(ref _timeProvider);
+
+    public void SetTimeProvider(TimeProvider? timeProvider) =>
+        Volatile.Write(ref _timeProvider, timeProvider);
+}
+#endif

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -115,8 +115,9 @@ internal sealed class CircuitBreakerCore
             ? null
             : new AsyncLocal<TransitionPublication?>();
         _monitor = options.Monitor;
-        _monitor?.Bind(this);
     }
+
+    internal void BindMonitor() => _monitor?.Bind(this);
 
     public string Describe() =>
         _consecutiveFailureLimit is { } limit

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -77,11 +77,6 @@ internal sealed class CircuitBreakerStrategy : Strategy
                 out var rejection,
                 out var admissionGeneration))
         {
-            if (recordState)
-            {
-                RecordState(alias);
-            }
-
             KevlarMetrics.Rejection(context, "circuit_open", rejection!, _core.TelemetryName);
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection!));
         }
@@ -181,11 +176,6 @@ internal sealed class CircuitBreakerStrategy : Strategy
     {
         if (!entry.Allowed)
         {
-            if (recordState)
-            {
-                RecordState(alias);
-            }
-
             KevlarMetrics.Rejection(
                 context,
                 "circuit_open",

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -1,15 +1,15 @@
-using System.Runtime.ExceptionServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
 
 internal sealed class CircuitBreakerStrategy : Strategy
 {
-    private readonly Lock _metricsNamesGate = new();
-    private readonly HashSet<StrategyMetricAlias> _metricsAliases = [];
     protected internal override bool InvokesContinuationAtMostOnce => true;
     private readonly CircuitBreakerCore _core;
     private readonly OutcomeJudge _judge;
+#if NET9_0_OR_GREATER
+    private readonly KevlarMetrics.StateMetricRegistration<CircuitBreakerStrategy> _metricsRegistration;
+#endif
 
     public CircuitBreakerStrategy(CircuitBreakerOptions options, OutcomeJudge judge)
         : this(
@@ -35,6 +35,9 @@ internal sealed class CircuitBreakerStrategy : Strategy
             breakDurationGenerator,
             RecordTransitionState,
             optionsType);
+#if NET9_0_OR_GREATER
+        _metricsRegistration = KevlarMetrics.RegisterCircuitStateSource(this);
+#endif
         _judge = judge;
         HasHandlingOverride = hasHandlingOverride;
     }
@@ -65,10 +68,10 @@ internal sealed class CircuitBreakerStrategy : Strategy
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         var alias = new StrategyMetricAlias(context.ShieldName, context.StrategyIndex);
-        var recordState = RegisterMetricsAlias(alias);
+        RegisterMetricsAlias(alias);
         if (_core.RequiresAsyncExecution)
         {
-            return ExecuteConfiguredAsync(next, context, alias, recordState);
+            return ExecuteConfiguredAsync(next, context);
         }
 
         if (!_core.TryEnter(
@@ -86,46 +89,29 @@ internal sealed class CircuitBreakerStrategy : Strategy
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(rejection!));
         }
 
-        if (recordState)
-        {
-            try
-            {
-                RecordState(alias);
-            }
-            catch
-            {
-                _core.AbandonProbe(admissionGeneration);
-                throw;
-            }
-        }
-
         var execution = next.InvokeAsync(context);
         // Stryker disable once all: Route selection is performance-only; both branches call Complete.
         return execution.IsCompletedSuccessfully
-            ? new ValueTask<Outcome<T>>(Complete(execution.Result, context, admissionGeneration, alias, recordState))
-            : AwaitOutcomeAsync(execution, context, admissionGeneration, alias, recordState);
+            ? new ValueTask<Outcome<T>>(Complete(execution.Result, context, admissionGeneration))
+            : AwaitOutcomeAsync(execution, context, admissionGeneration);
     }
 
     private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,
-        long admissionGeneration,
-        StrategyMetricAlias alias,
-        bool recordState)
+        long admissionGeneration)
     {
         // Stryker disable once all: ConfigureAwait is execution-context policy, not outcome behavior.
         var outcome = await execution.ConfigureAwait(false);
-        return Complete(outcome, context, admissionGeneration, alias, recordState);
+        return Complete(outcome, context, admissionGeneration);
     }
 
     private Outcome<T> Complete<T>(
         Outcome<T> outcome,
         KevlarContext context,
-        long admissionGeneration,
-        StrategyMetricAlias alias,
-        bool recordState)
+        long admissionGeneration)
     {
-        if (_judge.ShouldHandle(in outcome, context, attempt: 0, alias.StrategyIndex))
+        if (_judge.ShouldHandle(in outcome, context, attempt: 0, context.StrategyIndex))
         {
             _core.RecordFailure(
                 context.TimeProvider,
@@ -143,111 +129,42 @@ internal sealed class CircuitBreakerStrategy : Strategy
             _core.AbandonProbe(admissionGeneration);
         }
 
-        if (recordState)
-        {
-            RecordState(alias);
-        }
-
         return outcome;
     }
 
-    private void RecordState(StrategyMetricAlias alias)
+    private void RegisterMetricsAlias(StrategyMetricAlias alias)
     {
+#if NET9_0_OR_GREATER
         if (KevlarMetrics.CircuitStateEnabled)
         {
-            while (true)
-            {
-                var state = _core.State;
-                KevlarMetrics.RecordCircuitState(alias.ShieldName, alias.StrategyIndex, state);
-                if (state == _core.State)
-                {
-                    return;
-                }
-            }
+            _metricsRegistration.Add(alias);
         }
+#endif
     }
 
-    private bool RegisterMetricsAlias(StrategyMetricAlias alias)
+    private void RecordTransitionState(CircuitState _)
     {
-        if (!KevlarMetrics.CircuitStateEnabled)
+#if NET9_0_OR_GREATER
+        if (KevlarMetrics.CircuitStateEnabled && _metricsRegistration.Observations.Length == 0)
         {
-            return false;
+            _metricsRegistration.Add(new StrategyMetricAlias(null, -1));
         }
-
-        lock (_metricsNamesGate)
-        {
-            if (_metricsAliases.Contains(alias))
-            {
-                return true;
-            }
-
-            if (_metricsAliases.Count >= KevlarMetrics.MaxTrackedStrategyAliases)
-            {
-                return false;
-            }
-
-            _metricsAliases.Add(alias);
-            return true;
-        }
-    }
-
-    private void RecordTransitionState(CircuitState state)
-    {
-        if (!KevlarMetrics.CircuitStateEnabled)
-        {
-            return;
-        }
-
-        StrategyMetricAlias[] aliases;
-        lock (_metricsNamesGate)
-        {
-            if (_metricsAliases.Count == 0)
-            {
-                _metricsAliases.Add(new StrategyMetricAlias(null, -1));
-            }
-
-            aliases = [.. _metricsAliases];
-        }
-
-        List<Exception>? failures = null;
-        foreach (var alias in aliases)
-        {
-            try
-            {
-                KevlarMetrics.RecordCircuitState(alias.ShieldName, alias.StrategyIndex, state);
-            }
-            catch (Exception exception)
-            {
-                (failures ??= []).Add(exception);
-            }
-        }
-
-        if (failures is [var failure])
-        {
-            ExceptionDispatchInfo.Capture(failure).Throw();
-        }
-
-        if (failures is { Count: > 1 })
-        {
-            throw new AggregateException(failures).Flatten();
-        }
+#endif
     }
 
     private ValueTask<Outcome<T>> ExecuteConfiguredAsync<T, TState>(
         Continuation<T, TState> next,
-        KevlarContext context,
-        StrategyMetricAlias alias,
-        bool recordState)
+        KevlarContext context)
     {
         var entry = _core.TryEnterAsync(context.TimeProvider, context);
         if (!entry.IsCompletedSuccessfully)
         {
-            return AwaitConfiguredEntryAsync(entry, next, context, alias, recordState);
+            return AwaitConfiguredEntryAsync(entry, next, context);
         }
 
         try
         {
-            return ExecuteConfiguredEntry(entry.Result, next, context, alias, recordState);
+            return ExecuteConfiguredEntry(entry.Result, next, context);
         }
         catch (Exception exception)
         {
@@ -258,20 +175,16 @@ internal sealed class CircuitBreakerStrategy : Strategy
     private async ValueTask<Outcome<T>> AwaitConfiguredEntryAsync<T, TState>(
         ValueTask<CircuitBreakerCore.EntryResult> entry,
         Continuation<T, TState> next,
-        KevlarContext context,
-        StrategyMetricAlias alias,
-        bool recordState)
+        KevlarContext context)
     {
         var result = await entry.ConfigureAwait(false);
-        return await ExecuteConfiguredEntry(result, next, context, alias, recordState).ConfigureAwait(false);
+        return await ExecuteConfiguredEntry(result, next, context).ConfigureAwait(false);
     }
 
     private ValueTask<Outcome<T>> ExecuteConfiguredEntry<T, TState>(
         CircuitBreakerCore.EntryResult entry,
         Continuation<T, TState> next,
-        KevlarContext context,
-        StrategyMetricAlias alias,
-        bool recordState)
+        KevlarContext context)
     {
         if (!entry.Allowed)
         {
@@ -288,55 +201,34 @@ internal sealed class CircuitBreakerStrategy : Strategy
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(entry.Rejection!));
         }
 
-        if (recordState)
-        {
-            try
-            {
-                RecordState(alias);
-            }
-            catch
-            {
-                _core.AbandonProbe(entry.AdmissionGeneration);
-                throw;
-            }
-        }
-
         var execution = next.InvokeAsync(context);
         return execution.IsCompletedSuccessfully
-            ? CompleteConfigured(execution.Result, context, entry.AdmissionGeneration, alias, recordState)
+            ? CompleteConfigured(execution.Result, context, entry.AdmissionGeneration)
             : AwaitConfiguredOutcomeAsync(
                 execution,
                 context,
-                entry.AdmissionGeneration,
-                alias,
-                recordState);
+                entry.AdmissionGeneration);
     }
 
     private async ValueTask<Outcome<T>> AwaitConfiguredOutcomeAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,
-        long admissionGeneration,
-        StrategyMetricAlias alias,
-        bool recordState)
+        long admissionGeneration)
     {
         var outcome = await execution.ConfigureAwait(false);
         return await CompleteConfigured(
             outcome,
             context,
-            admissionGeneration,
-            alias,
-            recordState).ConfigureAwait(false);
+            admissionGeneration).ConfigureAwait(false);
     }
 
     private ValueTask<Outcome<T>> CompleteConfigured<T>(
         Outcome<T> outcome,
         KevlarContext context,
-        long admissionGeneration,
-        StrategyMetricAlias alias,
-        bool recordState)
+        long admissionGeneration)
     {
         ValueTask recording;
-        if (_judge.ShouldHandle(in outcome, context, attempt: 0, alias.StrategyIndex))
+        if (_judge.ShouldHandle(in outcome, context, attempt: 0, context.StrategyIndex))
         {
             recording = _core.RecordFailureAsync(
                 context.TimeProvider,
@@ -359,30 +251,18 @@ internal sealed class CircuitBreakerStrategy : Strategy
 
         if (!recording.IsCompletedSuccessfully)
         {
-            return AwaitConfiguredRecordingAsync(recording, outcome, alias, recordState);
+            return AwaitConfiguredRecordingAsync(recording, outcome);
         }
 
         recording.GetAwaiter().GetResult();
-        if (recordState)
-        {
-            RecordState(alias);
-        }
-
         return new ValueTask<Outcome<T>>(outcome);
     }
 
     private async ValueTask<Outcome<T>> AwaitConfiguredRecordingAsync<T>(
         ValueTask recording,
-        Outcome<T> outcome,
-        StrategyMetricAlias alias,
-        bool recordState)
+        Outcome<T> outcome)
     {
         await recording.ConfigureAwait(false);
-        if (recordState)
-        {
-            RecordState(alias);
-        }
-
         return outcome;
     }
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -30,16 +30,17 @@ internal sealed class CircuitBreakerStrategy : Strategy
         CircuitBreakerBreakDurationGenerator? breakDurationGenerator,
         Type optionsType)
     {
+#if NET9_0_OR_GREATER
+        _metricsRegistration = KevlarMetrics.RegisterCircuitStateSource(this);
+#endif
         _core = new CircuitBreakerCore(
             options,
             breakDurationGenerator,
             RecordTransitionState,
             optionsType);
-#if NET9_0_OR_GREATER
-        _metricsRegistration = KevlarMetrics.RegisterCircuitStateSource(this);
-#endif
         _judge = judge;
         HasHandlingOverride = hasHandlingOverride;
+        _core.BindMonitor();
     }
 
     internal static CircuitBreakerStrategy Create<TResult>(

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -7,9 +7,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
     protected internal override bool InvokesContinuationAtMostOnce => true;
     private readonly CircuitBreakerCore _core;
     private readonly OutcomeJudge _judge;
-#if NET9_0_OR_GREATER
     private readonly KevlarMetrics.StateMetricRegistration<CircuitBreakerStrategy> _metricsRegistration;
-#endif
 
     public CircuitBreakerStrategy(CircuitBreakerOptions options, OutcomeJudge judge)
         : this(
@@ -30,9 +28,7 @@ internal sealed class CircuitBreakerStrategy : Strategy
         CircuitBreakerBreakDurationGenerator? breakDurationGenerator,
         Type optionsType)
     {
-#if NET9_0_OR_GREATER
         _metricsRegistration = KevlarMetrics.RegisterCircuitStateSource(this);
-#endif
         _core = new CircuitBreakerCore(
             options,
             breakDurationGenerator,
@@ -135,22 +131,18 @@ internal sealed class CircuitBreakerStrategy : Strategy
 
     private void RegisterMetricsAlias(StrategyMetricAlias alias)
     {
-#if NET9_0_OR_GREATER
         if (KevlarMetrics.CircuitStateEnabled)
         {
             _metricsRegistration.Add(alias);
         }
-#endif
     }
 
     private void RecordTransitionState(CircuitState _)
     {
-#if NET9_0_OR_GREATER
-        if (KevlarMetrics.CircuitStateEnabled && _metricsRegistration.Observations.Length == 0)
+        if (KevlarMetrics.CircuitStateEnabled && !_metricsRegistration.HasObservations)
         {
             _metricsRegistration.Add(new StrategyMetricAlias(null, -1));
         }
-#endif
     }
 
     private ValueTask<Outcome<T>> ExecuteConfiguredAsync<T, TState>(

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -1,12 +1,9 @@
-using System.Runtime.ExceptionServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
 
 internal sealed class ConcurrencyLimitStrategy : Strategy
 {
-    private readonly Lock _metricsPublicationGate = new();
-    private readonly HashSet<StrategyMetricAlias> _metricsAliases = [];
     // Atomic permits serve the uncontended path; the semaphore carries permits only to registered waiters.
     private readonly SemaphoreSlim _semaphore;
     private readonly int _maxConcurrency;
@@ -17,9 +14,10 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly string _telemetryName;
     private int _available;
     private int _waiters;
-    private StrategyMetricAlias[] _metricsAliasSnapshot = [];
     private long _pending;
-    private long _metricsState;
+#if NET9_0_OR_GREATER
+    private readonly KevlarMetrics.StateMetricRegistration<ConcurrencyLimitStrategy> _metricsRegistration;
+#endif
 
     protected internal override bool InvokesContinuationAtMostOnce => true;
 
@@ -33,9 +31,10 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     internal (int Available, int Running, int Queued) CaptureState()
     {
-        var state = Volatile.Read(ref _metricsState);
-        var running = (int)(state >> 32);
-        var queued = (int)(state & uint.MaxValue);
+        var pending = Math.Max(0, Volatile.Read(ref _pending));
+        var available = Volatile.Read(ref _available);
+        var running = (int)Math.Min(pending, _maxConcurrency - available);
+        var queued = (int)Math.Min(int.MaxValue, pending - running);
         return (_maxConcurrency - running, running, queued);
     }
 
@@ -69,6 +68,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         var alias = new StrategyMetricAlias(context.ShieldName, context.StrategyIndex);
+        RegisterMetricsAlias(alias);
         if (Interlocked.Increment(ref _pending) > _capacity)
         {
             Interlocked.Decrement(ref _pending);
@@ -81,17 +81,16 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             context.CancellationToken.ThrowIfCancellationRequested();
             if (TryAcquirePermit())
             {
-                return ExecuteAcquired(next, context, alias, queued: false);
+                return ExecuteAcquired(next, context);
             }
         }
         catch (OperationCanceledException cancelled)
         {
             Interlocked.Decrement(ref _pending);
-            RecordState(alias);
             return new ValueTask<Outcome<T>>(Outcome<T>.FromException(NormalizeCancellation(cancelled, context)));
         }
 
-        return ExecuteQueuedAsync(next, context, alias);
+        return ExecuteQueuedAsync(next, context);
     }
 
     private ValueTask<Outcome<T>> RejectAsync<T>(KevlarContext context)
@@ -135,10 +134,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     private async ValueTask<Outcome<T>> ExecuteQueuedAsync<T, TState>(
         Continuation<T, TState> next,
-        KevlarContext context,
-        StrategyMetricAlias alias)
+        KevlarContext context)
     {
-        UpdateMetricsState(inflightDelta: 0, queuedDelta: 1);
         Interlocked.Increment(ref _waiters);
         try
         {
@@ -146,103 +143,43 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             {
                 if (context.IsSynchronous)
                 {
-                    RecordState(alias);
                     _semaphore.Wait(context.CancellationToken);
                 }
                 else
                 {
-                    using var waitCancellation = context.CancellationToken.CanBeCanceled
-                        ? CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken)
-                        : new CancellationTokenSource();
-                    var wait = _semaphore.WaitAsync(waitCancellation.Token);
-                    try
-                    {
-                        RecordState(alias);
-                    }
-                    catch (Exception publicationFailure)
-                    {
-                        waitCancellation.Cancel();
-                        try
-                        {
-                            await wait.ConfigureAwait(false);
-                            ReleasePermit();
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            // Cancellation withdrew the wait before it took a permit.
-                        }
-
-                        ExceptionDispatchInfo.Capture(publicationFailure).Throw();
-                    }
-
-                    await wait.ConfigureAwait(false);
+                    await _semaphore.WaitAsync(context.CancellationToken).ConfigureAwait(false);
                 }
             }
         }
         catch (OperationCanceledException cancelled)
         {
-            ReleaseQueued(alias);
+            Interlocked.Decrement(ref _pending);
             return Outcome<T>.FromException(NormalizeCancellation(cancelled, context));
-        }
-        catch (Exception publicationFailure)
-        {
-            ReleaseQueued(alias, publicationFailure);
-            ExceptionDispatchInfo.Capture(publicationFailure).Throw();
-            throw;
         }
         finally
         {
             Interlocked.Decrement(ref _waiters);
         }
 
-        return await ExecuteAcquired(next, context, alias, queued: true).ConfigureAwait(false);
+        return await ExecuteAcquired(next, context).ConfigureAwait(false);
     }
 
     private ValueTask<Outcome<T>> ExecuteAcquired<T, TState>(
         Continuation<T, TState> next,
-        KevlarContext context,
-        StrategyMetricAlias alias,
-        bool queued)
+        KevlarContext context)
     {
-        UpdateMetricsState(inflightDelta: 1, queuedDelta: queued ? -1 : 0);
-        try
-        {
-            RecordState(alias);
-        }
-        catch (Exception publicationFailure)
-        {
-            UpdateMetricsState(inflightDelta: -1, queuedDelta: 0);
-            ReleasePermit();
-            Interlocked.Decrement(ref _pending);
-            try
-            {
-                RecordState(alias);
-            }
-            catch (Exception correctionFailure)
-            {
-                publicationFailure = new AggregateException(
-                    publicationFailure,
-                    correctionFailure).Flatten();
-            }
-
-            ExceptionDispatchInfo.Capture(publicationFailure).Throw();
-            throw;
-        }
-
         var execution = next.InvokeAsync(context);
         if (!execution.IsCompletedSuccessfully)
         {
-            return AwaitExecutionAsync(execution, alias);
+            return AwaitExecutionAsync(execution);
         }
 
         var outcome = execution.Result;
-        CompleteExecution(alias);
+        CompleteExecution();
         return new ValueTask<Outcome<T>>(outcome);
     }
 
-    private async ValueTask<Outcome<T>> AwaitExecutionAsync<T>(
-        ValueTask<Outcome<T>> execution,
-        StrategyMetricAlias alias)
+    private async ValueTask<Outcome<T>> AwaitExecutionAsync<T>(ValueTask<Outcome<T>> execution)
     {
         try
         {
@@ -250,33 +187,14 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         }
         finally
         {
-            CompleteExecution(alias);
+            CompleteExecution();
         }
     }
 
-    private void CompleteExecution(StrategyMetricAlias alias)
+    private void CompleteExecution()
     {
-        UpdateMetricsState(inflightDelta: -1, queuedDelta: 0);
+        Interlocked.Decrement(ref _pending);
         ReleasePermit();
-        Interlocked.Decrement(ref _pending);
-        RecordState(alias);
-    }
-
-    private void ReleaseQueued(
-        StrategyMetricAlias alias,
-        Exception? publicationFailure = null)
-    {
-        Interlocked.Decrement(ref _pending);
-        UpdateMetricsState(inflightDelta: 0, queuedDelta: -1);
-
-        try
-        {
-            RecordState(alias);
-        }
-        catch (Exception correctionFailure) when (publicationFailure is not null)
-        {
-            throw new AggregateException(publicationFailure, correctionFailure).Flatten();
-        }
     }
 
     private static OperationCanceledException NormalizeCancellation(
@@ -318,82 +236,13 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         }
     }
 
-    private void UpdateMetricsState(int inflightDelta, int queuedDelta)
+    private void RegisterMetricsAlias(StrategyMetricAlias alias)
     {
-        while (true)
+#if NET9_0_OR_GREATER
+        if (KevlarMetrics.ConcurrencyStateEnabled)
         {
-            var state = Volatile.Read(ref _metricsState);
-            var inflight = (int)(state >> 32);
-            var queued = (int)(state & uint.MaxValue);
-            var updated = ((long)(inflight + inflightDelta) << 32)
-                | (uint)(queued + queuedDelta);
-            if (Interlocked.CompareExchange(ref _metricsState, updated, state) == state)
-            {
-                return;
-            }
+            _metricsRegistration.Add(alias);
         }
-    }
-
-    private void RecordState(StrategyMetricAlias alias)
-    {
-        if (!KevlarMetrics.ConcurrencyStateEnabled)
-        {
-            return;
-        }
-
-        lock (_metricsPublicationGate)
-        {
-            if (_metricsAliases.Count < KevlarMetrics.MaxTrackedStrategyAliases
-                && _metricsAliases.Add(alias))
-            {
-                _metricsAliasSnapshot = [.. _metricsAliases];
-            }
-
-            while (true)
-            {
-                var state = Volatile.Read(ref _metricsState);
-                var inflight = (int)(state >> 32);
-                var queued = (int)(state & uint.MaxValue);
-                var aliases = _metricsAliasSnapshot;
-                RecordStateForAliases(aliases, inflight, queued);
-
-                if (state == Volatile.Read(ref _metricsState)
-                    && ReferenceEquals(aliases, _metricsAliasSnapshot))
-                {
-                    return;
-                }
-            }
-        }
-    }
-
-    private void RecordStateForAliases(StrategyMetricAlias[] aliases, int inflight, int queued)
-    {
-        List<Exception>? failures = null;
-        foreach (var alias in aliases)
-        {
-            try
-            {
-                KevlarMetrics.RecordConcurrencyState(
-                    alias.ShieldName,
-                    alias.StrategyIndex,
-                    inflight,
-                    queued,
-                    _maxConcurrency);
-            }
-            catch (Exception exception)
-            {
-                (failures ??= []).Add(exception);
-            }
-        }
-
-        if (failures is [var failure])
-        {
-            ExceptionDispatchInfo.Capture(failure).Throw();
-        }
-
-        if (failures is { Count: > 1 })
-        {
-            throw new AggregateException(failures).Flatten();
-        }
+#endif
     }
 }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -15,9 +15,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private int _available;
     private int _waiters;
     private long _pending;
-#if NET9_0_OR_GREATER
     private readonly KevlarMetrics.StateMetricRegistration<ConcurrencyLimitStrategy> _metricsRegistration;
-#endif
 
     protected internal override bool InvokesContinuationAtMostOnce => true;
 
@@ -238,11 +236,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     private void RegisterMetricsAlias(StrategyMetricAlias alias)
     {
-#if NET9_0_OR_GREATER
         if (KevlarMetrics.ConcurrencyStateEnabled)
         {
             _metricsRegistration.Add(alias);
         }
-#endif
     }
 }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -30,7 +30,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     internal (int Available, int Running, int Queued) CaptureState()
     {
-        var available = Math.Min(_maxConcurrency, Math.Max(0, Volatile.Read(ref _available)));
+        var available = Math.Min(
+            _maxConcurrency,
+            Math.Max(0, Volatile.Read(ref _available) + _semaphore.CurrentCount));
         var queued = Math.Min(_queueLimit, Math.Max(0, Volatile.Read(ref _queued)));
         return (available, _maxConcurrency - available, queued);
     }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -16,11 +16,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly Action<ConcurrencyLimitRejectedEvent>? _onRejected;
     private readonly Func<ConcurrencyLimitRejectedEvent, ValueTask>? _onRejectedAsync;
     private readonly string _telemetryName;
-    private int _available;
-    private int _queued;
-    private int _running;
     private int _waiters;
     private long _pending;
+    private long _state;
     private readonly KevlarMetrics.StateMetricRegistration<ConcurrencyLimitStrategy> _metricsRegistration;
 
     protected internal override bool InvokesContinuationAtMostOnce => true;
@@ -62,6 +60,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         _onRejected = options.OnRejected;
         _onRejectedAsync = options.OnRejectedAsync;
         _telemetryName = options.Name ?? "ConcurrencyLimit";
+        _metricsRegistration = KevlarMetrics.RegisterConcurrencyStateSource(this);
     }
 
     public override string Describe() =>
@@ -73,8 +72,6 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         RegisterMetricsAlias(alias);
         if (!TryReserveCapacity())
         {
-            Interlocked.Decrement(ref _pending);
-            RecordState(alias);
             return RejectAsync<T>(context);
         }
 

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -4,7 +4,11 @@ namespace Kevlar.Strategies;
 
 internal sealed class ConcurrencyLimitStrategy : Strategy
 {
-    // Atomic permits serve the uncontended path; the semaphore carries permits only to registered waiters.
+    private const long RunningIncrement = 1L << 32;
+    private const long QueuedIncrement = 1;
+
+    // The high 32 bits track running executions and the low 32 bits track queued executions.
+    // The semaphore is only a wake-up signal; permit ownership lives in _state.
     private readonly SemaphoreSlim _semaphore;
     private readonly int _maxConcurrency;
     private readonly int _queueLimit;
@@ -31,8 +35,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     internal (int Available, int Running, int Queued) CaptureState()
     {
-        var running = Math.Min(_maxConcurrency, Math.Max(0, Volatile.Read(ref _running)));
-        var queued = Math.Min(_queueLimit, Math.Max(0, Volatile.Read(ref _queued)));
+        var state = Volatile.Read(ref _state);
+        var running = Math.Min(_maxConcurrency, Math.Max(0, (int)(state >> 32)));
+        var queued = Math.Min(_queueLimit, Math.Max(0, (int)(state & uint.MaxValue)));
         return (_maxConcurrency - running, running, queued);
     }
 
@@ -54,7 +59,6 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         _maxConcurrency = options.MaxConcurrency;
         _queueLimit = options.QueueLimit;
         _capacity = options.MaxConcurrency + (long)options.QueueLimit;
-        _available = options.MaxConcurrency;
         _onRejected = options.OnRejected;
         _onRejectedAsync = options.OnRejectedAsync;
         _telemetryName = options.Name ?? "ConcurrencyLimit";
@@ -79,7 +83,6 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             context.CancellationToken.ThrowIfCancellationRequested();
             if (TryAcquirePermit())
             {
-                Interlocked.Increment(ref _running);
                 return ExecuteAcquired(next, context);
             }
         }
@@ -135,33 +138,35 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         Continuation<T, TState> next,
         KevlarContext context)
     {
-        Interlocked.Increment(ref _queued);
+        Interlocked.Add(ref _state, QueuedIncrement);
         Interlocked.Increment(ref _waiters);
         try
         {
-            if (!TryAcquirePermit())
+            if (!TryAcquireQueuedPermit(drainSignal: true))
             {
-                if (context.IsSynchronous)
+                do
                 {
-                    _semaphore.Wait(context.CancellationToken);
+                    if (context.IsSynchronous)
+                    {
+                        _semaphore.Wait(context.CancellationToken);
+                    }
+                    else
+                    {
+                        await _semaphore.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+                    }
                 }
-                else
-                {
-                    await _semaphore.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-                }
+                while (!TryAcquireQueuedPermit(drainSignal: false));
             }
-
-            Interlocked.Increment(ref _running);
         }
         catch (OperationCanceledException cancelled)
         {
+            Interlocked.Add(ref _state, -QueuedIncrement);
             Interlocked.Decrement(ref _pending);
             return Outcome<T>.FromException(NormalizeCancellation(cancelled, context));
         }
         finally
         {
             Interlocked.Decrement(ref _waiters);
-            Interlocked.Decrement(ref _queued);
         }
 
         return await ExecuteAcquired(next, context).ConfigureAwait(false);
@@ -196,7 +201,6 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     private void CompleteExecution()
     {
-        Interlocked.Decrement(ref _running);
         Interlocked.Decrement(ref _pending);
         ReleasePermit();
     }
@@ -213,17 +217,30 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             : cancelled;
 
     private bool TryAcquirePermit()
+        => TryAcquirePermitCore(isQueued: false, drainSignal: true);
+
+    private bool TryAcquireQueuedPermit(bool drainSignal)
+        => TryAcquirePermitCore(isQueued: true, drainSignal);
+
+    private bool TryAcquirePermitCore(bool isQueued, bool drainSignal)
     {
         while (true)
         {
-            var available = Volatile.Read(ref _available);
-            if (available == 0)
+            var state = Volatile.Read(ref _state);
+            var running = (int)(state >> 32);
+            if (running >= _maxConcurrency)
             {
                 return false;
             }
 
-            if (Interlocked.CompareExchange(ref _available, available - 1, available) == available)
+            var updated = state + RunningIncrement - (isQueued ? QueuedIncrement : 0);
+            if (Interlocked.CompareExchange(ref _state, updated, state) == state)
             {
+                if (drainSignal)
+                {
+                    _ = _semaphore.Wait(0);
+                }
+
                 return true;
             }
         }
@@ -248,10 +265,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     private void ReleasePermit()
     {
-        // Publish first. A waiter that registers concurrently either claims this permit on its
-        // atomic retry, or leaves it here for this release to transfer to the semaphore.
-        Interlocked.Increment(ref _available);
-        if (Volatile.Read(ref _waiters) > 0 && TryAcquirePermit())
+        Interlocked.Add(ref _state, -RunningIncrement);
+        if (Volatile.Read(ref _waiters) > 0)
         {
             _semaphore.Release();
         }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -13,6 +13,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly Func<ConcurrencyLimitRejectedEvent, ValueTask>? _onRejectedAsync;
     private readonly string _telemetryName;
     private int _available;
+    private int _queued;
     private int _waiters;
     private long _pending;
     private readonly KevlarMetrics.StateMetricRegistration<ConcurrencyLimitStrategy> _metricsRegistration;
@@ -29,11 +30,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     internal (int Available, int Running, int Queued) CaptureState()
     {
-        var pending = Math.Max(0, Volatile.Read(ref _pending));
-        var available = Volatile.Read(ref _available);
-        var running = (int)Math.Min(pending, _maxConcurrency - available);
-        var queued = (int)Math.Min(int.MaxValue, pending - running);
-        return (_maxConcurrency - running, running, queued);
+        var available = Math.Min(_maxConcurrency, Math.Max(0, Volatile.Read(ref _available)));
+        var queued = Math.Min(_queueLimit, Math.Max(0, Volatile.Read(ref _queued)));
+        return (available, _maxConcurrency - available, queued);
     }
 
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
@@ -134,6 +133,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         Continuation<T, TState> next,
         KevlarContext context)
     {
+        Interlocked.Increment(ref _queued);
         Interlocked.Increment(ref _waiters);
         try
         {
@@ -157,6 +157,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         finally
         {
             Interlocked.Decrement(ref _waiters);
+            Interlocked.Decrement(ref _queued);
         }
 
         return await ExecuteAcquired(next, context).ConfigureAwait(false);

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -201,8 +201,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     private void CompleteExecution()
     {
-        Interlocked.Decrement(ref _pending);
+        // Keep the capacity reservation until permit ownership has been published.
         ReleasePermit();
+        Interlocked.Decrement(ref _pending);
     }
 
     private static OperationCanceledException NormalizeCancellation(

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -53,7 +53,10 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             nameof(options.QueueLimit),
             options.QueueLimit,
             "must not be negative");
-        _semaphore = new SemaphoreSlim(0, options.MaxConcurrency);
+        // Wake-ups can become redundant when a caller acquires directly before a releasing
+        // execution publishes its signal. Permit ownership is validated through _state, so
+        // accepting the extra signal prevents a completion from throwing SemaphoreFullException.
+        _semaphore = new SemaphoreSlim(0);
         _maxConcurrency = options.MaxConcurrency;
         _queueLimit = options.QueueLimit;
         _capacity = options.MaxConcurrency + (long)options.QueueLimit;

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -14,6 +14,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     private readonly string _telemetryName;
     private int _available;
     private int _queued;
+    private int _running;
     private int _waiters;
     private long _pending;
     private readonly KevlarMetrics.StateMetricRegistration<ConcurrencyLimitStrategy> _metricsRegistration;
@@ -30,11 +31,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     internal (int Available, int Running, int Queued) CaptureState()
     {
-        var available = Math.Min(
-            _maxConcurrency,
-            Math.Max(0, Volatile.Read(ref _available) + _semaphore.CurrentCount));
+        var running = Math.Min(_maxConcurrency, Math.Max(0, Volatile.Read(ref _running)));
         var queued = Math.Min(_queueLimit, Math.Max(0, Volatile.Read(ref _queued)));
-        return (available, _maxConcurrency - available, queued);
+        return (_maxConcurrency - running, running, queued);
     }
 
     public ConcurrencyLimitStrategy(ConcurrencyLimitOptions options)
@@ -80,6 +79,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             context.CancellationToken.ThrowIfCancellationRequested();
             if (TryAcquirePermit())
             {
+                Interlocked.Increment(ref _running);
                 return ExecuteAcquired(next, context);
             }
         }
@@ -150,6 +150,8 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
                     await _semaphore.WaitAsync(context.CancellationToken).ConfigureAwait(false);
                 }
             }
+
+            Interlocked.Increment(ref _running);
         }
         catch (OperationCanceledException cancelled)
         {
@@ -194,6 +196,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
 
     private void CompleteExecution()
     {
+        Interlocked.Decrement(ref _running);
         Interlocked.Decrement(ref _pending);
         ReleasePermit();
     }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -67,7 +67,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
     {
         var alias = new StrategyMetricAlias(context.ShieldName, context.StrategyIndex);
         RegisterMetricsAlias(alias);
-        if (Interlocked.Increment(ref _pending) > _capacity)
+        if (!TryReserveCapacity())
         {
             Interlocked.Decrement(ref _pending);
             RecordState(alias);
@@ -217,6 +217,23 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
             }
 
             if (Interlocked.CompareExchange(ref _available, available - 1, available) == available)
+            {
+                return true;
+            }
+        }
+    }
+
+    private bool TryReserveCapacity()
+    {
+        while (true)
+        {
+            var pending = Volatile.Read(ref _pending);
+            if (pending >= _capacity)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _pending, pending + 1, pending) == pending)
             {
                 return true;
             }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -138,11 +138,12 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         Continuation<T, TState> next,
         KevlarContext context)
     {
-        Interlocked.Add(ref _state, QueuedIncrement);
+        var queuedState = Interlocked.Add(ref _state, QueuedIncrement);
+        var hasPrecedingWaiter = (uint)queuedState > 1;
         Interlocked.Increment(ref _waiters);
         try
         {
-            if (!TryAcquireQueuedPermit(drainSignal: true))
+            if (hasPrecedingWaiter || !TryAcquireQueuedPermit(drainSignal: true))
             {
                 do
                 {
@@ -229,7 +230,7 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         {
             var state = Volatile.Read(ref _state);
             var running = (int)(state >> 32);
-            if (running >= _maxConcurrency)
+            if (running >= _maxConcurrency || (!isQueued && (uint)state > 0))
             {
                 return false;
             }

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -35,9 +35,7 @@ internal sealed class RateLimitStrategy : Strategy
     private Reservation? _queueHead;
     private Reservation? _queueTail;
     private int _queuedReservations;
-#if NET9_0_OR_GREATER
     private readonly KevlarMetrics.StateMetricRegistration<RateLimitStrategy> _metricsRegistration;
-#endif
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 
@@ -403,12 +401,10 @@ internal sealed class RateLimitStrategy : Strategy
 
     private void RegisterMetricsAlias(StrategyMetricAlias alias, TimeProvider timeProvider)
     {
-#if NET9_0_OR_GREATER
         if (KevlarMetrics.RateStateEnabled)
         {
             _metricsRegistration.Add(alias, timeProvider);
         }
-#endif
     }
 
     internal (long Available, int Queued) CaptureState(TimeProvider timeProvider)

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -27,8 +27,6 @@ internal sealed class RateLimitStrategy : Strategy
     private readonly Action<RateLimitRejectedEvent>? _onRejected;
     private readonly Func<RateLimitRejectedEvent, ValueTask>? _onRejectedAsync;
     private readonly string _telemetryName;
-    private readonly Lock _metricsPublicationGate = new();
-    private readonly HashSet<StrategyMetricAlias> _metricsAliases = [];
     private readonly object _queueGate = new();
 
     private double _theoreticalArrival = double.NegativeInfinity;
@@ -85,6 +83,7 @@ internal sealed class RateLimitStrategy : Strategy
         _onRejected = options.OnRejected;
         _onRejectedAsync = options.OnRejectedAsync;
         _telemetryName = options.Name ?? "RateLimit";
+        _metricsRegistration = KevlarMetrics.RegisterRateStateSource(this);
     }
 
     public override string Describe()

--- a/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
+++ b/src/Kevlar/Strategies/RateLimit/RateLimitStrategy.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -31,15 +30,14 @@ internal sealed class RateLimitStrategy : Strategy
     private readonly Lock _metricsPublicationGate = new();
     private readonly HashSet<StrategyMetricAlias> _metricsAliases = [];
     private readonly object _queueGate = new();
-    private StrategyMetricAlias[] _metricsAliasSnapshot = [];
-    private List<double>? _reentrantImmediateAdmissionTimestamps;
 
     private double _theoreticalArrival = double.NegativeInfinity;
     private Reservation? _queueHead;
     private Reservation? _queueTail;
     private int _queuedReservations;
-    private int _metricsAdmissionDepth;
-    private int _untrackedImmediateAdmissions;
+#if NET9_0_OR_GREATER
+    private readonly KevlarMetrics.StateMetricRegistration<RateLimitStrategy> _metricsRegistration;
+#endif
 
     protected internal override bool IsDuplicateReferenceUnsafe => true;
 
@@ -100,7 +98,10 @@ internal sealed class RateLimitStrategy : Strategy
 
     public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
-        if (!TryAcquireAndRecord(context, out var reservation, out var retryAfter))
+        RegisterMetricsAlias(
+            new StrategyMetricAlias(context.ShieldName, context.StrategyIndex),
+            context.TimeProvider);
+        if (!TryAcquire(context.TimeProvider, out var reservation, out var retryAfter, out _))
         {
             return RejectAsync<T>(context, retryAfter);
         }
@@ -153,175 +154,6 @@ internal sealed class RateLimitStrategy : Strategy
         return Outcome<T>.FromException(rejection);
     }
 
-    private bool TryAcquireAndRecord(
-        KevlarContext context,
-        out Reservation? reservation,
-        out TimeSpan? retryAfter)
-    {
-        if (!KevlarMetrics.RateStateEnabled)
-        {
-            if (_queueLimit > 0)
-            {
-                return TryAcquire(context.TimeProvider, out reservation, out retryAfter, out _);
-            }
-
-            // Register before rechecking publication state so an admission that observed
-            // metrics disabled cannot race past a rollback that starts concurrently.
-            Interlocked.Increment(ref _untrackedImmediateAdmissions);
-            try
-            {
-                if (Volatile.Read(ref _metricsAdmissionDepth) == 0 &&
-                    !KevlarMetrics.RateStateEnabled)
-                {
-                    return TryAcquire(context.TimeProvider, out reservation, out retryAfter, out _);
-                }
-            }
-            finally
-            {
-                Interlocked.Decrement(ref _untrackedImmediateAdmissions);
-            }
-        }
-
-        lock (_metricsPublicationGate)
-        {
-            return TryAcquireAndRecordUnderLock(context, out reservation, out retryAfter);
-        }
-    }
-
-    private bool TryAcquireAndRecordUnderLock(
-        KevlarContext context,
-        out Reservation? reservation,
-        out TimeSpan? retryAfter)
-    {
-        Interlocked.Increment(ref _metricsAdmissionDepth);
-        try
-        {
-            if (_metricsAdmissionDepth == 1)
-            {
-                // Once depth is visible, new fast-path admissions join the publication gate.
-                // Drain admissions already beyond that check before capturing rollback state.
-                var spinWait = new SpinWait();
-                while (Volatile.Read(ref _untrackedImmediateAdmissions) != 0)
-                {
-                    spinWait.SpinOnce();
-                }
-            }
-
-            var previousTheoreticalArrival = _queueLimit == 0
-                ? Volatile.Read(ref _theoreticalArrival)
-                : 0;
-            var acquired = TryAcquire(
-                context.TimeProvider,
-                out reservation,
-                out retryAfter,
-                out var admissionTimestamp);
-            var nestedAdmissionIndex = -1;
-            if (acquired && _queueLimit == 0 && _metricsAdmissionDepth > 1)
-            {
-                var admissions = _reentrantImmediateAdmissionTimestamps ??= [];
-                nestedAdmissionIndex = admissions.Count;
-                admissions.Add(admissionTimestamp);
-            }
-
-            try
-            {
-                RecordStateUnderLock(
-                    new StrategyMetricAlias(context.ShieldName, context.StrategyIndex),
-                    context.TimeProvider);
-                return acquired;
-            }
-            catch (Exception publicationFailure)
-            {
-                if (acquired)
-                {
-                    RollbackAcquisition(
-                        reservation,
-                        previousTheoreticalArrival,
-                        nestedAdmissionIndex);
-                }
-
-                try
-                {
-                    RecordStateUnderLock(
-                        new StrategyMetricAlias(context.ShieldName, context.StrategyIndex),
-                        context.TimeProvider);
-                }
-                catch (Exception correctionFailure)
-                {
-                    publicationFailure = new AggregateException(
-                        publicationFailure,
-                        correctionFailure).Flatten();
-                }
-
-                ExceptionDispatchInfo.Capture(publicationFailure).Throw();
-                throw;
-            }
-        }
-        finally
-        {
-            if (Interlocked.Decrement(ref _metricsAdmissionDepth) == 0)
-            {
-                _reentrantImmediateAdmissionTimestamps?.Clear();
-            }
-        }
-    }
-
-    private void RollbackAcquisition(
-        Reservation? reservation,
-        double previousTheoreticalArrival,
-        int nestedAdmissionIndex)
-    {
-        if (reservation is not null)
-        {
-            CancelReservation(reservation)?.TrySetResult(true);
-            return;
-        }
-
-        if (_queueLimit == 0)
-        {
-            RollbackImmediatePermit(previousTheoreticalArrival, nestedAdmissionIndex);
-            return;
-        }
-
-        RollbackQueuedPermit();
-    }
-
-    private void RollbackImmediatePermit(
-        double previousTheoreticalArrival,
-        int nestedAdmissionIndex)
-    {
-        var restored = previousTheoreticalArrival;
-        var admissions = _reentrantImmediateAdmissionTimestamps;
-        var firstAdmission = nestedAdmissionIndex < 0 ? 0 : nestedAdmissionIndex + 1;
-        if (admissions is not null)
-        {
-            for (var index = firstAdmission; index < admissions.Count; index++)
-            {
-                restored = GetNextArrival(restored, admissions[index]);
-            }
-
-            if (nestedAdmissionIndex >= 0)
-            {
-                admissions.RemoveAt(nestedAdmissionIndex);
-            }
-        }
-
-        Volatile.Write(ref _theoreticalArrival, restored);
-    }
-
-    private void RollbackQueuedPermit()
-    {
-        lock (_queueGate)
-        {
-            for (var queued = _queueHead; queued is not null; queued = queued.Next)
-            {
-                queued.DueTimestamp -= _timestampUnitsPerPermit;
-            }
-
-            _theoreticalArrival -= _timestampUnitsPerPermit;
-        }
-    }
-
     private async ValueTask<Outcome<T>> ExecuteReservedAsync<T, TState>(
         Continuation<T, TState> next,
         KevlarContext context,
@@ -333,32 +165,6 @@ internal sealed class RateLimitStrategy : Strategy
             {
                 if (TryConsumeReservation(reservation, context.TimeProvider, out var wait, out var nextTurn))
                 {
-                    try
-                    {
-                        RecordState(
-                            new StrategyMetricAlias(context.ShieldName, context.StrategyIndex),
-                            context.TimeProvider);
-                    }
-                    catch (Exception publicationFailure)
-                    {
-                        RollbackQueuedPermit();
-                        try
-                        {
-                            RecordState(
-                                new StrategyMetricAlias(context.ShieldName, context.StrategyIndex),
-                                context.TimeProvider);
-                        }
-                        catch (Exception correctionFailure)
-                        {
-                            publicationFailure = new AggregateException(
-                                publicationFailure,
-                                correctionFailure).Flatten();
-                        }
-
-                        nextTurn?.TrySetResult(true);
-                        ExceptionDispatchInfo.Capture(publicationFailure).Throw();
-                    }
-
                     nextTurn?.TrySetResult(true);
                     break;
                 }
@@ -379,9 +185,6 @@ internal sealed class RateLimitStrategy : Strategy
         catch (OperationCanceledException cancelled)
         {
             CancelReservation(reservation)?.TrySetResult(true);
-            RecordState(
-                new StrategyMetricAlias(context.ShieldName, context.StrategyIndex),
-                context.TimeProvider);
             return Outcome<T>.FromException(cancelled);
         }
 
@@ -598,69 +401,14 @@ internal sealed class RateLimitStrategy : Strategy
             : TimeSpan.FromSeconds(seconds);
     }
 
-    private void RecordState(StrategyMetricAlias alias, TimeProvider timeProvider)
+    private void RegisterMetricsAlias(StrategyMetricAlias alias, TimeProvider timeProvider)
     {
-        if (!KevlarMetrics.RateStateEnabled)
+#if NET9_0_OR_GREATER
+        if (KevlarMetrics.RateStateEnabled)
         {
-            return;
+            _metricsRegistration.Add(alias, timeProvider);
         }
-
-        lock (_metricsPublicationGate)
-        {
-            RecordStateUnderLock(alias, timeProvider);
-        }
-    }
-
-    private void RecordStateUnderLock(StrategyMetricAlias alias, TimeProvider timeProvider)
-    {
-        if (_metricsAliases.Count < KevlarMetrics.MaxTrackedStrategyAliases
-            && _metricsAliases.Add(alias))
-        {
-            _metricsAliasSnapshot = [.. _metricsAliases];
-        }
-
-        while (true)
-        {
-            var state = CaptureState(timeProvider);
-            var aliases = _metricsAliasSnapshot;
-            RecordStateForAliases(aliases, state.Available, state.Queued);
-
-            if (state == CaptureState(timeProvider)
-                && ReferenceEquals(aliases, _metricsAliasSnapshot))
-            {
-                return;
-            }
-        }
-    }
-
-    private void RecordStateForAliases(StrategyMetricAlias[] aliases, long available, int queued)
-    {
-        List<Exception>? failures = null;
-        foreach (var alias in aliases)
-        {
-            try
-            {
-                KevlarMetrics.RecordRateState(
-                    alias.ShieldName,
-                    alias.StrategyIndex,
-                    available,
-                    queued);
-            }
-            catch (Exception exception)
-            {
-                (failures ??= []).Add(exception);
-            }
-        }
-
-        if (failures is [var failure])
-        {
-            ExceptionDispatchInfo.Capture(failure).Throw();
-        }
-
-        if (failures is { Count: > 1 })
-        {
-            throw new AggregateException(failures).Flatten();
-        }
+#endif
     }
 
     internal (long Available, int Queued) CaptureState(TimeProvider timeProvider)

--- a/tests/Kevlar.Chaos.Tests/DocsConsistencyTests.cs
+++ b/tests/Kevlar.Chaos.Tests/DocsConsistencyTests.cs
@@ -15,6 +15,7 @@ public class DocsConsistencyTests
         using var observer = new InstrumentObserver();
 
         await ExerciseEveryInstrumentAsync();
+        observer.RecordObservableInstruments();
 
         var documented = ParseInstrumentTable();
         var available = documented
@@ -241,6 +242,7 @@ public class DocsConsistencyTests
     {
         Counter<long> => "Counter",
         Histogram<double> => "Histogram",
+        ObservableGauge<long> => "ObservableGauge",
 #if NET9_0_OR_GREATER
         Gauge<long> => "Gauge",
 #endif
@@ -306,6 +308,8 @@ public class DocsConsistencyTests
 
         public ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> Tags { get; } =
             new(StringComparer.Ordinal);
+
+        public void RecordObservableInstruments() => _listener.RecordObservableInstruments();
 
         public void Dispose() => _listener.Dispose();
 

--- a/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
+++ b/tests/Kevlar.Testing.Tests/TelemetryRecorderTests.cs
@@ -52,6 +52,42 @@ public class TelemetryRecorderTests
         await Assert.That(executions[1].Tags["kevlar.execution.outcome"]).IsEqualTo("failure");
     }
 
+#if NET9_0_OR_GREATER
+    [Test]
+    public async Task Metric_Wait_Collects_Observable_Gauges()
+    {
+        using var recorder = new TelemetryRecorder();
+        var baseline = recorder.Metrics.Count;
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var execution = Shield.ConcurrencyLimit(1)
+            .WithName("observable-wait")
+            .ExecuteAsync(async _ =>
+            {
+                started.SetResult();
+                await release.Task;
+            }).AsTask();
+        await started.Task;
+
+        try
+        {
+            await recorder.WaitForMetricCountAsync(baseline + 1)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(recorder.Metrics.Any(metric =>
+                    metric.InstrumentName == "kevlar.concurrency_limit.inflight"
+                    && metric.Value == 1
+                    && Equals(metric.Tags["kevlar.shield.name"], "observable-wait")))
+                .IsTrue();
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        await execution;
+    }
+#endif
+
     [Test]
     public async Task Records_Typed_And_Untyped_Callbacks_In_Order()
     {

--- a/tests/Kevlar.Testing.Tests/TimeControlTests.cs
+++ b/tests/Kevlar.Testing.Tests/TimeControlTests.cs
@@ -316,7 +316,14 @@ public class TimeControlTests
             _listener.Start();
         }
 
-        public bool WasObserved => Volatile.Read(ref _wasObserved) != 0;
+        public bool WasObserved
+        {
+            get
+            {
+                _listener.RecordObservableInstruments();
+                return Volatile.Read(ref _wasObserved) != 0;
+            }
+        }
 
         public void Dispose() => _listener.Dispose();
 

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1773,6 +1773,22 @@ public class MetricsTests
         await Assert.That(strategy.IsAlive).IsFalse();
     }
 
+    [Test]
+    public async Task State_Gauges_Do_Not_Retain_Time_Providers_Without_Collection()
+    {
+        using var listener = new KevlarMeterListener();
+        var timeProvider = CreateCollectibleStateTimeProvider();
+
+        for (var attempt = 0; timeProvider.IsAlive && attempt < 10; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        await Assert.That(timeProvider.IsAlive).IsFalse();
+    }
+
     [System.Runtime.CompilerServices.MethodImpl(
         System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private static WeakReference CreateCollectibleStateStrategy()
@@ -1780,6 +1796,18 @@ public class MetricsTests
         var shield = Shield.ConcurrencyLimit(1).WithName("metrics-collectible-strategy");
         shield.Execute(static _ => { });
         return new WeakReference(shield.Strategies[0]);
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference CreateCollectibleStateTimeProvider()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var shield = Shield.RateLimit(1, TimeSpan.FromMinutes(1))
+            .WithName("metrics-collectible-time-provider")
+            .WithTimeProvider(timeProvider);
+        shield.Execute(static _ => { });
+        return new WeakReference(timeProvider);
     }
 
 #endif

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1855,6 +1855,32 @@ public class MetricsTests
         await Assert.That(timeProvider.IsAlive).IsFalse();
     }
 
+    [Test]
+    public async Task State_Gauges_Do_Not_Retain_Providers_For_Abandoned_Shield_Aliases()
+    {
+        using var listener = new KevlarMeterListener();
+        var shared = Shield.RateLimit(1, TimeSpan.FromMinutes(1));
+        var timeProvider = CreateCollectibleStateTimeProviderAlias(shared);
+
+        for (var attempt = 0; timeProvider.IsAlive && attempt < 10; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        listener.RecordObservableInstruments();
+
+        await Assert.That(timeProvider.IsAlive).IsFalse();
+        await Assert.That(listener.AllLongMeasurements("kevlar.rate_limit.available")
+                .Any(measurement => measurement.Tags.TryGetValue(
+                    "kevlar.shield.name",
+                    out var name)
+                    && Equals(name, "metrics-collectible-provider-alias")))
+            .IsFalse();
+        GC.KeepAlive(shared);
+    }
+
     [System.Runtime.CompilerServices.MethodImpl(
         System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private static WeakReference CreateCollectibleStateStrategy()
@@ -1873,6 +1899,18 @@ public class MetricsTests
             .WithName("metrics-collectible-time-provider")
             .WithTimeProvider(timeProvider);
         shield.Execute(static _ => { });
+        return new WeakReference(timeProvider);
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference CreateCollectibleStateTimeProviderAlias(Shield shared)
+    {
+        var timeProvider = new FakeTimeProvider();
+        shared
+            .WithName("metrics-collectible-provider-alias")
+            .WithTimeProvider(timeProvider)
+            .Execute(static _ => { });
         return new WeakReference(timeProvider);
     }
 

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1737,6 +1737,28 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Concurrency_New_Arrival_Cannot_Bypass_Queued_Caller()
+    {
+        var strategy = new ConcurrencyLimitStrategy(new ConcurrencyLimitOptions
+        {
+            MaxConcurrency = 1,
+            QueueLimit = 2,
+        });
+        var state = typeof(ConcurrencyLimitStrategy).GetField(
+            "_state",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var acquire = typeof(ConcurrencyLimitStrategy).GetMethod(
+            "TryAcquirePermit",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+        state.SetValue(strategy, 1L);
+
+        await Assert.That((bool)acquire.Invoke(strategy, null)!).IsFalse();
+        await Assert.That(strategy.CaptureState())
+            .IsEqualTo((Available: 1, Running: 0, Queued: 1));
+    }
+
+    [Test]
     public async Task Concurrency_Redundant_Wake_Signal_Does_Not_Fail_Completion()
     {
         var strategy = new ConcurrencyLimitStrategy(new ConcurrencyLimitOptions

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1661,6 +1661,34 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Concurrency_Parked_Permit_Is_Reported_As_Available()
+    {
+        var strategy = new ConcurrencyLimitStrategy(new ConcurrencyLimitOptions
+        {
+            MaxConcurrency = 1,
+            QueueLimit = 1,
+        });
+        var acquire = typeof(ConcurrencyLimitStrategy).GetMethod(
+            "TryAcquirePermit",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var release = typeof(ConcurrencyLimitStrategy).GetMethod(
+            "ReleasePermit",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var waiters = typeof(ConcurrencyLimitStrategy).GetField(
+            "_waiters",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+        await Assert.That((bool)acquire.Invoke(strategy, null)!).IsTrue();
+        waiters.SetValue(strategy, 1);
+        release.Invoke(strategy, null);
+        waiters.SetValue(strategy, 0);
+
+        var state = strategy.CaptureState();
+        await Assert.That(state.Available).IsEqualTo(1);
+        await Assert.That(state.Running).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task State_Registry_Compaction_Tolerates_Collected_Entries()
     {
         var registry = new KevlarMetrics.StateMetricRegistry<object>();
@@ -1710,6 +1738,36 @@ public class MetricsTests
         await Assert.That(observations.Length).IsEqualTo(1);
         GC.KeepAlive(strategy);
         GC.KeepAlive(secondProvider);
+    }
+
+    [Test]
+    public async Task State_Registration_Reclaims_Dead_Aliases_Before_Enforcing_Cap()
+    {
+        var registry = new KevlarMetrics.StateMetricRegistry<object>();
+        var strategy = new object();
+        var registration = registry.Register(strategy);
+        var providers = Enumerable.Range(0, KevlarMetrics.MaxTrackedStrategyAliases)
+            .Select(index => AddCollectibleStateObservation(
+                registration,
+                $"metrics-collected-alias-{index}"))
+            .ToArray();
+
+        for (var attempt = 0; providers.Any(static provider => provider.IsAlive) && attempt < 10; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        var liveProvider = new FakeTimeProvider();
+        var liveAlias = new StrategyMetricAlias("metrics-live-after-collected-aliases", 0);
+        registration.Add(liveAlias, liveProvider);
+
+        await Assert.That(providers.All(static provider => !provider.IsAlive)).IsTrue();
+        await Assert.That(registration.Observations.Select(static observation => observation.Alias))
+            .IsEquivalentTo([liveAlias]);
+        GC.KeepAlive(strategy);
+        GC.KeepAlive(liveProvider);
     }
 
     [Test]
@@ -1961,9 +2019,16 @@ public class MetricsTests
         System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private static WeakReference AddCollectibleStateObservation(
         KevlarMetrics.StateMetricRegistration<object> registration)
+        => AddCollectibleStateObservation(registration, "metrics-republished-state");
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference AddCollectibleStateObservation(
+        KevlarMetrics.StateMetricRegistration<object> registration,
+        string alias)
     {
         var timeProvider = new FakeTimeProvider();
-        registration.Add(new StrategyMetricAlias("metrics-republished-state", 0), timeProvider);
+        registration.Add(new StrategyMetricAlias(alias, 0), timeProvider);
         return new WeakReference(timeProvider);
     }
 

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 using Kevlar.Internal;
+using Kevlar.Strategies;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
@@ -1644,6 +1645,22 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Concurrency_Reservation_Is_Not_Reported_As_Queued()
+    {
+        var strategy = new ConcurrencyLimitStrategy(new ConcurrencyLimitOptions
+        {
+            MaxConcurrency = 1,
+            QueueLimit = 0,
+        });
+        var reserve = typeof(ConcurrencyLimitStrategy).GetMethod(
+            "TryReserveCapacity",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+        await Assert.That((bool)reserve.Invoke(strategy, null)!).IsTrue();
+        await Assert.That(strategy.CaptureState().Queued).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task State_Registry_Compaction_Tolerates_Collected_Entries()
     {
         var registry = new KevlarMetrics.StateMetricRegistry<object>();
@@ -1667,6 +1684,32 @@ public class MetricsTests
         _ = registry.Observe(static (_, _) => 0).ToArray();
 
         await Assert.That(((Array)registrations.GetValue(registry)!).Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task State_Registration_Is_Published_Only_Once()
+    {
+        var registry = new KevlarMetrics.StateMetricRegistry<object>();
+        var strategy = new object();
+        var registration = registry.Register(strategy);
+        var firstProvider = AddCollectibleStateObservation(registration);
+
+        for (var attempt = 0; firstProvider.IsAlive && attempt < 10; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        _ = registry.Observe(static (_, _) => 0).ToArray();
+        var secondProvider = new FakeTimeProvider();
+        registration.Add(new StrategyMetricAlias("metrics-republished-state", 0), secondProvider);
+        var observations = registry.Observe(static (_, _) => 0).ToArray();
+
+        await Assert.That(firstProvider.IsAlive).IsFalse();
+        await Assert.That(observations.Length).IsEqualTo(1);
+        GC.KeepAlive(strategy);
+        GC.KeepAlive(secondProvider);
     }
 
     [Test]
@@ -1911,6 +1954,16 @@ public class MetricsTests
             .WithName("metrics-collectible-provider-alias")
             .WithTimeProvider(timeProvider)
             .Execute(static _ => { });
+        return new WeakReference(timeProvider);
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference AddCollectibleStateObservation(
+        KevlarMetrics.StateMetricRegistration<object> registration)
+    {
+        var timeProvider = new FakeTimeProvider();
+        registration.Add(new StrategyMetricAlias("metrics-republished-state", 0), timeProvider);
         return new WeakReference(timeProvider);
     }
 

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -53,6 +53,8 @@ public class MetricsTests
 
         public IReadOnlyCollection<Instrument> Instruments => _instruments.Values.ToArray();
 
+        public void RecordObservableInstruments() => _listener.RecordObservableInstruments();
+
         public IReadOnlyCollection<long> Values(string instrument, string? shieldName, bool requireName = true) =>
             _measurements
                 .Where(measurement => measurement.Instrument == instrument)
@@ -1233,10 +1235,17 @@ public class MetricsTests
         }).WithTimeProvider(timeProvider).WithName("metrics-circuit-state");
 
         await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        listener.RecordObservableInstruments();
         _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        listener.RecordObservableInstruments();
         timeProvider.Advance(TimeSpan.FromSeconds(1));
-        await shield.ExecuteAsync(_ => new ValueTask<int>(2));
+        await shield.ExecuteAsync(_ =>
+        {
+            listener.RecordObservableInstruments();
+            return new ValueTask<int>(2);
+        });
         monitor.Isolate();
+        listener.RecordObservableInstruments();
         _ = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(3));
 
         await Assert.That(listener.Values("kevlar.circuit_breaker.state", "metrics-circuit-state"))
@@ -1255,17 +1264,20 @@ public class MetricsTests
             .WithName("metrics-manual-circuit-state");
 
         await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
+        listener.RecordObservableInstruments();
         var closedMeasurements = listener.Values(
             "kevlar.circuit_breaker.state",
             "metrics-manual-circuit-state").Count(value => value == 0);
 
         monitor.Isolate();
+        listener.RecordObservableInstruments();
         await Assert.That(listener.Values(
                 "kevlar.circuit_breaker.state",
                 "metrics-manual-circuit-state"))
             .Contains(3);
 
         monitor.Reset();
+        listener.RecordObservableInstruments();
         await Assert.That(listener.Values(
                 "kevlar.circuit_breaker.state",
                 "metrics-manual-circuit-state").Count(value => value == 0))
@@ -1283,6 +1295,7 @@ public class MetricsTests
         monitor.Isolate();
         _ = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
         monitor.Reset();
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.circuit_breaker.state",
@@ -1304,14 +1317,20 @@ public class MetricsTests
         monitor.Isolate();
 
         using var listener = new KevlarMeterListener();
+        listener.RecordObservableInstruments();
+        var unnamedMeasurements = listener.Values(
+            "kevlar.circuit_breaker.state",
+            shieldName: null,
+            requireName: false).Count;
         _ = await shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1));
         monitor.Reset();
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.circuit_breaker.state",
                 shieldName: null,
                 requireName: false).Count)
-            .IsEqualTo(0);
+            .IsEqualTo(unnamedMeasurements * 2);
         await Assert.That(listener.Values(
                 "kevlar.circuit_breaker.state",
                 "metrics-disabled-circuit-alias").Last())
@@ -1330,6 +1349,7 @@ public class MetricsTests
         await first.ExecuteAsync(_ => ValueTask.CompletedTask);
         await second.ExecuteAsync(_ => ValueTask.CompletedTask);
         monitor.Isolate();
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.circuit_breaker.state",
@@ -1341,6 +1361,7 @@ public class MetricsTests
             .IsEqualTo(3);
 
         monitor.Reset();
+        listener.RecordObservableInstruments();
         await Assert.That(listener.Values(
                 "kevlar.circuit_breaker.state",
                 "metrics-circuit-alias-first").Last())
@@ -1352,61 +1373,53 @@ public class MetricsTests
     }
 
     [Test]
-    public async Task Circuit_Execution_Sample_Cannot_Overwrite_A_Newer_Transition()
+    public async Task State_Gauge_Callbacks_Run_Only_During_Collection()
     {
-        CircuitBreakerMonitor? monitor = null;
-        var openMeasurements = 0;
-        using var listener = new KevlarMeterListener((instrument, value) =>
+        var callbacks = 0;
+        using var listener = new KevlarMeterListener((instrument, _) =>
         {
-            if (instrument == "kevlar.circuit_breaker.state"
-                && value == 1
-                && Interlocked.Increment(ref openMeasurements) == 2)
+            if (instrument == "kevlar.concurrency_limit.inflight")
             {
-                monitor!.Reset();
+                callbacks++;
             }
         });
-        monitor = new CircuitBreakerMonitor();
-        var shield = Shield.CircuitBreaker(options =>
-        {
-            options.ConsecutiveFailures = 1;
-            options.Monitor = monitor;
-        }).WithName("metrics-circuit-transition-race");
+        var shield = Shield.ConcurrencyLimit(1).WithName("metrics-collection-only");
 
-        _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
+        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
+        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
 
-        await Assert.That(listener.Values(
-                "kevlar.circuit_breaker.state",
-                "metrics-circuit-transition-race").Last())
-            .IsEqualTo(0);
+        await Assert.That(callbacks).IsEqualTo(0);
+        listener.RecordObservableInstruments();
+        await Assert.That(callbacks).IsGreaterThan(0);
     }
 
     [Test]
-    public async Task Circuit_Metric_Failure_Releases_An_Admitted_Probe()
+    public async Task State_Gauge_Listener_Failure_Does_Not_Fail_Execution()
     {
-        var halfOpenMeasurements = 0;
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        using var listener = new KevlarMeterListener((instrument, value) =>
+        var callbackInvoked = false;
+        using var listener = new KevlarMeterListener((instrument, _) =>
         {
-            if (instrument == "kevlar.circuit_breaker.state"
-                && value == 2
-                && Interlocked.Increment(ref halfOpenMeasurements) == 2)
+            if (instrument == "kevlar.rate_limit.available")
             {
-                throw metricsFailure;
+                callbackInvoked = true;
+                throw new InvalidOperationException("metrics callback");
             }
         });
-        var timeProvider = new FakeTimeProvider();
-        var shield = Shield.CircuitBreaker(1, TimeSpan.FromSeconds(1))
-            .WithTimeProvider(timeProvider)
-            .WithName("metrics-circuit-probe-failure");
+        var shield = Shield.RateLimit(10, TimeSpan.FromSeconds(1))
+            .WithName("metrics-listener-failure");
 
-        _ = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException());
-        timeProvider.Advance(TimeSpan.FromSeconds(1));
-        var thrown = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => new ValueTask<int>(1)))
-            .Throws<InvalidOperationException>();
-        await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(42))).IsEqualTo(42);
 
-        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(2))).IsEqualTo(2);
+        try
+        {
+            listener.RecordObservableInstruments();
+        }
+        catch (AggregateException)
+        {
+            // Listener exceptions belong to collection, never shield execution.
+        }
+
+        await Assert.That(callbackInvoked).IsTrue();
     }
 
     [Test]
@@ -1419,6 +1432,7 @@ public class MetricsTests
             .WithName(name);
 
         await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
+        listener.RecordObservableInstruments();
 
         var measurements = listener.LongMeasurements(
             "kevlar.concurrency_limit.capacity",
@@ -1444,6 +1458,7 @@ public class MetricsTests
         }
 
         monitor.Isolate();
+        listener.RecordObservableInstruments();
 
         var isolatedAliases = listener.AllLongMeasurements("kevlar.circuit_breaker.state")
             .Where(measurement => measurement.Value == 3)
@@ -1468,6 +1483,7 @@ public class MetricsTests
         var shield = Shield.ConcurrencyLimit(1).WithName("metrics-immediate-concurrency");
 
         await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
+        listener.RecordObservableInstruments();
 
         var queued = listener.Values(
             "kevlar.concurrency_limit.queued",
@@ -1499,6 +1515,7 @@ public class MetricsTests
         await bothEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
         release.TrySetResult();
         await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.concurrency_limit.inflight",
@@ -1539,6 +1556,7 @@ public class MetricsTests
         await firstExecution;
         releaseSecond.TrySetResult();
         await secondExecution;
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.concurrency_limit.inflight",
@@ -1577,59 +1595,12 @@ public class MetricsTests
             .ToArray();
         release.TrySetResult();
         await Task.WhenAll(queued.Prepend(holder));
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.concurrency_limit.inflight",
                 "metrics-concurrency-handoffs").All(value => value <= 1))
             .IsTrue();
-    }
-
-    [Test]
-    public async Task Concurrency_Metric_Failure_Releases_The_Pending_Wait()
-    {
-        var throwOnQueued = true;
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        using var observer = new KevlarMeterListener();
-        using var listener = new KevlarMeterListener((instrument, value) =>
-        {
-            if (throwOnQueued && instrument == "kevlar.concurrency_limit.queued" && value == 1)
-            {
-                throwOnQueued = false;
-                throw metricsFailure;
-            }
-        });
-        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var shield = Shield.ConcurrencyLimit(1, 1)
-            .WithName("metrics-concurrency-pending-failure");
-        var holder = shield.ExecuteAsync(async _ =>
-        {
-            entered.TrySetResult();
-            await release.Task;
-        }).AsTask();
-        await entered.Task;
-
-        var failed = shield.ExecuteAsync(_ => ValueTask.CompletedTask).AsTask();
-        InvalidOperationException? thrown;
-        try
-        {
-            thrown = await Assert.That(async () =>
-                    await failed.WaitAsync(TimeSpan.FromSeconds(5)))
-                .Throws<InvalidOperationException>();
-            await Assert.That(observer.Values(
-                    "kevlar.concurrency_limit.queued",
-                    "metrics-concurrency-pending-failure").Last())
-                .IsEqualTo(0);
-        }
-        finally
-        {
-            release.TrySetResult();
-            await holder;
-        }
-
-        await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
     }
 
     [Test]
@@ -1647,11 +1618,15 @@ public class MetricsTests
             return 1;
         }).AsTask();
         await entered.Task;
+        listener.RecordObservableInstruments();
         var queued = shield.ExecuteAsync(_ => new ValueTask<int>(2), cancellation.Token).AsTask();
+        listener.RecordObservableInstruments();
         cancellation.Cancel();
         await Assert.That(async () => await queued).Throws<OperationCanceledException>();
+        listener.RecordObservableInstruments();
         release.SetResult();
         _ = await occupying;
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values("kevlar.concurrency_limit.inflight", "metrics-concurrency-state"))
             .Contains(1)
@@ -1663,6 +1638,7 @@ public class MetricsTests
             .All(value => value == 1)).IsTrue();
 
         await Shield.ConcurrencyLimit(1).ExecuteAsync(_ => new ValueTask<int>(3));
+        listener.RecordObservableInstruments();
         await Assert.That(listener.Values("kevlar.concurrency_limit.inflight", null, requireName: false).Count > 0)
             .IsTrue();
     }
@@ -1682,10 +1658,14 @@ public class MetricsTests
         }).WithTimeProvider(timeProvider).WithName("metrics-rate-state");
 
         await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+        listener.RecordObservableInstruments();
         await shield.ExecuteAsync(_ => new ValueTask<int>(2));
+        listener.RecordObservableInstruments();
         var queued = shield.ExecuteAsync(_ => new ValueTask<int>(3), cancellation.Token).AsTask();
+        listener.RecordObservableInstruments();
         cancellation.Cancel();
         await Assert.That(async () => await queued).Throws<OperationCanceledException>();
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values("kevlar.rate_limit.available", "metrics-rate-state"))
             .Contains(1)
@@ -1716,6 +1696,7 @@ public class MetricsTests
         var second = shield.ExecuteAsync(
             _ => ValueTask.CompletedTask,
             secondCancellation.Token).AsTask();
+        listener.RecordObservableInstruments();
         await Assert.That(listener.Values(
                 "kevlar.rate_limit.queued",
                 "metrics-concurrent-rate-cancellation"))
@@ -1726,6 +1707,7 @@ public class MetricsTests
             Task.Run(secondCancellation.Cancel));
         await Assert.That(async () => await first).Throws<OperationCanceledException>();
         await Assert.That(async () => await second).Throws<OperationCanceledException>();
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.rate_limit.queued",
@@ -1761,6 +1743,7 @@ public class MetricsTests
         await Assert.That(async () => await firstQueued).Throws<OperationCanceledException>();
         secondCancellation.Cancel();
         await Assert.That(async () => await secondQueued).Throws<OperationCanceledException>();
+        listener.RecordObservableInstruments();
 
         await Assert.That(listener.Values(
                 "kevlar.rate_limit.queued",
@@ -1773,281 +1756,32 @@ public class MetricsTests
     }
 
     [Test]
-    public async Task Rate_Metric_Failure_Removes_The_Queued_Reservation()
+    public async Task State_Gauges_Do_Not_Retain_Collected_Strategies()
     {
-        var throwOnQueued = true;
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        using var observer = new KevlarMeterListener();
-        using var listener = new KevlarMeterListener((instrument, value) =>
+        using var listener = new KevlarMeterListener();
+        var strategy = CreateCollectibleStateStrategy();
+
+        for (var attempt = 0; strategy.IsAlive && attempt < 10; attempt++)
         {
-            if (throwOnQueued && instrument == "kevlar.rate_limit.queued" && value == 1)
-            {
-                throwOnQueued = false;
-                throw metricsFailure;
-            }
-        });
-        using var cancellation = new CancellationTokenSource();
-        var timeProvider = new FakeTimeProvider();
-        var shield = Shield.RateLimit(options =>
-        {
-            options.Permits = 1;
-            options.Window = TimeSpan.FromHours(1);
-            options.QueueLimit = 1;
-        }).WithTimeProvider(timeProvider).WithName("metrics-rate-reservation-failure");
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-        var thrown = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => ValueTask.CompletedTask))
-            .Throws<InvalidOperationException>();
-        await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
-        await Assert.That(observer.Values(
-                "kevlar.rate_limit.queued",
-                "metrics-rate-reservation-failure").Last())
-            .IsEqualTo(0);
-
-        var queued = shield.ExecuteAsync(_ => ValueTask.CompletedTask, cancellation.Token).AsTask();
-        cancellation.Cancel();
-        await Assert.That(async () => await queued).Throws<OperationCanceledException>();
-    }
-
-    [Test]
-    public async Task Rate_Metric_Failure_Restores_An_Immediate_Permit()
-    {
-        var throwOnAvailable = true;
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        using var observer = new KevlarMeterListener();
-        using var listener = new KevlarMeterListener((instrument, value) =>
-        {
-            if (throwOnAvailable && instrument == "kevlar.rate_limit.available" && value == 0)
-            {
-                throwOnAvailable = false;
-                throw metricsFailure;
-            }
-        });
-        var invoked = false;
-        var shield = Shield.RateLimit(1, TimeSpan.FromHours(1))
-            .WithName("metrics-rate-immediate-failure");
-
-        var thrown = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ =>
-                {
-                    invoked = true;
-                    return ValueTask.CompletedTask;
-                }))
-            .Throws<InvalidOperationException>();
-        await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
-        await Assert.That(invoked).IsFalse();
-        await Assert.That(observer.Values(
-                "kevlar.rate_limit.available",
-                "metrics-rate-immediate-failure").Last())
-            .IsEqualTo(1);
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-    }
-
-    [Test]
-    public async Task Rate_Metric_Failure_Preserves_A_Nested_Admission()
-    {
-        var timeProvider = new FakeTimeProvider();
-        var nested = false;
-        var nestedInvocations = 0;
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        Shield? shield = null;
-        using var listener = new KevlarMeterListener((instrument, value) =>
-        {
-            if (nested || instrument != "kevlar.rate_limit.available" || value != 1)
-            {
-                return;
-            }
-
-            nested = true;
-            timeProvider.Advance(TimeSpan.FromHours(2));
-            shield!.ExecuteAsync(_ =>
-            {
-                nestedInvocations++;
-                return ValueTask.CompletedTask;
-            }).GetAwaiter().GetResult();
-            throw metricsFailure;
-        });
-        shield = Shield.RateLimit(options =>
-        {
-            options.Permits = 1;
-            options.Window = TimeSpan.FromHours(1);
-            options.Burst = 2;
-        }).WithTimeProvider(timeProvider).WithName("metrics-rate-nested-failure");
-
-        var thrown = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => ValueTask.CompletedTask))
-            .Throws<InvalidOperationException>();
-        await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
-        await Assert.That(nestedInvocations).IsEqualTo(1);
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-        _ = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => ValueTask.CompletedTask))
-            .Throws<RateLimitExceededException>();
-    }
-
-    [Test]
-    public async Task Rate_Metric_Failure_Preserves_Admission_After_Listener_Disables()
-    {
-        var nested = false;
-        var nestedInvocations = 0;
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        Shield? shield = null;
-        KevlarMeterListener? listener = null;
-        listener = new KevlarMeterListener((instrument, value) =>
-        {
-            if (nested || instrument != "kevlar.rate_limit.available" || value != 1)
-            {
-                return;
-            }
-
-            nested = true;
-            listener!.Dispose();
-            shield!.ExecuteAsync(_ =>
-            {
-                nestedInvocations++;
-                return ValueTask.CompletedTask;
-            }).GetAwaiter().GetResult();
-            throw metricsFailure;
-        });
-        using (listener)
-        {
-            shield = Shield.RateLimit(options =>
-            {
-                options.Permits = 1;
-                options.Window = TimeSpan.FromHours(1);
-                options.Burst = 2;
-            }).WithName("metrics-rate-disabled-nested-failure");
-
-            var thrown = await Assert.That(async () =>
-                    await shield.ExecuteAsync(_ => ValueTask.CompletedTask))
-                .Throws<InvalidOperationException>();
-            await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
         }
 
-        await Assert.That(nestedInvocations).IsEqualTo(1);
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-        _ = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => ValueTask.CompletedTask))
-            .Throws<RateLimitExceededException>();
+        listener.RecordObservableInstruments();
+
+        await Assert.That(strategy.IsAlive).IsFalse();
     }
 
-    [Test]
-    public async Task Rate_Metric_Rollback_Preserves_An_Admission_That_Observed_Metrics_Disabled()
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference CreateCollectibleStateStrategy()
     {
-        using var timeProvider = new BlockingFirstTimestampTimeProvider();
-        var shield = Shield.RateLimit(options =>
-        {
-            options.Permits = 1;
-            options.Window = TimeSpan.FromHours(1);
-            options.Burst = 2;
-        }).WithTimeProvider(timeProvider).WithName("metrics-rate-concurrent-enable");
-        var untracked = Task.Run(async () => await shield.ExecuteAsync(_ => ValueTask.CompletedTask));
-
-        await Assert.That(timeProvider.WaitForBlockedSample(TimeSpan.FromSeconds(5))).IsTrue();
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        var throwOnce = true;
-        using var listener = new KevlarMeterListener((instrument, _) =>
-        {
-            if (throwOnce && instrument == "kevlar.rate_limit.available")
-            {
-                throwOnce = false;
-                throw metricsFailure;
-            }
-        });
-        var failedAdmission = Task.Run(async () => await shield.ExecuteAsync(_ => ValueTask.CompletedTask));
-
-        timeProvider.ReleaseBlockedSample();
-        await untracked.WaitAsync(TimeSpan.FromSeconds(5));
-        var thrown = await Assert.That(async () =>
-                await failedAdmission.WaitAsync(TimeSpan.FromSeconds(5)))
-            .Throws<InvalidOperationException>();
-        await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-        _ = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => ValueTask.CompletedTask))
-            .Throws<RateLimitExceededException>();
+        var shield = Shield.ConcurrencyLimit(1).WithName("metrics-collectible-strategy");
+        shield.Execute(static _ => { });
+        return new WeakReference(shield.Strategies[0]);
     }
 
-    [Test]
-    public async Task Rate_Queue_Reports_Zero_Availability_After_Its_Due_Time()
-    {
-        var timeProvider = new FakeTimeProvider();
-        var advancedWithQueuedReservation = false;
-        var observedInvalidAvailability = false;
-        using var listener = new KevlarMeterListener((instrument, value) =>
-        {
-            if (instrument == "kevlar.rate_limit.queued"
-                && value == 1
-                && !advancedWithQueuedReservation)
-            {
-                advancedWithQueuedReservation = true;
-                timeProvider.Advance(TimeSpan.FromSeconds(1));
-            }
-            else if (instrument == "kevlar.rate_limit.available"
-                && value > 0
-                && advancedWithQueuedReservation)
-            {
-                observedInvalidAvailability = true;
-            }
-        });
-        var shield = Shield.RateLimit(options =>
-        {
-            options.Permits = 1;
-            options.Window = TimeSpan.FromSeconds(1);
-            options.QueueLimit = 1;
-        }).WithTimeProvider(timeProvider).WithName("metrics-rate-due-reservation");
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-
-        await Assert.That(advancedWithQueuedReservation).IsTrue();
-        await Assert.That(observedInvalidAvailability).IsFalse();
-    }
-
-    [Test]
-    public async Task Rate_Metric_Failure_Restores_A_Consumed_Queued_Permit()
-    {
-        var timeProvider = new FakeTimeProvider();
-        var reservationQueued = false;
-        var throwOnConsumption = true;
-        var metricsFailure = new InvalidOperationException("metrics callback");
-        using var listener = new KevlarMeterListener((instrument, value) =>
-        {
-            if (instrument != "kevlar.rate_limit.queued")
-            {
-                return;
-            }
-
-            if (value == 1 && !reservationQueued)
-            {
-                reservationQueued = true;
-                timeProvider.Advance(TimeSpan.FromSeconds(1));
-            }
-            else if (value == 0 && reservationQueued && throwOnConsumption)
-            {
-                throwOnConsumption = false;
-                throw metricsFailure;
-            }
-        });
-        var shield = Shield.RateLimit(options =>
-        {
-            options.Permits = 1;
-            options.Window = TimeSpan.FromSeconds(1);
-            options.QueueLimit = 1;
-        }).WithTimeProvider(timeProvider).WithName("metrics-rate-consumption-failure");
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-        var thrown = await Assert.That(async () =>
-                await shield.ExecuteAsync(_ => ValueTask.CompletedTask))
-            .Throws<InvalidOperationException>();
-        await Assert.That(ReferenceEquals(thrown, metricsFailure)).IsTrue();
-
-        await shield.ExecuteAsync(_ => ValueTask.CompletedTask);
-    }
 #endif
 
     private static Dictionary<(CircuitState From, CircuitState To), long> CircuitTransitionTotals(

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -273,7 +273,7 @@ public class MetricsTests
             .All(instrument => instrument is Histogram<double>)).IsTrue();
         await Assert.That(listener.Instruments
             .Where(instrument => instrument.Name is not ("kevlar.execution.duration" or "kevlar.attempt.duration"))
-            .All(instrument => instrument is Counter<long> or Gauge<long>)).IsTrue();
+            .All(instrument => instrument is Counter<long> or ObservableGauge<long>)).IsTrue();
         await Assert.That(listener.Instruments.All(instrument => instrument.Meter.Name == "Kevlar")).IsTrue();
         await Assert.That(listener.Instruments.All(instrument => instrument.Meter.Version == "1.0")).IsTrue();
         await Assert.That(listener.Instruments.All(instrument =>

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1689,30 +1689,27 @@ public class MetricsTests
     }
 
     [Test]
-    public async Task Concurrency_State_Uses_Atomic_Running_Count_During_Permit_Transfer()
+    public async Task Concurrency_Queued_Permit_Transition_Updates_State_Atomically()
     {
         var strategy = new ConcurrencyLimitStrategy(new ConcurrencyLimitOptions
         {
             MaxConcurrency = 2,
             QueueLimit = 1,
         });
-        var available = typeof(ConcurrencyLimitStrategy).GetField(
-            "_available",
+        var state = typeof(ConcurrencyLimitStrategy).GetField(
+            "_state",
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        var running = typeof(ConcurrencyLimitStrategy).GetField(
-            "_running",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        var semaphore = typeof(ConcurrencyLimitStrategy).GetField(
-            "_semaphore",
+        var acquireQueued = typeof(ConcurrencyLimitStrategy).GetMethod(
+            "TryAcquireQueuedPermit",
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
 
-        available.SetValue(strategy, 1);
-        running.SetValue(strategy, 1);
-        ((SemaphoreSlim)semaphore.GetValue(strategy)!).Release();
+        state.SetValue(strategy, 1L);
+        await Assert.That((bool)acquireQueued.Invoke(strategy, [false])!).IsTrue();
 
-        var state = strategy.CaptureState();
-        await Assert.That(state.Available).IsEqualTo(1);
-        await Assert.That(state.Running).IsEqualTo(1);
+        var snapshot = strategy.CaptureState();
+        await Assert.That(snapshot.Available).IsEqualTo(1);
+        await Assert.That(snapshot.Running).IsEqualTo(1);
+        await Assert.That(snapshot.Queued).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1689,6 +1689,33 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Concurrency_State_Uses_Atomic_Running_Count_During_Permit_Transfer()
+    {
+        var strategy = new ConcurrencyLimitStrategy(new ConcurrencyLimitOptions
+        {
+            MaxConcurrency = 2,
+            QueueLimit = 1,
+        });
+        var available = typeof(ConcurrencyLimitStrategy).GetField(
+            "_available",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var running = typeof(ConcurrencyLimitStrategy).GetField(
+            "_running",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var semaphore = typeof(ConcurrencyLimitStrategy).GetField(
+            "_semaphore",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+        available.SetValue(strategy, 1);
+        running.SetValue(strategy, 1);
+        ((SemaphoreSlim)semaphore.GetValue(strategy)!).Release();
+
+        var state = strategy.CaptureState();
+        await Assert.That(state.Available).IsEqualTo(1);
+        await Assert.That(state.Running).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task State_Registry_Compaction_Tolerates_Collected_Entries()
     {
         var registry = new KevlarMetrics.StateMetricRegistry<object>();
@@ -1766,6 +1793,57 @@ public class MetricsTests
         await Assert.That(providers.All(static provider => !provider.IsAlive)).IsTrue();
         await Assert.That(registration.Observations.Select(static observation => observation.Alias))
             .IsEquivalentTo([liveAlias]);
+        GC.KeepAlive(strategy);
+        GC.KeepAlive(liveProvider);
+    }
+
+    [Test]
+    public async Task State_Registration_Serializes_Provider_Revival_With_Compaction()
+    {
+        var registry = new KevlarMetrics.StateMetricRegistry<object>();
+        var strategy = new object();
+        var registration = registry.Register(strategy);
+        var alias = new StrategyMetricAlias("metrics-provider-revival", 0);
+        var oldProvider = AddCollectibleStateObservation(registration, alias.ShieldName!);
+
+        for (var attempt = 0; oldProvider.IsAlive && attempt < 10; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        var gateField = typeof(KevlarMetrics.StateMetricRegistration<object>).GetField(
+            "_gate",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var gate = (Lock)gateField.GetValue(registration)!;
+        var liveProvider = new FakeTimeProvider();
+        using var started = new ManualResetEventSlim();
+        Task revival;
+        bool startedWhileCompactionHeld;
+        bool completedWhileCompactionHeld;
+        using (gate.EnterScope())
+        {
+            revival = Task.Run(() =>
+            {
+                started.Set();
+                registration.Add(alias, liveProvider);
+            });
+            startedWhileCompactionHeld = started.Wait(TimeSpan.FromSeconds(5));
+            completedWhileCompactionHeld = startedWhileCompactionHeld
+                && revival.Wait(TimeSpan.FromMilliseconds(200));
+        }
+
+        await revival.WaitAsync(TimeSpan.FromSeconds(5));
+        registration.RemoveCollectedObservations();
+
+        await Assert.That(oldProvider.IsAlive).IsFalse();
+        await Assert.That(startedWhileCompactionHeld).IsTrue();
+        await Assert.That(completedWhileCompactionHeld).IsFalse();
+        await Assert.That(registration.Observations).Count().IsEqualTo(1);
+        await Assert.That(registration.Observations[0].TryGetTimeProvider(out var retainedProvider))
+            .IsTrue();
+        await Assert.That(ReferenceEquals(retainedProvider, liveProvider)).IsTrue();
         GC.KeepAlive(strategy);
         GC.KeepAlive(liveProvider);
     }

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1737,6 +1737,42 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Concurrency_Redundant_Wake_Signal_Does_Not_Fail_Completion()
+    {
+        var strategy = new ConcurrencyLimitStrategy(new ConcurrencyLimitOptions
+        {
+            MaxConcurrency = 1,
+            QueueLimit = 2,
+        });
+        var state = typeof(ConcurrencyLimitStrategy).GetField(
+            "_state",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var waiters = typeof(ConcurrencyLimitStrategy).GetField(
+            "_waiters",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var semaphore = (SemaphoreSlim)typeof(ConcurrencyLimitStrategy).GetField(
+            "_semaphore",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(strategy)!;
+        var acquire = typeof(ConcurrencyLimitStrategy).GetMethod(
+            "TryAcquirePermit",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var release = typeof(ConcurrencyLimitStrategy).GetMethod(
+            "ReleasePermit",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+        state.SetValue(strategy, 0L);
+        await Assert.That((bool)acquire.Invoke(strategy, null)!).IsTrue();
+        semaphore.Release();
+        waiters.SetValue(strategy, 1);
+
+        release.Invoke(strategy, null);
+
+        await Assert.That(semaphore.CurrentCount).IsEqualTo(2);
+        await Assert.That(strategy.CaptureState().Running).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task State_Registry_Compaction_Tolerates_Collected_Entries()
     {
         var registry = new KevlarMetrics.StateMetricRegistry<object>();

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1604,6 +1604,72 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Concurrency_Queued_Never_Includes_Rejected_Callers()
+    {
+        using var listener = new KevlarMeterListener();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.ConcurrencyLimit(1).WithName("metrics-concurrency-rejections");
+        var holder = shield.ExecuteAsync(async _ =>
+        {
+            entered.TrySetResult();
+            await release.Task;
+        }).AsTask();
+        await entered.Task;
+
+        var rejections = Enumerable.Range(0, 8)
+            .Select(worker => Task.Run(() =>
+            {
+                for (var attempt = 0; attempt < 5_000; attempt++)
+                {
+                    _ = shield.ExecuteOutcome(static _ => { });
+                }
+            }))
+            .ToArray();
+        while (rejections.Any(static task => !task.IsCompleted))
+        {
+            listener.RecordObservableInstruments();
+            await Task.Yield();
+        }
+
+        await Task.WhenAll(rejections);
+        listener.RecordObservableInstruments();
+        release.TrySetResult();
+        await holder;
+
+        await Assert.That(listener.Values(
+                "kevlar.concurrency_limit.queued",
+                "metrics-concurrency-rejections").All(static value => value == 0))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task State_Registry_Compaction_Tolerates_Collected_Entries()
+    {
+        var registry = new KevlarMetrics.StateMetricRegistry<object>();
+        var registration = registry.Register(new object());
+        var registrations = typeof(KevlarMetrics.StateMetricRegistry<object>).GetField(
+            "_registrations",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        registrations.SetValue(
+            registry,
+            new WeakReference<KevlarMetrics.StateMetricRegistration<object>>[] { null! });
+
+        registry.Publish(registration);
+        await Assert.That(((Array)registrations.GetValue(registry)!)
+                .Cast<object?>()
+                .All(static item => item is not null))
+            .IsTrue();
+
+        registrations.SetValue(
+            registry,
+            new WeakReference<KevlarMetrics.StateMetricRegistration<object>>[] { null! });
+        _ = registry.Observe(static (_, _) => 0).ToArray();
+
+        await Assert.That(((Array)registrations.GetValue(registry)!).Length).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Concurrency_Gauges_Track_Inflight_Queue_And_Cancellation()
     {
         using var listener = new KevlarMeterListener();

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1478,6 +1478,30 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Full_Live_Alias_Registration_Does_Not_Allocate_For_Overflow()
+    {
+        var registry = new KevlarMetrics.StateMetricRegistry<object>();
+        var strategy = new object();
+        var registration = registry.Register(strategy);
+        for (var index = 0; index < KevlarMetrics.MaxTrackedStrategyAliases; index++)
+        {
+            registration.Add(new StrategyMetricAlias($"metrics-full-alias-{index}", 0));
+        }
+
+        var overflow = new StrategyMetricAlias("metrics-overflow-alias", 0);
+        registration.Add(overflow);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var iteration = 0; iteration < 100; iteration++)
+        {
+            registration.Add(overflow);
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        await Assert.That(allocated).IsEqualTo(0);
+        GC.KeepAlive(strategy);
+    }
+
+    [Test]
     public async Task Immediately_Admitted_Execution_Is_Not_Reported_As_Queued()
     {
         using var listener = new KevlarMeterListener();


### PR DESCRIPTION
Closes #221

## Summary
- replace execution-time state gauge writes with pull-based ObservableGauge callbacks
- weakly register circuit breaker, concurrency limiter, and rate limiter state without retaining abandoned strategies
- preserve testing snapshots and add listener-failure, collection-timing, lifetime, allocation, and contention coverage
- document observable instrument types and execution-path locking behavior

## Validation
- dotnet build Kevlar.slnx -c Release
- Kevlar.Tests metrics: 41/41 on net10.0
- Kevlar.Tests behavior: 1051/1052 on net10.0 and 1033/1034 on net8.0; only the existing base-branch generated-doc failure for Kevlar.Outcome remains (covered by #294)
- Kevlar.Testing.Tests: 57/57 on net10.0 and 55/55 on net8.0
- Kevlar.AllocationTests: 4/4 on net10.0 and 4/4 on net8.0
- BenchmarkDotNet dry run for StateMetricsContentionBenchmarks
- npm run build