### PR TITLE
feat(circuit-breaker): support monitor fan-out

### DIFF
--- a/docs/api/Kevlar.CircuitBreakerMonitor.yml
+++ b/docs/api/Kevlar.CircuitBreakerMonitor.yml
@@ -23,9 +23,9 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: >-
-    Observes and manually controls a single circuit breaker. Create one, assign it to
+    Observes and manually controls one or more circuit breakers. Create one, assign it to
 
-    <xref href="Kevlar.CircuitBreakerOptions.Monitor" data-throw-if-not-resolved="false"></xref>, and keep a reference to it.
+    each <xref href="Kevlar.CircuitBreakerOptions.Monitor" data-throw-if-not-resolved="false"></xref> to control, and keep a reference to it.
   example: []
   syntax:
     content: public sealed class CircuitBreakerMonitor
@@ -53,7 +53,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Forces the circuit open. Executions are rejected until <xref href="Kevlar.CircuitBreakerMonitor.Reset" data-throw-if-not-resolved="false"></xref> is called.
+  summary: Forces every bound circuit open. Executions are rejected until <xref href="Kevlar.CircuitBreakerMonitor.Reset" data-throw-if-not-resolved="false"></xref> is called.
   example: []
   syntax:
     content: public void Isolate()
@@ -74,7 +74,7 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: >-
-    Forces the circuit open and asynchronously waits for configured transition observers.
+    Forces every bound circuit open and asynchronously waits for configured transition observers.
 
     A reentrant call from a transition callback queues its transition behind the active
 
@@ -104,7 +104,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Closes the circuit and clears all failure metrics.
+  summary: Closes every bound circuit and clears all failure metrics.
   example: []
   syntax:
     content: public void Reset()
@@ -125,7 +125,7 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: >-
-    Closes the circuit, clears all failure metrics, and asynchronously waits for configured
+    Closes every bound circuit, clears all failure metrics, and asynchronously waits for configured
 
     transition observers. A reentrant call from a transition callback queues its transition
 
@@ -174,7 +174,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: The current state of the bound circuit.
+  summary: The worst state among the bound circuits, ordered isolated, open, half-open, then closed.
   example: []
   syntax:
     content: public CircuitState State { get; }
@@ -198,17 +198,17 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: >-
-    Raised on every state transition of the bound circuit, after
+    Raised on every state transition of each bound circuit, after
 
     <xref href="Kevlar.CircuitBreakerOptions.OnStateChanged" data-throw-if-not-resolved="false"></xref> completes. Transitions are delivered
 
-    serially outside the circuit lock, so handlers may read state or call <xref href="Kevlar.CircuitBreakerMonitor.Reset" data-throw-if-not-resolved="false"></xref>
+    serially per circuit outside its lock; different circuits may publish concurrently.
 
-    or <xref href="Kevlar.CircuitBreakerMonitor.Isolate" data-throw-if-not-resolved="false"></xref> without deadlocking. Handlers run synchronously and block later
+    Handlers may read state or call <xref href="Kevlar.CircuitBreakerMonitor.Reset" data-throw-if-not-resolved="false"></xref> or <xref href="Kevlar.CircuitBreakerMonitor.Isolate" data-throw-if-not-resolved="false"></xref> without
 
-    transition publishers, so they should not perform I/O, wait on external work, or otherwise
+    deadlocking. Handlers run synchronously and block later transitions from the same circuit,
 
-    run for a long time.
+    so they should not perform I/O, wait on external work, or otherwise run for a long time.
   example: []
   syntax:
     content: public event Action<CircuitBreakerStateChangedEvent>? StateChanged

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -560,7 +560,9 @@ synchronous `Execute` still runs a hook that completes synchronously; only a hoo
 yields requires `ExecuteAsync`.
 
 Polly's `CircuitBreakerManualControl` and `CircuitBreakerStateProvider` are separately shareable.
