### PR TITLE
fix(analyzers): track deferred state mutations

### DIFF
--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3264,11 +3264,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
             if (visitedLocals.Add(localReference.Local)
-                && TryGetStableInitializer(localReference, context, out var initializer)
+                && TryGetStableAliasInitializer(localReference, context, out var initializer)
                 && initializer is not null)
             {
                 if (TryFindDeferredStateContext(
                     initializer,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+
+                if (TryFindDeferredStateMutation(
+                    localReference,
                     context,
                     knownTypes,
                     visitedLocals,
@@ -3451,6 +3461,135 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         capturedContext = null!;
         return false;
+    }
+
+    private static bool TryFindDeferredStateMutation(
+        ILocalReferenceOperation localReference,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol> visitedLocals,
+        out SyntaxNode capturedContext)
+    {
+        var semanticModel = context.Operation.SemanticModel;
+        if (semanticModel is null)
+        {
+            capturedContext = null!;
+            return false;
+        }
+
+        var scope = GetExecutableScope(localReference.Syntax, context.CancellationToken);
+        var body = scope is AnonymousFunctionExpressionSyntax anonymous
+            ? anonymous.Body
+            : GetFunctionBody(scope) ?? scope;
+        var controlFlowGraph = TryCreateControlFlowGraph(
+            localReference.Syntax,
+            semanticModel,
+            context.CancellationToken);
+        var mutations = body.DescendantNodesAndSelf(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax)
+            .Where(candidate => (candidate is InvocationExpressionSyntax
+                    or AssignmentExpressionSyntax)
+                && candidate.SpanStart < localReference.Syntax.SpanStart
+                && CanReach(
+                    candidate,
+                    localReference.Syntax,
+                    controlFlowGraph))
+            .ToArray();
+
+        foreach (var invocationSyntax in mutations.OfType<InvocationExpressionSyntax>())
+        {
+            if (semanticModel.GetOperation(
+                    invocationSyntax,
+                    context.CancellationToken) is not IInvocationOperation invocation
+                || !IsKnownRetainingMutation(invocation.TargetMethod)
+                || !IsRootedInLocal(
+                    GetReceiver(invocation),
+                    localReference.Local,
+                    context,
+                    visitedLocals: null))
+            {
+                continue;
+            }
+
+            foreach (var argument in invocation.Arguments)
+            {
+                if (TryFindDeferredStateContext(
+                    argument.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    return true;
+                }
+            }
+        }
+
+        foreach (var assignmentSyntax in mutations.OfType<AssignmentExpressionSyntax>())
+        {
+            if (semanticModel.GetOperation(
+                assignmentSyntax,
+                    context.CancellationToken) is ISimpleAssignmentOperation assignment
+                && IsRootedInLocal(
+                    assignment.Target,
+                    localReference.Local,
+                    context,
+                    visitedLocals: null)
+                && TryFindDeferredStateContext(
+                    assignment.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+            {
+                return true;
+            }
+        }
+
+        capturedContext = null!;
+        return false;
+    }
+
+    private static bool IsRootedInLocal(
+        IOperation? operation,
+        ILocalSymbol local,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        operation = Unwrap(operation);
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            if (SymbolEqualityComparer.Default.Equals(localReference.Local, local))
+            {
+                return true;
+            }
+
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            return visitedLocals.Add(localReference.Local)
+                && TryGetStableAliasInitializer(localReference, context, out var initializer)
+                && IsRootedInLocal(initializer, local, context, visitedLocals);
+        }
+
+        return operation switch
+        {
+            IFieldReferenceOperation field => IsRootedInLocal(
+                field.Instance,
+                local,
+                context,
+                visitedLocals),
+            IPropertyReferenceOperation property => IsRootedInLocal(
+                property.Instance,
+                local,
+                context,
+                visitedLocals),
+            IArrayElementReferenceOperation arrayElement => IsRootedInLocal(
+                arrayElement.ArrayReference,
+                local,
+                context,
+                visitedLocals),
+            _ => false,
+        };
     }
 
     private static bool IsInstanceParameterStored(

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -48,7 +48,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             StringComparer.Ordinal,
             "System.Tuple",
             "System.ValueTuple",
-            "System.Collections.Generic.KeyValuePair");
+            "System.Collections.Generic.KeyValuePair",
+            "System.Collections.Generic.LinkedListNode");
 
     private static readonly ImmutableHashSet<string> RetainingMutationNames =
         ImmutableHashSet.Create(
@@ -3803,6 +3804,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 foreach (var localKill in EnumerateLocalFunctionMutationKills(
                     invocation,
                     localReference.Local,
+                    initializer,
                     context))
                 {
                     kills.Add((
@@ -3847,25 +3849,39 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         RemovesOne: false,
                         Receiver: "root"));
                 }
-                else if (GetStaticArrayRetainedValue(invocation) is { } retainedValue
-                    && TryFindDeferredStateContext(
-                        retainedValue,
-                        context,
-                        knownTypes,
-                        visitedLocals,
-                        out capturedContext))
+                else
                 {
-                    origins.Add((
-                        invocation.Syntax,
-                        capturedContext,
-                        Slot: null,
-                        GetDeferredValueKey(
+                    if (IsFullStaticArrayOverwrite(invocation, initializer))
+                    {
+                        kills.Add((
+                            invocation.Syntax,
+                            Slot: null,
+                            ClearsAll: true,
+                            Value: null,
+                            RemovesOne: false,
+                            Receiver: "root"));
+                    }
+
+                    if (GetStaticArrayRetainedValue(invocation) is { } retainedValue
+                        && TryFindDeferredStateContext(
                             retainedValue,
                             context,
-                            visitedLocals: null),
-                        Receiver: "root",
-                        MayRetainMultiple: true,
-                        AllowsDuplicateValues: true));
+                            knownTypes,
+                            visitedLocals,
+                            out capturedContext))
+                    {
+                        origins.Add((
+                            invocation.Syntax,
+                            capturedContext,
+                            Slot: null,
+                            GetDeferredValueKey(
+                                retainedValue,
+                                context,
+                                visitedLocals: null),
+                            Receiver: "root",
+                            MayRetainMultiple: true,
+                            AllowsDuplicateValues: true));
+                    }
                 }
 
                 continue;
@@ -4471,6 +4487,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         string Receiver)> EnumerateLocalFunctionMutationKills(
         IInvocationOperation localFunctionInvocation,
         ILocalSymbol local,
+        IOperation initializer,
         OperationAnalysisContext context)
     {
         var semanticModel = context.Operation.SemanticModel;
@@ -4504,15 +4521,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                if (IsKnownStaticArrayMutation(invocation.TargetMethod)
-                    && invocation.TargetMethod.Name == "Clear"
-                    && invocation.Arguments.Length == 1
-                    && GetStaticArrayMutationTarget(invocation) is { } arrayTarget
+                if (GetStaticArrayMutationTarget(invocation) is { } arrayTarget
                     && IsRootedInLocalFunctionArgument(
                         arrayTarget,
                         localFunctionInvocation,
                         local,
-                        context))
+                        context)
+                    && (invocation.TargetMethod.Name == "Clear"
+                            && invocation.Arguments.Length == 1
+                        || IsFullStaticArrayOverwrite(invocation, initializer)))
                 {
                     yield return (
                         Slot: null,
@@ -4872,6 +4889,52 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    private static bool IsFullStaticArrayOverwrite(
+        IInvocationOperation invocation,
+        IOperation initializer)
+    {
+        if (invocation.TargetMethod.Name is not ("Copy" or "ConstrainedCopy")
+            || !TryGetKnownArrayLength(initializer, out var destinationLength)
+            || invocation.Arguments.FirstOrDefault(static argument =>
+                    argument.Parameter?.Name == "length")?.Value.ConstantValue
+                is not { HasValue: true, Value: int copiedLength }
+            || copiedLength != destinationLength)
+        {
+            return false;
+        }
+
+        var destinationIndex = invocation.Arguments.FirstOrDefault(static argument =>
+            argument.Parameter?.Name == "destinationIndex");
+        return destinationIndex is null
+            || destinationIndex.Value.ConstantValue is
+                { HasValue: true, Value: 0 };
+    }
+
+    private static bool TryGetKnownArrayLength(
+        IOperation initializer,
+        out int length)
+    {
+        if (Unwrap(initializer) is IArrayCreationOperation arrayCreation)
+        {
+            if (arrayCreation.Initializer is { } arrayInitializer)
+            {
+                length = arrayInitializer.ElementValues.Length;
+                return true;
+            }
+
+            if (arrayCreation.DimensionSizes.Length == 1
+                && arrayCreation.DimensionSizes[0].ConstantValue is
+                    { HasValue: true, Value: int dimension })
+            {
+                length = dimension;
+                return true;
+            }
+        }
+
+        length = 0;
+        return false;
     }
 
     private static bool IsArrayLike(IOperation operation)

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -4317,13 +4317,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
                 if (GetStaticArrayMutationTarget(invocation) is { } arrayTarget
                     && GetStaticArrayRetainedValue(invocation) is { } arrayRetainedValue
+                    && MapLocalFunctionValue(
+                        arrayRetainedValue,
+                        localFunctionInvocation) is { } mappedArrayRetainedValue
                     && IsRootedInLocalFunctionArgument(
                         arrayTarget,
                         localFunctionInvocation,
                         local,
                         context)
                     && TryFindDeferredStateContext(
-                        arrayRetainedValue,
+                        mappedArrayRetainedValue,
                         context,
                         knownTypes,
                         visitedLocals,
@@ -4333,7 +4336,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         arrayContext,
                         Slot: null,
                         GetDeferredValueKey(
-                            arrayRetainedValue,
+                            mappedArrayRetainedValue,
                             context,
                             visitedLocals: null),
                         Receiver: "root",
@@ -4367,8 +4370,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     : EnumerateRetainedDictionaryValues(invocation);
                 foreach (var retainedValue in retainedValues)
                 {
-                    if (!TryFindDeferredStateContext(
+                    var mappedRetainedValue = MapLocalFunctionValue(
                         retainedValue,
+                        localFunctionInvocation);
+                    if (!TryFindDeferredStateContext(
+                        mappedRetainedValue,
                         context,
                         knownTypes,
                         visitedLocals,
@@ -4381,14 +4387,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         capturedContext,
                         Slot: null,
                         GetDeferredValueKey(
-                            keyArgument?.Value ?? retainedValue,
+                            keyArgument is null
+                                ? mappedRetainedValue
+                                : MapLocalFunctionValue(
+                                    keyArgument.Value,
+                                    localFunctionInvocation),
                             context,
                             visitedLocals: null),
                         receiverKey,
                         MayRetainMultiple: IsBulkRetainingMutation(
                             invocation.TargetMethod)
                             && !IsSetType(receiver?.Type)
-                            && MayRetainMultipleValues(retainedValue),
+                            && MayRetainMultipleValues(mappedRetainedValue),
                         AllowsDuplicateValues: keyArgument is null
                             && !IsSetType(receiver?.Type));
                     if (keyArgument is not null)
@@ -4431,26 +4441,34 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     && IsDictionaryType(property.Property.ContainingType)
                         ? property.Arguments.FirstOrDefault()?.Value
                         : null;
+                var mappedDictionaryKey = dictionaryKey is null
+                    ? null
+                    : MapLocalFunctionValue(
+                        dictionaryKey,
+                        localFunctionInvocation);
+                var mappedValue = MapLocalFunctionValue(
+                    value,
+                    localFunctionInvocation);
                 IOperation retainedOperation;
                 SyntaxNode retainedContext;
-                if (dictionaryKey is not null
+                if (mappedDictionaryKey is not null
                     && TryFindDeferredStateContext(
-                        dictionaryKey,
+                        mappedDictionaryKey,
                         context,
                         knownTypes,
                         visitedLocals,
                         out retainedContext))
                 {
-                    retainedOperation = dictionaryKey;
+                    retainedOperation = mappedDictionaryKey;
                 }
                 else if (TryFindDeferredStateContext(
-                    value,
+                    mappedValue,
                     context,
                     knownTypes,
                     visitedLocals,
                     out retainedContext))
                 {
-                    retainedOperation = value;
+                    retainedOperation = mappedValue;
                 }
                 else
                 {
@@ -4465,7 +4483,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         local,
                         context),
                     GetDeferredValueKey(
-                        dictionaryKey ?? retainedOperation,
+                        mappedDictionaryKey ?? retainedOperation,
                         context,
                         visitedLocals: null),
                     GetLocalFunctionMutationReceiver(
@@ -4474,7 +4492,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         local,
                         context) ?? "root",
                     MayRetainMultiple: false,
-                    AllowsDuplicateValues: dictionaryKey is null);
+                    AllowsDuplicateValues: mappedDictionaryKey is null);
             }
         }
     }
@@ -4517,6 +4535,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 if (semanticModel.GetOperation(
                         invocationSyntax,
                         context.CancellationToken) is not IInvocationOperation invocation)
+                {
+                    continue;
+                }
+
+                if (IsPotentiallyConditionalLocalMutation(invocationSyntax, body))
                 {
                     continue;
                 }
@@ -4609,6 +4632,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
             foreach (var assignmentSyntax in mutations.OfType<AssignmentExpressionSyntax>())
             {
+                if (IsPotentiallyConditionalLocalMutation(assignmentSyntax, body))
+                {
+                    continue;
+                }
+
                 var operation = semanticModel.GetOperation(
                     assignmentSyntax,
                     context.CancellationToken);
@@ -4684,6 +4712,37 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         };
     }
 
+    private static bool IsPotentiallyConditionalLocalMutation(
+        SyntaxNode mutation,
+        SyntaxNode body) =>
+        mutation.Ancestors().TakeWhile(ancestor => ancestor != body)
+            .Any(static ancestor => ancestor is IfStatementSyntax
+                or SwitchStatementSyntax
+                or SwitchExpressionSyntax
+                or ConditionalExpressionSyntax
+                or WhileStatementSyntax
+                or DoStatementSyntax
+                or ForStatementSyntax
+                or ForEachStatementSyntax
+                or ForEachVariableStatementSyntax
+                or CatchClauseSyntax)
+        || body.DescendantNodes(descendIntoChildren: static node =>
+                node is not AnonymousFunctionExpressionSyntax
+                    and not LocalFunctionStatementSyntax)
+            .Any(candidate => candidate.SpanStart < mutation.SpanStart
+                && candidate is (IfStatementSyntax
+                    or SwitchStatementSyntax
+                    or WhileStatementSyntax
+                    or DoStatementSyntax
+                    or ForStatementSyntax
+                    or ForEachStatementSyntax
+                    or ForEachVariableStatementSyntax
+                    or ReturnStatementSyntax
+                    or ThrowStatementSyntax
+                    or GotoStatementSyntax
+                    or BreakStatementSyntax
+                    or ContinueStatementSyntax));
+
     private static string GetLocalFunctionReceiverKey(
         IOperation? receiver,
         IInvocationOperation localFunctionInvocation,
@@ -4711,10 +4770,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             IPropertyReferenceOperation property =>
                 $"{GetLocalFunctionReceiverKey(property.Instance, localFunctionInvocation, local, context)}" +
                 $".property:{property.Property.ToDisplayString()}:" +
-                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+                GetLocalFunctionArgumentKey(property.Arguments, localFunctionInvocation),
             IArrayElementReferenceOperation array =>
                 $"{GetLocalFunctionReceiverKey(array.ArrayReference, localFunctionInvocation, local, context)}" +
-                $".array:{GetArgumentKey(array.Indices)}",
+                $".array:{GetLocalFunctionArgumentKey(array.Indices, localFunctionInvocation)}",
             _ => GetDeferredReceiverKey(
                 receiver,
                 local,
@@ -4738,10 +4797,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             IPropertyReferenceOperation property =>
                 $"{GetLocalFunctionReceiverKey(property.Instance, localFunctionInvocation, local, context)}" +
                 $".property:{property.Property.ToDisplayString()}:" +
-                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+                GetLocalFunctionArgumentKey(property.Arguments, localFunctionInvocation),
             IArrayElementReferenceOperation array =>
                 $"{GetLocalFunctionReceiverKey(array.ArrayReference, localFunctionInvocation, local, context)}" +
-                $".array:{GetArgumentKey(array.Indices)}",
+                $".array:{GetLocalFunctionArgumentKey(array.Indices, localFunctionInvocation)}",
             _ => null,
         };
     }
@@ -4774,6 +4833,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IInvocationOperation localFunctionInvocation) =>
         localFunctionInvocation.Arguments.FirstOrDefault(argument =>
             SymbolEqualityComparer.Default.Equals(argument.Parameter, parameter))?.Value;
+
+    private static IOperation MapLocalFunctionValue(
+        IOperation operation,
+        IInvocationOperation localFunctionInvocation)
+    {
+        operation = Unwrap(operation)!;
+        return operation is IParameterReferenceOperation parameterReference
+            && TryGetLocalFunctionArgument(
+                parameterReference.Parameter,
+                localFunctionInvocation) is { } argument
+                    ? argument
+                    : operation;
+    }
+
+    private static string GetLocalFunctionArgumentKey(
+        IEnumerable<IOperation> arguments,
+        IInvocationOperation localFunctionInvocation) =>
+        GetArgumentKey(arguments.Select(argument =>
+            MapLocalFunctionValue(argument, localFunctionInvocation)));
+
+    private static string GetLocalFunctionArgumentKey(
+        ImmutableArray<IArgumentOperation> arguments,
+        IInvocationOperation localFunctionInvocation) =>
+        GetLocalFunctionArgumentKey(
+            arguments.Select(static argument => argument.Value),
+            localFunctionInvocation);
 
     private static bool IsKnownClearingMutation(IMethodSymbol method) =>
         method.Name == "Clear"
@@ -4835,7 +4920,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 StringComparison.Ordinal));
 
     private static bool IsKnownValueRemovingMutation(IMethodSymbol method) =>
-        method.Name == "Remove"
+        method.Name is "Remove" or "TryRemove"
         && method.Parameters.Length > 0
         && RetainingCollectionNamespaces.Contains(
             method.ContainingNamespace.ToDisplayString());

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3506,31 +3506,266 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             SyntaxNode Node,
             SyntaxNode Context,
             string? Slot,
-            string? Value)>();
+            string? Value,
+            string? Receiver,
+            bool MayRetainMultiple,
+            bool AllowsDuplicateValues)>();
         var kills = new List<(
             SyntaxNode Node,
             string? Slot,
             bool ClearsAll,
             string? Value,
-            bool RemovesOne)>();
+            bool RemovesOne,
+            string? Receiver)>();
+        var slotInvalidations = new List<(SyntaxNode Node, string Receiver)>();
         var retainingMutationCount = 0;
-        if (TryFindDeferredStateContext(
-            initializer,
-            context,
-            knownTypes,
-            visitedLocals,
-            out capturedContext))
+        var hasIndeterminateRetainingMutation = false;
+        var addedInitializerOrigins = false;
+        var unwrappedInitializer = Unwrap(initializer)!;
+        if (unwrappedInitializer is IArrayCreationOperation
+            {
+                Initializer: { } arrayInitializer,
+            })
+        {
+            for (var index = 0; index < arrayInitializer.ElementValues.Length; index++)
+            {
+                var element = arrayInitializer.ElementValues[index];
+                if (TryFindDeferredStateContext(
+                    element,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    origins.Add((
+                        element.Syntax,
+                        capturedContext,
+                        $"root.array:{GetConstantIdentityKey(
+                            SpecialType.System_Int32,
+                            index)}",
+                        GetDeferredValueKey(
+                            element,
+                            context,
+                            visitedLocals: null),
+                        Receiver: "root",
+                        MayRetainMultiple: false,
+                        AllowsDuplicateValues: true));
+                    addedInitializerOrigins = true;
+                }
+            }
+        }
+        else if (unwrappedInitializer.Syntax is CollectionExpressionSyntax collection)
+        {
+            var index = 0;
+            var hasSpread = false;
+            foreach (var element in collection.Elements)
+            {
+                var expression = element switch
+                {
+                    ExpressionElementSyntax expressionElement =>
+                        expressionElement.Expression,
+                    SpreadElementSyntax spreadElement => spreadElement.Expression,
+                    _ => null,
+                };
+                var elementOperation = expression is null
+                    ? null
+                    : semanticModel.GetOperation(expression, context.CancellationToken);
+                if (elementOperation is not null
+                    && TryFindDeferredStateContext(
+                        elementOperation,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
+                {
+                    origins.Add((
+                        expression!,
+                        capturedContext,
+                        element is SpreadElementSyntax || hasSpread
+                            ? null
+                            : GetIndexedCollectionSlot(
+                                unwrappedInitializer.Type,
+                                "root",
+                                index),
+                        GetDeferredValueKey(
+                            element is SpreadElementSyntax
+                                ? semanticModel.GetOperation(
+                                    capturedContext,
+                                    context.CancellationToken)
+                                : elementOperation,
+                            context,
+                            visitedLocals: null),
+                        Receiver: "root",
+                        MayRetainMultiple: element is SpreadElementSyntax,
+                        AllowsDuplicateValues:
+                            !IsSetType(unwrappedInitializer.Type)));
+                    addedInitializerOrigins = true;
+                }
+
+                hasSpread |= element is SpreadElementSyntax;
+                index++;
+            }
+        }
+        else if (unwrappedInitializer is IObjectCreationOperation
+            {
+                Initializer: { } objectInitializer,
+            } objectCreation)
+        {
+            foreach (var argument in objectCreation.Arguments)
+            {
+                if (argument.Parameter is not { } parameter
+                    || (!IsInstanceParameterStored(
+                            objectCreation.Constructor,
+                            parameter,
+                            semanticModel,
+                            context.CancellationToken)
+                        && !IsKnownRetainingFrameworkConstructorParameter(
+                            objectCreation.Constructor,
+                            parameter))
+                    || !TryFindDeferredStateContext(
+                        argument.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
+                {
+                    continue;
+                }
+
+                origins.Add((
+                    argument.Value.Syntax,
+                    capturedContext,
+                    Slot: null,
+                    GetDeferredValueKey(
+                        semanticModel.GetOperation(
+                            capturedContext,
+                            context.CancellationToken),
+                        context,
+                        visitedLocals: null),
+                    Receiver: "root",
+                    MayRetainMultiple:
+                        MayRetainMultipleValues(argument.Value),
+                    AllowsDuplicateValues: !IsSetType(objectCreation.Type)));
+                addedInitializerOrigins = true;
+            }
+
+            foreach (var initializerAssignment in
+                EnumerateInitializerAssignments(objectCreation, "root"))
+            {
+                if (TryFindDeferredStateContext(
+                    initializerAssignment.Assignment.Value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out capturedContext))
+                {
+                    origins.Add((
+                        initializerAssignment.Assignment.Syntax,
+                        capturedContext,
+                        initializerAssignment.Slot,
+                        GetDeferredValueKey(
+                            initializerAssignment.Assignment.Value,
+                            context,
+                            visitedLocals: null),
+                        initializerAssignment.Receiver,
+                        MayRetainMultiple: false,
+                        AllowsDuplicateValues: true));
+                    addedInitializerOrigins = true;
+                }
+            }
+
+            foreach (var initializerOperation in objectInitializer.Initializers)
+            {
+                if (initializerOperation is IInvocationOperation invocation)
+                {
+                    if (IsDictionaryType(invocation.TargetMethod.ContainingType)
+                        && invocation.Arguments.FirstOrDefault(static argument =>
+                            argument.Parameter?.Ordinal == 0) is { } keyArgument)
+                    {
+                        foreach (var argument in invocation.Arguments)
+                        {
+                            if (!TryFindDeferredStateContext(
+                                argument.Value,
+                                context,
+                                knownTypes,
+                                visitedLocals,
+                                out capturedContext))
+                            {
+                                continue;
+                            }
+
+                            origins.Add((
+                                invocation.Syntax,
+                                capturedContext,
+                                Slot: null,
+                                GetDeferredValueKey(
+                                    keyArgument.Value,
+                                    context,
+                                    visitedLocals: null),
+                                Receiver: "root",
+                                MayRetainMultiple: false,
+                                AllowsDuplicateValues: false));
+                            addedInitializerOrigins = true;
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    foreach (var argument in invocation.Arguments)
+                    {
+                        if (!TryFindDeferredStateContext(
+                            argument.Value,
+                            context,
+                            knownTypes,
+                            visitedLocals,
+                            out capturedContext))
+                        {
+                            continue;
+                        }
+
+                        origins.Add((
+                            argument.Value.Syntax,
+                            capturedContext,
+                            Slot: null,
+                            GetDeferredValueKey(
+                                argument.Value,
+                                context,
+                                visitedLocals: null),
+                            GetInitializerReceiverKey(GetReceiver(invocation)),
+                            MayRetainMultiple: false,
+                            AllowsDuplicateValues:
+                                !IsSetType(GetReceiver(invocation)?.Type)));
+                        addedInitializerOrigins = true;
+                    }
+                }
+            }
+        }
+
+        if (!addedInitializerOrigins
+            && TryFindDeferredStateContext(
+                initializer,
+                context,
+                knownTypes,
+                visitedLocals,
+                out capturedContext))
         {
             origins.Add((
                 initializer.Syntax,
                 capturedContext,
                 Slot: null,
                 GetDeferredValueKey(
-                    semanticModel.GetOperation(capturedContext, context.CancellationToken),
+                    semanticModel.GetOperation(
+                        capturedContext,
+                        context.CancellationToken),
                     context,
-                    visitedLocals: null)));
+                    visitedLocals: null),
+                Receiver: "root",
+                MayRetainMultiple: false,
+                AllowsDuplicateValues: !IsSetType(unwrappedInitializer.Type)));
         }
 
+        var startsEmpty = IsKnownEmptyDeferredContainer(initializer);
         foreach (var invocationSyntax in mutations.OfType<InvocationExpressionSyntax>())
         {
             if (semanticModel.GetOperation(
@@ -3545,6 +3780,45 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
+            if (IsKnownSlotInvalidatingMutation(invocation.TargetMethod))
+            {
+                slotInvalidations.Add((
+                    invocation.Syntax,
+                    GetDeferredReceiverKey(
+                        GetReceiver(invocation),
+                        localReference.Local,
+                        context,
+                    visitedLocals: null)));
+            }
+
+            if (invocation.TargetMethod.Name == "RemoveAt"
+                && invocation.Arguments.Length == 1
+                && invocation.Arguments[0].Value.ConstantValue is
+                    { HasValue: true, Value: int index }
+                && GetReceiver(invocation) is { } indexedReceiver)
+            {
+                var removedReceiverKey = GetDeferredReceiverKey(
+                    indexedReceiver,
+                    localReference.Local,
+                    context,
+                    visitedLocals: null);
+                var removedSlot = GetIndexedCollectionSlot(
+                    indexedReceiver.Type,
+                    removedReceiverKey,
+                    index);
+                if (removedSlot is not null)
+                {
+                    kills.Add((
+                        invocation.Syntax,
+                        removedSlot,
+                        ClearsAll: false,
+                        Value: null,
+                        RemovesOne: false,
+                        removedReceiverKey));
+                    continue;
+                }
+            }
+
             if (IsKnownClearingMutation(invocation.TargetMethod))
             {
                 kills.Add((
@@ -3552,7 +3826,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     Slot: null,
                     ClearsAll: true,
                     Value: null,
-                    RemovesOne: false));
+                    RemovesOne: false,
+                    GetDeferredReceiverKey(
+                        GetReceiver(invocation),
+                        localReference.Local,
+                        context,
+                        visitedLocals: null)));
                 continue;
             }
 
@@ -3566,7 +3845,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         invocation.Arguments[0].Value,
                         context,
                         visitedLocals: null),
-                    RemovesOne: false));
+                    RemovesOne: false,
+                    GetDeferredReceiverKey(
+                        GetReceiver(invocation),
+                        localReference.Local,
+                        context,
+                        visitedLocals: null)));
                 continue;
             }
 
