### PR TITLE
refactor(exceptions)!: separate timeout failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project are documented here. The format follows
 
 ### Changed
 
+- `TimeoutExceededException` now derives directly from `KevlarException`. It no longer counts as
+  an `ExecutionRejectedException`: fail-fast rejections mean the delegate did not run, while a
+  timeout means it ran and exceeded its budget.
 - Strategy callback events now expose their position through public
   `KevlarContext.StrategyIndex`; the duplicate properties on limiter rejection events were removed.
   Circuit transitions use `CircuitBreakerStateChangedEvent` and carry execution context, while

--- a/docs/api/Kevlar.ExecutionRejectedException.yml
+++ b/docs/api/Kevlar.ExecutionRejectedException.yml
@@ -34,7 +34,6 @@ items:
   - Kevlar.ConcurrencyLimitExceededException
   - Kevlar.Extensions.RateLimiting.RateLimiterAdapterRejectedException
   - Kevlar.RateLimitExceededException
-  - Kevlar.TimeoutExceededException
   implements:
   - System.Runtime.Serialization.ISerializable
   inheritedMembers:

--- a/docs/api/Kevlar.KevlarException.yml
+++ b/docs/api/Kevlar.KevlarException.yml
@@ -29,6 +29,7 @@ items:
   derivedClasses:
   - Kevlar.ExecutionRejectedException
   - Kevlar.KevlarConfigurationException
+  - Kevlar.TimeoutExceededException
   implements:
   - System.Runtime.Serialization.ISerializable
   inheritedMembers:

--- a/docs/api/Kevlar.TimeoutExceededException.yml
+++ b/docs/api/Kevlar.TimeoutExceededException.yml
@@ -24,17 +24,15 @@ items:
   summary: Thrown when a timeout strategy cancels an execution that exceeded its allotted time.
   example: []
   syntax:
-    content: 'public sealed class TimeoutExceededException : ExecutionRejectedException, ISerializable'
-    content.vb: Public NotInheritable Class TimeoutExceededException Inherits ExecutionRejectedException Implements ISerializable
+    content: 'public sealed class TimeoutExceededException : KevlarException, ISerializable'
+    content.vb: Public NotInheritable Class TimeoutExceededException Inherits KevlarException Implements ISerializable
   inheritance:
   - System.Object
   - System.Exception
   - Kevlar.KevlarException
-  - Kevlar.ExecutionRejectedException
   implements:
   - System.Runtime.Serialization.ISerializable
   inheritedMembers:
-  - Kevlar.ExecutionRejectedException.RetryAfter
   - System.Exception.GetBaseException
   - System.Exception.ToString
   - System.Exception.GetType
@@ -64,7 +62,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Initializes a timeout rejection without a recorded timeout.
+  summary: Initializes a timeout exception without a recorded timeout.
   example: []
   syntax:
     content: public TimeoutExceededException()
@@ -87,7 +85,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Initializes a timeout rejection with a custom message.
+  summary: Initializes a timeout exception with a custom message.
   example: []
   syntax:
     content: public TimeoutExceededException(string message)
@@ -113,7 +111,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Initializes a timeout rejection with a custom message and cause.
+  summary: Initializes a timeout exception with a custom message and cause.
   example: []
   syntax:
     content: public TimeoutExceededException(string message, Exception innerException)
@@ -239,14 +237,6 @@ references:
   name: KevlarException
   nameWithType: KevlarException
   fullName: Kevlar.KevlarException
-- uid: Kevlar.ExecutionRejectedException
-  commentId: T:Kevlar.ExecutionRejectedException
-  parent: Kevlar
-  isExternal: true
-  href: Kevlar.ExecutionRejectedException.html
-  name: ExecutionRejectedException
-  nameWithType: ExecutionRejectedException
-  fullName: Kevlar.ExecutionRejectedException
 - uid: System.Runtime.Serialization.ISerializable
   commentId: T:System.Runtime.Serialization.ISerializable
   parent: System.Runtime.Serialization
@@ -255,14 +245,6 @@ references:
   name: ISerializable
   nameWithType: ISerializable
   fullName: System.Runtime.Serialization.ISerializable
