### PR TITLE
docs(analyzers): document tooling and opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
-- The `Kevlar` package now includes its Roslyn analyzers automatically. `KEV014` detects pooled
-  event contexts captured by deferred work.
+- The `Kevlar` package now includes its diagnostics-only Roslyn analyzers automatically. `KEV014`
+  detects pooled event contexts captured by deferred work.
 - `Kevlar.Extensions.Logging` emits stable, structured `ILogger` events for retry, timeout,
   circuit-state, hedge, fallback, rejection, and callback-error activity. `WithLogging` decorates
   individual shields, while `AddKevlarLogging` applies to named, reloading, partitioned, and HTTP

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ configuration-bound shields and `IKevlarRegistry`.
 
 | Package | What it adds |
 |---|---|
-| [`Kevlar`](https://www.nuget.org/packages/Kevlar) | Core strategies, Shield API, and analyzers |
+| [`Kevlar`](https://www.nuget.org/packages/Kevlar) | Core strategies, Shield API, and diagnostics-only analyzers |
 | [`Kevlar.Chaos`](https://www.nuget.org/packages/Kevlar.Chaos) | Controlled latency, faults, outcomes and custom behaviour |
 | [`Kevlar.Extensions.DependencyInjection`](https://www.nuget.org/packages/Kevlar.Extensions.DependencyInjection) | Named and configuration-bound shields for Microsoft DI |
 | [`Kevlar.Extensions.Http`](https://www.nuget.org/packages/Kevlar.Extensions.Http) | `HttpClientFactory` integration, request replay and transient-fault handling |

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -5,7 +5,29 @@ sidebar_position: 13
 # Analyzers
 
 The `Kevlar` package includes these analyzers automatically. No separate analyzer package is
-required.
+required. They report diagnostics only; Kevlar does not install code fixes or IDE code actions.
+
+## Toolchain compatibility
+
+Kevlar's analyzers reference Microsoft.CodeAnalysis 4.8.0. Use Visual Studio 2022 17.8 or later,
+or the .NET 8.0.100 SDK or later. An older compiler can report `CS9057` because the analyzer was
+built against a newer compiler; projects that treat warnings as errors will then fail their build.
+Updating the compiler host is the preferred fix.
+
+## Disabling analyzers
+
+To use the runtime library without its bundled analyzers, exclude the analyzer asset on the
+`Kevlar` package reference:
+
+<!-- doc-test-project-fragment -->
+```xml
+<ItemGroup>
+  <PackageReference Include="Kevlar" ExcludeAssets="analyzers" />
+</ItemGroup>
+```
+
+If the reference already has `ExcludeAssets`, add `analyzers` to its semicolon-separated value.
+Prefer per-rule suppression when most analyzer coverage remains useful.
 
 The analyzers report only hazards that are provable from the current expression or a stable local
 initializer. They do not guess what a factory method returns or follow a local that is reassigned.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -33,6 +33,11 @@ using var response = await shield.ExecuteAsync(
 Its default backoff is exponential with equal jitter, starting at 250ms and capped at 30s. This
 executable version removes the delays and verifies the count:
 
+Bundled analyzer conventions: name the execution token `_` only for genuinely uncancellable work;
+otherwise pass it through. Plain `Retry(3)` also raises an informational diagnostic; narrow
+handling or set [`dotnet_diagnostic.KEV011.severity = none`](analyzers.md#kev011-implicit-default-handling)
+when broad default handling is deliberate.
+
 <!-- doc-test-run: getting-started-retry-count -->
 ```csharp
 var attempts = 0;

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -51,6 +51,7 @@ foreach ($packageId in $requiredPackages)
 }
 
 $snippets = [System.Collections.Generic.List[object]]::new()
+$projectFragments = [System.Collections.Generic.List[object]]::new()
 $installPackageIds = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
 $projectCommands = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
 
@@ -203,6 +204,46 @@ foreach ($documentPath in $documentPaths)
             continue
         }
 
+        if ($lines[$lineIndex] -match '^```xml\s*$')
+        {
+            $startLine = $lineOffset + $lineIndex + 2
+            $directive = if ($lineIndex -gt 0) { $lines[$lineIndex - 1].Trim() } else { '' }
+            $body = [System.Collections.Generic.List[string]]::new()
+            for ($lineIndex++; $lineIndex -lt $lines.Count -and $lines[$lineIndex] -notmatch '^```\s*$'; $lineIndex++)
+            {
+                $body.Add($lines[$lineIndex])
+            }
+
+            if ($lineIndex -ge $lines.Count)
+            {
+                throw "Unclosed XML fence at ${relativePath}:$startLine."
+            }
+
+            if ($directive -eq '<!-- doc-test-project-fragment -->')
+            {
+                $source = $body -join "`n"
+                try
+                {
+                    [xml]$fragment = "<Project>`n$source`n</Project>"
+                }
+                catch
+                {
+                    throw "Invalid MSBuild project fragment at ${relativePath}:$startLine. $($_.Exception.Message)"
+                }
+
+                $projectFragments.Add([pscustomobject]@{
+                    Id = "${relativePath}:$startLine"
+                    Xml = $fragment
+                })
+            }
+            elseif ($directive -match '^<!--\s*doc-test-project-fragment')
+            {
+                throw "Malformed doc-test-project-fragment directive before ${relativePath}:$startLine."
+            }
+
+            continue
+        }
+
         if ($lines[$lineIndex] -match '^```(?:bash|sh|shell|powershell|pwsh)\s*$')
         {
             for ($lineIndex++; $lineIndex -lt $lines.Count -and $lines[$lineIndex] -notmatch '^```\s*$'; $lineIndex++)
@@ -220,6 +261,33 @@ foreach ($documentPath in $documentPaths)
             }
         }
     }
+}
+
+$analyzerOptOutCount = 0
+foreach ($projectFragment in $projectFragments)
+{
+    foreach ($packageReference in $projectFragment.Xml.SelectNodes('/Project/ItemGroup/PackageReference'))
+    {
+        $include = $packageReference.GetAttribute('Include')
+        if ([string]::IsNullOrWhiteSpace($include))
+        {
+            throw "$($projectFragment.Id) contains a PackageReference without Include."
+        }
+
+        $excludeAssets = @(
+            $packageReference.GetAttribute('ExcludeAssets') -split ';' |
+                ForEach-Object { $_.Trim() })
+        if ($include -eq 'Kevlar' -and
+            $excludeAssets -contains 'analyzers')
+        {
+            $analyzerOptOutCount++
+        }
+    }
+}
+
+if ($analyzerOptOutCount -ne 1)
+{
+    throw "Documentation must contain exactly one verified Kevlar PackageReference that excludes analyzer assets."
 }
 
 foreach ($packageId in $installPackageIds)


### PR DESCRIPTION
## Summary
- document analyzer compiler requirements, diagnostics-only behavior, and full analyzer opt-out
- add getting-started conventions for unused cancellation tokens and intentional broad retry handling
- verify marked MSBuild project fragments and keep the analyzer opt-out snippet under test
- clarify analyzer wording in the README and changelog

## Test plan
- [x] `pwsh scripts/Verify-Docs.ps1`
- [x] `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath <local-packages> -Version 0.0.0-local -NoImplicitUsings`
- [x] `npm run build` from `docs/`

Closes #335
