### PR TITLE
fix(deps): restore .NET 8 package floors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,15 +12,15 @@
     <!-- Core (netstandard2.0 only) -->
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
-    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
     <PackageVersion Include="Reservoir" Version="[1.4.0,2.0.0)" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
 
     <!-- Satellites -->
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 29
+---
+
+# Support policy
+
+## Minimum dependency versions
+
+Kevlar keeps shipped dependency floors compatible with .NET 8-era applications. These are minimum
+versions, not forced runtime versions: NuGet can select a later compatible version requested by the
+application. Test-only and build-only dependencies are not part of this package contract.
+
+| Dependency | Minimum version | Shipped by |
+|---|---:|---|
+| `Microsoft.Bcl.TimeProvider` | `8.0.1` | `Kevlar`, `Kevlar.Chaos` |
+| `Microsoft.Extensions.Configuration.Abstractions` | `8.0.0` | `Kevlar.Extensions.DependencyInjection`, `Kevlar.Extensions.Http` |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | `8.0.2` | `Kevlar.Extensions.DependencyInjection` |
+| `Microsoft.Extensions.Http` | `8.0.1` | `Kevlar.Extensions.Http` |
+| `Microsoft.Extensions.Logging` | `8.0.1` | `Kevlar.Extensions.Logging` |
+| `Microsoft.Extensions.Logging.Abstractions` | `8.0.3` | `Kevlar.Extensions.Logging` |
+| `Microsoft.Extensions.Options` | `8.0.2` | `Kevlar.Extensions.DependencyInjection` |
+| `Microsoft.Extensions.Primitives` | `8.0.0` | `Kevlar.Extensions.DependencyInjection`, `Kevlar.Extensions.Http` |
+| `Microsoft.Extensions.TimeProvider.Testing` | `8.0.0` | `Kevlar.Testing` |
+| `System.Threading.RateLimiting` | `8.0.0` | `Kevlar.Extensions.RateLimiting` |
+| `System.Threading.Tasks.Extensions` | `4.6.3` | `Kevlar`, `Kevlar.Chaos` |
+| `System.Runtime.CompilerServices.Unsafe` | `6.1.2` | `Kevlar.Chaos` |
+| `Grpc.Core.Api` | `2.83.0` | `Kevlar.Extensions.Grpc` |
+| `Grpc.Net.ClientFactory` | `2.83.0` | `Kevlar.Extensions.Grpc` |
+| `Reservoir` | `[1.4.0, 2.0.0)` | `Kevlar` |
+
+Package verification rejects accidental dependency floors above major version 8, except for the
+documented gRPC and Reservoir version lines. Raising a floor is a compatibility decision and must
+be called out in release notes.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -44,6 +44,7 @@ const sidebars: SidebarsConfig = {
     'benchmarks',
     'stress-tests',
     'thread-safety',
+    'support-policy',
     'faq',
   ],
 };

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,9 @@
         "Microsoft.Extensions.Configuration.Abstractions",
         "Microsoft.Extensions.DependencyInjection.Abstractions",
         "Microsoft.Extensions.Http",
+        "Microsoft.Extensions.Logging",
+        "Microsoft.Extensions.Logging.Abstractions",
+        "Microsoft.Extensions.Options",
         "Microsoft.Extensions.Primitives",
         "Microsoft.Extensions.TimeProvider.Testing",
         "System.Threading.RateLimiting"

--- a/scripts/PackageDependencyPolicy.ps1
+++ b/scripts/PackageDependencyPolicy.ps1
@@ -1,0 +1,39 @@
+$shippedDependencyFloorExceptions = @(
+    'Grpc.Core.Api'
+    'Grpc.Net.ClientFactory'
+    'Reservoir'
+)
+
+function Assert-ShippedDependencyFloor
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$DependencyId,
+
+        [Parameter(Mandatory)]
+        [string]$DependencyVersion,
+
+        [Parameter(Mandatory)]
+        [string]$Context
+    )
+
+    if ($DependencyId.StartsWith('Kevlar', [StringComparison]::Ordinal) -or
+        $DependencyId -in $shippedDependencyFloorExceptions)
+    {
+        return
+    }
+
+    if ($DependencyVersion -notmatch '^[\[(]?\s*(?<minimum>\d+(?:\.\d+){1,3})')
+    {
+        throw "$Context dependency '$DependencyId' has an unrecognized version '$DependencyVersion'."
+    }
+
+    $minimumVersion = [Version]$Matches['minimum']
+    if ($minimumVersion.Major -gt 8)
+    {
+        throw (
+            "$Context dependency '$DependencyId' has minimum version '$DependencyVersion'; " +
+            'shipped dependency floors must remain at major version 8 or earlier.')
+    }
+}

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -9,6 +9,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot 'PackageDependencyPolicy.ps1')
 
 $isCiBuild = $env:CI -eq 'true'
 $ciPropertyValue = $isCiBuild.ToString().ToLowerInvariant()