@@ -3577,7 +3861,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     Slot: null,
                     ClearsAll: false,
                     Value: null,
-                    RemovesOne: true));
+                    RemovesOne: true,
+                    GetDeferredReceiverKey(
+                        GetReceiver(invocation),
+                        localReference.Local,
+                        context,
+                        visitedLocals: null)));
                 continue;
             }
 
@@ -3586,9 +3875,75 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            retainingMutationCount += IsBulkRetainingMutation(invocation.TargetMethod)
+            var receiver = GetReceiver(invocation);
+            var receiverKey = GetDeferredReceiverKey(
+                receiver,
+                localReference.Local,
+                context,
+                visitedLocals: null);
+            var isBulkMutation = IsBulkRetainingMutation(invocation.TargetMethod);
+            var isPotentiallyRepeated = invocation.Syntax.Ancestors().Any(static node =>
+                node is WhileStatementSyntax
+                    or DoStatementSyntax
+                    or ForStatementSyntax
+                    or ForEachStatementSyntax
+                    or ForEachVariableStatementSyntax);
+            var isPathDependent = invocation.Syntax.Ancestors().Any(static node =>
+                node is IfStatementSyntax
+                    or SwitchStatementSyntax
+                    or SwitchExpressionSyntax
+                    or ConditionalExpressionSyntax
+                    or CatchClauseSyntax);
+            var appendSlot = startsEmpty
+                && !hasIndeterminateRetainingMutation
+                && !isBulkMutation
+                && !isPotentiallyRepeated
+                && invocation.TargetMethod.Name == "Add"
+                && invocation.Arguments.Length == 1
+                    ? GetIndexedCollectionSlot(
+                        receiver?.Type,
+                        receiverKey,
+                        retainingMutationCount)
+                    : null;
+            retainingMutationCount += isBulkMutation
                 ? 2
                 : 1;
+            hasIndeterminateRetainingMutation |= isBulkMutation
+                || isPotentiallyRepeated
+                || isPathDependent;
+            if (IsDictionaryType(invocation.TargetMethod.ContainingType)
+                && invocation.Arguments.FirstOrDefault(static argument =>
+                    argument.Parameter?.Ordinal == 0) is { } keyArgument)
+            {
+                foreach (var argument in invocation.Arguments)
+                {
+                    if (!TryFindDeferredStateContext(
+                        argument.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
+                    {
+                        continue;
+                    }
+
+                    origins.Add((
+                        invocation.Syntax,
+                        capturedContext,
+                        Slot: null,
+                        GetDeferredValueKey(
+                            keyArgument.Value,
+                            context,
+                            visitedLocals: null),
+                        receiverKey,
+                        MayRetainMultiple: false,
+                        AllowsDuplicateValues: false));
+                    break;
+                }
+
+                continue;
+            }
+
             foreach (var argument in invocation.Arguments)
             {
                 if (TryFindDeferredStateContext(
@@ -3601,79 +3956,183 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     origins.Add((
                         invocation.Syntax,
                         capturedContext,
-                        Slot: null,
+                        appendSlot,
                         GetDeferredValueKey(
-                            semanticModel.GetOperation(
-                                capturedContext,
-                                context.CancellationToken),
+                            isBulkMutation
+                                ? semanticModel.GetOperation(
+                                    capturedContext,
+                                    context.CancellationToken)
+                                : argument.Value,
                             context,
-                            visitedLocals: null)));
+                            visitedLocals: null),
+                        receiverKey,
+                        isBulkMutation
+                            && !IsSetType(receiver?.Type)
+                            && MayRetainMultipleValues(argument.Value),
+                        AllowsDuplicateValues:
+                            !IsSetType(receiver?.Type)));
                 }
             }
         }
 
         foreach (var assignmentSyntax in mutations.OfType<AssignmentExpressionSyntax>())
         {
-            if (semanticModel.GetOperation(
+            var assignmentOperation = semanticModel.GetOperation(
                 assignmentSyntax,
-                    context.CancellationToken) is ISimpleAssignmentOperation assignment
+                context.CancellationToken);
+            var target = assignmentOperation switch
+            {
+                ISimpleAssignmentOperation assignment => assignment.Target,
+                ICoalesceAssignmentOperation assignment => assignment.Target,
+                _ => null,
+            };
+            var value = assignmentOperation switch
+            {
+                ISimpleAssignmentOperation assignment => assignment.Value,
+                ICoalesceAssignmentOperation assignment => assignment.Value,
+                _ => null,
+            };
+            if (target is not null
+                && value is not null
                 && IsRootedInLocal(
-                    assignment.Target,
+                    target,
                     localReference.Local,
                     context,
                     visitedLocals: null))
             {
                 var slot = GetDeferredMutationSlot(
-                    assignment.Target,
+                    target,
                     localReference.Local,
                     context,
                     visitedLocals: null);
-                if (TryFindDeferredStateContext(
-                    assignment.Value,
+                var dictionaryKeyArgument = target is IPropertyReferenceOperation property
+                    && property.Property.IsIndexer
+                    && IsDictionaryType(property.Property.ContainingType)
+                        ? property.Arguments.FirstOrDefault()
+                        : null;
+                if (dictionaryKeyArgument is not null
+                    && (TryFindDeferredStateContext(
+                            dictionaryKeyArgument.Value,
+                            context,
+                            knownTypes,
+                            visitedLocals,
+                            out capturedContext)
+                        || TryFindDeferredStateContext(
+                            value,
+                            context,
+                            knownTypes,
+                            visitedLocals,
+                            out capturedContext)))
+                {
+                    origins.Add((
+                        assignmentSyntax,
+                        capturedContext,
+                        slot,
+                        GetDeferredValueKey(
+                            dictionaryKeyArgument.Value,
+                            context,
+                            visitedLocals: null),
+                        GetDeferredMutationReceiver(
+                            target,
+                            localReference.Local,
+                            context,
+                            visitedLocals: null),
+                        MayRetainMultiple: false,
+                        AllowsDuplicateValues: false));
+                }
+                else if (TryFindDeferredStateContext(
+                    value,
                     context,
                     knownTypes,
                     visitedLocals,
                     out capturedContext))
                 {
                     origins.Add((
-                        assignment.Syntax,
+                        assignmentSyntax,
                         capturedContext,
                         slot,
                         GetDeferredValueKey(
-                            semanticModel.GetOperation(
-                                capturedContext,
-                                context.CancellationToken),
+                            value,
                             context,
-                            visitedLocals: null)));
+                            visitedLocals: null),
+                        GetDeferredMutationReceiver(
+                            target,
+                            localReference.Local,
+                            context,
+                            visitedLocals: null),
+                        MayRetainMultiple: false,
+                        AllowsDuplicateValues: true));
                 }
-                else
+
+                if (assignmentOperation is ISimpleAssignmentOperation)
                 {
                     kills.Add((
-                        assignment.Syntax,
+                        assignmentSyntax,
                         slot,
                         ClearsAll: false,
                         Value: null,
-                        RemovesOne: false));
+                        RemovesOne: false,
+                        GetDeferredMutationReceiver(
+                            target,
+                            localReference.Local,
+                            context,
+                            visitedLocals: null)));
                 }
             }
         }
 
-        var startsEmpty = IsKnownEmptyDeferredContainer(initializer);
         foreach (var origin in origins)
         {
-            var matchingValueOrigins = origin.Value is null
-                ? 0
-                : origins.Count(candidate => candidate.Value == origin.Value);
             var relevantKills = kills
                 .Where(kill => kill.ClearsAll
+                    && IsWithinReceiver(origin.Receiver, kill.Receiver)
                     || origin.Slot is not null
-                        && kill.Slot == origin.Slot
+                        && IsWithinSlot(origin.Slot, kill.Slot)
+                        && !slotInvalidations.Any(invalidation =>
+                            invalidation.Node != kill.Node
+                            && invalidation.Receiver == origin.Receiver
+                            && CanCoOccurBefore(
+                                origin.Node,
+                                invalidation.Node,
+                                kill.Node,
+                                controlFlowGraph))
                     || origin.Value is not null
-                        && matchingValueOrigins == 1
                         && kill.Value == origin.Value
+                        && origin.Receiver == kill.Receiver
+                        && !origin.MayRetainMultiple
+                        && (!origin.AllowsDuplicateValues
+                            || origin.Node is AssignmentExpressionSyntax
+                            || !CanRepeatBefore(
+                                origin.Node,
+                                kill.Node,
+                                controlFlowGraph)
+                            && kills.Count(candidateKill =>
+                                    candidateKill.Value == origin.Value
+                                    && candidateKill.Receiver == origin.Receiver
+                                    && (candidateKill == kill
+                                        || CanCoOccurBefore(
+                                            origin.Node,
+                                            candidateKill.Node,
+                                            kill.Node,
+                                            controlFlowGraph)))
+                                >= origins.Count(candidateOrigin =>
+                                    candidateOrigin.Value == origin.Value
+                                    && candidateOrigin.Receiver == origin.Receiver
+                                    && (candidateOrigin == origin
+                                        || CanCoOccurBefore(
+                                            origin.Node,
+                                            candidateOrigin.Node,
+                                            kill.Node,
+                                            controlFlowGraph))))
                     || startsEmpty
                         && retainingMutationCount == 1
                         && origins.Count == 1
+                        && origin.Receiver == kill.Receiver
+                        && (origin.Node is AssignmentExpressionSyntax
+                            || !CanRepeatBefore(
+                                origin.Node,
+                                kill.Node,
+                                controlFlowGraph))
                         && kill.RemovesOne)
                 .Select(static kill => kill.Node)
                 .ToList();
@@ -3698,20 +4157,121 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         && RetainingCollectionNamespaces.Contains(
             method.ContainingNamespace.ToDisplayString());
 
+    private static bool CanCoOccurBefore(
+        SyntaxNode first,
+        SyntaxNode second,
+        SyntaxNode destination,
+        ControlFlowGraph? controlFlowGraph) =>
+        (CanReachWithoutKills(
+                first,
+                second,
+                [destination],
+                controlFlowGraph)
+            && CanReach(
+                second,
+                destination,
+                controlFlowGraph,
+                requireTraversal: second.SpanStart >= destination.SpanStart))
+        || (CanReachWithoutKills(
+                second,
+                first,
+                [destination],
+                controlFlowGraph)
+            && CanReach(
+                first,
+                destination,
+                controlFlowGraph,
+                requireTraversal: first.SpanStart >= destination.SpanStart));
+
+    private static bool CanRepeatBefore(
+        SyntaxNode origin,
+        SyntaxNode destination,
+        ControlFlowGraph? controlFlowGraph) =>
+        CanReachWithoutKills(
+            origin,
+            origin,
+            [destination],
+            controlFlowGraph);
+
+    private static bool IsWithinReceiver(
+        string? originReceiver,
+        string? mutationReceiver) =>
+        originReceiver is not null
+        && mutationReceiver is not null
+        && (originReceiver == mutationReceiver
+            || originReceiver.StartsWith(
+                mutationReceiver + ".",
+                StringComparison.Ordinal));
+
+    private static bool IsWithinSlot(string originSlot, string? mutationSlot) =>
+        mutationSlot is not null
+        && (originSlot == mutationSlot
+            || originSlot.StartsWith(
+                mutationSlot + ".",
+                StringComparison.Ordinal));
+
     private static bool IsKnownValueRemovingMutation(IMethodSymbol method) =>
         method.Name == "Remove"
         && method.Parameters.Length > 0
         && RetainingCollectionNamespaces.Contains(
             method.ContainingNamespace.ToDisplayString());
 
+    private static bool IsDictionaryType(INamedTypeSymbol type) =>
+        IsDictionaryInterface(type)
+        || type.AllInterfaces.Any(IsDictionaryInterface);
+
+    private static bool IsDictionaryInterface(INamedTypeSymbol type) =>
+        type.Name == "IDictionary"
+        && type.ContainingNamespace.ToDisplayString()
+            == "System.Collections.Generic";
+
+    private static bool IsSetType(ITypeSymbol? type) =>
+        type is INamedTypeSymbol namedType
+        && (IsSetInterface(namedType)
+            || namedType.AllInterfaces.Any(IsSetInterface));
+
+    private static bool IsSetInterface(INamedTypeSymbol type) =>
+        type.Name == "ISet"
+        && type.ContainingNamespace.ToDisplayString()
+            == "System.Collections.Generic";
+
     private static bool IsKnownSingleRemovingMutation(IMethodSymbol method) =>
         method.Name is "Dequeue" or "Pop" or "TryDequeue" or "TryPop" or "TryTake"
+        && RetainingCollectionNamespaces.Contains(
+            method.ContainingNamespace.ToDisplayString());
+
+    private static bool IsKnownSlotInvalidatingMutation(IMethodSymbol method) =>
+        method.Name is "Insert"
+            or "InsertRange"
+            or "Remove"
+            or "RemoveAt"
+            or "RemoveRange"
+            or "Reverse"
+            or "Sort"
         && RetainingCollectionNamespaces.Contains(
             method.ContainingNamespace.ToDisplayString());
 
     private static bool IsBulkRetainingMutation(IMethodSymbol method) =>
         method.Name.EndsWith("Range", StringComparison.Ordinal)
         || method.Name == "UnionWith";
+
+    private static bool MayRetainMultipleValues(IOperation operation)
+    {
+        operation = Unwrap(operation)!;
+        if (operation is IArrayCreationOperation { Initializer: { } arrayInitializer })
+        {
+            return arrayInitializer.ElementValues.Length > 1;
+        }
+
+        if (operation.Syntax is CollectionExpressionSyntax collection)
+        {
+            return collection.Elements.Count > 1
+                || collection.Elements.Any(static element =>
+                    element is SpreadElementSyntax);
+        }
+
+        return true;
+    }
 
     private static bool IsKnownEmptyDeferredContainer(IOperation initializer)
     {
@@ -3763,6 +4323,149 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         };
     }
 
