### PR TITLE
fix(retry): cap generated delays by default

### DIFF
--- a/docs/api/Kevlar.Extensions.Http.HttpShield.yml
+++ b/docs/api/Kevlar.Extensions.Http.HttpShield.yml
@@ -200,7 +200,9 @@ items:
   summary: >-
     A <xref href="Kevlar.RetryOptions%601.DelayGenerator" data-throw-if-not-resolved="false"></xref> honouring the response's
 
-    <code>Retry-After</code> header when present and longer than the computed backoff.
+    <code>Retry-After</code> header when present and longer than the computed backoff, capped at the
+
+    default backoff's 30-second maximum.
   example: []
   syntax:
     content: public static ValueTask<TimeSpan?> RetryAfter(RetryEvent<HttpResponseMessage> retry)

--- a/docs/api/Kevlar.RetryOptions-1.yml
+++ b/docs/api/Kevlar.RetryOptions-1.yml
@@ -179,6 +179,8 @@ items:
     An absolute upper bound applied to every delay, including delays produced by
 
     <xref href="Kevlar.RetryOptions%601.DelayGenerator" data-throw-if-not-resolved="false"></xref> (so a huge <code>Retry-After</code> header cannot stall the pipeline).
+
+    When unset, <xref href="Kevlar.Backoff.MaxDelay" data-throw-if-not-resolved="false"></xref> is used when the backoff provides one.
   example: []
   syntax:
     content: public TimeSpan? MaxDelay { get; set; }
@@ -360,9 +362,11 @@ items:
 
     Return a non-null value to replace the backoff-computed delay;
 
-    <xref href="Kevlar.RetryOptions%601.MaxDelay" data-throw-if-not-resolved="false"></xref> still caps the returned value. The generator is awaited before
+    <xref href="Kevlar.RetryOptions%601.MaxDelay" data-throw-if-not-resolved="false"></xref> still caps the returned value. When it is unset,
 
-    <xref href="Kevlar.RetryOptions%601.OnRetry" data-throw-if-not-resolved="false"></xref> runs.
+    <xref href="Kevlar.Backoff.MaxDelay" data-throw-if-not-resolved="false"></xref> caps the value when available. The generator is awaited
+
+    before <xref href="Kevlar.RetryOptions%601.OnRetry" data-throw-if-not-resolved="false"></xref> runs.
   example: []
   syntax:
     content: public Func<RetryEvent<TResult>, ValueTask<TimeSpan?>>? DelayGenerator { get; set; }
@@ -788,6 +792,13 @@ references:
   name: Backoff
   nameWithType: Backoff
   fullName: Kevlar.Backoff
+- uid: Kevlar.Backoff.MaxDelay
+  commentId: P:Kevlar.Backoff.MaxDelay
+  isExternal: true
+  href: Kevlar.Backoff.html#Kevlar_Backoff_MaxDelay
+  name: MaxDelay
+  nameWithType: Backoff.MaxDelay
+  fullName: Kevlar.Backoff.MaxDelay
 - uid: Kevlar.RetryOptions`1.MaxDelay*
   commentId: Overload:Kevlar.RetryOptions`1.MaxDelay
   isExternal: true

--- a/docs/api/Kevlar.RetryOptions.yml
+++ b/docs/api/Kevlar.RetryOptions.yml
@@ -219,6 +219,8 @@ items:
     An absolute upper bound applied to every delay, including delays produced by
 
     <xref href="Kevlar.RetryOptions.DelayGenerator" data-throw-if-not-resolved="false"></xref> (so a huge <code>Retry-After</code> header cannot stall the pipeline).
+
+    When unset, <xref href="Kevlar.Backoff.MaxDelay" data-throw-if-not-resolved="false"></xref> is used when the backoff provides one.
   example: []
   syntax:
     content: public TimeSpan? MaxDelay { get; set; }
@@ -275,6 +277,8 @@ items:
     backoff-computed delay; return a non-null value to replace it (for example, from an
 
     HTTP <code>Retry-After</code> header). <xref href="Kevlar.RetryOptions.MaxDelay" data-throw-if-not-resolved="false"></xref> still caps the returned value.
+
+    When it is unset, <xref href="Kevlar.Backoff.MaxDelay" data-throw-if-not-resolved="false"></xref> caps the value when available.
 
     The generator is awaited before <xref href="Kevlar.RetryOptions.OnRetry" data-throw-if-not-resolved="false"></xref> runs. Do not retain the pooled
 
@@ -749,6 +753,13 @@ references:
   name: Backoff
   nameWithType: Backoff
   fullName: Kevlar.Backoff
