### PR TITLE
ci(release): publish packages before tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,14 +427,6 @@ jobs:
           ./scripts/Get-ReleaseNotes.ps1 -Version $env:RELEASE_VERSION -OutputPath $notesPath
           "RELEASE_NOTES_PATH=$notesPath" >> $env:GITHUB_ENV
 
-      - name: Create and push release tag
-        if: inputs.release_dry_run != true
-        shell: pwsh
-        env:
-          RELEASE_VERSION: ${{ steps.gitversion.outputs.semVer }}
-        run: |
-          ./scripts/Push-ReleaseTag.ps1 -Version $env:RELEASE_VERSION -Commit $env:GITHUB_SHA
-
       - name: NuGet login
         if: inputs.release_dry_run != true
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
@@ -447,6 +439,14 @@ jobs:
         shell: pwsh
         run: |
           ./scripts/Push-NuGetRelease.ps1 -PackagesPath packages -ApiKey '${{ steps.login.outputs.NUGET_API_KEY }}'
+
+      - name: Create and push release tag
+        if: inputs.release_dry_run != true
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ steps.gitversion.outputs.semVer }}
+        run: |
+          ./scripts/Push-ReleaseTag.ps1 -Version $env:RELEASE_VERSION -Commit $env:GITHUB_SHA
 
       - name: Create GitHub release
         if: inputs.release_dry_run != true

--- a/scripts/Verify-ReleaseWorkflow.ps1
+++ b/scripts/Verify-ReleaseWorkflow.ps1
@@ -106,9 +106,9 @@ $tagIndex = $publish.IndexOf('- name: Create and push release tag', [StringCompa
 $packageIndex = $publish.IndexOf('- name: Push to NuGet', [StringComparison]::Ordinal)
 $releaseIndex = $publish.IndexOf('- name: Create GitHub release', [StringComparison]::Ordinal)
 if ($tagIndex -lt 0 -or $packageIndex -lt 0 -or $releaseIndex -lt 0 -or
-    $tagIndex -ge $packageIndex -or $packageIndex -ge $releaseIndex)
+    $packageIndex -ge $tagIndex -or $tagIndex -ge $releaseIndex)
 {
-    throw 'Release ordering must be tag, NuGet push, then GitHub release.'
+    throw 'Release ordering must be NuGet push, tag, then GitHub release.'
 }
 
 $githubReleaseScript = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'Publish-GitHubRelease.ps1') -Raw


### PR DESCRIPTION
## Summary
- publish NuGet packages before creating the release tag
- keep GitHub release creation after the tag
- enforce the failure-safe ordering in the release workflow verifier

## Test plan
- [x] `pwsh scripts/Verify-ReleaseWorkflow.ps1`
- [x] `dotnet build Kevlar.slnx -c Release`

Closes #343