+    private static string? GetInitializerMutationSlot(IOperation target)
+    {
+        target = Unwrap(target)!;
+        return target switch
+        {
+            IFieldReferenceOperation field =>
+                $"{GetInitializerReceiverKey(field.Instance)}" +
+                $".field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"{GetInitializerReceiverKey(property.Instance)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array =>
+                $"{GetInitializerReceiverKey(array.ArrayReference)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
+            _ => null,
+        };
+    }
+
+    private static string? GetIndexedCollectionSlot(
+        ITypeSymbol? type,
+        string receiver,
+        int index)
+    {
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return null;
+        }
+
+        var indexer = namedType.GetMembers()
+            .OfType<IPropertySymbol>()
+            .FirstOrDefault(static property => property.IsIndexer
+                && property.SetMethod is not null
+                && property.Parameters.Length == 1
+                && property.Parameters[0].Type.SpecialType
+                    == SpecialType.System_Int32);
+        return indexer is null
+            ? null
+            : $"{receiver}.property:{indexer.ToDisplayString()}:" +
+                GetConstantIdentityKey(SpecialType.System_Int32, index);
+    }
+
+    private static string? GetInitializerMutationReceiver(IOperation target)
+    {
+        target = Unwrap(target)!;
+        return target switch
+        {
+            IFieldReferenceOperation field => GetInitializerReceiverKey(field.Instance),
+            IPropertyReferenceOperation property =>
+                GetInitializerReceiverKey(property.Instance),
+            IArrayElementReferenceOperation array =>
+                GetInitializerReceiverKey(array.ArrayReference),
+            _ => null,
+        };
+    }
+
+    private static IEnumerable<(
+        ISimpleAssignmentOperation Assignment,
+        string Slot,
+        string Receiver)> EnumerateInitializerAssignments(
+        IObjectCreationOperation creation,
+        string prefix)
+    {
+        if (creation.Initializer is null)
+        {
+            yield break;
+        }
+
+        foreach (var assignment in creation.Initializer.Initializers
+            .OfType<ISimpleAssignmentOperation>())
+        {
+            var relativeSlot = GetInitializerMutationSlot(assignment.Target);
+            var relativeReceiver = GetInitializerMutationReceiver(assignment.Target);
+            if (relativeSlot is null || relativeReceiver is null)
+            {
+                continue;
+            }
+
+            var slot = CombineInitializerPath(prefix, relativeSlot);
+            if (Unwrap(assignment.Value) is IObjectCreationOperation nestedCreation
+                && nestedCreation.Initializer is not null)
+            {
+                foreach (var nested in EnumerateInitializerAssignments(
+                    nestedCreation,
+                    slot))
+                {
+                    yield return nested;
+                }
+
+                continue;
+            }
+
+            yield return (
+                assignment,
+                slot,
+                CombineInitializerPath(prefix, relativeReceiver));
+        }
+    }
+
+    private static string CombineInitializerPath(string prefix, string relativePath) =>
+        prefix == "root"
+            ? relativePath
+            : prefix + relativePath.Substring("root".Length);
+
+    private static string GetInitializerReceiverKey(IOperation? receiver)
+    {
+        receiver = Unwrap(receiver);
+        return receiver switch
+        {
+            null or IInstanceReferenceOperation => "root",
+            IFieldReferenceOperation field =>
+                $"{GetInitializerReceiverKey(field.Instance)}" +
+                $".field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"{GetInitializerReceiverKey(property.Instance)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array =>
+                $"{GetInitializerReceiverKey(array.ArrayReference)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
+            _ => $"{receiver.Kind}@{receiver.Syntax.SpanStart}",
+        };
+    }
+
+    private static string? GetDeferredMutationReceiver(
+        IOperation target,
+        ILocalSymbol local,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        target = Unwrap(target)!;
+        var receiver = target switch
+        {
+            IFieldReferenceOperation field => field.Instance,
+            IPropertyReferenceOperation property => property.Instance,
+            IArrayElementReferenceOperation array => array.ArrayReference,
+            _ => null,
+        };
+        return receiver is null
+            ? null
+            : GetDeferredReceiverKey(receiver, local, context, visitedLocals);
+    }
+
     private static string GetDeferredReceiverKey(
         IOperation? receiver,
         ILocalSymbol local,
@@ -3772,13 +4475,23 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         receiver = Unwrap(receiver);
         if (receiver is ILocalReferenceOperation localReference)
         {
-            return IsRootedInLocal(
-                localReference,
-                local,
-                context,
-                visitedLocals)
-                ? "root"
-                : $"local:{localReference.Local.ToDisplayString()}";
+            if (SymbolEqualityComparer.Default.Equals(localReference.Local, local))
+            {
+                return "root";
+            }
+
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (visitedLocals.Add(localReference.Local)
+                && TryGetStableAliasInitializer(localReference, context, out var initializer))
+            {
+                return GetDeferredReceiverKey(
+                    initializer,
+                    local,
+                    context,
+                    visitedLocals);
+            }
+
+            return $"local:{localReference.Local.ToDisplayString()}";
         }
 
         return receiver switch
@@ -3798,12 +4511,38 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     }
 
     private static string GetArgumentKey(IEnumerable<IOperation> arguments) =>
-        string.Join(",", arguments.Select(GetConstantKey));
+        string.Join(",", arguments.Select(GetOperationIdentityKey));
 
-    private static string GetConstantKey(IOperation operation) =>
-        operation.ConstantValue is { HasValue: true } constant
-            ? constant.Value?.ToString() ?? "null"
-            : "?";
+    private static string GetOperationIdentityKey(IOperation operation)
+    {
+        operation = Unwrap(operation)!;
+        return operation switch
+        {
+            { ConstantValue: { HasValue: true } constant } =>
+                GetConstantIdentityKey(operation.Type?.SpecialType, constant.Value),
+            ILocalReferenceOperation local =>
+                GetLocalIdentityKey(local.Local),
+            IParameterReferenceOperation parameter =>
+                $"parameter:{parameter.Parameter.ToDisplayString()}",
+            IFieldReferenceOperation field =>
+                $"{GetOptionalOperationIdentityKey(field.Instance)}" +
+                $".field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"{GetOptionalOperationIdentityKey(property.Instance)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array =>
+                $"{GetOperationIdentityKey(array.ArrayReference)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
+            _ => $"{operation.Kind}@{operation.Syntax.SpanStart}",
+        };
+    }
+
+    private static string GetOptionalOperationIdentityKey(IOperation? operation) =>
+        operation is null ? "static" : GetOperationIdentityKey(operation);
+
+    private static string GetLocalIdentityKey(ILocalSymbol local) =>
+        $"local:{local.Name}@{local.Locations.FirstOrDefault()?.SourceSpan.Start}";
 
     private static string? GetDeferredValueKey(
         IOperation? operation,
@@ -3825,14 +4564,28 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             IParameterReferenceOperation parameter =>
                 $"parameter:{parameter.Parameter.ToDisplayString()}",
-            IFieldReferenceOperation field => $"field:{field.Field.ToDisplayString()}",
+            IFieldReferenceOperation field =>
+                $"{GetDeferredValueKey(field.Instance, context, visitedLocals)}" +
+                $".field:{field.Field.ToDisplayString()}",
             IPropertyReferenceOperation property =>
-                $"property:{property.Property.ToDisplayString()}",
+                $"{GetDeferredValueKey(property.Instance, context, visitedLocals)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array =>
+                $"{GetDeferredValueKey(array.ArrayReference, context, visitedLocals)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
+            ILocalReferenceOperation local =>
+                GetLocalIdentityKey(local.Local),
             { ConstantValue: { HasValue: true } constant } =>
-                $"constant:{constant.Value?.ToString() ?? "null"}",
+                GetConstantIdentityKey(operation.Type?.SpecialType, constant.Value),
             _ => operation?.Syntax.ToString(),
         };
     }
+
+    private static string GetConstantIdentityKey(
+        SpecialType? type,
+        object? value) =>
+        $"constant:{type}:{value?.ToString() ?? "null"}";
 
     private static bool IsRootedInLocal(
         IOperation? operation,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3994,6 +3994,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             {
                 foreach (var argument in invocation.Arguments)
                 {
+                    if (!IsRetainedDictionaryArgument(invocation, argument))
+                    {
+                        continue;
+                    }
+
                     if (!TryFindDeferredStateContext(
                         argument.Value,
                         context,
@@ -4257,11 +4262,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            foreach (var invocationSyntax in body.DescendantNodesAndSelf(
-                         descendIntoChildren: static node =>
-                             node is not AnonymousFunctionExpressionSyntax
-                                 and not LocalFunctionStatementSyntax)
-                     .OfType<InvocationExpressionSyntax>())
+            var mutations = body.DescendantNodesAndSelf(
+                    descendIntoChildren: static node =>
+                        node is not AnonymousFunctionExpressionSyntax
+                            and not LocalFunctionStatementSyntax)
+                .Where(static node => node is InvocationExpressionSyntax
+                    or AssignmentExpressionSyntax)
+                .ToArray();
+            foreach (var invocationSyntax in mutations.OfType<InvocationExpressionSyntax>())
             {
                 if (semanticModel.GetOperation(
                         invocationSyntax,
@@ -4319,6 +4327,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     : null;
                 foreach (var argument in invocation.Arguments)
                 {
+                    if (keyArgument is not null
+                        && !IsRetainedDictionaryArgument(invocation, argument))
+                    {
+                        continue;
+                    }
+
                     if (!TryFindDeferredStateContext(
                         argument.Value,
                         context,
@@ -4347,6 +4361,80 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         break;
                     }
                 }
+            }
+
+            foreach (var assignmentSyntax in mutations.OfType<AssignmentExpressionSyntax>())
+            {
+                var assignmentOperation = semanticModel.GetOperation(
+                    assignmentSyntax,
+                    context.CancellationToken);
+                var target = assignmentOperation switch
+                {
+                    ISimpleAssignmentOperation assignment => assignment.Target,
+                    ICoalesceAssignmentOperation assignment => assignment.Target,
+                    _ => null,
+                };
+                var value = assignmentOperation switch
+                {
+                    ISimpleAssignmentOperation assignment => assignment.Value,
+                    ICoalesceAssignmentOperation assignment => assignment.Value,
+                    _ => null,
+                };
+                if (target is null
+                    || value is null
+                    || !IsRootedInLocal(
+                        target,
+                        local,
+                        context,
+                        visitedLocals: null))
+                {
+                    continue;
+                }
+
+                var dictionaryKey = target is IPropertyReferenceOperation property
+                    && property.Property.IsIndexer
+                    && IsDictionaryType(property.Property.ContainingType)
+                        ? property.Arguments.FirstOrDefault()?.Value
+                        : null;
+                IOperation retainedOperation;
+                SyntaxNode retainedContext;
+                if (dictionaryKey is not null
+                    && TryFindDeferredStateContext(
+                        dictionaryKey,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out retainedContext))
+                {
+                    retainedOperation = dictionaryKey;
+                }
+                else if (TryFindDeferredStateContext(
+                    value,
+                    context,
+                    knownTypes,
+                    visitedLocals,
+                    out retainedContext))
+                {
+                    retainedOperation = value;
+                }
+                else
+                {
+                    continue;
+                }
+
+                yield return (
+                    retainedContext,
+                    GetDeferredValueKey(
+                        dictionaryKey ?? retainedOperation,
+                        context,
+                        visitedLocals: null),
+                    GetDeferredMutationReceiver(
+                        target,
+                        local,
+                        context,
+                        visitedLocals: null) ?? "root",
+                    MayRetainMultiple: false,
+                    AllowsDuplicateValues: dictionaryKey is null);
             }
         }
     }
@@ -4424,6 +4512,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsDictionaryType(INamedTypeSymbol type) =>
         IsDictionaryInterface(type)
         || type.AllInterfaces.Any(IsDictionaryInterface);
+
+    private static bool IsRetainedDictionaryArgument(
+        IInvocationOperation invocation,
+        IArgumentOperation argument) =>
+        argument.Parameter is { } parameter
+        && (parameter.Ordinal == 0
+            || invocation.TargetMethod.Name switch
+            {
+                "GetOrAdd" => parameter.Name == "value",
+                "AddOrUpdate" => parameter.Name == "addValue",
+                _ => true,
+            });
 
     private static bool IsDictionaryInterface(INamedTypeSymbol type) =>
         type.Name == "IDictionary"

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -5004,15 +5004,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         if (invocation.TargetMethod.Name is "Fill" or "Clear")
         {
-            return invocation.Arguments.FirstOrDefault()?.Value;
+            return GetArgumentValue(invocation, "array");
         }
 
-        return invocation.Arguments.FirstOrDefault(static argument =>
-                argument.Parameter?.Name == "destinationArray")?.Value
-            ?? invocation.Arguments
-                .Where(static argument => IsArrayLike(argument.Value))
-                .Skip(1)
-                .FirstOrDefault()?.Value;
+        return GetArgumentValue(invocation, "destinationArray");
     }
 
     private static IOperation? GetStaticArrayRetainedValue(
@@ -5025,16 +5020,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         if (invocation.TargetMethod.Name == "Fill")
         {
-            return invocation.Arguments.FirstOrDefault(static argument =>
-                argument.Parameter?.Name == "value")?.Value;
+            return GetArgumentValue(invocation, "value");
         }
 
         if (invocation.TargetMethod.Name is "Copy" or "ConstrainedCopy")
         {
-            return invocation.Arguments.FirstOrDefault(static argument =>
-                    argument.Parameter?.Name == "sourceArray")?.Value
-                ?? invocation.Arguments.FirstOrDefault(static argument =>
-                    IsArrayLike(argument.Value))?.Value;
+            return GetArgumentValue(invocation, "sourceArray");
         }
 
         return null;
@@ -5053,17 +5044,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             {
                 Initializer: { } sourceInitializer,
             }
-            || invocation.Arguments.FirstOrDefault(static argument =>
-                    argument.Parameter?.Name == "length")?.Value.ConstantValue
+            || GetArgumentValue(invocation, "length")?.ConstantValue
                 is not { HasValue: true, Value: int copiedLength })
         {
             yield return retainedValue;
             yield break;
         }
 
-        var sourceIndexArgument = invocation.Arguments.FirstOrDefault(static argument =>
-            argument.Parameter?.Name == "sourceIndex");
-        var sourceIndex = sourceIndexArgument?.Value.ConstantValue switch
+        var sourceIndex = GetArgumentValue(invocation, "sourceIndex")?.ConstantValue switch
         {
             null => 0,
             { HasValue: true, Value: int value } => value,
@@ -5089,19 +5077,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     {
         if (invocation.TargetMethod.Name is not ("Copy" or "ConstrainedCopy")
             || !TryGetKnownArrayLength(initializer, out var destinationLength)
-            || invocation.Arguments.FirstOrDefault(static argument =>
-                    argument.Parameter?.Name == "length")?.Value.ConstantValue
+            || GetArgumentValue(invocation, "length")?.ConstantValue
                 is not { HasValue: true, Value: int copiedLength }
             || copiedLength != destinationLength)
         {
             return false;
         }
 
-        var destinationIndex = invocation.Arguments.FirstOrDefault(static argument =>
-            argument.Parameter?.Name == "destinationIndex");
+        var destinationIndex = GetArgumentValue(invocation, "destinationIndex");
         return destinationIndex is null
-            || destinationIndex.Value.ConstantValue is
+            || destinationIndex.ConstantValue is
                 { HasValue: true, Value: 0 };
+    }
+
+    private static IOperation? GetArgumentValue(
+        IInvocationOperation invocation,
+        string parameterName)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Name == parameterName)
+            {
+                return argument.Value;
+            }
+        }
+
+        return null;
     }
 
     private static bool TryGetKnownArrayLength(
@@ -5127,14 +5128,6 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         length = 0;
         return false;
-    }
-
-    private static bool IsArrayLike(IOperation operation)
-    {
-        var type = Unwrap(operation)?.Type;
-        return type is IArrayTypeSymbol
-            || type is INamedTypeSymbol { Name: "Array" } namedType
-                && namedType.ContainingNamespace.ToDisplayString() == "System";
     }
 
     private static bool IsDictionaryType(INamedTypeSymbol type) =>

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3862,25 +3862,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                             Receiver: "root"));
                     }
 
-                    if (GetStaticArrayRetainedValue(invocation) is { } retainedValue
-                        && TryFindDeferredStateContext(
-                            retainedValue,
-                            context,
-                            knownTypes,
-                            visitedLocals,
-                            out capturedContext))
+                    foreach (var retainedValue in EnumerateStaticArrayRetainedValues(invocation))
                     {
-                        origins.Add((
-                            invocation.Syntax,
-                            capturedContext,
-                            Slot: null,
-                            GetDeferredValueKey(
+                        if (TryFindDeferredStateContext(
                                 retainedValue,
                                 context,
-                                visitedLocals: null),
-                            Receiver: "root",
-                            MayRetainMultiple: true,
-                            AllowsDuplicateValues: true));
+                                knownTypes,
+                                visitedLocals,
+                                out capturedContext))
+                        {
+                            origins.Add((
+                                invocation.Syntax,
+                                capturedContext,
+                                Slot: null,
+                                GetDeferredValueKey(
+                                    retainedValue,
+                                    context,
+                                    visitedLocals: null),
+                                Receiver: "root",
+                                MayRetainMultiple: true,
+                                AllowsDuplicateValues: true));
+                        }
                     }
                 }
 