-- uid: Kevlar.ExecutionRejectedException.RetryAfter
-  commentId: P:Kevlar.ExecutionRejectedException.RetryAfter
-  parent: Kevlar.ExecutionRejectedException
-  isExternal: true
-  href: Kevlar.ExecutionRejectedException.html#Kevlar_ExecutionRejectedException_RetryAfter
-  name: RetryAfter
-  nameWithType: ExecutionRejectedException.RetryAfter
-  fullName: Kevlar.ExecutionRejectedException.RetryAfter
 - uid: System.Exception.GetBaseException
   commentId: M:System.Exception.GetBaseException
   parent: System.Exception

--- a/docs/docs/exceptions.md
+++ b/docs/docs/exceptions.md
@@ -12,9 +12,10 @@ fault, or reports a testing assertion failure.
 
 The **default clause** column says whether a reactive strategy handles the exception when no custom
 [`When` clause](handling-failures.md) is present. The default handles ordinary errors but excludes
-`OperationCanceledException`, circuit-open, rate-limit, and concurrency-limit rejections, and fatal
-runtime exceptions. Use an explicit clause to include an excluded rejection or narrow the ordinary
-errors handled by a retry, breaker, hedge, or fallback.
+`OperationCanceledException`, fail-fast execution rejections, and fatal runtime exceptions. A
+timeout remains handled because the delegate ran and produced a recoverable attempt failure. Use an
+explicit clause to include an excluded rejection or narrow the ordinary errors handled by a retry,
+breaker, hedge, or fallback.
 
 | Exception | Thrown by | Properties | Base class | Catch pattern | Default clause |
 |---|---|---|---|---|---|
@@ -22,7 +23,7 @@ errors handled by a retry, breaker, hedge, or fallback.
 | `KevlarConfigurationException` | Invalid values supplied through a strategy options callback or returned by a dynamic duration generator | `Message` names the options type, property, requirement, and offending value. | `KevlarException` | Catch during startup while building shields. | N/A |
 | `ExecutionRejectedException` | Abstract base for execution rejections | `RetryAfter` estimates when execution may be attempted again; inherited `InnerException` carries a cause when known. | `KevlarException` | `catch (ExecutionRejectedException e)` | N/A |
 | `KevlarProxyException` | Internal bookkeeping for adapter-owned exception proxies | `OriginalException` is the failure exposed to handling clauses, public outcomes, and adapter callers; inherited `InnerException` preserves the same cause. | `Exception` | Catch `OriginalException`'s concrete type, such as `RpcException`. | N/A |
-| `TimeoutExceededException` | Timeout | `Timeout` is the winning budget; a strategy-produced timeout carries the delegate's cancellation exception in inherited `InnerException`. `RetryAfter` is `null`. | `ExecutionRejectedException` | `catch (TimeoutExceededException e) when (e.Timeout == budget)` | Yes |
+| `TimeoutExceededException` | Timeout | `Timeout` is the winning budget; a strategy-produced timeout carries the delegate's cancellation exception in inherited `InnerException`. | `KevlarException` | `catch (TimeoutExceededException e) when (e.Timeout == budget)` | Yes |
 | `CircuitOpenException` | Circuit breaker | Inherited `RetryAfter` is the remaining break duration; `IsIsolated` distinguishes manual isolation; inherited `InnerException` is the last failure when known. | `ExecutionRejectedException` | `catch (CircuitOpenException e) when (e.RetryAfter is { } delay)` | No |
 | `RateLimitExceededException` | Rate limit | Inherited `RetryAfter` estimates when a permit may become available. | `ExecutionRejectedException` | `catch (RateLimitExceededException e) when (e.RetryAfter is { } delay)` | No |
 | `RateLimiterAdapterRejectedException` | System.Threading.RateLimiting adapter | Inherited `RetryAfter` is copied from rejected lease metadata when supplied. | `ExecutionRejectedException` | `catch (RateLimiterAdapterRejectedException e) when (e.RetryAfter is { } delay)` | No |
@@ -39,28 +40,37 @@ isolated circuit has `IsIsolated == true` and no automatic retry time.
 `CircuitOpenException.InnerException` is diagnostic history, not a new failure from the rejected
 call.
 
+An execution rejection is fail-fast: the protected delegate did not run. A timeout is different:
+the delegate ran, exceeded its budget, and was abandoned after cancellation. For that reason,
+`TimeoutExceededException` derives directly from `KevlarException`, outside the rejection family.
+
 ## Catching core rejections
 
 Catch a concrete type when its metadata changes recovery behavior. Catch