-Kevlar uses one `CircuitBreakerMonitor`, attached one-to-one to a breaker strategy.
+Kevlar combines both roles in `CircuitBreakerMonitor`. One monitor can bind to multiple breaker
+strategies: manual controls fan out, `State` reports the worst bound state, and `StateChanged`
+fires for each breaker's transitions.
 
 ## Rate limiting
 

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -133,17 +133,22 @@ await monitor.IsolateAsync(); // async equivalents await transition callbacks
 await monitor.ResetAsync();
 ```
 
-A monitor binds to exactly **one** breaker: assign it to `CircuitBreakerOptions.Monitor` when building the shield, and keep your reference. Binding it twice throws, as does using it before binding.
+A monitor can bind to **one or more** breakers: assign it to each
+`CircuitBreakerOptions.Monitor` you want to control, and keep your reference. `Isolate` and
+`Reset` fan out to every bound breaker. `State` reports the worst current state, ordered
+`Isolated`, `Open`, `HalfOpen`, then `Closed`. Using a monitor before binding still throws.
 
-Transitions are delivered serially in state-change order: awaited `OnStateChanged`, then
-`monitor.StateChanged`. The monitor intentionally retains an
+Each breaker raises its own events. Transitions are delivered serially per breaker in state-change
+order: awaited `OnStateChanged`, then `monitor.StateChanged`. Different breakers bound to the same
+monitor may publish concurrently. The monitor intentionally retains an
 `Action<CircuitBreakerStateChangedEvent>` event so both observers share one event shape and
 delivery model. Execution-driven transitions carry the triggering pooled context. Manual
 `Isolate`/`Reset` transitions carry a detached context with `StrategyIndex == -1`, no shield name,
 and an empty property bag. Callbacks run outside the circuit lock, so they can read `State` or call
 the synchronous or asynchronous monitor controls; a reentrant transition is queued behind the
 transition currently being delivered. Use `ResetAsync()` and `IsolateAsync()` when `OnStateChanged`
-may yield so the calling thread is not blocked. If an observer throws,
+may yield so the calling thread is not blocked; these methods await every bound breaker in binding
+order. If an observer throws,
 later observers still run and the circuit keeps its new, usable state. Observer failures are
 reported through `KevlarDiagnostics.OnCallbackError` and never replace an execution outcome or
 block a transition.

--- a/docs/docs/thread-safety.md
+++ b/docs/docs/thread-safety.md
@@ -12,7 +12,7 @@ execution-scoped objects that must remain owned by one operation.
 |---|---|
 | `Shield`, `Shield<TResult>`, `ShieldBuilder`, `ShieldBuilder<TResult>` | Immutable and thread-safe. Fluent calls return new values; copies intentionally share existing stateful strategies. |
 | [`PartitionedShield<TKey>` and `PartitionedShield<TKey, TResult>`](partitioning.md) | Thread-safe. Partition creation is coordinated and retained state is bounded by `PartitionedShieldOptions`. Eviction can occur immediately after a lookup, so a snapshot is never a reservation. |
-| `CircuitBreakerMonitor` | Thread-safe after construction and bindable to exactly one circuit breaker. `StateChanged` notifications are serialized. |
+| `CircuitBreakerMonitor` | Thread-safe and bindable to multiple circuit breakers. `StateChanged` notifications are serialized per breaker; different breakers may publish concurrently. |
 | `KevlarContext`, `KevlarProperties` | Execution-scoped and not safe for caller-created concurrent access. Do not retain them after the delegate or callback returns. Hedge attempts receive detached property containers, but mutable values stored inside them remain the caller's responsibility. |
 | `IKevlarRegistry`, `IShieldProvider` | Thread-safe singleton services. Registry lookups return immutable snapshots. Reloading names expose only a keyed provider; query it or the registry once per operation. |
 | `ExecutionProbe`, `TelemetryRecorder` | Thread-safe test observers. Their snapshot collections are immutable copies; dispose `TelemetryRecorder` to detach its listener. |

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -3,54 +3,113 @@ using Kevlar.Strategies;
 namespace Kevlar;
 
 /// <summary>
-/// Observes and manually controls a single circuit breaker. Create one, assign it to
-/// <see cref="CircuitBreakerOptions.Monitor"/>, and keep a reference to it.
+/// Observes and manually controls one or more circuit breakers. Create one, assign it to
+/// each <see cref="CircuitBreakerOptions.Monitor"/> to control, and keep a reference to it.
 /// </summary>
 public sealed class CircuitBreakerMonitor
 {
-    private CircuitBreakerCore? _core;
-
-    /// <summary>The current state of the bound circuit.</summary>
-    public CircuitState State => BoundCore().State;
+    private CircuitBreakerCore[]? _cores;
 
     /// <summary>
-    /// Raised on every state transition of the bound circuit, after
+    /// The worst state among the bound circuits, ordered isolated, open, half-open, then closed.
+    /// </summary>
+    public CircuitState State
+    {
+        get
+        {
+            var cores = BoundCores();
+            var state = cores[0].State;
+            var severity = Severity(state);
+            for (var index = 1; index < cores.Length; index++)
+            {
+                var candidate = cores[index].State;
+                var candidateSeverity = Severity(candidate);
+                if (candidateSeverity > severity)
+                {
+                    state = candidate;
+                    severity = candidateSeverity;
+                }
+            }
+
+            return state;
+        }
+    }
+
+    /// <summary>
+    /// Raised on every state transition of each bound circuit, after
     /// <see cref="CircuitBreakerOptions.OnStateChanged"/> completes. Transitions are delivered
-    /// serially outside the circuit lock, so handlers may read state or call <see cref="Reset"/>
-    /// or <see cref="Isolate"/> without deadlocking. Handlers run synchronously and block later
-    /// transition publishers, so they should not perform I/O, wait on external work, or otherwise
-    /// run for a long time.
+    /// serially per circuit outside its lock; different circuits may publish concurrently.
+    /// Handlers may read state or call <see cref="Reset"/> or <see cref="Isolate"/> without
+    /// deadlocking. Handlers run synchronously and block later transitions from the same circuit,
+    /// so they should not perform I/O, wait on external work, or otherwise run for a long time.
     /// </summary>
     public event Action<CircuitBreakerStateChangedEvent>? StateChanged;
 
-    /// <summary>Forces the circuit open. Executions are rejected until <see cref="Reset"/> is called.</summary>
-    public void Isolate() => BoundCore().Isolate();
+    /// <summary>
+    /// Forces every bound circuit open. Executions are rejected until <see cref="Reset"/> is called.
+    /// </summary>
+    public void Isolate()
+    {
+        foreach (var core in BoundCores())
+        {
+            core.Isolate();
+        }
+    }
 
     /// <summary>
-    /// Forces the circuit open and asynchronously waits for configured transition observers.
+    /// Forces every bound circuit open and asynchronously waits for configured transition observers.
     /// A reentrant call from a transition callback queues its transition behind the active
     /// publication and returns before that queued transition reaches observers; do not use the
     /// returned task to order reentrant transition work.
     /// Executions are rejected until <see cref="ResetAsync"/> is called.
     /// </summary>
-    public ValueTask IsolateAsync() => BoundCore().IsolateAsync();
+    public ValueTask IsolateAsync()
+    {
+        var cores = BoundCores();
+        return cores.Length == 1
+            ? cores[0].IsolateAsync()
+            : IsolateAllAsync(cores);
+    }
 
-    /// <summary>Closes the circuit and clears all failure metrics.</summary>
-    public void Reset() => BoundCore().Reset();
+    /// <summary>Closes every bound circuit and clears all failure metrics.</summary>
+    public void Reset()
+    {
+        foreach (var core in BoundCores())
+        {
+            core.Reset();
+        }
+    }
 
     /// <summary>
-    /// Closes the circuit, clears all failure metrics, and asynchronously waits for configured
+    /// Closes every bound circuit, clears all failure metrics, and asynchronously waits for configured
     /// transition observers. A reentrant call from a transition callback queues its transition
     /// behind the active publication and returns before that queued transition reaches observers;
     /// do not use the returned task to order reentrant transition work.
     /// </summary>
-    public ValueTask ResetAsync() => BoundCore().ResetAsync();
+    public ValueTask ResetAsync()
+    {
+        var cores = BoundCores();
+        return cores.Length == 1
+            ? cores[0].ResetAsync()
+            : ResetAllAsync(cores);
+    }
 
     internal void Bind(CircuitBreakerCore core)
     {
-        if (Interlocked.CompareExchange(ref _core, core, null) is not null)
+        while (true)
         {
-            throw new InvalidOperationException("This CircuitBreakerMonitor is already bound to another circuit breaker.");
+            var cores = Volatile.Read(ref _cores);
+            var updated = new CircuitBreakerCore[(cores?.Length ?? 0) + 1];
+            if (cores is not null)
+            {
+                Array.Copy(cores, updated, cores.Length);
+            }
+
+            updated[^1] = core;
+            if (ReferenceEquals(Interlocked.CompareExchange(ref _cores, updated, cores), cores))
+            {
+                return;
+            }
         }
     }
 
@@ -78,7 +137,32 @@ public sealed class CircuitBreakerMonitor
         }
     }
 
-    private CircuitBreakerCore BoundCore() =>
-        _core ?? throw new InvalidOperationException(
+    private CircuitBreakerCore[] BoundCores() =>
+        Volatile.Read(ref _cores) ?? throw new InvalidOperationException(
             "This CircuitBreakerMonitor has not been bound. Assign it to CircuitBreakerOptions.Monitor when building the shield.");
+
+    private static int Severity(CircuitState state) => state switch
+    {
+        CircuitState.Closed => 0,
+        CircuitState.HalfOpen => 1,
+        CircuitState.Open => 2,
+        CircuitState.Isolated => 3,
+        _ => throw new ArgumentOutOfRangeException(nameof(state)),
+    };
+
+    private static async ValueTask IsolateAllAsync(CircuitBreakerCore[] cores)
+    {
+        foreach (var core in cores)
+        {
+            await core.IsolateAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async ValueTask ResetAllAsync(CircuitBreakerCore[] cores)
+    {
+        foreach (var core in cores)
+        {
+            await core.ResetAsync().ConfigureAwait(false);
+        }
+    }
 }

--- a/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
@@ -6,6 +6,54 @@ namespace Kevlar.Tests;
 public class CircuitBreakerStateReportingTests
 {
     [Test]
+    public async Task Monitor_Aggregates_And_Controls_Multiple_Breakers()
+    {
+        var firstTimeProvider = new FakeTimeProvider();
+        var secondTimeProvider = new FakeTimeProvider();
+        var monitor = new CircuitBreakerMonitor();
+        var first = CreateBreaker(firstTimeProvider, monitor);
+        var second = CreateBreaker(secondTimeProvider, monitor);
+
+        await first.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("first"));
+        await second.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("second"));
+        firstTimeProvider.Advance(TimeSpan.FromSeconds(30));
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+
+        var transitions = new List<CircuitState>();
+        monitor.StateChanged += change => transitions.Add(change.To);
+
+        monitor.Isolate();
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Isolated);
+        await Assert.That(transitions).IsEquivalentTo(
+        [
+            CircuitState.Isolated,
+            CircuitState.Isolated,
+        ]);
+        var firstRejection = await Assert.That(
+            async () => await first.ExecuteAsync(_ => new ValueTask<int>(1)))
+            .Throws<CircuitOpenException>();
+        var secondRejection = await Assert.That(
+            async () => await second.ExecuteAsync(_ => new ValueTask<int>(2)))
+            .Throws<CircuitOpenException>();
+        await Assert.That(firstRejection!.IsIsolated).IsTrue();
+        await Assert.That(secondRejection!.IsIsolated).IsTrue();
+
+        transitions.Clear();
+        monitor.Reset();
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+        await Assert.That(transitions).IsEquivalentTo(
+        [
+            CircuitState.Closed,
+            CircuitState.Closed,
+        ]);
+        await Assert.That(await first.ExecuteAsync(_ => new ValueTask<int>(1))).IsEqualTo(1);
+        await Assert.That(await second.ExecuteAsync(_ => new ValueTask<int>(2))).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task State_Reports_HalfOpen_After_Break_Elapses_Without_A_Call()
     {
         var timeProvider = new FakeTimeProvider();

--- a/tests/Kevlar.Tests/ConcurrencyTests.cs
+++ b/tests/Kevlar.Tests/ConcurrencyTests.cs
@@ -5,6 +5,41 @@ namespace Kevlar.Tests;
 public class ConcurrencyTests
 {
     [Test]
+    public async Task Monitor_Preserves_Concurrent_Bindings()
+    {
+        const int breakerCount = 32;
+        var monitor = new CircuitBreakerMonitor();
+        var shields = new Shield[breakerCount];
+
+        Parallel.For(0, breakerCount, index =>
+        {
+            shields[index] = Shield.CircuitBreaker(options =>
+            {
+                options.ConsecutiveFailures = 1;
+                options.Monitor = monitor;
+            });
+        });
+
+        var transitions = 0;
+        monitor.StateChanged += _ => Interlocked.Increment(ref transitions);
+
+        monitor.Isolate();
+
+        await Assert.That(Volatile.Read(ref transitions)).IsEqualTo(breakerCount);
+        var outcomes = await Task.WhenAll(shields.Select(shield =>
+            shield.ExecuteOutcomeAsync(_ => new ValueTask<int>(1)).AsTask()));
+        await Assert.That(outcomes.Count(outcome => outcome.Exception is CircuitOpenException))
+            .IsEqualTo(breakerCount);
+
+        monitor.Reset();
+
+        await Assert.That(Volatile.Read(ref transitions)).IsEqualTo(breakerCount * 2);
+        var results = await Task.WhenAll(shields.Select(shield =>
+            shield.ExecuteAsync(_ => new ValueTask<int>(1)).AsTask()));
+        await Assert.That(results).IsEquivalentTo(Enumerable.Repeat(1, breakerCount));
+    }
+
+    [Test]
     public async Task A_Failure_Storm_Produces_Exactly_One_Open_Transition()
     {
         var transitions = new List<CircuitBreakerStateChangedEvent>();

--- a/tests/Kevlar.Tests/OptionsValidationTests.cs
+++ b/tests/Kevlar.Tests/OptionsValidationTests.cs
@@ -259,28 +259,6 @@ public class OptionsValidationTests
     }
 
     [Test]
-    public async Task Monitor_Cannot_Be_Bound_Twice()
-    {
-        var monitor = new CircuitBreakerMonitor();
-        _ = Shield.CircuitBreaker(options =>
-        {
-            options.ConsecutiveFailures = 1;
-            options.BreakDuration = TimeSpan.FromSeconds(1);
-            options.Monitor = monitor;
-        });
-
-        var exception = await Assert.That(() => Shield.CircuitBreaker(options =>
-        {
-            options.ConsecutiveFailures = 1;
-            options.BreakDuration = TimeSpan.FromSeconds(1);
-            options.Monitor = monitor;
-        })).Throws<InvalidOperationException>();
-
-        await Assert.That(exception!.Message)
-            .IsEqualTo("This CircuitBreakerMonitor is already bound to another circuit breaker.");
-    }
-
-    [Test]
     public async Task Unbound_Monitor_Throws_A_Helpful_Error()
     {
         var monitor = new CircuitBreakerMonitor();


### PR DESCRIPTION
## Summary
- allow one `CircuitBreakerMonitor` to bind to multiple breakers
- fan out sync/async isolate and reset controls
- report aggregate state as `Isolated` > `Open` > `HalfOpen` > `Closed`
- document per-breaker event ordering and cross-breaker concurrency

## Test plan
- [x] focused aggregate/control test
- [x] focused concurrent-binding test
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] full `Kevlar.Tests` on `net8.0` and `net10.0`
- [x] `pwsh scripts/Verify-Docs.ps1`
- [x] `npm run build` (`docs/`)

Closes #350