@@ -4282,10 +4284,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         ILocalSymbol local,
         OperationAnalysisContext context,
         KnownTypes knownTypes,
-        HashSet<ISymbol> visitedLocals)
+        HashSet<ISymbol> visitedLocals,
+        HashSet<IMethodSymbol>? visitedLocalFunctions = null)
     {
         var semanticModel = context.Operation.SemanticModel;
         if (semanticModel is null)
+        {
+            yield break;
+        }
+
+        var callPath = visitedLocalFunctions is null
+            ? new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)
+            : new HashSet<IMethodSymbol>(
+                visitedLocalFunctions,
+                SymbolEqualityComparer.Default);
+        if (!callPath.Add(localFunctionInvocation.TargetMethod))
         {
             yield break;
         }
@@ -4315,33 +4328,57 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
+                if (invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
+                    && !StartsAsynchronousWork(invocation.TargetMethod))
+                {
+                    foreach (var nestedOrigin in EnumerateLocalFunctionRetainingOrigins(
+                        invocation,
+                        local,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        callPath))
+                    {
+                        yield return nestedOrigin;
+                    }
+
+                    continue;
+                }
+
                 if (GetStaticArrayMutationTarget(invocation) is { } arrayTarget
-                    && GetStaticArrayRetainedValue(invocation) is { } arrayRetainedValue
-                    && MapLocalFunctionValue(
-                        arrayRetainedValue,
-                        localFunctionInvocation) is { } mappedArrayRetainedValue
                     && IsRootedInLocalFunctionArgument(
                         arrayTarget,
                         localFunctionInvocation,
                         local,
-                        context)
-                    && TryFindDeferredStateContext(
-                        mappedArrayRetainedValue,
-                        context,
-                        knownTypes,
-                        visitedLocals,
-                        out var arrayContext))
+                        context))
                 {
-                    yield return (
-                        arrayContext,
-                        Slot: null,
-                        GetDeferredValueKey(
+                    foreach (var arrayRetainedValue in EnumerateStaticArrayRetainedValues(invocation))
+                    {
+                        var mappedArrayRetainedValue = MapLocalFunctionValue(
+                            arrayRetainedValue,
+                            localFunctionInvocation);
+                        if (!TryFindDeferredStateContext(
                             mappedArrayRetainedValue,
                             context,
-                            visitedLocals: null),
-                        Receiver: "root",
-                        MayRetainMultiple: true,
-                        AllowsDuplicateValues: true);
+                            knownTypes,
+                            visitedLocals,
+                            out var arrayContext))
+                        {
+                            continue;
+                        }
+
+                        yield return (
+                            arrayContext,
+                            Slot: null,
+                            GetDeferredValueKey(
+                                mappedArrayRetainedValue,
+                                context,
+                                visitedLocals: null),
+                            Receiver: "root",
+                            MayRetainMultiple: true,
+                            AllowsDuplicateValues: true);
+                    }
+
                     continue;
                 }
 
@@ -4506,10 +4543,21 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         IInvocationOperation localFunctionInvocation,
         ILocalSymbol local,
         IOperation initializer,
-        OperationAnalysisContext context)
+        OperationAnalysisContext context,
+        HashSet<IMethodSymbol>? visitedLocalFunctions = null)
     {
         var semanticModel = context.Operation.SemanticModel;
         if (semanticModel is null)
+        {
+            yield break;
+        }
+
+        var callPath = visitedLocalFunctions is null
+            ? new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default)
+            : new HashSet<IMethodSymbol>(
+                visitedLocalFunctions,
+                SymbolEqualityComparer.Default);
+        if (!callPath.Add(localFunctionInvocation.TargetMethod))
         {
             yield break;
         }
@@ -4541,6 +4589,22 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
                 if (IsPotentiallyConditionalLocalMutation(invocationSyntax, body))
                 {
+                    continue;
+                }
+
+                if (invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
+                    && !StartsAsynchronousWork(invocation.TargetMethod))
+                {
+                    foreach (var nestedKill in EnumerateLocalFunctionMutationKills(
+                        invocation,
+                        local,
+                        initializer,
+                        context,
+                        callPath))
+                    {
+                        yield return nestedKill;
+                    }
+
                     continue;
                 }
 
@@ -4974,6 +5038,49 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    private static IEnumerable<IOperation> EnumerateStaticArrayRetainedValues(
+        IInvocationOperation invocation)
+    {
+        if (GetStaticArrayRetainedValue(invocation) is not { } retainedValue)
+        {
+            yield break;
+        }
+
+        if (invocation.TargetMethod.Name is not ("Copy" or "ConstrainedCopy")
+            || Unwrap(retainedValue) is not IArrayCreationOperation
+            {
+                Initializer: { } sourceInitializer,
+            }
+            || invocation.Arguments.FirstOrDefault(static argument =>
+                    argument.Parameter?.Name == "length")?.Value.ConstantValue
+                is not { HasValue: true, Value: int copiedLength })
+        {
+            yield return retainedValue;
+            yield break;
+        }
+
+        var sourceIndexArgument = invocation.Arguments.FirstOrDefault(static argument =>
+            argument.Parameter?.Name == "sourceIndex");
+        var sourceIndex = sourceIndexArgument?.Value.ConstantValue switch
+        {
+            null => 0,
+            { HasValue: true, Value: int value } => value,
+            _ => -1,
+        };
+        if (sourceIndex < 0
+            || copiedLength < 0
+            || sourceIndex > sourceInitializer.ElementValues.Length - copiedLength)
+        {
+            yield return retainedValue;
+            yield break;
+        }
+
+        for (var index = sourceIndex; index < sourceIndex + copiedLength; index++)
+        {
+            yield return sourceInitializer.ElementValues[index];
+        }
     }
 
     private static bool IsFullStaticArrayOverwrite(
@@ -5420,8 +5527,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             { ConstantValue: { HasValue: true } constant } =>
                 GetConstantIdentityKey(operation.Type, constant.Value),
-            ILocalReferenceOperation local =>
-                GetLocalIdentityKey(local.Local),
+            ILocalReferenceOperation local => HasPotentialReassignment(local)
+                ? $"{GetLocalIdentityKey(local.Local)}@reference:{local.Syntax.SpanStart}"
+                : GetLocalIdentityKey(local.Local),
             IParameterReferenceOperation parameter =>
                 $"parameter:{parameter.Parameter.ToDisplayString()}",
             IFieldReferenceOperation field =>
@@ -5443,6 +5551,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static string GetLocalIdentityKey(ILocalSymbol local) =>
         $"local:{local.Name}@{local.Locations.FirstOrDefault()?.SourceSpan.Start}";
+
+    private static bool HasPotentialReassignment(ILocalReferenceOperation localReference)
+    {
+        if (localReference.Local.DeclaringSyntaxReferences.FirstOrDefault()
+                ?.GetSyntax(CancellationToken.None) is not { } declaration)
+        {
+            return true;
+        }
+
+        var scope = GetExecutableScope(declaration, CancellationToken.None);
+        return scope.DescendantNodes().OfType<IdentifierNameSyntax>()
+            .Any(identifier => identifier.Identifier.ValueText == localReference.Local.Name
+                && IsReassigned(identifier));
+    }
 
     private static string? GetDeferredValueKey(
         IOperation? operation,
@@ -5474,8 +5596,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             IArrayElementReferenceOperation array =>
                 $"{GetDeferredValueKey(array.ArrayReference, context, visitedLocals)}" +
                 $".array:{GetArgumentKey(array.Indices)}",
-            ILocalReferenceOperation local =>
-                GetLocalIdentityKey(local.Local),
+            ILocalReferenceOperation local => HasPotentialReassignment(local)
+                ? $"{GetLocalIdentityKey(local.Local)}@reference:{local.Syntax.SpanStart}"
+                : GetLocalIdentityKey(local.Local),
             { ConstantValue: { HasValue: true } constant } =>
                 GetConstantIdentityKey(operation.Type, constant.Value),
             _ => operation?.Syntax.ToString(),

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -67,6 +67,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             "Insert",
             "InsertRange",
             "GetOrAdd",
+            "TryUpdate",
             "UnionWith",
             "TryAdd");
 
@@ -3799,6 +3800,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         localOrigin.AllowsDuplicateValues));
                 }
 
+                foreach (var localKill in EnumerateLocalFunctionMutationKills(
+                    invocation,
+                    localReference.Local,
+                    context))
+                {
+                    kills.Add((
+                        invocation.Syntax,
+                        localKill.Slot,
+                        localKill.ClearsAll,
+                        localKill.Value,
+                        localKill.RemovesOne,
+                        localKill.Receiver));
+                }
+
                 continue;
             }
 
@@ -3971,16 +3986,26 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     or SwitchExpressionSyntax
                     or ConditionalExpressionSyntax
                     or CatchClauseSyntax);
-            var appendSlot = startsEmpty
+            var retainedSlot = startsEmpty
                 && !hasIndeterminateRetainingMutation
                 && !isBulkMutation
                 && !isPotentiallyRepeated
-                && invocation.TargetMethod.Name == "Add"
-                && invocation.Arguments.Length == 1
-                    ? GetIndexedCollectionSlot(
-                        receiver?.Type,
-                        receiverKey,
-                        retainingMutationCount)
+                    ? invocation.TargetMethod switch
+                    {
+                        { Name: "Add" } when invocation.Arguments.Length == 1 =>
+                            GetIndexedCollectionSlot(
+                                receiver?.Type,
+                                receiverKey,
+                                retainingMutationCount),
+                        { Name: "Insert" } when invocation.Arguments.Length == 2
+                            && invocation.Arguments[0].Value.ConstantValue is
+                                { HasValue: true, Value: int insertIndex } =>
+                            GetIndexedCollectionSlot(
+                                receiver?.Type,
+                                receiverKey,
+                                insertIndex),
+                        _ => null,
+                    }
                     : null;
             retainingMutationCount += isBulkMutation
                 ? 2