-`ExecutionRejectedException` when every execution rejection shares one response; catch
-`KevlarException` only when other future core exception families should share it too.
+`ExecutionRejectedException` when every fail-fast rejection shares one response; this catch does
+not match timeouts. Catch `KevlarException` only when timeouts, rejections, configuration failures,
+and future core exception families should share handling.
 
-<!-- doc-test-run: catch-kevlar-exception -->
+<!-- doc-test-run: execution-rejection-does-not-catch-timeout -->
 ```csharp
-var caughtExecutionRejection = false;
+var caughtTimeoutOutsideRejectionFamily = false;
 try
 {
     await Shield.Empty.ExecuteAsync<int>(
         _ => throw new TimeoutExceededException(TimeSpan.FromSeconds(1)));
 }
-catch (ExecutionRejectedException exception) when (exception.RetryAfter is null)
+catch (ExecutionRejectedException)
 {
-    caughtExecutionRejection = true;
+    throw new InvalidOperationException("A timeout must not be caught as a fail-fast rejection.");
+}
+catch (TimeoutExceededException)
+{
+    caughtTimeoutOutsideRejectionFamily = true;
 }
 
-if (!caughtExecutionRejection)
+if (!caughtTimeoutOutsideRejectionFamily)
 {
-    throw new InvalidOperationException("The ExecutionRejectedException catch did not match.");
+    throw new InvalidOperationException("The timeout catch did not match.");
 }
 ```
 
@@ -210,11 +220,11 @@ if (!caughtAssertion)
 
 ## Timeout is not `System.TimeoutException`
 
-`TimeoutExceededException` deliberately derives from `ExecutionRejectedException` (and therefore
-`KevlarException`), not
-`System.TimeoutException`. A `catch (TimeoutException)` compiles but does not match a Kevlar timeout. <!-- doc-lint: allow-TimeoutException -->
-This mirrors Polly's `TimeoutRejectedException` behavior. Catch `TimeoutExceededException` and inspect
-its `Timeout` property.
+`TimeoutExceededException` derives directly from `KevlarException`, not
+`ExecutionRejectedException` or `System.TimeoutException`. <!-- doc-lint: allow-TimeoutException --> A `catch (ExecutionRejectedException)`
+therefore handles only fail-fast calls where the delegate did not run. A `catch (TimeoutException)` <!-- doc-lint: allow-TimeoutException -->
+compiles but does not match a Kevlar timeout. Catch
+`TimeoutExceededException` and inspect its `Timeout` property.
 
 ## Stack traces and inner exceptions
 
@@ -222,10 +232,10 @@ An application exception remains the same exception instance while it travels th
 At the execution boundary Kevlar rethrows it with `ExceptionDispatchInfo`, preserving the original
 throw site. `ExecuteOutcomeAsync` returns it instead through `Outcome<T>.Exception`.
 
-A rejection has its own stack trace because the strategy creates it. Only documented causal data is
-placed in `InnerException`: the delegate's cancellation when a timeout fires, the last breaker
-failure, a wrapped chaos cause, or an HTTP replay content failure. Do not assume every Kevlar-created
-exception has an inner exception.
+A strategy-created exception has its own stack trace. Only documented causal data is placed in
+`InnerException`: the delegate's cancellation when a timeout fires, the last breaker failure, a
+wrapped chaos cause, or an HTTP replay content failure. Do not assume every Kevlar-created exception
+has an inner exception.
 
 ## Configuration failures
 

--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -26,7 +26,7 @@ Shield.Timeout(o =>
 Exceeding the budget surfaces `TimeoutExceededException` (with a `Timeout` property). It derives from
 `KevlarException`, **not** from `System.TimeoutException`, so a reflexive `catch (TimeoutException)` <!-- doc-lint: allow-TimeoutException -->
 compiles but never matches — catch `TimeoutExceededException` (or `KevlarException` for any Kevlar
-rejection) instead.
+strategy exception) instead.
 
 ## Timeouts are cooperative
 
@@ -158,7 +158,7 @@ catch (TimeoutExceededException) when (attempts == 2)
 }
 ```
 
-The similar-looking `System.TimeoutException` clause does not handle Kevlar's timeout rejection:
+The similar-looking `System.TimeoutException` clause does not handle Kevlar's timeout failure:
 
 <!-- doc-test-run: system-timeout-clause-trap -->
 ```csharp