+- uid: Kevlar.Backoff.MaxDelay
+  commentId: P:Kevlar.Backoff.MaxDelay
+  isExternal: true
+  href: Kevlar.Backoff.html#Kevlar_Backoff_MaxDelay
+  name: MaxDelay
+  nameWithType: Backoff.MaxDelay
+  fullName: Kevlar.Backoff.MaxDelay
 - uid: Kevlar.RetryOptions.MaxDelay*
   commentId: Overload:Kevlar.RetryOptions.MaxDelay
   isExternal: true

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -223,7 +223,12 @@ shape.
 
 ### `HttpShield.RetryAfter`
 
-A `DelayGenerator` for retry options: when the failed response carries a `Retry-After` header (delta or date form), the retry waits what the server asked for. The server's suggestion is used only when it's *longer* than the computed backoff; no header → normal backoff applies. It returns a completed `ValueTask<TimeSpan?>`, so it binds directly as a method group (`options.DelayGenerator = HttpShield.RetryAfter`) and works with synchronous `Execute`.
+A `DelayGenerator` for retry options: when the failed response carries a `Retry-After` header
+(delta or date form), the retry waits what the server asked for, capped at 30 seconds by default.
+The server's suggestion is used only when it's *longer* than the computed backoff; no header →
+normal backoff applies. It returns a completed `ValueTask<TimeSpan?>`, so it binds directly as a
+method group (`options.DelayGenerator = HttpShield.RetryAfter`) and works with synchronous
+`Execute`. Use `HttpShield.RetryAfter(maxDelay)` to choose another cap.
 
 The standard shield composes this with a custom `Retry.DelayGenerator` and uses the longer result,
 awaiting the custom generator when it yields. Set `UseRetryAfterHeader` to `false` when the custom

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -95,7 +95,7 @@ Shield.Retry(o =>
 |---|---|---|
 | `MaxRetries` | `3` | Retries after the initial attempt — `3` means up to 4 total attempts; `int.MaxValue` = forever |
 | `Backoff` | `Backoff.Default` | The delay sequence (see above) |
-| `MaxDelay` | — | Absolute cap applied to every delay — including `DelayGenerator` output, so a hostile `Retry-After` can't stall the pipeline |
+| `MaxDelay` | backoff cap | Absolute cap applied to every delay, including `DelayGenerator` output. When unset, the backoff's cap applies (30s for `Backoff.Default`); a backoff without a cap falls back to the runtime timer limit |
 | `OnRetry` | — | Awaited before each retry sleeps — attempt number, final delay, failure. Return `default` when the work is synchronous |
 | `DelayGenerator` | — | Per-retry override returning `ValueTask<TimeSpan?>`: a `TimeSpan` replaces the computed delay, `null` keeps it. This is how [`Retry-After` support](../http.md) works |
 | `HandlesException` | — | Local exception predicate; replaces the ambient clause for this retry |
@@ -104,7 +104,7 @@ Shield.Retry(o =>
 Invalid option values throw [`KevlarConfigurationException`](../exceptions.md#configuration-failures)
 and identify the options type, property, and offending value.
 
-Order per retry: retry metrics are recorded → backoff computes the delay → `MaxDelay` clamps it → the awaited `DelayGenerator` may override it → the awaited `OnRetry` sees the final delay → sleep. The generator's `null` and negative results are ignored, and `MaxDelay` clamps its override.
+Order per retry: retry metrics are recorded → backoff computes the delay → effective cap (`MaxDelay ?? Backoff.MaxDelay`) clamps it → the awaited `DelayGenerator` may override it → the awaited `OnRetry` sees the final delay → sleep. The generator's `null` and negative results are ignored, and the effective cap clamps its override.
 
 Both hooks return `ValueTask`. A hook that completes synchronously (`return default;`, `new(value)`)
 costs nothing extra and works with synchronous `Execute`. A hook that yields is awaited by

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -3,6 +3,8 @@ namespace Kevlar.Extensions.Http;
 /// <summary>Building blocks for HTTP resilience shields.</summary>
 public static class HttpShield
 {
+    private static readonly TimeSpan DefaultRetryAfterMaxDelay = Backoff.Default.MaxDelay!.Value;
+
     /// <summary>
     /// Returns <see langword="true"/> for responses worth retrying: 5xx, 408 Request Timeout
     /// and 429 Too Many Requests.
@@ -81,12 +83,15 @@ public static class HttpShield
 
     /// <summary>
     /// A <see cref="RetryOptions{TResult}.DelayGenerator"/> honouring the response's
-    /// <c>Retry-After</c> header when present and longer than the computed backoff.
+    /// <c>Retry-After</c> header when present and longer than the computed backoff, capped at the
+    /// default backoff's 30-second maximum.
     /// </summary>
     public static ValueTask<TimeSpan?> RetryAfter(RetryEvent<HttpResponseMessage> retry) =>
-        new(RetryAfterCore(retry));
+        new(RetryAfterCore(retry, DefaultRetryAfterMaxDelay));
 
-    private static TimeSpan? RetryAfterCore(RetryEvent<HttpResponseMessage> retry)
+    private static TimeSpan? RetryAfterCore(
+        RetryEvent<HttpResponseMessage> retry,
+        TimeSpan maxDelay)
     {
         if (retry.Outcome.Result is not { } response)
         {
@@ -111,7 +116,13 @@ public static class HttpShield
             suggested = date - retry.Context.TimeProvider.GetUtcNow();
         }
 
-        return suggested is { } value && value > retry.Delay ? value : null;
+        if (suggested is not { } value || value <= retry.Delay)
+        {
+            return null;
+        }
+
+        var capped = value > maxDelay ? maxDelay : value;
+        return capped > retry.Delay ? capped : null;
     }
 
     /// <summary>
@@ -129,16 +140,7 @@ public static class HttpShield
             throw new ArgumentOutOfRangeException(nameof(maxDelay), "maxDelay must not be negative.");
         }
 
-        return retry =>
-        {
-            var suggested = RetryAfterCore(retry);
-            if (suggested is not { } value || value <= maxDelay)
-            {
-                return new ValueTask<TimeSpan?>(suggested);
-            }
-
-            return new ValueTask<TimeSpan?>(maxDelay > retry.Delay ? maxDelay : null);
-        };
+        return retry => new ValueTask<TimeSpan?>(RetryAfterCore(retry, maxDelay));
     }
 
     private static bool IsHttpClientTimeout(TaskCanceledException exception)
@@ -252,7 +254,9 @@ public static class HttpShield
         {
             var suggested = custom(retry);
             return suggested.IsCompletedSuccessfully
-                ? new ValueTask<TimeSpan?>(Longer(suggested.Result, RetryAfterCore(retry)))
+                ? new ValueTask<TimeSpan?>(Longer(
+                    suggested.Result,
+                    RetryAfterCore(retry, DefaultRetryAfterMaxDelay)))
                 : LongerAsync(suggested, retry);
         };
     }
@@ -260,7 +264,9 @@ public static class HttpShield
     private static async ValueTask<TimeSpan?> LongerAsync(
         ValueTask<TimeSpan?> custom,
         RetryEvent<HttpResponseMessage> retry) =>
-        Longer(await custom.ConfigureAwait(false), RetryAfterCore(retry));
+        Longer(
+            await custom.ConfigureAwait(false),
+            RetryAfterCore(retry, DefaultRetryAfterMaxDelay));
 
     private static TimeSpan? Longer(TimeSpan? first, TimeSpan? second)
     {

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -44,6 +44,7 @@ public sealed class RetryOptions
     /// <summary>
     /// An absolute upper bound applied to every delay, including delays produced by
     /// <see cref="DelayGenerator"/> (so a huge <c>Retry-After</c> header cannot stall the pipeline).
+    /// When unset, <see cref="Backoff.MaxDelay"/> is used when the backoff provides one.
     /// </summary>
     public TimeSpan? MaxDelay { get; set; }
 
@@ -58,6 +59,7 @@ public sealed class RetryOptions
     /// Overrides the computed delay for a specific retry. Receives the event with the
     /// backoff-computed delay; return a non-null value to replace it (for example, from an
     /// HTTP <c>Retry-After</c> header). <see cref="MaxDelay"/> still caps the returned value.
+    /// When it is unset, <see cref="Backoff.MaxDelay"/> caps the value when available.
     /// The generator is awaited before <see cref="OnRetry"/> runs. Do not retain the pooled
     /// <see cref="RetryEvent.Context"/> after the returned task completes.
     /// </summary>
@@ -94,6 +96,7 @@ public sealed class RetryOptions<TResult>
     /// <summary>
     /// An absolute upper bound applied to every delay, including delays produced by
     /// <see cref="DelayGenerator"/> (so a huge <c>Retry-After</c> header cannot stall the pipeline).
+    /// When unset, <see cref="Backoff.MaxDelay"/> is used when the backoff provides one.
     /// </summary>
     public TimeSpan? MaxDelay { get; set; }
 
@@ -142,8 +145,9 @@ public sealed class RetryOptions<TResult>
     /// <summary>
     /// Overrides the computed delay for a specific retry, with the typed handled outcome.
     /// Return a non-null value to replace the backoff-computed delay;
-    /// <see cref="MaxDelay"/> still caps the returned value. The generator is awaited before
-    /// <see cref="OnRetry"/> runs.
+    /// <see cref="MaxDelay"/> still caps the returned value. When it is unset,
+    /// <see cref="Backoff.MaxDelay"/> caps the value when available. The generator is awaited
+    /// before <see cref="OnRetry"/> runs.
     /// </summary>
     public Func<RetryEvent<TResult>, ValueTask<TimeSpan?>>? DelayGenerator { get; set; }
 }

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -70,7 +70,7 @@ internal sealed class RetryStrategy : Strategy
         _judge = judge;
         _maxRetries = maxRetries;
         _backoff = backoff!;
-        _maxDelay = maxDelay;
+        _maxDelay = maxDelay ?? _backoff.MaxDelay;
         _onRetry = onRetry;
         _delayGenerator = delayGenerator;
         _callbackResultType = callbackResultType;
@@ -116,7 +116,9 @@ internal sealed class RetryStrategy : Strategy
 
     public override string Describe()
     {
-        var cap = _maxDelay is { } max ? $", ≤{DescribeHelper.Time(max)}" : string.Empty;
+        var cap = _maxDelay is { } max && max != _backoff.MaxDelay
+            ? $", ≤{DescribeHelper.Time(max)}"
+            : string.Empty;
         return _maxRetries == int.MaxValue
             ? $"RetryForever({_backoff}{cap})"
             : $"Retry({_maxRetries}, {_backoff}{cap})";

--- a/tests/Kevlar.Tests/AsyncRetryDelayGeneratorTests.cs
+++ b/tests/Kevlar.Tests/AsyncRetryDelayGeneratorTests.cs
@@ -120,6 +120,55 @@ public class AsyncRetryDelayGeneratorTests
     }
 
     [Test]
+    public async Task Generator_Result_Uses_Backoff_Cap_When_MaxDelay_Is_Unset()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var seenByHook = TimeSpan.Zero;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.DelayGenerator = static _ => new(TimeSpan.FromDays(1));
+            options.OnRetry = retry =>
+            {
+                seenByHook = retry.Delay;
+                cancellation.Cancel();
+                return default;
+            };
+        });
+
+        await shield.ExecuteOutcomeAsync<int>(
+            static _ => throw new InvalidOperationException(),
+            cancellation.Token);
+
+        await Assert.That(seenByHook).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
+    public async Task Explicit_MaxDelay_Overrides_Backoff_Cap_For_Generator_Result()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var seenByHook = TimeSpan.Zero;
+        var shield = Shield.Retry(options =>
+        {
+            options.MaxRetries = 1;
+            options.MaxDelay = TimeSpan.FromDays(1);
+            options.DelayGenerator = static _ => new(TimeSpan.FromDays(1));
+            options.OnRetry = retry =>
+            {
+                seenByHook = retry.Delay;
+                cancellation.Cancel();
+                return default;
+            };
+        });
+
+        await shield.ExecuteOutcomeAsync<int>(
+            static _ => throw new InvalidOperationException(),
+            cancellation.Token);
+
+        await Assert.That(seenByHook).IsEqualTo(TimeSpan.FromDays(1));
+    }
+
+    [Test]
     public async Task Invalid_Generator_Result_Keeps_The_Previous_Delay()
     {
         var generated = new Queue<TimeSpan?>([null, TimeSpan.FromSeconds(-1)]);

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -311,6 +311,18 @@ public class HttpContractTests
     }
 
     [Test]