@@ -4038,7 +4063,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     origins.Add((
                         invocation.Syntax,
                         capturedContext,
-                        appendSlot,
+                        retainedSlot,
                         GetDeferredValueKey(
                             isBulkMutation
                                 ? semanticModel.GetOperation(
@@ -4439,6 +4464,165 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    private static IEnumerable<(
+        string? Slot,
+        bool ClearsAll,
+        string? Value,
+        bool RemovesOne,
+        string Receiver)> EnumerateLocalFunctionMutationKills(
+        IInvocationOperation localFunctionInvocation,
+        ILocalSymbol local,
+        OperationAnalysisContext context)
+    {
+        var semanticModel = context.Operation.SemanticModel;
+        if (semanticModel is null)
+        {
+            yield break;
+        }
+
+        foreach (var syntaxReference in
+            localFunctionInvocation.TargetMethod.DeclaringSyntaxReferences)
+        {
+            var declaration = syntaxReference.GetSyntax(context.CancellationToken);
+            if (GetFunctionBody(declaration) is not { } body)
+            {
+                continue;
+            }
+
+            var mutations = body.DescendantNodesAndSelf(
+                    descendIntoChildren: static node =>
+                        node is not AnonymousFunctionExpressionSyntax
+                            and not LocalFunctionStatementSyntax)
+                .Where(static node => node is InvocationExpressionSyntax
+                    or AssignmentExpressionSyntax)
+                .ToArray();
+            foreach (var invocationSyntax in mutations.OfType<InvocationExpressionSyntax>())
+            {
+                if (semanticModel.GetOperation(
+                        invocationSyntax,
+                        context.CancellationToken) is not IInvocationOperation invocation)
+                {
+                    continue;
+                }
+
+                if (IsKnownStaticArrayMutation(invocation.TargetMethod)
+                    && invocation.TargetMethod.Name == "Clear"
+                    && invocation.Arguments.Length == 1
+                    && IsRootedInLocal(
+                        invocation.Arguments[0].Value,
+                        local,
+                        context,
+                        visitedLocals: null))
+                {
+                    yield return (
+                        Slot: null,
+                        ClearsAll: true,
+                        Value: null,
+                        RemovesOne: false,
+                        Receiver: "root");
+                    continue;
+                }
+
+                var receiver = GetReceiver(invocation);
+                if (!IsRootedInLocal(
+                    receiver,
+                    local,
+                    context,
+                    visitedLocals: null))
+                {
+                    continue;
+                }
+
+                var receiverKey = GetDeferredReceiverKey(
+                    receiver,
+                    local,
+                    context,
+                    visitedLocals: null);
+                if (invocation.TargetMethod.Name == "RemoveAt"
+                    && invocation.Arguments.Length == 1
+                    && invocation.Arguments[0].Value.ConstantValue is
+                        { HasValue: true, Value: int index }
+                    && GetIndexedCollectionSlot(receiver?.Type, receiverKey, index)
+                        is { } removedSlot)
+                {
+                    yield return (
+                        removedSlot,
+                        ClearsAll: false,
+                        Value: null,
+                        RemovesOne: false,
+                        receiverKey);
+                    continue;
+                }
+
+                if (IsKnownClearingMutation(invocation.TargetMethod))
+                {
+                    yield return (
+                        Slot: null,
+                        ClearsAll: true,
+                        Value: null,
+                        RemovesOne: false,
+                        receiverKey);
+                    continue;
+                }
+
+                if (IsKnownValueRemovingMutation(invocation.TargetMethod))
+                {
+                    yield return (
+                        Slot: null,
+                        ClearsAll: false,
+                        GetDeferredValueKey(
+                            invocation.Arguments[0].Value,
+                            context,
+                            visitedLocals: null),
+                        RemovesOne: false,
+                        receiverKey);
+                    continue;
+                }
+
+                if (IsKnownSingleRemovingMutation(invocation.TargetMethod))
+                {
+                    yield return (
+                        Slot: null,
+                        ClearsAll: false,
+                        Value: null,
+                        RemovesOne: true,
+                        receiverKey);
+                }
+            }
+
+            foreach (var assignmentSyntax in mutations.OfType<AssignmentExpressionSyntax>())
+            {
+                var operation = semanticModel.GetOperation(
+                    assignmentSyntax,
+                    context.CancellationToken);
+                if (operation is not ISimpleAssignmentOperation assignment
+                    || !IsRootedInLocal(
+                        assignment.Target,
+                        local,
+                        context,
+                        visitedLocals: null))
+                {
+                    continue;
+                }
+
+                yield return (
+                    GetDeferredMutationSlot(
+                        assignment.Target,
+                        local,
+                        context,
+                        visitedLocals: null),
+                    ClearsAll: false,
+                    Value: null,
+                    RemovesOne: false,
+                    GetDeferredMutationReceiver(
+                        assignment.Target,
+                        local,
+                        context,
+                        visitedLocals: null) ?? "root");
+            }
+        }
+    }
+
     private static bool IsKnownClearingMutation(IMethodSymbol method) =>
         method.Name == "Clear"
         && method.Parameters.Length == 0
@@ -4522,6 +4706,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             {
                 "GetOrAdd" => parameter.Name == "value",
                 "AddOrUpdate" => parameter.Name == "addValue",
+                "TryUpdate" => parameter.Name == "newValue",
                 _ => true,
             });
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -59,12 +59,14 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             "AddFirst",
             "AddLast",
             "AddRange",
+            "AddOrUpdate",
             "Enqueue",
             "EnqueueRange",
             "Push",
             "PushRange",
             "Insert",
             "InsertRange",
+            "GetOrAdd",
             "UnionWith",
             "TryAdd");
 
@@ -3770,13 +3772,63 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             if (semanticModel.GetOperation(
                     invocationSyntax,
-                    context.CancellationToken) is not IInvocationOperation invocation
-                || !IsRootedInLocal(
+                    context.CancellationToken) is not IInvocationOperation invocation)
+            {
+                continue;
+            }
+
+            var isStaticArrayMutation = IsKnownStaticArrayMutation(invocation.TargetMethod)
+                && invocation.Arguments.Length > 0
+                && IsRootedInLocal(
+                    invocation.Arguments[0].Value,
+                    localReference.Local,
+                    context,
+                    visitedLocals: null);
+            if (!isStaticArrayMutation
+                && !IsRootedInLocal(
                     GetReceiver(invocation),
                     localReference.Local,
                     context,
                     visitedLocals: null))
             {
+                continue;
+            }
+
+            if (isStaticArrayMutation)
+            {
+                if (invocation.TargetMethod.Name == "Clear"
+                    && invocationSyntax.ArgumentList.Arguments.Count == 1)
+                {
+                    kills.Add((
+                        invocation.Syntax,
+                        Slot: null,
+                        ClearsAll: true,
+                        Value: null,
+                        RemovesOne: false,
+                        Receiver: "root"));
+                }
+                else if (invocation.TargetMethod.Name == "Fill"
+                    && invocation.Arguments.Length > 1
+                    && TryFindDeferredStateContext(
+                        invocation.Arguments[1].Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out capturedContext))
+                {
+                    origins.Add((
+                        invocation.Syntax,
+                        capturedContext,
+                        Slot: null,
+                        GetDeferredValueKey(
+                            invocation.Arguments[1].Value,
+                            context,
+                            visitedLocals: null),
+                        Receiver: "root",
+                        MayRetainMultiple: true,
+                        AllowsDuplicateValues: true));
+                }
+
                 continue;
             }
 
@@ -4216,6 +4268,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         && RetainingCollectionNamespaces.Contains(
             method.ContainingNamespace.ToDisplayString());
 
+    private static bool IsKnownStaticArrayMutation(IMethodSymbol method) =>
+        method.Name is "Fill" or "Clear"
+        && method.ContainingType.Name == "Array"
+        && method.ContainingNamespace.ToDisplayString() == "System";
+
     private static bool IsDictionaryType(INamedTypeSymbol type) =>
         IsDictionaryInterface(type)
         || type.AllInterfaces.Any(IsDictionaryInterface);
@@ -4236,7 +4293,13 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             == "System.Collections.Generic";
 
     private static bool IsKnownSingleRemovingMutation(IMethodSymbol method) =>
-        method.Name is "Dequeue" or "Pop" or "TryDequeue" or "TryPop" or "TryTake"
+        method.Name is "Dequeue"
+            or "Pop"
+            or "RemoveFirst"
+            or "RemoveLast"
+            or "TryDequeue"
+            or "TryPop"
+            or "TryTake"
         && RetainingCollectionNamespaces.Contains(
             method.ContainingNamespace.ToDisplayString());
 
@@ -6939,7 +7002,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 referenceCount++;
                 if ((allowMemberMutation ? IsReassigned(identifier) : IsWritten(identifier))
                     || local.Type is IArrayTypeSymbol
-                        && IsEscapingArrayReference(identifier, localReference.Syntax)
+                        && IsEscapingArrayReference(
+                            identifier,
+                            localReference.Syntax,
+                            semanticModel,
+                            context.CancellationToken)
                     || requireSingleUse && referenceCount > 1)
                 {
                     initializer = null;
@@ -6982,7 +7049,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static bool IsEscapingArrayReference(
         IdentifierNameSyntax identifier,
-        SyntaxNode permittedReference)
+        SyntaxNode permittedReference,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         if (identifier.SyntaxTree == permittedReference.SyntaxTree
             && identifier.Span == permittedReference.Span)
@@ -6994,6 +7063,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         {
             switch (ancestor)
             {
+                case ArgumentSyntax argument
+                    when IsKnownStaticArrayMutationArgument(
+                        argument,
+                        semanticModel,
+                        cancellationToken):
+                    return false;
                 case ArgumentSyntax:
                 case EqualsValueClauseSyntax:
                 case ReturnStatementSyntax:
@@ -7008,6 +7083,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         return true;
     }
+
+    private static bool IsKnownStaticArrayMutationArgument(
+        ArgumentSyntax argument,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken) =>
+        argument.Parent is ArgumentListSyntax
+        {
+            Arguments: { Count: > 0 } arguments,
+            Parent: InvocationExpressionSyntax invocationSyntax,
+        }
+        && arguments[0] == argument
+        && semanticModel.GetOperation(invocationSyntax, cancellationToken)
+            is IInvocationOperation invocation
+        && IsKnownStaticArrayMutation(invocation.TargetMethod);
 
     private static bool IsWritten(IdentifierNameSyntax identifier)
     {

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3768,12 +3768,37 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         }
 
         var startsEmpty = IsKnownEmptyDeferredContainer(initializer);
+        var startsWithSingleRetainedValue =
+            HasKnownSingleRetainedConstructorValue(initializer);
         foreach (var invocationSyntax in mutations.OfType<InvocationExpressionSyntax>())
         {
             if (semanticModel.GetOperation(
                     invocationSyntax,
                     context.CancellationToken) is not IInvocationOperation invocation)
             {
+                continue;
+            }
+
+            if (invocation.TargetMethod.MethodKind == MethodKind.LocalFunction
+                && !StartsAsynchronousWork(invocation.TargetMethod))
+            {
+                foreach (var localOrigin in EnumerateLocalFunctionRetainingOrigins(
+                    invocation,
+                    localReference.Local,
+                    context,
+                    knownTypes,
+                    visitedLocals))
+                {
+                    origins.Add((
+                        invocation.Syntax,
+                        localOrigin.Context,
+                        Slot: null,
+                        localOrigin.Value,
+                        localOrigin.Receiver,
+                        localOrigin.MayRetainMultiple,
+                        localOrigin.AllowsDuplicateValues));
+                }
+
                 continue;
             }
 
@@ -4135,6 +4160,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         foreach (var origin in origins)
         {
+            var hasSingleRetainedValue = origins.Count == 1
+                && (startsEmpty && retainingMutationCount == 1
+                    || startsWithSingleRetainedValue
+                        && retainingMutationCount == 0);
             var relevantKills = kills
                 .Where(kill => kill.ClearsAll
                     && IsWithinReceiver(origin.Receiver, kill.Receiver)
@@ -4176,9 +4205,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                                             candidateOrigin.Node,
                                             kill.Node,
                                             controlFlowGraph))))
-                    || startsEmpty
-                        && retainingMutationCount == 1
-                        && origins.Count == 1
+                    || hasSingleRetainedValue
                         && origin.Receiver == kill.Receiver
                         && (origin.Node is AssignmentExpressionSyntax
                             || !CanRepeatBefore(
@@ -4201,6 +4228,127 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         capturedContext = null!;
         return false;
+    }
+
+    private static IEnumerable<(
+        SyntaxNode Context,
+        string? Value,
+        string Receiver,
+        bool MayRetainMultiple,
+        bool AllowsDuplicateValues)> EnumerateLocalFunctionRetainingOrigins(
+        IInvocationOperation localFunctionInvocation,
+        ILocalSymbol local,
+        OperationAnalysisContext context,
+        KnownTypes knownTypes,
+        HashSet<ISymbol> visitedLocals)
+    {
+        var semanticModel = context.Operation.SemanticModel;
+        if (semanticModel is null)
+        {
+            yield break;
+        }
+
+        foreach (var syntaxReference in
+            localFunctionInvocation.TargetMethod.DeclaringSyntaxReferences)
+        {
+            var declaration = syntaxReference.GetSyntax(context.CancellationToken);
+            if (GetFunctionBody(declaration) is not { } body)
+            {
+                continue;
+            }
+
+            foreach (var invocationSyntax in body.DescendantNodesAndSelf(
+                         descendIntoChildren: static node =>
+                             node is not AnonymousFunctionExpressionSyntax
+                                 and not LocalFunctionStatementSyntax)
+                     .OfType<InvocationExpressionSyntax>())
+            {
+                if (semanticModel.GetOperation(
+                        invocationSyntax,
+                        context.CancellationToken) is not IInvocationOperation invocation)
+                {
+                    continue;
+                }
+
+                if (IsKnownStaticArrayMutation(invocation.TargetMethod)
+                    && invocation.TargetMethod.Name == "Fill"
+                    && invocation.Arguments.Length > 1
+                    && IsRootedInLocal(
+                        invocation.Arguments[0].Value,
+                        local,
+                        context,
+                        visitedLocals: null)
+                    && TryFindDeferredStateContext(
+                        invocation.Arguments[1].Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out var arrayContext))
+                {
+                    yield return (
+                        arrayContext,
+                        GetDeferredValueKey(
+                            invocation.Arguments[1].Value,
+                            context,
+                            visitedLocals: null),
+                        Receiver: "root",
+                        MayRetainMultiple: true,
+                        AllowsDuplicateValues: true);
+                    continue;
+                }
+
+                var receiver = GetReceiver(invocation);
+                if (!IsKnownRetainingMutation(invocation.TargetMethod)
+                    || !IsRootedInLocal(
+                        receiver,
+                        local,
+                        context,
+                        visitedLocals: null))
+                {
+                    continue;
+                }
+
+                var receiverKey = GetDeferredReceiverKey(
+                    receiver,
+                    local,
+                    context,
+                    visitedLocals: null);
+                var keyArgument = IsDictionaryType(invocation.TargetMethod.ContainingType)
+                    ? invocation.Arguments.FirstOrDefault(static argument =>
+                        argument.Parameter?.Ordinal == 0)
+                    : null;
+                foreach (var argument in invocation.Arguments)
+                {
+                    if (!TryFindDeferredStateContext(
+                        argument.Value,
+                        context,
+                        knownTypes,
+                        visitedLocals,
+                        out var capturedContext))
+                    {
+                        continue;
+                    }
+
+                    yield return (
+                        capturedContext,
+                        GetDeferredValueKey(
+                            keyArgument?.Value ?? argument.Value,
+                            context,
+                            visitedLocals: null),
+                        receiverKey,
+                        MayRetainMultiple: IsBulkRetainingMutation(
+                            invocation.TargetMethod)
+                            && !IsSetType(receiver?.Type)
+                            && MayRetainMultipleValues(argument.Value),
+                        AllowsDuplicateValues: keyArgument is null
+                            && !IsSetType(receiver?.Type));
+                    if (keyArgument is not null)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     private static bool IsKnownClearingMutation(IMethodSymbol method) =>
@@ -4361,6 +4509,40 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     Elements.Count: 0,
                 },
         };
+    }
+
+    private static bool HasKnownSingleRetainedConstructorValue(IOperation initializer)
+    {
+        if (Unwrap(initializer) is not IObjectCreationOperation objectCreation
+            || objectCreation.Initializer is { Initializers.Length: > 0 })
+        {
+            return false;
+        }
+
+        var retainedArguments = objectCreation.Arguments
+            .Where(argument => argument.Parameter is { } parameter
+                && IsKnownRetainingFrameworkConstructorParameter(
+                    objectCreation.Constructor,
+                    parameter))
+            .ToArray();
+        return retainedArguments.Length == 1
+            && HasKnownSingleValue(retainedArguments[0].Value);
+    }
+
+    private static bool HasKnownSingleValue(IOperation operation)
+    {
+        operation = Unwrap(operation)!;
+        if (operation is IArrayCreationOperation
+            {
+                Initializer: { ElementValues.Length: 1 },
+            })
+        {
+            return true;
+        }
+
+        return operation.Syntax is CollectionExpressionSyntax collection
+            && collection.Elements.Count == 1
+            && collection.Elements[0] is not SpreadElementSyntax;
     }
 
     private static string? GetDeferredMutationSlot(
@@ -4582,7 +4764,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         return operation switch
         {
             { ConstantValue: { HasValue: true } constant } =>
-                GetConstantIdentityKey(operation.Type?.SpecialType, constant.Value),
+                GetConstantIdentityKey(operation.Type, constant.Value),
             ILocalReferenceOperation local =>
                 GetLocalIdentityKey(local.Local),
             IParameterReferenceOperation parameter =>
@@ -4640,13 +4822,27 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             ILocalReferenceOperation local =>
                 GetLocalIdentityKey(local.Local),
             { ConstantValue: { HasValue: true } constant } =>
-                GetConstantIdentityKey(operation.Type?.SpecialType, constant.Value),
+                GetConstantIdentityKey(operation.Type, constant.Value),
             _ => operation?.Syntax.ToString(),
         };
     }
 
     private static string GetConstantIdentityKey(
         SpecialType? type,
+        object? value) =>
+        GetConstantIdentityKey(type?.ToString(), value);
+
+    private static string GetConstantIdentityKey(
+        ITypeSymbol? type,
+        object? value) =>
+        GetConstantIdentityKey(
+            type?.SpecialType is { } specialType and not SpecialType.None
+                ? specialType.ToString()
+                : type?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            value);
+
+    private static string GetConstantIdentityKey(
+        string? type,
         object? value) =>
         $"constant:{type}:{value?.ToString() ?? "null"}";
 

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -3793,7 +3793,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     origins.Add((
                         invocation.Syntax,
                         localOrigin.Context,
-                        Slot: null,
+                        localOrigin.Slot,
                         localOrigin.Value,
                         localOrigin.Receiver,
                         localOrigin.MayRetainMultiple,
@@ -3817,10 +3817,10 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var isStaticArrayMutation = IsKnownStaticArrayMutation(invocation.TargetMethod)
-                && invocation.Arguments.Length > 0
+            var staticArrayTarget = GetStaticArrayMutationTarget(invocation);
+            var isStaticArrayMutation = staticArrayTarget is not null
                 && IsRootedInLocal(
-                    invocation.Arguments[0].Value,
+                    staticArrayTarget,
                     localReference.Local,
                     context,
                     visitedLocals: null);
@@ -3847,10 +3847,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         RemovesOne: false,
                         Receiver: "root"));
                 }
-                else if (invocation.TargetMethod.Name == "Fill"
-                    && invocation.Arguments.Length > 1
+                else if (GetStaticArrayRetainedValue(invocation) is { } retainedValue
                     && TryFindDeferredStateContext(
-                        invocation.Arguments[1].Value,
+                        retainedValue,
                         context,
                         knownTypes,
                         visitedLocals,
@@ -3861,7 +3860,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                         capturedContext,
                         Slot: null,
                         GetDeferredValueKey(
-                            invocation.Arguments[1].Value,
+                            retainedValue,
                             context,
                             visitedLocals: null),
                         Receiver: "root",
@@ -4017,15 +4016,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && invocation.Arguments.FirstOrDefault(static argument =>
                     argument.Parameter?.Ordinal == 0) is { } keyArgument)
             {
-                foreach (var argument in invocation.Arguments)
+                foreach (var retainedValue in
+                    EnumerateRetainedDictionaryValues(invocation))
                 {
-                    if (!IsRetainedDictionaryArgument(invocation, argument))
-                    {
-                        continue;
-                    }
-
                     if (!TryFindDeferredStateContext(
-                        argument.Value,
+                        retainedValue,
                         context,
                         knownTypes,
                         visitedLocals,
@@ -4262,6 +4257,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static IEnumerable<(
         SyntaxNode Context,
+        string? Slot,
         string? Value,
         string Receiver,
         bool MayRetainMultiple,
@@ -4303,16 +4299,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     continue;
                 }
 
-                if (IsKnownStaticArrayMutation(invocation.TargetMethod)
-                    && invocation.TargetMethod.Name == "Fill"
-                    && invocation.Arguments.Length > 1
-                    && IsRootedInLocal(
-                        invocation.Arguments[0].Value,
+                if (GetStaticArrayMutationTarget(invocation) is { } arrayTarget
+                    && GetStaticArrayRetainedValue(invocation) is { } arrayRetainedValue
+                    && IsRootedInLocalFunctionArgument(
+                        arrayTarget,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null)
+                        context)
                     && TryFindDeferredStateContext(
-                        invocation.Arguments[1].Value,
+                        arrayRetainedValue,
                         context,
                         knownTypes,
                         visitedLocals,
@@ -4320,8 +4315,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 {
                     yield return (
                         arrayContext,
+                        Slot: null,
                         GetDeferredValueKey(
-                            invocation.Arguments[1].Value,
+                            arrayRetainedValue,
                             context,
                             visitedLocals: null),
                         Receiver: "root",
@@ -4332,34 +4328,31 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
                 var receiver = GetReceiver(invocation);
                 if (!IsKnownRetainingMutation(invocation.TargetMethod)
-                    || !IsRootedInLocal(
+                    || !IsRootedInLocalFunctionArgument(
                         receiver,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null))
+                        context))
                 {
                     continue;
                 }
 
-                var receiverKey = GetDeferredReceiverKey(
+                var receiverKey = GetLocalFunctionReceiverKey(
                     receiver,
+                    localFunctionInvocation,
                     local,
-                    context,
-                    visitedLocals: null);
+                    context);
                 var keyArgument = IsDictionaryType(invocation.TargetMethod.ContainingType)
                     ? invocation.Arguments.FirstOrDefault(static argument =>
                         argument.Parameter?.Ordinal == 0)
                     : null;
-                foreach (var argument in invocation.Arguments)
+                var retainedValues = keyArgument is null
+                    ? invocation.Arguments.Select(static argument => argument.Value)
+                    : EnumerateRetainedDictionaryValues(invocation);
+                foreach (var retainedValue in retainedValues)
                 {
-                    if (keyArgument is not null
-                        && !IsRetainedDictionaryArgument(invocation, argument))
-                    {
-                        continue;
-                    }
-
                     if (!TryFindDeferredStateContext(
-                        argument.Value,
+                        retainedValue,
                         context,
                         knownTypes,
                         visitedLocals,
@@ -4370,15 +4363,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
                     yield return (
                         capturedContext,
+                        Slot: null,
                         GetDeferredValueKey(
-                            keyArgument?.Value ?? argument.Value,
+                            keyArgument?.Value ?? retainedValue,
                             context,
                             visitedLocals: null),
                         receiverKey,
                         MayRetainMultiple: IsBulkRetainingMutation(
                             invocation.TargetMethod)
                             && !IsSetType(receiver?.Type)
-                            && MayRetainMultipleValues(argument.Value),
+                            && MayRetainMultipleValues(retainedValue),
                         AllowsDuplicateValues: keyArgument is null
                             && !IsSetType(receiver?.Type));
                     if (keyArgument is not null)
@@ -4407,11 +4401,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 };
                 if (target is null
                     || value is null
-                    || !IsRootedInLocal(
+                    || !IsRootedInLocalFunctionArgument(
                         target,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null))
+                        context))
                 {
                     continue;
                 }
@@ -4449,15 +4443,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
                 yield return (
                     retainedContext,
+                    GetLocalFunctionMutationSlot(
+                        target,
+                        localFunctionInvocation,
+                        local,
+                        context),
                     GetDeferredValueKey(
                         dictionaryKey ?? retainedOperation,
                         context,
                         visitedLocals: null),
-                    GetDeferredMutationReceiver(
+                    GetLocalFunctionMutationReceiver(
                         target,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null) ?? "root",
+                        context) ?? "root",
                     MayRetainMultiple: false,
                     AllowsDuplicateValues: dictionaryKey is null);
             }
@@ -4508,11 +4507,12 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 if (IsKnownStaticArrayMutation(invocation.TargetMethod)
                     && invocation.TargetMethod.Name == "Clear"
                     && invocation.Arguments.Length == 1
-                    && IsRootedInLocal(
-                        invocation.Arguments[0].Value,
+                    && GetStaticArrayMutationTarget(invocation) is { } arrayTarget
+                    && IsRootedInLocalFunctionArgument(
+                        arrayTarget,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null))
+                        context))
                 {
                     yield return (
                         Slot: null,
@@ -4524,20 +4524,20 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 }
 
                 var receiver = GetReceiver(invocation);
-                if (!IsRootedInLocal(
+                if (!IsRootedInLocalFunctionArgument(
                     receiver,
+                    localFunctionInvocation,
                     local,
-                    context,
-                    visitedLocals: null))
+                    context))
                 {
                     continue;
                 }
 
-                var receiverKey = GetDeferredReceiverKey(
+                var receiverKey = GetLocalFunctionReceiverKey(
                     receiver,
+                    localFunctionInvocation,
                     local,
-                    context,
-                    visitedLocals: null);
+                    context);
                 if (invocation.TargetMethod.Name == "RemoveAt"
                     && invocation.Arguments.Length == 1
                     && invocation.Arguments[0].Value.ConstantValue is
@@ -4596,32 +4596,167 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     assignmentSyntax,
                     context.CancellationToken);
                 if (operation is not ISimpleAssignmentOperation assignment
-                    || !IsRootedInLocal(
+                    || !IsRootedInLocalFunctionArgument(
                         assignment.Target,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null))
+                        context))
                 {
                     continue;
                 }
 
                 yield return (
-                    GetDeferredMutationSlot(
+                    GetLocalFunctionMutationSlot(
                         assignment.Target,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null),
+                        context),
                     ClearsAll: false,
                     Value: null,
                     RemovesOne: false,
-                    GetDeferredMutationReceiver(
+                    GetLocalFunctionMutationReceiver(
                         assignment.Target,
+                        localFunctionInvocation,
                         local,
-                        context,
-                        visitedLocals: null) ?? "root");
+                        context) ?? "root");
             }
         }
     }
+
+    private static bool IsRootedInLocalFunctionArgument(
+        IOperation? operation,
+        IInvocationOperation localFunctionInvocation,
+        ILocalSymbol local,
+        OperationAnalysisContext context)
+    {
+        operation = Unwrap(operation);
+        if (operation is IParameterReferenceOperation parameterReference
+            && TryGetLocalFunctionArgument(
+                parameterReference.Parameter,
+                localFunctionInvocation) is { } argument)
+        {
+            return IsRootedInLocal(
+                argument,
+                local,
+                context,
+                visitedLocals: null);
+        }
+
+        return operation switch
+        {
+            IFieldReferenceOperation field => IsRootedInLocalFunctionArgument(
+                field.Instance,
+                localFunctionInvocation,
+                local,
+                context),
+            IPropertyReferenceOperation property => IsRootedInLocalFunctionArgument(
+                property.Instance,
+                localFunctionInvocation,
+                local,
+                context),
+            IArrayElementReferenceOperation array => IsRootedInLocalFunctionArgument(
+                array.ArrayReference,
+                localFunctionInvocation,
+                local,
+                context),
+            _ => IsRootedInLocal(
+                operation,
+                local,
+                context,
+                visitedLocals: null),
+        };
+    }
+
+    private static string GetLocalFunctionReceiverKey(
+        IOperation? receiver,
+        IInvocationOperation localFunctionInvocation,
+        ILocalSymbol local,
+        OperationAnalysisContext context)
+    {
+        receiver = Unwrap(receiver);
+        if (receiver is IParameterReferenceOperation parameterReference
+            && TryGetLocalFunctionArgument(
+                parameterReference.Parameter,
+                localFunctionInvocation) is { } argument)
+        {
+            return GetDeferredReceiverKey(
+                argument,
+                local,
+                context,
+                visitedLocals: null);
+        }
+
+        return receiver switch
+        {
+            IFieldReferenceOperation field =>
+                $"{GetLocalFunctionReceiverKey(field.Instance, localFunctionInvocation, local, context)}" +
+                $".field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"{GetLocalFunctionReceiverKey(property.Instance, localFunctionInvocation, local, context)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array =>
+                $"{GetLocalFunctionReceiverKey(array.ArrayReference, localFunctionInvocation, local, context)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
+            _ => GetDeferredReceiverKey(
+                receiver,
+                local,
+                context,
+                visitedLocals: null),
+        };
+    }
+
+    private static string? GetLocalFunctionMutationSlot(
+        IOperation target,
+        IInvocationOperation localFunctionInvocation,
+        ILocalSymbol local,
+        OperationAnalysisContext context)
+    {
+        target = Unwrap(target)!;
+        return target switch
+        {
+            IFieldReferenceOperation field =>
+                $"{GetLocalFunctionReceiverKey(field.Instance, localFunctionInvocation, local, context)}" +
+                $".field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"{GetLocalFunctionReceiverKey(property.Instance, localFunctionInvocation, local, context)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array =>
+                $"{GetLocalFunctionReceiverKey(array.ArrayReference, localFunctionInvocation, local, context)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
+            _ => null,
+        };
+    }
+
+    private static string? GetLocalFunctionMutationReceiver(
+        IOperation target,
+        IInvocationOperation localFunctionInvocation,
+        ILocalSymbol local,
+        OperationAnalysisContext context)
+    {
+        target = Unwrap(target)!;
+        var receiver = target switch
+        {
+            IFieldReferenceOperation field => field.Instance,
+            IPropertyReferenceOperation property => property.Instance,
+            IArrayElementReferenceOperation array => array.ArrayReference,
+            _ => null,
+        };
+        return receiver is null
+            ? null
+            : GetLocalFunctionReceiverKey(
+                receiver,
+                localFunctionInvocation,
+                local,
+                context);
+    }
+
+    private static IOperation? TryGetLocalFunctionArgument(
+        IParameterSymbol parameter,
+        IInvocationOperation localFunctionInvocation) =>
+        localFunctionInvocation.Arguments.FirstOrDefault(argument =>
+            SymbolEqualityComparer.Default.Equals(argument.Parameter, parameter))?.Value;
 
     private static bool IsKnownClearingMutation(IMethodSymbol method) =>
         method.Name == "Clear"
@@ -4689,9 +4824,63 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             method.ContainingNamespace.ToDisplayString());
 
     private static bool IsKnownStaticArrayMutation(IMethodSymbol method) =>
-        method.Name is "Fill" or "Clear"
+        method.Name is "Fill" or "Clear" or "Copy" or "ConstrainedCopy"
         && method.ContainingType.Name == "Array"
         && method.ContainingNamespace.ToDisplayString() == "System";
+
+    private static IOperation? GetStaticArrayMutationTarget(
+        IInvocationOperation invocation)
+    {
+        if (!IsKnownStaticArrayMutation(invocation.TargetMethod))
+        {
+            return null;
+        }
+
+        if (invocation.TargetMethod.Name is "Fill" or "Clear")
+        {
+            return invocation.Arguments.FirstOrDefault()?.Value;
+        }
+
+        return invocation.Arguments.FirstOrDefault(static argument =>
+                argument.Parameter?.Name == "destinationArray")?.Value
+            ?? invocation.Arguments
+                .Where(static argument => IsArrayLike(argument.Value))
+                .Skip(1)
+                .FirstOrDefault()?.Value;
+    }
+
+    private static IOperation? GetStaticArrayRetainedValue(
+        IInvocationOperation invocation)
+    {
+        if (!IsKnownStaticArrayMutation(invocation.TargetMethod))
+        {
+            return null;
+        }
+
+        if (invocation.TargetMethod.Name == "Fill")
+        {
+            return invocation.Arguments.FirstOrDefault(static argument =>
+                argument.Parameter?.Name == "value")?.Value;
+        }
+
+        if (invocation.TargetMethod.Name is "Copy" or "ConstrainedCopy")
+        {
+            return invocation.Arguments.FirstOrDefault(static argument =>
+                    argument.Parameter?.Name == "sourceArray")?.Value
+                ?? invocation.Arguments.FirstOrDefault(static argument =>
+                    IsArrayLike(argument.Value))?.Value;
+        }
+
+        return null;
+    }
+
+    private static bool IsArrayLike(IOperation operation)
+    {
+        var type = Unwrap(operation)?.Type;
+        return type is IArrayTypeSymbol
+            || type is INamedTypeSymbol { Name: "Array" } namedType
+                && namedType.ContainingNamespace.ToDisplayString() == "System";
+    }
 
     private static bool IsDictionaryType(INamedTypeSymbol type) =>
         IsDictionaryInterface(type)
@@ -4709,6 +4898,39 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 "TryUpdate" => parameter.Name == "newValue",
                 _ => true,
             });
+
+    private static IEnumerable<IOperation> EnumerateRetainedDictionaryValues(
+        IInvocationOperation invocation)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (IsRetainedDictionaryArgument(invocation, argument))
+            {
+                yield return argument.Value;
+                continue;
+            }
+
+            if (!IsStoredDictionaryValueFactory(argument)
+                || Unwrap(argument.Value) is not IDelegateCreationOperation delegateCreation
+                || Unwrap(delegateCreation.Target) is not IAnonymousFunctionOperation anonymous)
+            {
+                continue;
+            }
+
+            foreach (var returnedValue in ExecutableDescendantOperations(anonymous.Body)
+                         .OfType<IReturnOperation>()
+                         .Select(static operation => operation.ReturnedValue)
+                         .OfType<IOperation>())
+            {
+                yield return returnedValue;
+            }
+        }
+    }
+
+    private static bool IsStoredDictionaryValueFactory(IArgumentOperation argument) =>
+        argument.Parameter?.Name is "valueFactory"
+            or "addValueFactory"
+            or "updateValueFactory";
 
     private static bool IsDictionaryInterface(INamedTypeSymbol type) =>
         type.Name == "IDictionary"
@@ -7568,16 +7790,30 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
     private static bool IsKnownStaticArrayMutationArgument(
         ArgumentSyntax argument,
         SemanticModel semanticModel,
-        CancellationToken cancellationToken) =>
-        argument.Parent is ArgumentListSyntax
+        CancellationToken cancellationToken)
+    {
+        if (argument.Parent is not ArgumentListSyntax
         {
-            Arguments: { Count: > 0 } arguments,
             Parent: InvocationExpressionSyntax invocationSyntax,
         }
-        && arguments[0] == argument
-        && semanticModel.GetOperation(invocationSyntax, cancellationToken)
-            is IInvocationOperation invocation
-        && IsKnownStaticArrayMutation(invocation.TargetMethod);
+            || semanticModel.GetOperation(invocationSyntax, cancellationToken)
+                is not IInvocationOperation invocation
+            || !IsKnownStaticArrayMutation(invocation.TargetMethod))
+        {
+            return false;
+        }
+
+        var target = GetStaticArrayMutationTarget(invocation);
+        if (target is not null && target.Syntax.Span.Contains(argument.Expression.Span))
+        {
+            return true;
+        }
+
+        var source = invocation.TargetMethod.Name is "Copy" or "ConstrainedCopy"
+            ? GetStaticArrayRetainedValue(invocation)
+            : null;
+        return source is not null && source.Syntax.Span.Contains(argument.Expression.Span);
+    }
 
     private static bool IsWritten(IdentifierNameSyntax identifier)
     {

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -1487,9 +1487,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         List<SyntaxNode>? kills,
         ControlFlowGraph? controlFlowGraph)
     {
-        if (kills is null || kills.Count == 0 || controlFlowGraph is null)
+        if (kills is null || kills.Count == 0)
         {
-            return CanReach(source, target, controlFlowGraph);
+            return CanReach(
+                source,
+                target,
+                controlFlowGraph,
+                requireTraversal: source.SpanStart >= target.SpanStart);
+        }
+
+        if (controlFlowGraph is null)
+        {
+            return source.SpanStart < target.SpanStart;
         }
 
         var sourceSyntax = source is VariableDeclaratorSyntax
@@ -1507,7 +1516,8 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         foreach (var sourceBlock in sourceBlocks)
         {
-            if (targetBlocks.Contains(sourceBlock)
+            if (source.SpanStart < target.SpanStart
+                && targetBlocks.Contains(sourceBlock)
                 && !ContainsKill(sourceBlock, kills, source.SpanStart, target.SpanStart))
             {
                 return true;
@@ -3489,25 +3499,32 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 node is not AnonymousFunctionExpressionSyntax
                     and not LocalFunctionStatementSyntax)
             .Where(candidate => (candidate is InvocationExpressionSyntax
-                    or AssignmentExpressionSyntax)
-                && candidate.SpanStart < localReference.Syntax.SpanStart
-                && CanReach(
-                    candidate,
-                    localReference.Syntax,
-                    controlFlowGraph))
+                    or AssignmentExpressionSyntax))
             .ToArray();
+        var origins = new List<(SyntaxNode Node, SyntaxNode Context, string? Slot)>();
+        var kills = new List<(SyntaxNode Node, string? Slot, bool ClearsAll)>();
 
         foreach (var invocationSyntax in mutations.OfType<InvocationExpressionSyntax>())
         {
             if (semanticModel.GetOperation(
                     invocationSyntax,
                     context.CancellationToken) is not IInvocationOperation invocation
-                || !IsKnownRetainingMutation(invocation.TargetMethod)
                 || !IsRootedInLocal(
                     GetReceiver(invocation),
                     localReference.Local,
                     context,
                     visitedLocals: null))
+            {
+                continue;
+            }
+
+            if (IsKnownClearingMutation(invocation.TargetMethod))
+            {
+                kills.Add((invocation.Syntax, null, ClearsAll: true));
+                continue;
+            }
+
+            if (!IsKnownRetainingMutation(invocation.TargetMethod))
             {
                 continue;
             }
@@ -3521,7 +3538,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     visitedLocals,
                     out capturedContext))
                 {
-                    return true;
+                    origins.Add((invocation.Syntax, capturedContext, Slot: null));
                 }
             }
         }
@@ -3535,14 +3552,40 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     assignment.Target,
                     localReference.Local,
                     context,
-                    visitedLocals: null)
-                && TryFindDeferredStateContext(
+                    visitedLocals: null))
+            {
+                var slot = GetDeferredMutationSlot(assignment.Target);
+                if (TryFindDeferredStateContext(
                     assignment.Value,
                     context,
                     knownTypes,
                     visitedLocals,
                     out capturedContext))
+                {
+                    origins.Add((assignment.Syntax, capturedContext, slot));
+                }
+                else
+                {
+                    kills.Add((assignment.Syntax, slot, ClearsAll: false));
+                }
+            }
+        }
+
+        foreach (var origin in origins)
+        {
+            var relevantKills = kills
+                .Where(kill => kill.ClearsAll
+                    || origin.Slot is not null
+                        && (kill.Slot is null || kill.Slot == origin.Slot))
+                .Select(static kill => kill.Node)
+                .ToList();
+            if (CanReachWithoutKills(
+                origin.Node,
+                localReference.Syntax,
+                relevantKills,
+                controlFlowGraph))
             {
+                capturedContext = origin.Context;
                 return true;
             }
         }