--- a/src/Kevlar/Exceptions/TimeoutExceededException.cs
+++ b/src/Kevlar/Exceptions/TimeoutExceededException.cs
@@ -1,23 +1,23 @@
 namespace Kevlar;
 
 /// <summary>Thrown when a timeout strategy cancels an execution that exceeded its allotted time.</summary>
-public sealed class TimeoutExceededException : ExecutionRejectedException
+public sealed class TimeoutExceededException : KevlarException
 {
     private const string DefaultMessage = "The execution exceeded its allotted timeout.";
 
-    /// <summary>Initializes a timeout rejection without a recorded timeout.</summary>
+    /// <summary>Initializes a timeout exception without a recorded timeout.</summary>
     public TimeoutExceededException()
         : base(DefaultMessage)
     {
     }
 
-    /// <summary>Initializes a timeout rejection with a custom message.</summary>
+    /// <summary>Initializes a timeout exception with a custom message.</summary>
     public TimeoutExceededException(string message)
         : base(message)
     {
     }
 
-    /// <summary>Initializes a timeout rejection with a custom message and cause.</summary>
+    /// <summary>Initializes a timeout exception with a custom message and cause.</summary>
     public TimeoutExceededException(string message, Exception innerException)
         : base(message, innerException)
     {

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -49,9 +49,7 @@ internal abstract class OutcomeJudge
             outcome.Exception is { } exception && IsOrdinaryError(exception);
 
         private static bool IsOrdinaryError(Exception exception) =>
-            // A timeout is a recoverable attempt outcome; other execution rejections are fail-fast.
-            exception is TimeoutExceededException
-            || exception is not (
+            exception is not (
                 OperationCanceledException
                 or ExecutionRejectedException
                 or OutOfMemoryException

--- a/tests/Kevlar.Tests/ExceptionContractTests.cs
+++ b/tests/Kevlar.Tests/ExceptionContractTests.cs
@@ -31,13 +31,22 @@ public class ExceptionContractTests
             typeof(CircuitOpenException),
             typeof(RateLimitExceededException),
             typeof(ConcurrencyLimitExceededException),
-            typeof(TimeoutExceededException),
         ];
 
         foreach (var rejectionType in rejectionTypes)
         {
             await Assert.That(rejectionType.IsSubclassOf(typeof(ExecutionRejectedException))).IsTrue();
         }
+    }
+
+    [Test]
+    public async Task Timeout_Is_Not_An_Execution_Rejection()
+    {
+        await Assert.That(
+            typeof(ExecutionRejectedException).IsAssignableFrom(typeof(TimeoutExceededException)))
+            .IsFalse();
+        await Assert.That(typeof(KevlarException).IsAssignableFrom(typeof(TimeoutExceededException)))
+            .IsTrue();
     }
 
     [Test]
@@ -49,7 +58,6 @@ public class ExceptionContractTests
             new CircuitOpenException(retryAfter, isIsolated: false, lastException: null),
             new RateLimitExceededException(retryAfter),
             new ConcurrencyLimitExceededException(),
-            new TimeoutExceededException(TimeSpan.FromSeconds(1)),
         ];
 
         foreach (var rejection in rejections)
@@ -61,7 +69,6 @@ public class ExceptionContractTests
         await Assert.That(rejections[0].RetryAfter).IsEqualTo(retryAfter);
         await Assert.That(rejections[1].RetryAfter).IsEqualTo(retryAfter);
         await Assert.That(rejections[2].RetryAfter).IsNull();
-        await Assert.That(rejections[3].RetryAfter).IsNull();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- derive `TimeoutExceededException` directly from `KevlarException`
- remove obsolete default-judge timeout special case
- keep timeouts handled by default while fail-fast rejections remain excluded
- document and compile-test the distinct catch contracts
- refresh generated API inheritance metadata

## Breaking change
`catch (ExecutionRejectedException)` no longer catches timeouts. Catch `TimeoutExceededException` or `KevlarException` when timeout handling is required.

## Test plan
- [x] focused exception, timeout, and docs-consistency tests
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] full `Kevlar.Tests` on `net8.0` and `net10.0`
- [x] 187 documentation snippets compiled/executed on both TFMs
- [x] `pwsh scripts/Verify-ApiDocs.ps1`
- [x] `pwsh scripts/Verify-Docs.ps1`
- [x] `pwsh scripts/Verify-Changelog.ps1`
- [x] `npm run build` (`docs/`)

Closes #328
