### PR TITLE
fix(release): derive publish package set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,10 +412,11 @@ jobs:
       - name: Verify publish artifacts
         shell: pwsh
         run: |
+          $expectedPackageIds = @(./scripts/Get-PackablePackageIds.ps1)
           $packageIds = @(Get-ChildItem packages -Filter *.nupkg | ForEach-Object { $_.BaseName -replace '\.[0-9].*$', '' } | Sort-Object)
           $symbolPackageIds = @(Get-ChildItem packages -Filter *.snupkg | ForEach-Object { $_.BaseName -replace '\.[0-9].*$', '' } | Sort-Object)
-          if ($packageIds.Count -ne 7 -or ($packageIds -join ',') -ne ($symbolPackageIds -join ',')) {
-            throw "Expected 7 matching nupkg/snupkg artifacts; got nupkg=[$($packageIds -join ', ')], snupkg=[$($symbolPackageIds -join ', ')]."
+          if (($packageIds -join ',') -ne ($expectedPackageIds -join ',') -or ($symbolPackageIds -join ',') -ne ($expectedPackageIds -join ',')) {
+            throw "Expected nupkg/snupkg artifacts for [$($expectedPackageIds -join ', ')]; got nupkg=[$($packageIds -join ', ')], snupkg=[$($symbolPackageIds -join ', ')]."
           }
 
       - name: Extract release notes

--- a/scripts/Get-PackablePackageIds.ps1
+++ b/scripts/Get-PackablePackageIds.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+param(
+    [string]$RepositoryRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$sourceRoot = Join-Path $RepositoryRoot 'src'
+$packageIds = foreach ($projectFile in Get-ChildItem -LiteralPath $sourceRoot -Recurse -File -Filter '*.csproj')
+{
+    [xml]$project = Get-Content -LiteralPath $projectFile.FullName -Raw
+    $isPackable = $project.SelectNodes('/Project/PropertyGroup/IsPackable') | Select-Object -Last 1
+    if ($null -eq $isPackable -or $isPackable.InnerText -ne 'true')
+    {
+        continue
+    }
+
+    $packageId = $project.SelectNodes('/Project/PropertyGroup/PackageId') | Select-Object -Last 1
+    if ($null -ne $packageId -and -not [string]::IsNullOrWhiteSpace($packageId.InnerText))
+    {
+        $packageId.InnerText
+        continue
+    }
+
+    $assemblyName = $project.SelectNodes('/Project/PropertyGroup/AssemblyName') | Select-Object -Last 1
+    if ($null -ne $assemblyName -and -not [string]::IsNullOrWhiteSpace($assemblyName.InnerText))
+    {
+        $assemblyName.InnerText
+        continue
+    }
+
+    $projectFile.BaseName
+}
+
+$packageIds | Sort-Object -Unique

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -334,6 +334,8 @@ $expectedDependencies = @{
         '.NETStandard2.0' = @('Grpc.Core.Api', 'Grpc.Net.ClientFactory', 'Kevlar', 'Kevlar.Extensions.DependencyInjection')
     }
 }
+$expectedPackageIds = @(& (Join-Path $PSScriptRoot 'Get-PackablePackageIds.ps1') -RepositoryRoot $repositoryRoot)
+Assert-Set 'package dependency table IDs' @($expectedDependencies.Keys) $expectedPackageIds
 
 $expectedDependencyVersions = @{}
 foreach ($dependencyId in @(
@@ -354,9 +356,9 @@ foreach ($dependencyId in @(
 }
 
 $packageFiles = @(Get-ChildItem -LiteralPath $packageDirectory -Filter '*.nupkg' -File)
-Assert-Set 'package IDs' ($packageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) @($expectedDependencies.Keys | ForEach-Object { $_ })
+Assert-Set 'package IDs' ($packageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) $expectedPackageIds
 $symbolPackageFiles = @(Get-ChildItem -LiteralPath $packageDirectory -Filter '*.snupkg' -File)
-Assert-Set 'symbol package IDs' ($symbolPackageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) @($expectedDependencies.Keys | ForEach-Object { $_ })
+Assert-Set 'symbol package IDs' ($symbolPackageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) $expectedPackageIds
 
 foreach ($packageId in $expectedDependencies.Keys)
 {

--- a/scripts/Verify-ReleaseWorkflow.ps1
+++ b/scripts/Verify-ReleaseWorkflow.ps1
@@ -63,6 +63,7 @@ Assert-Contains 'Changelog release notes' './scripts/Get-ReleaseNotes.ps1'
 Assert-Contains 'Retry-safe release tag' './scripts/Push-ReleaseTag.ps1'
 Assert-Contains 'Retry-safe NuGet publication' './scripts/Push-NuGetRelease.ps1'
 Assert-Contains 'Retry-safe GitHub release' './scripts/Publish-GitHubRelease.ps1'
+Assert-Contains 'Derived publish package set' '$expectedPackageIds = @(./scripts/Get-PackablePackageIds.ps1)'
 
 $packageVerificationScript = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'Verify-Packages.ps1') -Raw
 foreach ($requiredVerification in @('Verify-ReleaseApiBaselines.ps1', 'Verify-PublicApi.ps1'))
@@ -71,6 +72,27 @@ foreach ($requiredVerification in @('Verify-ReleaseApiBaselines.ps1', 'Verify-Pu
     {
         throw "Package verification must invoke '$requiredVerification' for stable releases."
     }
+}
+
+$dependencyTablePattern = [regex]'(?ms)^\$expectedDependencies = @\{(?<body>.*?)^\}\r?$'
+$dependencyTableMatch = $dependencyTablePattern.Match($packageVerificationScript)
+if (-not $dependencyTableMatch.Success)
+{
+    throw 'Verify-Packages.ps1 expected dependency table was not found.'
+}
+
+$dependencyPackageIds = @(
+    [regex]::Matches(
+        $dependencyTableMatch.Groups['body'].Value,
+        "(?m)^    '(?<id>Kevlar(?:\.[^']+)?)' = @\{") |
+        ForEach-Object { $_.Groups['id'].Value } |
+        Sort-Object)
+$packablePackageIds = @(& (Join-Path $PSScriptRoot 'Get-PackablePackageIds.ps1'))
+if (($dependencyPackageIds -join ',') -ne ($packablePackageIds -join ','))
+{
+    throw (
+        "Packable project IDs must match Verify-Packages.ps1: " +
+        "projects=[$($packablePackageIds -join ', ')], table=[$($dependencyPackageIds -join ', ')].")
 }
 
 Assert-StepGuarded 'Create and push release tag'


### PR DESCRIPTION
## Summary
- derive publish artifact IDs from packable source projects instead of a stale literal count
- share the derived set with package verification so project and dependency-table inventories cannot drift
- extend the release workflow guard to verify all three inventories agree

## Test plan
- [x] `pwsh scripts/Verify-ReleaseWorkflow.ps1`
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet pack Kevlar.slnx -c Release --no-build -p:Version=0.0.0-local`
- [x] `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local`
- [x] publish artifact check passes for all 8 nupkg/snupkg pairs

Closes #322