@@ -3550,6 +3593,34 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         capturedContext = null!;
         return false;
     }
+
+    private static bool IsKnownClearingMutation(IMethodSymbol method) =>
+        method.Name == "Clear"
+        && method.Parameters.Length == 0
+        && RetainingCollectionNamespaces.Contains(
+            method.ContainingNamespace.ToDisplayString());
+
+    private static string? GetDeferredMutationSlot(IOperation target)
+    {
+        target = Unwrap(target)!;
+        return target switch
+        {
+            IFieldReferenceOperation field => $"field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array => $"array:{GetArgumentKey(array.Indices)}",
+            _ => null,
+        };
+    }
+
+    private static string GetArgumentKey(IEnumerable<IOperation> arguments) =>
+        string.Join(",", arguments.Select(GetConstantKey));
+
+    private static string GetConstantKey(IOperation operation) =>
+        operation.ConstantValue is { HasValue: true } constant
+            ? constant.Value?.ToString() ?? "null"
+            : "?";
 
     private static bool IsRootedInLocal(
         IOperation? operation,

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -54,9 +54,18 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         ImmutableHashSet.Create(
             StringComparer.Ordinal,
             "Add",
+            "AddAfter",
+            "AddBefore",
+            "AddFirst",
+            "AddLast",
+            "AddRange",
             "Enqueue",
+            "EnqueueRange",
             "Push",
+            "PushRange",
             "Insert",
+            "InsertRange",
+            "UnionWith",
             "TryAdd");
 
     /// <summary>The KEV002 rule.</summary>
@@ -3277,18 +3286,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 && TryGetStableAliasInitializer(localReference, context, out var initializer)
                 && initializer is not null)
             {
-                if (TryFindDeferredStateContext(
-                    initializer,
-                    context,
-                    knownTypes,
-                    visitedLocals,
-                    out capturedContext))
-                {
-                    return true;
-                }
-
                 if (TryFindDeferredStateMutation(
                     localReference,
+                    initializer,
                     context,
                     knownTypes,
                     visitedLocals,
@@ -3475,6 +3475,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
     private static bool TryFindDeferredStateMutation(
         ILocalReferenceOperation localReference,
+        IOperation initializer,
         OperationAnalysisContext context,
         KnownTypes knownTypes,
         HashSet<ISymbol> visitedLocals,
@@ -3501,8 +3502,34 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
             .Where(candidate => (candidate is InvocationExpressionSyntax
                     or AssignmentExpressionSyntax))
             .ToArray();
-        var origins = new List<(SyntaxNode Node, SyntaxNode Context, string? Slot)>();
-        var kills = new List<(SyntaxNode Node, string? Slot, bool ClearsAll)>();
+        var origins = new List<(
+            SyntaxNode Node,
+            SyntaxNode Context,
+            string? Slot,
+            string? Value)>();
+        var kills = new List<(
+            SyntaxNode Node,
+            string? Slot,
+            bool ClearsAll,
+            string? Value,
+            bool RemovesOne)>();
+        var retainingMutationCount = 0;
+        if (TryFindDeferredStateContext(
+            initializer,
+            context,
+            knownTypes,
+            visitedLocals,
+            out capturedContext))
+        {
+            origins.Add((
+                initializer.Syntax,
+                capturedContext,
+                Slot: null,
+                GetDeferredValueKey(
+                    semanticModel.GetOperation(capturedContext, context.CancellationToken),
+                    context,
+                    visitedLocals: null)));
+        }
 
         foreach (var invocationSyntax in mutations.OfType<InvocationExpressionSyntax>())
         {
@@ -3520,7 +3547,37 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
             if (IsKnownClearingMutation(invocation.TargetMethod))
             {
-                kills.Add((invocation.Syntax, null, ClearsAll: true));
+                kills.Add((
+                    invocation.Syntax,
+                    Slot: null,
+                    ClearsAll: true,
+                    Value: null,
+                    RemovesOne: false));
+                continue;
+            }
+
+            if (IsKnownValueRemovingMutation(invocation.TargetMethod))
+            {
+                kills.Add((
+                    invocation.Syntax,
+                    Slot: null,
+                    ClearsAll: false,
+                    GetDeferredValueKey(
+                        invocation.Arguments[0].Value,
+                        context,
+                        visitedLocals: null),
+                    RemovesOne: false));
+                continue;
+            }
+
+            if (IsKnownSingleRemovingMutation(invocation.TargetMethod))
+            {
+                kills.Add((
+                    invocation.Syntax,
+                    Slot: null,
+                    ClearsAll: false,
+                    Value: null,
+                    RemovesOne: true));
                 continue;
             }
 
@@ -3529,6 +3586,9 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
+            retainingMutationCount += IsBulkRetainingMutation(invocation.TargetMethod)
+                ? 2
+                : 1;
             foreach (var argument in invocation.Arguments)
             {
                 if (TryFindDeferredStateContext(
@@ -3538,7 +3598,16 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     visitedLocals,
                     out capturedContext))
                 {
-                    origins.Add((invocation.Syntax, capturedContext, Slot: null));
+                    origins.Add((
+                        invocation.Syntax,
+                        capturedContext,
+                        Slot: null,
+                        GetDeferredValueKey(
+                            semanticModel.GetOperation(
+                                capturedContext,
+                                context.CancellationToken),
+                            context,
+                            visitedLocals: null)));
                 }
             }
         }
@@ -3554,7 +3623,11 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     context,
                     visitedLocals: null))
             {
-                var slot = GetDeferredMutationSlot(assignment.Target);
+                var slot = GetDeferredMutationSlot(
+                    assignment.Target,
+                    localReference.Local,
+                    context,
+                    visitedLocals: null);
                 if (TryFindDeferredStateContext(
                     assignment.Value,
                     context,
@@ -3562,21 +3635,46 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
                     visitedLocals,
                     out capturedContext))
                 {
-                    origins.Add((assignment.Syntax, capturedContext, slot));
+                    origins.Add((
+                        assignment.Syntax,
+                        capturedContext,
+                        slot,
+                        GetDeferredValueKey(
+                            semanticModel.GetOperation(
+                                capturedContext,
+                                context.CancellationToken),
+                            context,
+                            visitedLocals: null)));
                 }
                 else
                 {
-                    kills.Add((assignment.Syntax, slot, ClearsAll: false));
+                    kills.Add((
+                        assignment.Syntax,
+                        slot,
+                        ClearsAll: false,
+                        Value: null,
+                        RemovesOne: false));
                 }
             }
         }
 
+        var startsEmpty = IsKnownEmptyDeferredContainer(initializer);
         foreach (var origin in origins)
         {
+            var matchingValueOrigins = origin.Value is null
+                ? 0
+                : origins.Count(candidate => candidate.Value == origin.Value);
             var relevantKills = kills
                 .Where(kill => kill.ClearsAll
                     || origin.Slot is not null
-                        && (kill.Slot is null || kill.Slot == origin.Slot))
+                        && kill.Slot == origin.Slot
+                    || origin.Value is not null
+                        && matchingValueOrigins == 1
+                        && kill.Value == origin.Value
+                    || startsEmpty
+                        && retainingMutationCount == 1
+                        && origins.Count == 1
+                        && kill.RemovesOne)
                 .Select(static kill => kill.Node)
                 .ToList();
             if (CanReachWithoutKills(
@@ -3600,17 +3698,102 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         && RetainingCollectionNamespaces.Contains(
             method.ContainingNamespace.ToDisplayString());
 
-    private static string? GetDeferredMutationSlot(IOperation target)
+    private static bool IsKnownValueRemovingMutation(IMethodSymbol method) =>
+        method.Name == "Remove"
+        && method.Parameters.Length > 0
+        && RetainingCollectionNamespaces.Contains(
+            method.ContainingNamespace.ToDisplayString());
+
+    private static bool IsKnownSingleRemovingMutation(IMethodSymbol method) =>
+        method.Name is "Dequeue" or "Pop" or "TryDequeue" or "TryPop" or "TryTake"
+        && RetainingCollectionNamespaces.Contains(
+            method.ContainingNamespace.ToDisplayString());
+
+    private static bool IsBulkRetainingMutation(IMethodSymbol method) =>
+        method.Name.EndsWith("Range", StringComparison.Ordinal)
+        || method.Name == "UnionWith";
+
+    private static bool IsKnownEmptyDeferredContainer(IOperation initializer)
+    {
+        initializer = Unwrap(initializer)!;
+        return initializer switch
+        {
+            IObjectCreationOperation objectCreation =>
+                objectCreation.Initializer is null or { Initializers.Length: 0 }
+                && objectCreation.Arguments.All(argument => argument.Parameter is null
+                    || !IsKnownRetainingFrameworkConstructorParameter(
+                        objectCreation.Constructor,
+                        argument.Parameter)),
+            IArrayCreationOperation arrayCreation => arrayCreation.Initializer is null,
+            IInvocationOperation
+            {
+                TargetMethod:
+                {
+                    Name: "Empty",
+                    Parameters.Length: 0,
+                },
+            } => true,
+            _ => initializer.Syntax is CollectionExpressionSyntax
+                {
+                    Elements.Count: 0,
+                },
+        };
+    }
+
+    private static string? GetDeferredMutationSlot(
+        IOperation target,
+        ILocalSymbol local,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedLocals)
     {
         target = Unwrap(target)!;
         return target switch
         {
-            IFieldReferenceOperation field => $"field:{field.Field.ToDisplayString()}",
+            IFieldReferenceOperation field =>
+                $"{GetDeferredReceiverKey(field.Instance, local, context, visitedLocals)}" +
+                $".field:{field.Field.ToDisplayString()}",
             IPropertyReferenceOperation property =>
-                $"property:{property.Property.ToDisplayString()}:" +
+                $"{GetDeferredReceiverKey(property.Instance, local, context, visitedLocals)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
                 GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
-            IArrayElementReferenceOperation array => $"array:{GetArgumentKey(array.Indices)}",
+            IArrayElementReferenceOperation array =>
+                $"{GetDeferredReceiverKey(array.ArrayReference, local, context, visitedLocals)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
             _ => null,
+        };
+    }
+
+    private static string GetDeferredReceiverKey(
+        IOperation? receiver,
+        ILocalSymbol local,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        receiver = Unwrap(receiver);
+        if (receiver is ILocalReferenceOperation localReference)
+        {
+            return IsRootedInLocal(
+                localReference,
+                local,
+                context,
+                visitedLocals)
+                ? "root"
+                : $"local:{localReference.Local.ToDisplayString()}";
+        }
+
+        return receiver switch
+        {
+            IFieldReferenceOperation field =>
+                $"{GetDeferredReceiverKey(field.Instance, local, context, visitedLocals)}" +
+                $".field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"{GetDeferredReceiverKey(property.Instance, local, context, visitedLocals)}" +
+                $".property:{property.Property.ToDisplayString()}:" +
+                GetArgumentKey(property.Arguments.Select(static argument => argument.Value)),
+            IArrayElementReferenceOperation array =>
+                $"{GetDeferredReceiverKey(array.ArrayReference, local, context, visitedLocals)}" +
+                $".array:{GetArgumentKey(array.Indices)}",
+            _ => "?",
         };
     }
 
@@ -3621,6 +3804,35 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         operation.ConstantValue is { HasValue: true } constant
             ? constant.Value?.ToString() ?? "null"
             : "?";
+
+    private static string? GetDeferredValueKey(
+        IOperation? operation,
+        OperationAnalysisContext context,
+        HashSet<ISymbol>? visitedLocals)
+    {
+        operation = Unwrap(operation);
+        if (operation is ILocalReferenceOperation localReference)
+        {
+            visitedLocals ??= new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (visitedLocals.Add(localReference.Local)
+                && TryGetStableAliasInitializer(localReference, context, out var initializer))
+            {
+                return GetDeferredValueKey(initializer, context, visitedLocals);
+            }
+        }
+
+        return operation switch
+        {
+            IParameterReferenceOperation parameter =>
+                $"parameter:{parameter.Parameter.ToDisplayString()}",
+            IFieldReferenceOperation field => $"field:{field.Field.ToDisplayString()}",
+            IPropertyReferenceOperation property =>
+                $"property:{property.Property.ToDisplayString()}",
+            { ConstantValue: { HasValue: true } constant } =>
+                $"constant:{constant.Value?.ToString() ?? "null"}",
+            _ => operation?.Syntax.ToString(),
+        };
+    }
 
     private static bool IsRootedInLocal(
         IOperation? operation,

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4032,6 +4032,7 @@ public class PipelineHazardAnalyzerTests
         var mutations = new[]
         {
             "events.Add(item);",
+            "events.AddRange(new[] { item });",
             "var alias = events; alias.Add(item);",
         };
         foreach (var mutation in mutations)
@@ -4073,6 +4074,71 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Distinguishes_Nested_Deferred_State_Slots()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new RetryEvent[2][];
+                events[0] = new RetryEvent[1];
+                events[1] = new RetryEvent[1];
+                events[0][0] = item;
+                events[1][0] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+        var dynamicIndexDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var index = 0;
+                var events = new RetryEvent[2];
+                events[index] = item;
+                events[1] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            dynamicIndexDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Distinguishes_Deferred_Object_State_Slots()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        var state = new Holder();
+                        state.First.Event = item;
+                        state.Second.Event = default;
+                        state.Second.Field = default;
+                        ThreadPool.QueueUserWorkItem(static value => { }, state);
+                    });
+
+                private sealed class Holder
+                {
+                    public Bucket First { get; } = new();
+                    public Bucket Second { get; } = new();
+                }
+
+                private sealed class Bucket
+                {
+                    public RetryEvent Event { get; set; }
+                    public RetryEvent Field;
+                }
+            }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Tracks_Deferred_Mutations_Through_Loop_BackEdges()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -4100,6 +4166,11 @@ public class PipelineHazardAnalyzerTests
         var statements = new[]
         {
             "var events = new System.Collections.Generic.List<RetryEvent>(); events.Add(item); events.Clear();",
+            "var events = new System.Collections.Generic.List<RetryEvent> { item }; events.Clear();",
+            "System.Collections.Generic.List<RetryEvent> events = []; events.Add(item); events.Remove(item);",
+            "var events = new System.Collections.Generic.List<RetryEvent>(); events.Add(item); events.Remove(item);",
+            "var events = new System.Collections.Generic.Stack<RetryEvent>(); events.Push(item); events.Pop();",
+            "var events = new System.Collections.Generic.Queue<RetryEvent>(); events.Enqueue(item); events.Dequeue();",
             "var events = new RetryEvent[1]; events[0] = item; events[0] = default;",
         };
         foreach (var statement in statements)
@@ -4113,6 +4184,28 @@ public class PipelineHazardAnalyzerTests
                 """);
 
             await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Keeps_Deferred_State_When_Removals_Leave_Retained_Values()
+    {
+        var statements = new[]
+        {
+            "var events = new System.Collections.Generic.List<RetryEvent>(); events.Add(item); events.Add(item); events.Remove(item);",
+            "var events = new System.Collections.Generic.Queue<RetryEvent>(); events.Enqueue(default); events.Enqueue(item); events.Dequeue();",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{statement}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
         }
     }
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4134,6 +4134,17 @@ public class PipelineHazardAnalyzerTests
 
             await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
         }
+
+        var overwriteDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new[] { item };
+                Array.Copy(new[] { default(RetryEvent) }, events, 1);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(overwriteDiagnostics).IsEmpty();
     }
 
     [Test]
@@ -5152,6 +5163,31 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_LinkedList_Node_Values()
+    {
+        var mutations = new[]
+        {
+            "events.AddFirst(new System.Collections.Generic.LinkedListNode<RetryEvent>(item));",
+            "events.AddLast(new System.Collections.Generic.LinkedListNode<RetryEvent>(item));",
+            "var anchor = events.AddFirst(default(RetryEvent)); events.AddBefore(anchor, new System.Collections.Generic.LinkedListNode<RetryEvent>(item));",
+            "var anchor = events.AddFirst(default(RetryEvent)); events.AddAfter(anchor, new System.Collections.Generic.LinkedListNode<RetryEvent>(item));",
+        };
+        foreach (var mutation in mutations)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    var events = new System.Collections.Generic.LinkedList<RetryEvent>();
+                    {{mutation}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4073,6 +4073,50 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Deferred_Mutations_Through_Loop_BackEdges()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                while (Environment.TickCount >= 0)
+                {
+                    ThreadPool.QueueUserWorkItem(
+                        static (System.Collections.Generic.List<RetryEvent> state) =>
+                            Console.WriteLine(state.Count),
+                        events,
+                        preferLocal: false);
+                    events.Add(item);
+                }
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Deferred_State_Cleared_Before_Scheduling()
+    {
+        var statements = new[]
+        {
+            "var events = new System.Collections.Generic.List<RetryEvent>(); events.Add(item); events.Clear();",
+            "var events = new RetryEvent[1]; events[0] = item; events[0] = default;",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{statement}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
+        }
+    }
+
+    [Test]
     public async Task KEV014_Ignores_Deferred_State_Mutations_On_Exiting_Paths()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4333,6 +4333,23 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_Invoked_Local_Function_Mutations()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                void Add() => events.Add(item);
+
+                Add();
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Ignores_Deferred_State_Cleared_Before_Scheduling()
     {
         var statements = new[]
@@ -4343,6 +4360,7 @@ public class PipelineHazardAnalyzerTests
             "var events = new System.Collections.Generic.List<RetryEvent>(); events.Add(item); events.Remove(item);",
             "var events = new System.Collections.Generic.Stack<RetryEvent>(); events.Push(item); events.Pop();",
             "var events = new System.Collections.Generic.Queue<RetryEvent>(); events.Enqueue(item); events.Dequeue();",
+            "var events = new System.Collections.Generic.Queue<RetryEvent>(new[] { item }); events.Dequeue();",
             "var events = new RetryEvent[1]; events[0] = item; events[0] = default;",
             "var events = new[] { item }; events[0] = default;",
         };
@@ -4680,6 +4698,34 @@ public class PipelineHazardAnalyzerTests
                 events["1"] = default;
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Distinguishes_Enum_Type_Dictionary_Keys()
+    {
+        var diagnostics = await AnalyzeBodyAsync(
+            """
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.Dictionary<object, RetryEvent>();
+                events[First.Key] = item;
+                events[Second.Key] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """,
+            """
+            private enum First
+            {
+                Key,
+            }
+
+            private enum Second
+            {
+                Key,
+            }
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4097,10 +4097,25 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var distinctDynamicIndicesDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var i = Environment.TickCount;
+                var j = Environment.ProcessId;
+                var events = new RetryEvent[2];
+                events[i] = item;
+                events[j] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
         await AssertRuleAsync(
             dynamicIndexDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            distinctDynamicIndicesDiagnostics,
             "KEV014",
             DiagnosticSeverity.Warning);
     }