@@ -444,6 +445,10 @@ foreach ($packageId in $expectedDependencies.Keys)
             foreach ($dependency in $dependencies)
             {
                 $dependencyId = $dependency.GetAttribute('id')
+                Assert-ShippedDependencyFloor `
+                    -DependencyId $dependencyId `
+                    -DependencyVersion $dependency.GetAttribute('version') `
+                    -Context "$packageId $framework"
                 $expectedExcludedAssets = if ($dependencyId -eq 'Kevlar' -and $packageId -ne 'Kevlar')
                 {
                     @()
@@ -905,9 +910,16 @@ sealed class ExpectedConsumerException : Exception;
     <PackageReference Include="Kevlar.Extensions.RateLimiting" Version="$Version" />
     <PackageReference Include="Kevlar.Testing" Version="$Version" />
     <PackageReference Include="Kevlar.Extensions.Grpc" Version="$Version" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="System.Threading.RateLimiting" Version="8.0.0" />
   </ItemGroup>
 </Project>
@@ -916,6 +928,40 @@ sealed class ExpectedConsumerException : Exception;
         Write-TextFile $projectPath $consumerProject
         Write-TextFile (Join-Path $consumerDirectory 'Program.cs') $runtimeProgram
         Invoke-DotNet @('restore', $projectPath, '--configfile', $nugetConfigPath, '--no-cache', '--force-evaluate')
+        if ($framework -eq 'net8.0')
+        {
+            $packageListJson = (& dotnet list $projectPath package --include-transitive --format json --no-restore | Out-String)
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw 'Unable to inspect the .NET 8 consumer dependency graph.'
+            }
+
+            $packageList = $packageListJson | ConvertFrom-Json
+            $resolvedPackages = @(
+                $packageList.projects.frameworks.topLevelPackages
+                $packageList.projects.frameworks.transitivePackages)
+            $expectedNet8Versions = @{
+                'Microsoft.Bcl.TimeProvider' = '8.0.1'
+                'Microsoft.Extensions.Configuration' = '8.0.0'
+                'Microsoft.Extensions.Configuration.Abstractions' = '8.0.0'
+                'Microsoft.Extensions.DependencyInjection' = '8.0.1'
+                'Microsoft.Extensions.DependencyInjection.Abstractions' = '8.0.2'
+                'Microsoft.Extensions.Http' = '8.0.1'
+                'Microsoft.Extensions.Logging' = '8.0.1'
+                'Microsoft.Extensions.Logging.Abstractions' = '8.0.3'
+                'Microsoft.Extensions.Options' = '8.0.2'
+                'Microsoft.Extensions.Primitives' = '8.0.0'
+                'System.Threading.RateLimiting' = '8.0.0'
+            }
+            foreach ($entry in $expectedNet8Versions.GetEnumerator())
+            {
+                $resolvedVersion = @($resolvedPackages |
+                    Where-Object id -eq $entry.Key |
+                    ForEach-Object resolvedVersion)
+                Assert-Equal ".NET 8 consumer $($entry.Key) version" $resolvedVersion $entry.Value
+            }
+        }
+
         Invoke-DotNet @('build', $projectPath, '-c', 'Release', '--no-restore')
         $kevlarPdbFramework = $framework
         Copy-Item `

--- a/scripts/Verify-ReleaseWorkflow.ps1
+++ b/scripts/Verify-ReleaseWorkflow.ps1
@@ -102,6 +102,29 @@ if ($nugetPublishScript.Contains('--skip-duplicate', [StringComparison]::Ordinal
     throw 'NuGet publication must reject conflicting duplicates after comparing payloads.'
 }
 
+. (Join-Path $PSScriptRoot 'PackageDependencyPolicy.ps1')
+Assert-ShippedDependencyFloor `
+    -DependencyId 'Microsoft.Extensions.Options' `
+    -DependencyVersion '8.0.2' `
+    -Context 'fixture'
+$raisedFloorRejected = $false
+try
+{
+    Assert-ShippedDependencyFloor `
+        -DependencyId 'Microsoft.Extensions.Options' `
+        -DependencyVersion '10.0.11' `
+        -Context 'fixture'
+}
+catch
+{
+    $raisedFloorRejected = $_.Exception.Message -match 'major version 8 or earlier'
+}
+
+if (-not $raisedFloorRejected)
+{
+    throw 'Shipped dependency policy accepted a Microsoft.Extensions 10.x floor.'
+}
+
 $tagIndex = $publish.IndexOf('- name: Create and push release tag', [StringComparison]::Ordinal)
 $packageIndex = $publish.IndexOf('- name: Push to NuGet', [StringComparison]::Ordinal)
 $releaseIndex = $publish.IndexOf('- name: Create GitHub release', [StringComparison]::Ordinal)


### PR DESCRIPTION
## Summary
- restore shipped Microsoft dependency floors to supported .NET 8 versions
- reject future package floor drift above major version 8
- validate exact .NET 8 consumer graph and Renovate constraints
- document minimum supported dependency versions

## Test plan
- [x] `pwsh scripts/Verify-ReleaseWorkflow.ps1`
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `pwsh scripts/Verify-Docs.ps1`
- [x] `dotnet pack Kevlar.slnx -c Release --no-build -p:Version=0.0.0-local`
- [x] `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local`
- [x] `npm run build` from `docs/`
- [x] `npx --yes --package renovate -- renovate-config-validator renovate.json`

Closes #333