+    public async Task RetryAfter_Default_Caps_Server_Delay_To_Thirty_Seconds()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromHours(1));
+
+        var delay = await ObserveRetryDelay(timeProvider, () => response);
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
     public async Task RetryAfter_Max_Overload_Does_Not_Shorten_Backoff()
     {
         var timeProvider = new FakeTimeProvider();


### PR DESCRIPTION
## Summary
- cap custom `DelayGenerator` output at the retry strategy's effective `MaxDelay`
- default HTTP `Retry-After` handling to the same 30-second ceiling while preserving shorter backoff delays
- document the defaults and add regression coverage

Closes #337

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m` (1,199 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (1,230 passed)
- integration, testing, and allocation suites
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-issue337` (187 snippets on .NET 8 and .NET 10)
- `npm run build`

## Benchmarks
`RetryDelayGeneratorBenchmarks`, Windows x64, .NET 10:

| Case | Before | After | Allocated |
|---|---:|---:|---:|
| FixedDelay | 1.073 us | 1.078 us | 96 B |
| AsyncCompletedDelay | 1.081 us | 1.206 us | 96 B |
| AsyncYieldingDelay | 2.368 us | 2.313 us | 927 B |

The noisier async-completed case was rerun at default confidence: 1.076 us before, 1.077 us after, 96 B both.