@@ -4133,6 +4148,123 @@ public class PipelineHazardAnalyzerTests
                     public RetryEvent Field;
                 }
             }
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Honors_Overwritten_Object_Initializer_Slots()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        var state = new Holder { Event = item };
+                        state.Event = default;
+                        ThreadPool.QueueUserWorkItem(static value => { }, state);
+                    });
+
+                private sealed class Holder
+                {
+                    public RetryEvent Event { get; set; }
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Honors_Overwritten_Nested_Initializer_Slots()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        var state = new Holder
+                        {
+                            Child = new Bucket { Event = item },
+                        };
+                        state.Child.Event = default;
+                        ThreadPool.QueueUserWorkItem(static value => { }, state);
+                    });
+
+                private sealed class Holder
+                {
+                    public Bucket Child { get; set; } = new();
+                }
+
+                private sealed class Bucket
+                {
+                    public RetryEvent Event { get; set; }
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Parent_Overwrites_Kill_Nested_Slots()
+    {
+        var diagnostics = await AnalyzeSourceAsync("""
+            public sealed class TestSubject
+            {
+                public void Configure() =>
+                    _ = Shield.Retry(options => options.OnRetry = item =>
+                    {
+                        var state = new Holder();
+                        state.Child.Event = item;
+                        state.Child = new Bucket();
+                        ThreadPool.QueueUserWorkItem(static value => { }, state);
+                    });
+
+                private sealed class Holder
+                {
+                    public Bucket Child { get; set; } = new();
+                }
+
+                private sealed class Bucket
+                {
+                    public RetryEvent Event { get; set; }
+                }
+            }
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Coalescing_Assignment_Mutations()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new RetryEvent?[1];
+                events[0] ??= item;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Does_Not_Treat_Coalescing_Assignment_As_Overwrite()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new RetryEvent?[1];
+                events[0] = item;
+                events[0] ??= default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
             """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
@@ -4172,6 +4304,7 @@ public class PipelineHazardAnalyzerTests
             "var events = new System.Collections.Generic.Stack<RetryEvent>(); events.Push(item); events.Pop();",
             "var events = new System.Collections.Generic.Queue<RetryEvent>(); events.Enqueue(item); events.Dequeue();",
             "var events = new RetryEvent[1]; events[0] = item; events[0] = default;",
+            "var events = new[] { item }; events[0] = default;",
         };
         foreach (var statement in statements)
         {
@@ -4188,11 +4321,423 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Honors_Overwritten_Collection_Expression_Slots()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                System.Collections.Generic.List<RetryEvent> events = [item];
+                events[0] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Honors_Overwritten_Append_Slots()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                events.Add(item);
+                events[0] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Does_Not_Stabilize_Appends_Across_Branches()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                if (Environment.TickCount == 0)
+                {
+                    events.Add(default);
+                }
+                else
+                {
+                    events.Add(default);
+                }
+
+                events.Add(item);
+                events.Add(default);
+                events[2] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Invalidates_Slots_After_Structural_Mutations()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                System.Collections.Generic.List<RetryEvent?> events = [item];
+                events.Insert(0, default);
+                events[0] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Handles_Exact_RemoveAt_Kills()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                System.Collections.Generic.List<RetryEvent> events = [item];
+                events.RemoveAt(0);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Invalidates_Slots_For_All_Structural_Mutations()
+    {
+        var statements = new[]
+        {
+            "events.InsertRange(0, new RetryEvent?[] { default }); events[0] = default;",
+            "events.Remove(default); events[1] = default;",
+            "events.RemoveAt(0); events[1] = default;",
+            "events.RemoveRange(0, 1); events[1] = default;",
+            "events.Reverse(); events[0] = default;",
+            "events.Sort(); events[0] = default;",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    System.Collections.Generic.List<RetryEvent?> events = [default, item];
+                    {{statement}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Context_Assignments_Kill_Prior_Slot_Contents()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var other = item with { };
+                System.Collections.Generic.List<RetryEvent> events = [item];
+                events[0] = other;
+                events.Remove(other);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Collection_Expression_Spreads_And_Sets()
+    {
+        var spreadDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var source = new[] { item };
+                System.Collections.Generic.List<RetryEvent> events = [.. source];
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+        var setDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                System.Collections.Generic.HashSet<RetryEvent> events = [item];
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(spreadDiagnostics, "KEV014", DiagnosticSeverity.Warning);
+        await AssertRuleAsync(setDiagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Handles_Set_Union_Removal()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.HashSet<RetryEvent>();
+                events.UnionWith(new[] { item });
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Consumes_Duplicates_Across_Matching_Removals()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                events.Add(item);
+                events.Add(item);
+                events.Remove(item);
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Scopes_Removals_To_Nested_Collection_Receivers()
+    {
+        var mutations = new[]
+        {
+            "state[1].Clear();",
+            "state[1].Remove(item);",
+        };
+        foreach (var mutation in mutations)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    var state = new[]
+                    {
+                        new System.Collections.Generic.List<RetryEvent>(),
+                        new System.Collections.Generic.List<RetryEvent>(),
+                    };
+                    state[0].Add(item);
+                    {{mutation}}
+                    ThreadPool.QueueUserWorkItem(static value => { }, state);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Matches_Duplicate_Values_Per_Receiver()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var state = new[]
+                {
+                    new System.Collections.Generic.List<RetryEvent>(),
+                    new System.Collections.Generic.List<RetryEvent>(),
+                };
+                state[0].Add(item);
+                state[1].Add(item);
+                state[0].Remove(item);
+                state[1].Clear();
+                ThreadPool.QueueUserWorkItem(static value => { }, state);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Does_Not_Treat_Dictionary_Keys_As_Removed_Values()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.Dictionary<RetryEvent, RetryEvent>();
+                events.Add(default, item);
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Matches_Dictionary_Removals_To_Retained_Keys()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.Dictionary<RetryEvent, RetryEvent>();
+                events.Add(item, default);
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Dictionary_Indexer_Keys()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.Dictionary<RetryEvent, RetryEvent>();
+                events[item] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Distinguishes_Mixed_Type_Dictionary_Keys()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.Dictionary<object, RetryEvent>();
+                events[1] = item;
+                events["1"] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Matches_Dictionary_Initializer_Removals()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.Dictionary<int, RetryEvent>
+                {
+                    { 0, item },
+                };
+                events.Remove(0);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Preserves_Nested_Receiver_Alias_Paths()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var state = new[]
+                {
+                    new System.Collections.Generic.List<RetryEvent>(),
+                    new System.Collections.Generic.List<RetryEvent>(),
+                };
+                state[0].Add(item);
+                var second = state[1];
+                second.Clear();
+                ThreadPool.QueueUserWorkItem(static value => { }, state);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Distinguishes_Removal_Value_Receivers()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var other = item with { };
+                var contexts = new System.Collections.Generic.List<KevlarContext>();
+                contexts.Add(item.Context);
+                contexts.Remove(other.Context);
+                ThreadPool.QueueUserWorkItem(static state => { }, contexts);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Handles_Mutually_Exclusive_Matching_Adds()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                if (Environment.TickCount == 0)
+                {
+                    events.Add(item);
+                }
+                else
+                {
+                    events.Add(item);
+                }
+
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Handles_Exclusive_Matching_Adds_In_Loops()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                while (Environment.TickCount >= 0)
+                {
+                    if (Environment.TickCount == 0)
+                    {
+                        events.Add(item);
+                    }
+                    else
+                    {
+                        events.Add(item);
+                    }
+
+                    events.Remove(item);
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                }
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Keeps_Deferred_State_When_Removals_Leave_Retained_Values()
     {
         var statements = new[]
         {
             "var events = new System.Collections.Generic.List<RetryEvent>(); events.Add(item); events.Add(item); events.Remove(item);",
+            "var events = new System.Collections.Generic.List<RetryEvent> { item, item }; events.Remove(item);",
+            "System.Collections.Generic.List<RetryEvent> events = [item, item]; events.Remove(item);",
+            "var events = new System.Collections.Generic.List<RetryEvent>(); events.AddRange(new[] { item, item }); events.Remove(item);",
             "var events = new System.Collections.Generic.Queue<RetryEvent>(); events.Enqueue(default); events.Enqueue(item); events.Dequeue();",
         };
         foreach (var statement in statements)
@@ -4207,6 +4752,144 @@ public class PipelineHazardAnalyzerTests
 
             await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
         }
+    }
+
+    [Test]
+    public async Task KEV014_Combines_Constructor_And_Initializer_Origins()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>(
+                    new[] { item })
+                {
+                    item,
+                };
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Honors_Singleton_Bulk_Mutation_Cardinality()
+    {
+        var arrayDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                events.AddRange(new[] { item });
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+        var collectionDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                events.AddRange([item]);
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+        var spreadDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                events.AddRange([.. new[] { item }]);
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(arrayDiagnostics).IsEmpty();
+        await Assert.That(collectionDiagnostics).IsEmpty();
+        await AssertRuleAsync(
+            spreadDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Does_Not_Multiply_Repeated_Fixed_Slot_Assignments()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                System.Collections.Generic.List<RetryEvent?> events = [default];
+                for (var index = 0; index < 2; index++)
+                {
+                    events[0] = item;
+                }
+
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Preserves_Repeated_Loop_Retentions()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                for (var index = 0; index < 2; index++)
+                {
+                    events.Add(item);
+                }
+
+                events.Remove(item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Preserves_Repeated_Queue_Retentions()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.Queue<RetryEvent>();
+                for (var index = 0; index < 2; index++)
+                {
+                    events.Enqueue(item);
+                }
+
+                events.Dequeue();
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Handles_Per_Iteration_Matching_Removals()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                for (var index = 0; index < 2; index++)
+                {
+                    events.Add(item);
+                    events.Remove(item);
+                }
+
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4143,8 +4143,26 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var copiedSlices = new[]
+        {
+            "Array.Copy(new[] { item, default(RetryEvent) }, 1, events, 0, 1);",
+            "Array.ConstrainedCopy(new[] { item, default(RetryEvent) }, 1, events, 0, 1);",
+        };
 
         await Assert.That(overwriteDiagnostics).IsEmpty();
+        foreach (var copy in copiedSlices)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    var events = new RetryEvent[1];
+                    {{copy}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
+        }
     }
 
     [Test]
@@ -4182,6 +4200,17 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var reassignedIndexDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var index = 0;
+                var events = new RetryEvent[2];
+                events[index] = item;
+                index = 1;
+                events[index] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
 
         await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
         await AssertRuleAsync(
@@ -4190,6 +4219,10 @@ public class PipelineHazardAnalyzerTests
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(
             distinctDynamicIndicesDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            reassignedIndexDiagnostics,
             "KEV014",
             DiagnosticSeverity.Warning);
     }
@@ -4411,6 +4444,17 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var nestedInvocationDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                void Inner() => events.Add(item);
+                void Outer() => Inner();
+
+                Outer();
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
 
         await AssertRuleAsync(
             invocationDiagnostics,
@@ -4426,6 +4470,10 @@ public class PipelineHazardAnalyzerTests
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(
             erasedValueDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            nestedInvocationDiagnostics,
             "KEV014",
             DiagnosticSeverity.Warning);
     }

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4455,6 +4455,43 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var additionalMutations = new[]
+        {
+            """
+            var events = new System.Collections.Generic.Dictionary<int, RetryEvent>();
+            void Add() => events.Add(0, item);
+            Add();
+            """,
+            """
+            var events = new RetryEvent?[1];
+            void Set() => events[0] ??= item;
+            Set();
+            """,
+            """
+            var events = new System.Collections.Generic.Dictionary<int, RetryEvent>();
+            void Set() => events[0] = item;
+            Set();
+            """,
+            """
+            var events = new RetryEvent[1];
+            void Fill() => Array.Fill(events, item);
+            Fill();
+            """,
+            """
+            object[] events = new object[1];
+            void Copy() => Array.Copy(new object[] { item }, events, 1);
+            Copy();
+            """,
+            """
+            var events = new System.Collections.Generic.List<RetryEvent>();
+            void Add()
+            {
+                events.Add(item);
+                Add();
+            }
+            Add();
+            """,
+        };
 
         await AssertRuleAsync(
             invocationDiagnostics,
@@ -4476,6 +4513,18 @@ public class PipelineHazardAnalyzerTests
             nestedInvocationDiagnostics,
             "KEV014",
             DiagnosticSeverity.Warning);
+        foreach (var mutation in additionalMutations)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{mutation}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
     }
 
     [Test]
@@ -4518,6 +4567,50 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var additionalCleanups = new[]
+        {
+            """
+            var events = new System.Collections.Generic.List<RetryEvent> { item };
+            void Cleanup() => events.Remove(item);
+            Cleanup();
+            """,
+            """
+            var events = new System.Collections.Generic.List<RetryEvent>();
+            events.Add(item);
+            void Cleanup() => events.RemoveAt(0);
+            Cleanup();
+            """,
+            """
+            var events = new System.Collections.Generic.Queue<RetryEvent>(new[] { item });
+            void Cleanup() => events.Dequeue();
+            Cleanup();
+            """,
+            """
+            var events = new[] { item };
+            void Cleanup() => Array.Clear(events);
+            Cleanup();
+            """,
+            """
+            var events = new[] { item };
+            void Cleanup() => Array.Copy(new[] { default(RetryEvent) }, events, 1);
+            Cleanup();
+            """,
+            """
+            var events = new System.Collections.Generic.List<RetryEvent> { item };
+            void Inner() => events.Clear();
+            void Outer() => Inner();
+            Outer();
+            """,
+            """
+            var events = new System.Collections.Generic.List<RetryEvent> { item };
+            void Cleanup()
+            {
+                events.Clear();
+                Cleanup();
+            }
+            Cleanup();
+            """,
+        };
 
         await Assert.That(clearDiagnostics).IsEmpty();
         await Assert.That(overwriteDiagnostics).IsEmpty();
@@ -4525,6 +4618,18 @@ public class PipelineHazardAnalyzerTests
             conditionalDiagnostics,
             "KEV014",
             DiagnosticSeverity.Warning);
+        foreach (var cleanup in additionalCleanups)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    {{cleanup}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
+        }
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4367,6 +4367,23 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Follows_Invoked_Local_Function_Cleanup()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent> { item };
+                void Clear() => events.Clear();
+
+                Clear();
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Ignores_Deferred_State_Cleared_Before_Scheduling()
     {
         var statements = new[]
@@ -4378,6 +4395,7 @@ public class PipelineHazardAnalyzerTests
             "var events = new System.Collections.Generic.Stack<RetryEvent>(); events.Push(item); events.Pop();",
             "var events = new System.Collections.Generic.Queue<RetryEvent>(); events.Enqueue(item); events.Dequeue();",
             "var events = new System.Collections.Generic.Queue<RetryEvent>(new[] { item }); events.Dequeue();",
+            "System.Collections.Generic.List<RetryEvent> events = []; events.Insert(0, item); events.RemoveAt(0);",
             "var events = new RetryEvent[1]; events[0] = item; events[0] = default;",
             "var events = new[] { item }; events[0] = default;",
         };
@@ -4710,6 +4728,36 @@ public class PipelineHazardAnalyzerTests
 
             await Assert.That(diagnostics).IsEmpty();
         }
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Concurrent_Dictionary_TryUpdate_Values()
+    {
+        var retainedDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Concurrent.ConcurrentDictionary<int, object>();
+                var previous = new object();
+                events.TryAdd(0, previous);
+                events.TryUpdate(0, item, previous);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+        var comparisonDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Concurrent.ConcurrentDictionary<int, object>();
+                events.TryAdd(0, new object());
+                events.TryUpdate(0, new object(), item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(
+            retainedDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await Assert.That(comparisonDiagnostics).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4027,6 +4027,76 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Deferred_State_Added_To_Local_Collections()
+    {
+        var mutations = new[]
+        {
+            "events.Add(item);",
+            "var alias = events; alias.Add(item);",
+        };
+        foreach (var mutation in mutations)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    var events = new System.Collections.Generic.List<RetryEvent>();
+                    {{mutation}}
+                    ThreadPool.QueueUserWorkItem(
+                        static (System.Collections.Generic.List<RetryEvent> state) =>
+                            Console.WriteLine(state[0].Context.ShieldName),
+                        events,
+                        preferLocal: false);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Deferred_State_Added_To_Local_Arrays()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new RetryEvent[1];
+                events[0] = item;
+                ThreadPool.QueueUserWorkItem(
+                    static (RetryEvent[] state) =>
+                        Console.WriteLine(state[0].Context.ShieldName),
+                    events,
+                    preferLocal: false);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Deferred_State_Mutations_On_Exiting_Paths()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                if (Environment.TickCount == 0)
+                {
+                    events.Add(item);
+                    return;
+                }
+
+                ThreadPool.QueueUserWorkItem(
+                    static (System.Collections.Generic.List<RetryEvent> state) =>
+                        Console.WriteLine(state.Count),
+                    events,
+                    preferLocal: false);
+            });
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Ignores_Framework_Collection_Capacity_State()
     {
         var diagnostics = await AnalyzeBodyAsync("""

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4335,7 +4335,7 @@ public class PipelineHazardAnalyzerTests
     [Test]
     public async Task KEV014_Follows_Invoked_Local_Function_Mutations()
     {
-        var diagnostics = await AnalyzeBodyAsync("""
+        var invocationDiagnostics = await AnalyzeBodyAsync("""
             _ = Shield.Retry(options => options.OnRetry = item =>
             {
                 var events = new System.Collections.Generic.List<RetryEvent>();
@@ -4345,8 +4345,25 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var assignmentDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new RetryEvent[1];
+                void Set() => events[0] = item;
 
-        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+                Set();
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(
+            invocationDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            assignmentDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -4669,6 +4686,29 @@ public class PipelineHazardAnalyzerTests
                 """);
 
             await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
+    public async Task KEV014_Ignores_Concurrent_Dictionary_Factory_Arguments()
+    {
+        var mutations = new[]
+        {
+            "events.GetOrAdd(0, static (_, state) => state.RetryNumber, item);",
+            "events.AddOrUpdate(0, static (_, state) => state.RetryNumber, static (_, current, state) => current + state.RetryNumber, item);",
+        };
+        foreach (var mutation in mutations)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    var events = new System.Collections.Concurrent.ConcurrentDictionary<int, int>();
+                    {{mutation}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
         }
     }
 

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4114,6 +4114,29 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Static_Array_Copies()
+    {
+        var copies = new[]
+        {
+            "Array.Copy(new object[] { item }, events, 1);",
+            "Array.ConstrainedCopy(new object[] { item }, 0, events, 0, 1);",
+        };
+        foreach (var copy in copies)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    object[] events = new object[1];
+                    {{copy}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
     public async Task KEV014_Distinguishes_Nested_Deferred_State_Slots()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -4355,6 +4378,17 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var parameterDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent>();
+                void Add(System.Collections.Generic.List<RetryEvent> target) =>
+                    target.Add(item);
+
+                Add(events);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
 
         await AssertRuleAsync(
             invocationDiagnostics,
@@ -4364,12 +4398,16 @@ public class PipelineHazardAnalyzerTests
             assignmentDiagnostics,
             "KEV014",
             DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            parameterDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
     public async Task KEV014_Follows_Invoked_Local_Function_Cleanup()
     {
-        var diagnostics = await AnalyzeBodyAsync("""
+        var clearDiagnostics = await AnalyzeBodyAsync("""
             _ = Shield.Retry(options => options.OnRetry = item =>
             {
                 var events = new System.Collections.Generic.List<RetryEvent> { item };
@@ -4379,8 +4417,20 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var overwriteDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new RetryEvent[1];
+                void Set() => events[0] = item;
 
-        await Assert.That(diagnostics).IsEmpty();
+                Set();
+                events[0] = default;
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await Assert.That(clearDiagnostics).IsEmpty();
+        await Assert.That(overwriteDiagnostics).IsEmpty();
     }
 
     [Test]
@@ -4728,6 +4778,21 @@ public class PipelineHazardAnalyzerTests
 
             await Assert.That(diagnostics).IsEmpty();
         }
+    }
+
+    [Test]
+    public async Task KEV014_Tracks_Concurrent_Dictionary_Factory_Returns()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Concurrent.ConcurrentDictionary<int, object>();
+                events.GetOrAdd(0, _ => item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4074,6 +4074,46 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Static_Array_Mutations()
+    {
+        var fillDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new RetryEvent[1];
+                Array.Fill(events, item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+        var clearDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new[] { item };
+                Array.Clear(events);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+        var conditionalClearDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new[] { item };
+                if (DateTime.UtcNow.Ticks == 0)
+                {
+                    Array.Clear(events);
+                }
+
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
+
+        await AssertRuleAsync(fillDiagnostics, "KEV014", DiagnosticSeverity.Warning);
+        await Assert.That(clearDiagnostics).IsEmpty();
+        await AssertRuleAsync(
+            conditionalClearDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+    }
+
+    [Test]
     public async Task KEV014_Distinguishes_Nested_Deferred_State_Slots()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -4592,6 +4632,29 @@ public class PipelineHazardAnalyzerTests
     }
 
     [Test]
+    public async Task KEV014_Tracks_Concurrent_Dictionary_Upserts()
+    {
+        var mutations = new[]
+        {
+            "events.GetOrAdd(item, default(RetryEvent));",
+            "events.AddOrUpdate(item, default(RetryEvent), static (_, current) => current);",
+        };
+        foreach (var mutation in mutations)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    var events = new System.Collections.Concurrent.ConcurrentDictionary<RetryEvent, RetryEvent>();
+                    {{mutation}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await AssertRuleAsync(diagnostics, "KEV014", DiagnosticSeverity.Warning);
+        }
+    }
+
+    [Test]
     public async Task KEV014_Tracks_Dictionary_Indexer_Keys()
     {
         var diagnostics = await AnalyzeBodyAsync("""
@@ -4890,6 +4953,29 @@ public class PipelineHazardAnalyzerTests
             """);
 
         await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task KEV014_Handles_LinkedList_Endpoint_Removals()
+    {
+        var statements = new[]
+        {
+            "events.AddFirst(item); events.RemoveFirst();",
+            "events.AddLast(item); events.RemoveLast();",
+        };
+        foreach (var statement in statements)
+        {
+            var diagnostics = await AnalyzeBodyAsync($$"""
+                _ = Shield.Retry(options => options.OnRetry = item =>
+                {
+                    var events = new System.Collections.Generic.LinkedList<RetryEvent>();
+                    {{statement}}
+                    ThreadPool.QueueUserWorkItem(static state => { }, events);
+                });
+                """);
+
+            await Assert.That(diagnostics).IsEmpty();
+        }
     }
 
     [Test]

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -4400,6 +4400,17 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var erasedValueDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<object>();
+                void Add(System.Collections.Generic.List<object> target, object value) =>
+                    target.Add(value);
+
+                Add(events, item);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
 
         await AssertRuleAsync(
             invocationDiagnostics,
@@ -4411,6 +4422,10 @@ public class PipelineHazardAnalyzerTests
             DiagnosticSeverity.Warning);
         await AssertRuleAsync(
             parameterDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
+        await AssertRuleAsync(
+            erasedValueDiagnostics,
             "KEV014",
             DiagnosticSeverity.Warning);
     }
@@ -4439,9 +4454,29 @@ public class PipelineHazardAnalyzerTests
                 ThreadPool.QueueUserWorkItem(static state => { }, events);
             });
             """);
+        var conditionalDiagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.Retry(options => options.OnRetry = item =>
+            {
+                var events = new System.Collections.Generic.List<RetryEvent> { item };
+                void MaybeClear(bool clear)
+                {
+                    if (clear)
+                    {
+                        events.Clear();
+                    }
+                }
+
+                MaybeClear(false);
+                ThreadPool.QueueUserWorkItem(static state => { }, events);
+            });
+            """);
 
         await Assert.That(clearDiagnostics).IsEmpty();
         await Assert.That(overwriteDiagnostics).IsEmpty();
+        await AssertRuleAsync(
+            conditionalDiagnostics,
+            "KEV014",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -4457,6 +4492,7 @@ public class PipelineHazardAnalyzerTests
             "var events = new System.Collections.Generic.Queue<RetryEvent>(); events.Enqueue(item); events.Dequeue();",
             "var events = new System.Collections.Generic.Queue<RetryEvent>(new[] { item }); events.Dequeue();",
             "System.Collections.Generic.List<RetryEvent> events = []; events.Insert(0, item); events.RemoveAt(0);",
+            "var events = new System.Collections.Concurrent.ConcurrentDictionary<int, RetryEvent>(); events.TryAdd(0, item); events.TryRemove(0, out _);",
             "var events = new RetryEvent[1]; events[0] = item; events[0] = default;",
             "var events = new[] { item }; events[0] = default;",
         };


### PR DESCRIPTION
## Summary
- track pooled event context added to deferred local collections before scheduling
- model loop backedges, initializer elements, slot/receiver identity, removal multiplicity, and control-flow kills
- recognize concurrent-dictionary upserts/updates and factory returns, linked-list node wrappers/removals, static array mutation/copy helpers, and synchronous local-function effects
- model provable full-array copy overwrites without suppressing newly copied context
- map local-function parameters to call-site arguments while preserving slots and receiver paths
- distinguish stored dictionary values from transient factory/comparison inputs
- preserve exact primitive and enum constant identities and provable constructor cardinality
- follow stable aliases while preserving conservative warnings for ambiguous retained state
- add regressions for arrays, nested collections, bulk mutations, clearing/removal, loops, local functions, and mutually exclusive paths

This preserves and hardens the final review fix that landed on the #308 branch after #308 had already been merged.

## Validation
- `dotnet build Kevlar.slnx -c Release --no-restore`
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m`
- 290 analyzer tests pass
- projected combined branch coverage remains at or above the 89% gate