### PR TITLE
fix(resilience): dispose superseded results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,9 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
 - Coupled satellite packages exact-pin their `Kevlar` dependencies. Partial upgrades of
   dependency injection, logging, and gRPC packages fail restore with `NU1608` instead of risking
   runtime failures from incompatible internals.
+- Retry and hedging dispose superseded result values. `IAsyncDisposable` is preferred over
+  `IDisposable`; disposal failures are isolated through `CallbackErrorKind.ResultDisposal`, while
+  the selected terminal result remains caller-owned.
 - Circuit-breaker monitors and testing snapshots report `HalfOpen` as soon as break duration
   elapses. Stale outcomes cannot alter newer state generations, and exceptions that opened a
   circuit are released when it closes or resets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,7 +196,8 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
   runtime failures from incompatible internals.
 - Retry and hedging dispose superseded result values. `IAsyncDisposable` is preferred over
   `IDisposable`; disposal failures are isolated through `CallbackErrorKind.ResultDisposal`, while
-  the selected terminal result remains caller-owned.
+  the selected terminal result remains caller-owned. The `netstandard2.0` package carries the
+  required async-disposal runtime dependency.
 - Circuit-breaker monitors and testing snapshots report `HalfOpen` as soon as break duration
   elapses. Stale outcomes cannot alter newer state generations, and exceptions that opened a
   circuit are released when it closes or resets.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <!-- Core (netstandard2.0 only) -->
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />

--- a/docs/api/.manifest
+++ b/docs/api/.manifest
@@ -35,6 +35,7 @@
   "Kevlar.CallbackErrorKind.Logging": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.RateLimitRejected": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.RateLimiterAdapterRejected": "Kevlar.CallbackErrorKind.yml",
+  "Kevlar.CallbackErrorKind.ResultDisposal": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.Retry": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.Timeout": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.Chaos": "Kevlar.Chaos.yml",

--- a/docs/api/Kevlar.CallbackErrorEvent.yml
+++ b/docs/api/Kevlar.CallbackErrorEvent.yml
@@ -19,7 +19,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Describes an exception thrown by a strategy notification or observer.
+  summary: Describes an exception thrown by an isolated callback or cleanup operation.
   example: []
   syntax:
     content: public readonly struct CallbackErrorEvent
@@ -45,7 +45,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Gets the callback family that failed.
+  summary: Gets the callback or cleanup family that failed.
   example: []
   syntax:
     content: public CallbackErrorKind Kind { get; }
@@ -114,7 +114,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Gets the exception thrown by the callback.
+  summary: Gets the isolated exception.
   example: []
   syntax:
     content: public Exception Exception { get; }

--- a/docs/api/Kevlar.CallbackErrorKind.yml
+++ b/docs/api/Kevlar.CallbackErrorKind.yml
@@ -14,6 +14,7 @@ items:
   - Kevlar.CallbackErrorKind.Logging
   - Kevlar.CallbackErrorKind.RateLimitRejected
   - Kevlar.CallbackErrorKind.RateLimiterAdapterRejected
+  - Kevlar.CallbackErrorKind.ResultDisposal
   - Kevlar.CallbackErrorKind.Retry
   - Kevlar.CallbackErrorKind.Timeout
   langs:
@@ -26,7 +27,7 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Identifies a strategy notification whose failure was reported by Kevlar.
+  summary: Identifies an isolated callback or cleanup failure reported by Kevlar.
   example: []
   syntax:
     content: public enum CallbackErrorKind
@@ -249,6 +250,26 @@ items:
   example: []
   syntax:
     content: Logging = 10
+    return:
+      type: Kevlar.CallbackErrorKind
+- uid: Kevlar.CallbackErrorKind.ResultDisposal
+  commentId: F:Kevlar.CallbackErrorKind.ResultDisposal
+  id: ResultDisposal
+  parent: Kevlar.CallbackErrorKind
+  langs:
+  - csharp
+  - vb
+  name: ResultDisposal
+  nameWithType: CallbackErrorKind.ResultDisposal
+  fullName: Kevlar.CallbackErrorKind.ResultDisposal
+  type: Field
+  assemblies:
+  - Kevlar
+  namespace: Kevlar
+  summary: Disposal of a superseded result.
+  example: []
+  syntax:
+    content: ResultDisposal = 11
     return:
       type: Kevlar.CallbackErrorKind
 references:

--- a/docs/api/Kevlar.Extensions.Http.StandardHttpShieldOptions.yml
+++ b/docs/api/Kevlar.Extensions.Http.StandardHttpShieldOptions.yml
@@ -101,7 +101,9 @@ items:
   summary: >-
     Configures transient retries. Defaults to three jittered exponential retries that honour
 
-    <code>Retry-After</code> headers. Superseded responses are always disposed before notifications run.
+    <code>Retry-After</code> headers. Notifications observe the live handled response, which is
+
+    disposed before the next attempt starts.
   example: []
   syntax:
     content: public RetryOptions<HttpResponseMessage> Retry { get; set; }

--- a/docs/api/Kevlar.KevlarDiagnostics.yml
+++ b/docs/api/Kevlar.KevlarDiagnostics.yml
@@ -35,7 +35,9 @@ items:
 
     <ul><li><code>kevlar.executions</code> — completed public execution calls, including empty shields and
 
-    pre-cancelled calls; attributes <code>kevlar.shield.name</code>, <code>kevlar.execution.outcome</code> (<code>success</code>/<code>failure</code>)</li><li><code>kevlar.retries</code> — retry attempts; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.timeouts</code> — executions cancelled by a timeout strategy; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.hedges</code> — extra hedged attempts launched; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.fallbacks</code> — outcomes replaced by a fallback; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.rejections</code> — fail-fast rejections; attributes <code>kevlar.shield.name</code>, <code>kevlar.rejection.type</code> (<code>circuit_open</code>/<code>rate_limit</code>/<code>rate_limiter_adapter</code>/<code>concurrency_limit</code>)</li><li><code>kevlar.circuit_breaker.transitions</code> — circuit state changes; attributes <code>kevlar.circuit_breaker.state.from</code>, <code>kevlar.circuit_breaker.state.to</code></li><li><code>kevlar.callback_errors</code> — exceptions thrown by notifications or observers; attributes <code>kevlar.shield.name</code>, <code>kevlar.callback.kind</code></li><li><code>kevlar.execution.duration</code> — execution duration histogram in seconds; attributes <code>kevlar.shield.name</code>, <code>kevlar.execution.outcome</code></li><li><code>kevlar.strategy.events</code> — strategy and custom events; attributes include shield,
+    pre-cancelled calls; attributes <code>kevlar.shield.name</code>, <code>kevlar.execution.outcome</code> (<code>success</code>/<code>failure</code>)</li><li><code>kevlar.retries</code> — retry attempts; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.timeouts</code> — executions cancelled by a timeout strategy; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.hedges</code> — extra hedged attempts launched; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.fallbacks</code> — outcomes replaced by a fallback; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.rejections</code> — fail-fast rejections; attributes <code>kevlar.shield.name</code>, <code>kevlar.rejection.type</code> (<code>circuit_open</code>/<code>rate_limit</code>/<code>rate_limiter_adapter</code>/<code>concurrency_limit</code>)</li><li><code>kevlar.circuit_breaker.transitions</code> — circuit state changes; attributes <code>kevlar.circuit_breaker.state.from</code>, <code>kevlar.circuit_breaker.state.to</code></li><li><code>kevlar.callback_errors</code> — exceptions thrown by callbacks or cleanup operations;
+
+    attributes <code>kevlar.shield.name</code>, <code>kevlar.callback.kind</code></li><li><code>kevlar.execution.duration</code> — execution duration histogram in seconds; attributes <code>kevlar.shield.name</code>, <code>kevlar.execution.outcome</code></li><li><code>kevlar.strategy.events</code> — strategy and custom events; attributes include shield,
 
     strategy, event, severity, attempt, exception type, and an optional bounded operation key</li><li><code>kevlar.attempt.duration</code> — retry-attempt duration histogram in milliseconds with
 
@@ -97,9 +99,9 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: >-
-    Reports a callback failure without allowing diagnostics subscribers to affect execution.
+    Reports a callback or cleanup failure without allowing diagnostics subscribers to affect
 
-    Custom strategies can use this method to follow Kevlar's callback-isolation contract.
+    execution. Custom strategies can use this method to follow Kevlar's isolation contract.
   example: []
   syntax:
     content: public static void ReportCallbackError(CallbackErrorKind kind, KevlarContext context, Exception exception)
@@ -153,9 +155,11 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: >-
-    Raised when a strategy notification or observer throws. Each subscriber is isolated:
+    Raised when a strategy notification, observer, or superseded-result disposal throws. Each
 
-    subscriber failures are swallowed and do not prevent later subscribers from running.
+    subscriber is isolated: subscriber failures are swallowed and do not prevent later
+
+    subscribers from running.
   example: []
   syntax:
     content: public static event Action<CallbackErrorEvent>? OnCallbackError

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -415,7 +415,11 @@ shield so every additional send goes through safe replay and routing.
 
 ## Behaviour notes
 
-- **Superseded responses are handler-owned.** The handler disposes failed retry responses and losing hedge responses, including a loser that completes after the winner. A custom `OnRetry` response-disposal hook is unnecessary with `ShieldDelegatingHandler`; the hook that `HttpShield.Standard()` installs stays safe because `HttpResponseMessage.Dispose` is idempotent. The selected response remains caller-owned.
+- **Superseded responses are pipeline-owned.** Retry and hedging dispose failed or losing responses,
+  including a loser that completes after the winner; the handler retains an idempotent safety net
+  for custom strategies. A custom `OnRetry` disposal hook is unnecessary. `OnRetry` observes the
+  live response, disposal completes before the next attempt starts, and the selected response
+  remains caller-owned.
 - **Redirects remain transport-owned.** Each Kevlar attempt begins with the original absolute URI (or its routed authority). Normal `HttpClientHandler` redirect policy runs inside that attempt.
 - **State sharing depends on registration form.** Parameterless `AddStandardShield()`, its one-argument options callback, and `AddShield(shield)` build/capture one shield for that named client, so state survives handler rotation. Service-provider callbacks run once per `HttpClientFactory` handler lifetime and create fresh state unless they resolve and return shared state from DI.
 - **Configuration-backed state is replaced, not mutated.** Reload and handler rotation publish fresh complete pipelines. Requests already executing retain the snapshot they captured at send start.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -77,7 +77,7 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics
 | `kevlar.rejections` | Counter | `{rejection}` | `net8.0` | fail-fast rejections | `kevlar.shield.name`, `kevlar.rejection.type` (`circuit_open`/`rate_limit`/`rate_limiter_adapter`/`concurrency_limit`) |
 | `kevlar.circuit_breaker.transitions` | Counter | `{transition}` | `net8.0` | circuit state changes | `kevlar.circuit_breaker.state.from`, `kevlar.circuit_breaker.state.to` (`closed`/`open`/`half_open`/`isolated`) |
 | `kevlar.partitions.evictions` | Counter | `{partition}` | `net8.0` | partitions removed from bounded providers | `kevlar.partition.reason` (`capacity`/`idle`/`cleared`) |
-| `kevlar.callback_errors` | Counter | `{error}` | `net8.0` | exceptions thrown by strategy notifications or observers | `kevlar.shield.name`, `kevlar.callback.kind` |
+| `kevlar.callback_errors` | Counter | `{error}` | `net8.0` | exceptions thrown by strategy notifications, observers, or superseded-result disposal | `kevlar.shield.name`, `kevlar.callback.kind` |
 | `kevlar.execution.duration` | Histogram | `s` | `net8.0` | completed public execution duration | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
 | `kevlar.strategy.events` | Counter | `{event}` | `net8.0` | built-in strategy and caller-recorded events | `kevlar.shield.name`, `kevlar.strategy.index`, `kevlar.strategy.name`, `kevlar.event.name`, `kevlar.event.severity`, `kevlar.attempt.number`, optional `exception.type`, optional `kevlar.operation.key` |
 | `kevlar.attempt.duration` | Histogram | `ms` | `net8.0` | retry attempt duration, including the initial attempt | `kevlar.shield.name`, `kevlar.strategy.index`, `kevlar.strategy.name`, `kevlar.event.name`, `kevlar.event.severity`, `kevlar.attempt.number`, optional `exception.type`, optional `kevlar.operation.key` |
@@ -212,8 +212,8 @@ The event payloads and timing are documented on each [strategy page](/docs/categ
 
 ### Callback failures
 
-Notification and observer exceptions never replace the protected operation's result, failure,
-timeout, rejection, or fallback. Kevlar awaits every callback, reports each exception
+Notification, observer, and superseded-result disposal exceptions never replace the protected
+operation's result, failure, timeout, rejection, or fallback. Kevlar awaits every callback, reports each exception
 through `KevlarDiagnostics.OnCallbackError`, increments `kevlar.callback_errors`, and continues.
 Each diagnostics subscriber is isolated too: one throwing subscriber cannot prevent later
 subscribers from receiving the error.

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -126,7 +126,13 @@ flags untyped `Hedge(...)` for exactly this reason.
 - Each attempt gets a forked context — `Properties` are copied at launch time, so attempts don't see each other's writes.
 - Callback contexts are pooled. Do not retain them after the returned `ValueTask` completes; a generated action's isolated context remains valid until that attempt completes.
 - Callbacks and generators run without a strategy lock. They may re-enter the same shield, and concurrent shield executions may invoke them concurrently; keep captured state thread-safe.
-- Losing operations are cancelled first, then their isolated contexts are returned to the pool after those operations complete.
+- Losing operations are cancelled first. After each operation completes, any non-selected result
+  is disposed and its isolated context is returned to the pool. This also covers handled results
+  superseded by a later attempt and non-selected `OriginalAction` results produced inside an
+  `ActionGenerator`. Kevlar prefers `IAsyncDisposable` when both disposal interfaces are present;
+  the selected result remains caller-owned. Disposal failures are reported through
+  `KevlarDiagnostics.OnCallbackError` as `CallbackErrorKind.ResultDisposal` without changing the
+  selected outcome.
 - What counts as a failure is the ambient [handling clause](../handling-failures.md), unless the
   options set `HandlesException` or `HandlesResult` as a
   [per-strategy override](../handling-failures.md#per-strategy-overrides).

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -104,7 +104,14 @@ Shield.Retry(o =>
 Invalid option values throw [`KevlarConfigurationException`](../exceptions.md#configuration-failures)
 and identify the options type, property, and offending value.
 
-Order per retry: retry metrics are recorded → backoff computes the delay → effective cap (`MaxDelay ?? Backoff.MaxDelay`) clamps it → the awaited `DelayGenerator` may override it → the awaited `OnRetry` sees the final delay → sleep. The generator's `null` and negative results are ignored, and the effective cap clamps its override.
+Order per retry: retry metrics are recorded → backoff computes the delay → effective cap (`MaxDelay ?? Backoff.MaxDelay`) clamps it → the awaited `DelayGenerator` may override it → the awaited `OnRetry` sees the final delay and handled outcome → a superseded disposable result is disposed → sleep. The generator's `null` and negative results are ignored, and the effective cap clamps its override.
+
+When result handling triggers another attempt, Kevlar disposes the handled result before the next
+attempt starts. It prefers `IAsyncDisposable.DisposeAsync()` when a result implements both disposal
+interfaces. `OnRetry` runs first so it can inspect the live result. The final result returned to the
+caller is never disposed by the retry strategy. Disposal failures are reported through
+`KevlarDiagnostics.OnCallbackError` as `CallbackErrorKind.ResultDisposal` and do not replace the
+pipeline outcome.
 
 Both hooks return `ValueTask`. A hook that completes synchronously (`return default;`, `new(value)`)
 costs nothing extra and works with synchronous `Execute`. A hook that yields is awaited by

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -12,6 +12,7 @@ application. Test-only and build-only dependencies are not part of this package 
 
 | Dependency | Minimum version | Shipped by |
 |---|---:|---|
+| `Microsoft.Bcl.AsyncInterfaces` | `8.0.0` | `Kevlar` |
 | `Microsoft.Bcl.TimeProvider` | `8.0.1` | `Kevlar`, `Kevlar.Chaos` |
 | `Microsoft.Extensions.Configuration.Abstractions` | `8.0.0` | `Kevlar.Extensions.DependencyInjection`, `Kevlar.Extensions.Http` |
 | `Microsoft.Extensions.DependencyInjection.Abstractions` | `8.0.2` | `Kevlar.Extensions.DependencyInjection` |

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -292,7 +292,7 @@ $expectedDependencies = @{
     'Kevlar' = @{
         'net10.0' = @('Reservoir')
         'net8.0' = @('Reservoir')
-        '.NETStandard2.0' = @('Microsoft.Bcl.TimeProvider', 'Reservoir', 'System.Threading.Tasks.Extensions')
+        '.NETStandard2.0' = @('Microsoft.Bcl.AsyncInterfaces', 'Microsoft.Bcl.TimeProvider', 'Reservoir', 'System.Threading.Tasks.Extensions')
     }
     'Kevlar.Extensions.DependencyInjection' = @{
         'net10.0' = @('Kevlar', 'Microsoft.Extensions.Configuration.Abstractions', 'Microsoft.Extensions.DependencyInjection.Abstractions', 'Microsoft.Extensions.Options', 'Microsoft.Extensions.Primitives')
@@ -351,6 +351,7 @@ $exactPinnedPackageIds = @(
 
 $expectedDependencyVersions = @{}
 foreach ($dependencyId in @(
+    'Microsoft.Bcl.AsyncInterfaces',
     'Microsoft.Bcl.TimeProvider',
     'Microsoft.Extensions.Configuration.Abstractions',
     'Microsoft.Extensions.DependencyInjection.Abstractions',

--- a/src/Kevlar.Extensions.Http/HttpShield.cs
+++ b/src/Kevlar.Extensions.Http/HttpShield.cs
@@ -220,7 +220,6 @@ public static class HttpShield
         RetryOptions<HttpResponseMessage> target,
         bool useRetryAfterHeader)
     {
-        var onRetry = source.OnRetry;
         target.MaxRetries = source.MaxRetries;
         target.Backoff = source.Backoff;
         target.MaxDelay = source.MaxDelay ?? StandardHttpShieldOptions.DefaultRetryMaxDelay;
@@ -229,11 +228,7 @@ public static class HttpShield
             useRetryAfterHeader);
         target.HandlesException = source.HandlesException;
         target.HandlesResult = source.HandlesResult;
-        target.OnRetry = retry =>
-        {
-            retry.Outcome.Result?.Dispose();
-            return onRetry?.Invoke(retry) ?? default;
-        };
+        target.OnRetry = source.OnRetry;
     }
 
     private static Func<RetryEvent<HttpResponseMessage>, ValueTask<TimeSpan?>>? ComposeRetryDelayGenerator(

--- a/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpShieldOptions.cs
@@ -13,7 +13,8 @@ public sealed class StandardHttpShieldOptions
 
     /// <summary>
     /// Configures transient retries. Defaults to three jittered exponential retries that honour
-    /// <c>Retry-After</c> headers. Superseded responses are always disposed before notifications run.
+    /// <c>Retry-After</c> headers. Notifications observe the live handled response, which is
+    /// disposed before the next attempt starts.
     /// </summary>
     public RetryOptions<HttpResponseMessage> Retry { get; set; } = new()
     {

--- a/src/Kevlar/CallbackErrorEvent.cs
+++ b/src/Kevlar/CallbackErrorEvent.cs
@@ -1,6 +1,6 @@
 namespace Kevlar;
 
-/// <summary>Describes an exception thrown by a strategy notification or observer.</summary>
+/// <summary>Describes an exception thrown by an isolated callback or cleanup operation.</summary>
 public readonly struct CallbackErrorEvent
 {
     internal CallbackErrorEvent(
@@ -15,7 +15,7 @@ public readonly struct CallbackErrorEvent
         Exception = exception;
     }
 
-    /// <summary>Gets the callback family that failed.</summary>
+    /// <summary>Gets the callback or cleanup family that failed.</summary>
     public CallbackErrorKind Kind { get; }
 
     /// <summary>Gets the shield name, or <see langword="null"/> for an unnamed shield.</summary>
@@ -24,6 +24,6 @@ public readonly struct CallbackErrorEvent
     /// <summary>Gets the zero-based strategy position in the shield.</summary>
     public int StrategyIndex { get; }
 
-    /// <summary>Gets the exception thrown by the callback.</summary>
+    /// <summary>Gets the isolated exception.</summary>
     public Exception Exception { get; }
 }

--- a/src/Kevlar/CallbackErrorKind.cs
+++ b/src/Kevlar/CallbackErrorKind.cs
@@ -1,6 +1,6 @@
 namespace Kevlar;
 
-/// <summary>Identifies a strategy notification whose failure was reported by Kevlar.</summary>
+/// <summary>Identifies an isolated callback or cleanup failure reported by Kevlar.</summary>
 public enum CallbackErrorKind
 {
     /// <summary>A retry notification.</summary>
@@ -35,4 +35,7 @@ public enum CallbackErrorKind
 
     /// <summary>A logging formatter or severity callback.</summary>
     Logging,
+
+    /// <summary>Disposal of a superseded result.</summary>
+    ResultDisposal,
 }

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -65,7 +65,7 @@ internal static class KevlarMetrics
     private static readonly Counter<long> CallbackErrors = Meter.CreateCounter<long>(
         "kevlar.callback_errors",
         "{error}",
-        "Exceptions thrown by strategy notifications or observers.");
+        "Exceptions thrown by isolated callbacks or cleanup operations.");
     private static readonly Histogram<double> ExecutionDuration = Meter.CreateHistogram<double>(
         "kevlar.execution.duration",
         "s",
@@ -760,6 +760,7 @@ internal static class KevlarMetrics
         CallbackErrorKind.RateLimiterAdapterRejected => "rate_limiter_adapter_rejected",
         CallbackErrorKind.ChaosInjected => "chaos_injected",
         CallbackErrorKind.Logging => "logging",
+        CallbackErrorKind.ResultDisposal => "result_disposal",
         _ => throw new ArgumentOutOfRangeException(nameof(kind)),
     };
 

--- a/src/Kevlar/Internal/OutcomeDisposer.cs
+++ b/src/Kevlar/Internal/OutcomeDisposer.cs
@@ -1,0 +1,104 @@
+namespace Kevlar.Internal;
+
+internal static class OutcomeDisposer
+{
+    public static bool IsSameResult<T>(in Outcome<T> candidate, in Outcome<T> selected)
+    {
+        if (!candidate.IsSuccess || !selected.IsSuccess)
+        {
+            return false;
+        }
+
+        if (!typeof(T).IsValueType)
+        {
+            return ReferenceEquals(candidate.Result, selected.Result);
+        }
+
+        try
+        {
+            return EqualityComparer<T>.Default.Equals(candidate.Result!, selected.Result!);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static ValueTask DisposeResultAsync<T>(in Outcome<T> outcome, KevlarContext context)
+    {
+        if (!outcome.IsSuccess || !DisposalTraits<T>.MayRequireDisposal)
+        {
+            return default;
+        }
+
+        if (outcome.Result is IAsyncDisposable asyncDisposable)
+        {
+            return DisposeAsync(asyncDisposable, context);
+        }
+
+        if (outcome.Result is IDisposable disposable)
+        {
+            try
+            {
+                disposable.Dispose();
+            }
+            catch (Exception exception)
+            {
+                KevlarDiagnostics.ReportCallbackError(
+                    CallbackErrorKind.ResultDisposal,
+                    context,
+                    exception);
+            }
+        }
+
+        return default;
+    }
+
+    private static ValueTask DisposeAsync(IAsyncDisposable disposable, KevlarContext context)
+    {
+        ValueTask disposal;
+        try
+        {
+            disposal = disposable.DisposeAsync();
+        }
+        catch (Exception exception)
+        {
+            KevlarDiagnostics.ReportCallbackError(
+                CallbackErrorKind.ResultDisposal,
+                context,
+                exception);
+            return default;
+        }
+
+        if (disposal.IsCompletedSuccessfully)
+        {
+            disposal.GetAwaiter().GetResult();
+            return default;
+        }
+
+        return AwaitDisposalAsync(disposal, context);
+    }
+
+    private static async ValueTask AwaitDisposalAsync(ValueTask disposal, KevlarContext context)
+    {
+        try
+        {
+            await disposal.ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            KevlarDiagnostics.ReportCallbackError(
+                CallbackErrorKind.ResultDisposal,
+                context,
+                exception);
+        }
+    }
+
+    private static class DisposalTraits<T>
+    {
+        public static readonly bool MayRequireDisposal =
+            !typeof(T).IsValueType
+            || typeof(IAsyncDisposable).IsAssignableFrom(typeof(T))
+            || typeof(IDisposable).IsAssignableFrom(typeof(T));
+    }
+}

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" />
   </ItemGroup>

--- a/src/Kevlar/KevlarDiagnostics.cs
+++ b/src/Kevlar/KevlarDiagnostics.cs
@@ -20,7 +20,8 @@ namespace Kevlar;
 /// <item><c>kevlar.fallbacks</c> — outcomes replaced by a fallback; attribute <c>kevlar.shield.name</c></item>
 /// <item><c>kevlar.rejections</c> — fail-fast rejections; attributes <c>kevlar.shield.name</c>, <c>kevlar.rejection.type</c> (<c>circuit_open</c>/<c>rate_limit</c>/<c>rate_limiter_adapter</c>/<c>concurrency_limit</c>)</item>
 /// <item><c>kevlar.circuit_breaker.transitions</c> — circuit state changes; attributes <c>kevlar.circuit_breaker.state.from</c>, <c>kevlar.circuit_breaker.state.to</c></item>
-/// <item><c>kevlar.callback_errors</c> — exceptions thrown by notifications or observers; attributes <c>kevlar.shield.name</c>, <c>kevlar.callback.kind</c></item>
+/// <item><c>kevlar.callback_errors</c> — exceptions thrown by callbacks or cleanup operations;
+/// attributes <c>kevlar.shield.name</c>, <c>kevlar.callback.kind</c></item>
 /// <item><c>kevlar.execution.duration</c> — execution duration histogram in seconds; attributes <c>kevlar.shield.name</c>, <c>kevlar.execution.outcome</c></item>
 /// <item><c>kevlar.strategy.events</c> — strategy and custom events; attributes include shield,
 /// strategy, event, severity, attempt, exception type, and an optional bounded operation key</item>
@@ -40,14 +41,15 @@ public static class KevlarDiagnostics
     public const string MeterName = "Kevlar";
 
     /// <summary>
-    /// Raised when a strategy notification or observer throws. Each subscriber is isolated:
-    /// subscriber failures are swallowed and do not prevent later subscribers from running.
+    /// Raised when a strategy notification, observer, or superseded-result disposal throws. Each
+    /// subscriber is isolated: subscriber failures are swallowed and do not prevent later
+    /// subscribers from running.
     /// </summary>
     public static event Action<CallbackErrorEvent>? OnCallbackError;
 
     /// <summary>
-    /// Reports a callback failure without allowing diagnostics subscribers to affect execution.
-    /// Custom strategies can use this method to follow Kevlar's callback-isolation contract.
+    /// Reports a callback or cleanup failure without allowing diagnostics subscribers to affect
+    /// execution. Custom strategies can use this method to follow Kevlar's isolation contract.
     /// </summary>
     public static void ReportCallbackError(
         CallbackErrorKind kind,

--- a/src/Kevlar/PublicAPI.Shipped.txt
+++ b/src/Kevlar/PublicAPI.Shipped.txt
@@ -252,6 +252,7 @@ Kevlar.CallbackErrorEvent.StrategyIndex.get -> int
 Kevlar.CallbackErrorKind
 Kevlar.CallbackErrorKind.ChaosInjected = 9 -> Kevlar.CallbackErrorKind
 Kevlar.CallbackErrorKind.Logging = 10 -> Kevlar.CallbackErrorKind
+Kevlar.CallbackErrorKind.ResultDisposal = 11 -> Kevlar.CallbackErrorKind
 Kevlar.CallbackErrorKind.CircuitMonitor = 3 -> Kevlar.CallbackErrorKind
 Kevlar.CallbackErrorKind.CircuitStateChanged = 2 -> Kevlar.CallbackErrorKind
 Kevlar.CallbackErrorKind.ConcurrencyLimitRejected = 6 -> Kevlar.CallbackErrorKind

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -161,6 +161,7 @@ internal sealed class HedgingStrategy : Strategy
         int strategyIndex)
     {
         var pending = ListPool<HedgeAttempt<T>>.Shared.Rent();
+        Outcome<T>? terminalOutcome = null;
 
         try
         {
@@ -242,7 +243,9 @@ internal sealed class HedgingStrategy : Strategy
                 bool shouldHandle;
                 try
                 {
-                    var judgingContext = completedAttempt.FreezeContext(in outcome);
+                    var judgingContext = await completedAttempt
+                        .FreezeContextAsync(in outcome)
+                        .ConfigureAwait(false);
                     shouldHandle = _judge.ShouldHandle(
                         in outcome,
                         judgingContext,
@@ -261,12 +264,30 @@ internal sealed class HedgingStrategy : Strategy
                 }
                 finally
                 {
-                    completedAttempt.Dispose();
+                    await completedAttempt.DisposeAsync().ConfigureAwait(false);
                 }
 
                 if (!shouldHandle)
                 {
+                    if (lastOutcome is { } superseded)
+                    {
+                        if (!OutcomeDisposer.IsSameResult(in superseded, in outcome))
+                        {
+                            await OutcomeDisposer.DisposeResultAsync(
+                                in superseded,
+                                context).ConfigureAwait(false);
+                        }
+
+                        lastOutcome = null;
+                    }
+
+                    terminalOutcome = outcome;
                     return outcome;
+                }
+
+                if (lastOutcome is { } previous)
+                {
+                    await OutcomeDisposer.DisposeResultAsync(in previous, context).ConfigureAwait(false);
                 }
 
                 lastOutcome = outcome;
@@ -283,7 +304,10 @@ internal sealed class HedgingStrategy : Strategy
                 }
                 else if (pending.Count == 0)
                 {
-                    return lastOutcome!.Value;
+                    var terminal = lastOutcome!.Value;
+                    lastOutcome = null;
+                    terminalOutcome = terminal;
+                    return terminal;
                 }
             }
         }
@@ -292,7 +316,12 @@ internal sealed class HedgingStrategy : Strategy
             foreach (var attempt in pending)
             {
                 attempt.Cancellation.Cancel();
-                Cleanup(attempt);
+                Cleanup(attempt, terminalOutcome);
+            }
+
+            if (lastOutcome is { } superseded)
+            {
+                await OutcomeDisposer.DisposeResultAsync(in superseded, context).ConfigureAwait(false);
             }
 
             ListPool<HedgeAttempt<T>>.Shared.Return(pending);
@@ -469,7 +498,12 @@ internal sealed class HedgingStrategy : Strategy
         }
         catch
         {
-            ReleaseAttemptResources(fork, cancellation, contextCapture);
+            var release = ReleaseAttemptResourcesAsync(fork, cancellation, contextCapture);
+            if (!release.IsCompletedSuccessfully)
+            {
+                _ = release.AsTask();
+            }
+
             throw;
         }
     }
@@ -559,36 +593,55 @@ internal sealed class HedgingStrategy : Strategy
         KevlarContext invocationContext,
         in Outcome<T> outcome)
     {
-        var retained = false;
-        try
+        if (contextCapture.Capture(invocationContext, in outcome))
         {
-            retained = contextCapture.Capture(invocationContext, in outcome);
+            contextCapture.ReleaseInvocation();
+            return;
         }
-        finally
+
+        var disposal = OutcomeDisposer.DisposeResultAsync(in outcome, invocationContext);
+        if (disposal.IsCompletedSuccessfully)
         {
             try
             {
-                if (!retained)
-                {
-                    KevlarContext.Return(invocationContext);
-                }
+                disposal.GetAwaiter().GetResult();
+                KevlarContext.Return(invocationContext);
             }
             finally
             {
                 contextCapture.ReleaseInvocation();
             }
+
+            return;
+        }
+
+        _ = DisposeAndReleaseInvocationAsync(disposal, invocationContext, contextCapture);
+    }
+
+    private static async Task DisposeAndReleaseInvocationAsync<T>(
+        ValueTask disposal,
+        KevlarContext invocationContext,
+        OriginalActionContextCapture<T> contextCapture)
+    {
+        try
+        {
+            await disposal.ConfigureAwait(false);
+            KevlarContext.Return(invocationContext);
+        }
+        finally
+        {
+            contextCapture.ReleaseInvocation();
         }
     }
 
-    private static void ReleaseAttemptResources<T>(
+    private static ValueTask ReleaseAttemptResourcesAsync<T>(
         KevlarContext context,
         CancellationTokenSource cancellation,
         OriginalActionContextCapture<T>? contextCapture)
     {
         if (contextCapture is not null)
         {
-            contextCapture.ReleaseAttempt();
-            return;
+            return contextCapture.ReleaseAttemptAsync();
         }
 
         try
@@ -599,6 +652,8 @@ internal sealed class HedgingStrategy : Strategy
         {
             cancellation.Dispose();
         }
+
+        return default;
     }
 
     private sealed class OriginalActionContextCapture<T>
@@ -683,36 +738,47 @@ internal sealed class HedgingStrategy : Strategy
             }
         }
 
-        public void ReleaseInvocation() => ReleaseReference(stopAcceptingInvocations: false);
+        public void ReleaseInvocation() => ReleaseReference();
 
-        public KevlarContext Freeze(in Outcome<T> selectedOutcome)
+        public ValueTask<KevlarContext> FreezeAsync(in Outcome<T> selectedOutcome)
         {
             List<CapturedOriginalAction>? completions = null;
-            try
+            CapturedOriginalAction? selected = null;
+            lock (_sync)
             {
-                lock (_sync)
+                _frozen = true;
+                completions = _completions;
+                _completions = null;
+                if (completions is null)
                 {
-                    _frozen = true;
-                    completions = _completions;
-                    _completions = null;
-                    if (completions is null)
-                    {
-                        return _context!;
-                    }
-
-                    var selectedIndex = FindSelectedIndex(completions, in selectedOutcome);
-
-                    var selected = completions[selectedIndex];
-                    completions.RemoveAt(selectedIndex);
-                    _selectedContext = selected.Context;
-                    MergeContext(selected.Context, _context!);
-                    return selected.Context;
+                    return new ValueTask<KevlarContext>(_context!);
                 }
+
+                var selectedIndex = FindSelectedIndex(completions, in selectedOutcome);
+                selected = completions[selectedIndex];
+                completions.RemoveAt(selectedIndex);
+                _selectedContext = selected.Value.Context;
+                MergeContext(selected.Value.Context, _context!);
             }
-            finally
+
+            return CompleteFreezeAsync(selected.Value, selectedOutcome, completions);
+        }
+
+        private static async ValueTask<KevlarContext> CompleteFreezeAsync(
+            CapturedOriginalAction selected,
+            Outcome<T> selectedOutcome,
+            List<CapturedOriginalAction> completions)
+        {
+            var selectedOriginalOutcome = selected.Outcome;
+            if (!OutcomeDisposer.IsSameResult(in selectedOriginalOutcome, in selectedOutcome))
             {
-                ReturnContexts(completions);
+                await OutcomeDisposer.DisposeResultAsync(
+                    in selectedOriginalOutcome,
+                    selected.Context).ConfigureAwait(false);
             }
+
+            await DisposeAndReturnContextsAsync(completions).ConfigureAwait(false);
+            return selected.Context;
         }
 
         private static int FindSelectedIndex(
@@ -743,25 +809,20 @@ internal sealed class HedgingStrategy : Strategy
             return completions.Count - 1;
         }
 
-        public void ReleaseAttempt() => ReleaseReference(stopAcceptingInvocations: true);
-
-        private void ReleaseReference(bool stopAcceptingInvocations)
+        public ValueTask ReleaseAttemptAsync()
         {
             KevlarContext? context = null;
-            KevlarContext? selectedContext = null;
+            KevlarContext? selectedContext;
             CancellationTokenSource? cancellation = null;
-            List<CapturedOriginalAction>? completions = null;
+            List<CapturedOriginalAction>? completions;
             lock (_sync)
             {
-                if (stopAcceptingInvocations)
-                {
-                    _acceptingInvocations = false;
-                    _frozen = true;
-                    completions = _completions;
-                    _completions = null;
-                    selectedContext = _selectedContext;
-                    _selectedContext = null;
-                }
+                _acceptingInvocations = false;
+                _frozen = true;
+                completions = _completions;
+                _completions = null;
+                selectedContext = _selectedContext;
+                _selectedContext = null;
 
                 _references--;
                 if (_references == 0)
@@ -773,10 +834,49 @@ internal sealed class HedgingStrategy : Strategy
                 }
             }
 
-            ReturnContexts(completions);
+            return ReleaseAttemptCoreAsync(
+                completions,
+                selectedContext,
+                context,
+                cancellation);
+        }
+
+        private async ValueTask ReleaseAttemptCoreAsync(
+            List<CapturedOriginalAction>? completions,
+            KevlarContext? selectedContext,
+            KevlarContext? context,
+            CancellationTokenSource? cancellation)
+        {
+            if (completions is not null)
+            {
+                await DisposeAndReturnContextsAsync(completions).ConfigureAwait(false);
+            }
+
             if (selectedContext is not null)
             {
                 KevlarContext.Return(selectedContext);
+            }
+
+            if (context is not null)
+            {
+                ReturnCapture(context, cancellation!);
+            }
+        }
+
+        private void ReleaseReference()
+        {
+            KevlarContext? context = null;
+            CancellationTokenSource? cancellation = null;
+            lock (_sync)
+            {
+                _references--;
+                if (_references == 0)
+                {
+                    context = _context;
+                    cancellation = _cancellation;
+                    _context = null;
+                    _cancellation = null;
+                }
             }
 
             if (context is null)
@@ -784,13 +884,20 @@ internal sealed class HedgingStrategy : Strategy
                 return;
             }
 
+            ReturnCapture(context, cancellation!);
+        }
+
+        private void ReturnCapture(
+            KevlarContext context,
+            CancellationTokenSource cancellation)
+        {
             try
             {
                 KevlarContext.Return(context);
             }
             finally
             {
-                cancellation!.Dispose();
+                cancellation.Dispose();
                 Pool.Return(this);
             }
         }
@@ -830,16 +937,22 @@ internal sealed class HedgingStrategy : Strategy
             source.CopyCompletionPropertiesTo(target);
         }
 
-        private static void ReturnContexts(List<CapturedOriginalAction>? completions)
+        private static async ValueTask DisposeAndReturnContextsAsync(
+            List<CapturedOriginalAction> completions)
         {
-            if (completions is null)
-            {
-                return;
-            }
-
             foreach (var completion in completions)
             {
-                KevlarContext.Return(completion.Context);
+                try
+                {
+                    var outcome = completion.Outcome;
+                    await OutcomeDisposer.DisposeResultAsync(
+                        in outcome,
+                        completion.Context).ConfigureAwait(false);
+                }
+                finally
+                {
+                    KevlarContext.Return(completion.Context);
+                }
             }
         }
 
@@ -949,20 +1062,70 @@ internal sealed class HedgingStrategy : Strategy
         throw new InvalidOperationException("The completed hedge attempt was not pending.");
     }
 
-    private static void Cleanup<T>(HedgeAttempt<T> attempt)
+    private static void Cleanup<T>(HedgeAttempt<T> attempt, Outcome<T>? terminalOutcome)
     {
-        if (attempt.Task.IsCompleted)
+        if (attempt.Task.Status != TaskStatus.RanToCompletion)
         {
-            attempt.Dispose();
+            _ = CleanupAsync(attempt, terminalOutcome);
             return;
         }
 
-        _ = attempt.Task.ContinueWith(
-            static (_, state) => ((HedgeAttempt<T>)state!).Dispose(),
-            attempt,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        var outcome = attempt.Task.Result;
+        var disposal = terminalOutcome is { } terminal
+            && OutcomeDisposer.IsSameResult(in outcome, in terminal)
+                ? default
+                : OutcomeDisposer.DisposeResultAsync(in outcome, attempt.Context);
+        if (disposal.IsCompletedSuccessfully)
+        {
+            disposal.GetAwaiter().GetResult();
+            var release = attempt.DisposeAsync();
+            if (!release.IsCompletedSuccessfully)
+            {
+                _ = release.AsTask();
+            }
+            return;
+        }
+
+        _ = FinishCleanupAsync(disposal, attempt);
+    }
+
+    private static async Task CleanupAsync<T>(
+        HedgeAttempt<T> attempt,
+        Outcome<T>? terminalOutcome)
+    {
+        try
+        {
+            var outcome = await attempt.Task.ConfigureAwait(false);
+            if (terminalOutcome is not { } terminal
+                || !OutcomeDisposer.IsSameResult(in outcome, in terminal))
+            {
+                await OutcomeDisposer.DisposeResultAsync(
+                    in outcome,
+                    attempt.Context).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // Attempt failures are already represented by the selected pipeline outcome.
+        }
+        finally
+        {
+            await attempt.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async Task FinishCleanupAsync<T>(
+        ValueTask disposal,
+        HedgeAttempt<T> attempt)
+    {
+        try
+        {
+            await disposal.ConfigureAwait(false);
+        }
+        finally
+        {
+            await attempt.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     private static Outcome<T> NormalizeCancellation<T>(Outcome<T> outcome, KevlarContext context)
@@ -1006,10 +1169,11 @@ internal sealed class HedgingStrategy : Strategy
 
         private OriginalActionContextCapture<T>? ContextCapture { get; }
 
-        public KevlarContext FreezeContext(in Outcome<T> outcome) =>
-            ContextCapture?.Freeze(in outcome) ?? Context;
+        public ValueTask<KevlarContext> FreezeContextAsync(in Outcome<T> outcome) =>
+            ContextCapture?.FreezeAsync(in outcome) ?? new ValueTask<KevlarContext>(Context);
 
-        public void Dispose() => ReleaseAttemptResources(Context, Cancellation, ContextCapture);
+        public ValueTask DisposeAsync() =>
+            ReleaseAttemptResourcesAsync(Context, Cancellation, ContextCapture);
     }
 
     private static void CopyAttemptProperties(KevlarContext source, KevlarContext target) =>
@@ -1043,6 +1207,17 @@ internal sealed class HedgingStrategy : Strategy
 
         public HedgeAttempt<T> AsPending() => new(Execution.AsTask(), Cancellation, Context, Attempt, ContextCapture);
 
-        public void Dispose() => ReleaseAttemptResources(Context, Cancellation, ContextCapture);
+        public void Dispose()
+        {
+            var release = ReleaseAttemptResourcesAsync(Context, Cancellation, ContextCapture);
+            if (release.IsCompletedSuccessfully)
+            {
+                release.GetAwaiter().GetResult();
+            }
+            else
+            {
+                _ = release.AsTask();
+            }
+        }
     }
 }

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -246,6 +246,8 @@ internal sealed class RetryStrategy : Strategy
                         context).ConfigureAwait(false);
                 }
 
+                await OutcomeDisposer.DisposeResultAsync(in outcome, context).ConfigureAwait(false);
+
                 if (delay > TimeSpan.Zero || context.CancellationToken.IsCancellationRequested)
                 {
                     try

--- a/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
@@ -35,11 +35,6 @@ public class HttpResilienceTests
             {
                 options.MaxRetries = 3;
                 options.Backoff = Backoff.None;
-                options.OnRetry = retry =>
-                {
-                    retry.Outcome.Result?.Dispose();
-                    return default;
-                };
             })
             .Timeout(TimeSpan.FromSeconds(5));
 
@@ -136,11 +131,6 @@ public class HttpResilienceTests
             options.MaxRetries = 2;
             options.Backoff = Backoff.None;
             options.DelayGenerator = HttpShield.RetryAfter;
-            options.OnRetry = retry =>
-            {
-                retry.Outcome.Result?.Dispose();
-                return default;
-            };
         });
 
         var stopwatch = Stopwatch.StartNew();
@@ -197,11 +187,6 @@ public class HttpResilienceTests
             {
                 options.MaxRetries = 2;
                 options.Backoff = Backoff.None;
-                options.OnRetry = retry =>
-                {
-                    retry.Outcome.Result?.Dispose();
-                    return default;
-                };
             }));
 
         var factory = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>();

--- a/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
+++ b/tests/Kevlar.NetStandard.Tests/Kevlar.NetStandard.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" VersionOverride="$(TestBclTimeProviderVersion)" />
     <PackageReference Include="Microsoft.Bcl.TimeProvider" VersionOverride="$(TestBclTimeProviderVersion)" />
     <PackageReference Include="TUnit" Condition="'$(TargetFramework)' != 'net48'" />
   </ItemGroup>

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -386,6 +386,45 @@ public class HttpContractTests
     }
 
     [Test]
+    public async Task Standard_OnRetry_Observes_Live_Response_Before_Core_Disposal()
+    {
+        var handledContent = new TrackingContent();
+        var callbackSawLiveResponse = false;
+        var calls = 0;
+        var options = new StandardHttpShieldOptions
+        {
+            UseRetryAfterHeader = false,
+        };
+        options.Retry.MaxRetries = 1;
+        options.Retry.Backoff = Backoff.None;
+        options.Retry.OnRetry = retry =>
+        {
+            callbackSawLiveResponse = retry.Outcome.Result?.Content == handledContent
+                && !handledContent.IsDisposed;
+            return default;
+        };
+
+        using var result = await HttpShield.Standard(options).ExecuteAsync(_ =>
+        {
+            var attempt = Interlocked.Increment(ref calls);
+            var response = new HttpResponseMessage(
+                attempt == 1
+                    ? HttpStatusCode.ServiceUnavailable
+                    : HttpStatusCode.OK);
+            if (attempt == 1)
+            {
+                response.Content = handledContent;
+            }
+
+            return new ValueTask<HttpResponseMessage>(response);
+        });
+
+        await Assert.That(result.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(callbackSawLiveResponse).IsTrue();
+        await Assert.That(handledContent.IsDisposed).IsTrue();
+    }
+
+    [Test]
     public async Task Replacing_Retry_Options_Keeps_RetryAfter()
     {
         var options = new StandardHttpShieldOptions

--- a/tests/Kevlar.Tests/ResultDisposalTests.cs
+++ b/tests/Kevlar.Tests/ResultDisposalTests.cs
@@ -1,0 +1,327 @@
+namespace Kevlar.Tests;
+
+public class ResultDisposalTests
+{
+    [Test]
+    public async Task Retry_Disposes_Handled_Result_After_Callback_Before_Next_Attempt()
+    {
+        var handled = new DisposableResult(isHandled: true);
+        var final = new DisposableResult(isHandled: false);
+        var callbackSawLiveResult = false;
+        var nextAttemptSawDisposedResult = false;
+        var attempts = 0;
+        var shield = Shield.For<DisposableResult>()
+            .WhenResult(static result => result.IsHandled)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = retry =>
+                {
+                    callbackSawLiveResult = retry.Outcome.Result?.DisposeCount == 0;
+                    return default;
+                };
+            });
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            if (Interlocked.Increment(ref attempts) == 2)
+            {
+                nextAttemptSawDisposedResult = handled.DisposeCount == 1;
+                return new ValueTask<DisposableResult>(final);
+            }
+
+            return new ValueTask<DisposableResult>(handled);
+        });
+
+        await Assert.That(ReferenceEquals(result, final)).IsTrue();
+        await Assert.That(callbackSawLiveResult).IsTrue();
+        await Assert.That(nextAttemptSawDisposedResult).IsTrue();
+        await Assert.That(handled.DisposeCount).IsEqualTo(1);
+        await Assert.That(final.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Retry_Prefers_Async_Disposal()
+    {
+        var handled = new AsyncDisposableResult(isHandled: true);
+        var final = new AsyncDisposableResult(isHandled: false);
+        var attempts = 0;
+        var shield = Shield.For<AsyncDisposableResult>()
+            .WhenResult(static result => result.IsHandled)
+            .Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<AsyncDisposableResult>(
+            Interlocked.Increment(ref attempts) == 1 ? handled : final));
+
+        await Assert.That(ReferenceEquals(result, final)).IsTrue();
+        await Assert.That(handled.AsyncDisposeCount).IsEqualTo(1);
+        await Assert.That(handled.DisposeCount).IsEqualTo(0);
+        await Assert.That(final.AsyncDisposeCount).IsEqualTo(0);
+        await Assert.That(final.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Retry_Awaits_Async_Disposal_Before_The_Next_Attempt()
+    {
+        var handled = new BlockingAsyncDisposableResult(isHandled: true);
+        var final = new BlockingAsyncDisposableResult(isHandled: false);
+        var attempts = 0;
+        var shield = Shield.For<BlockingAsyncDisposableResult>()
+            .WhenResult(static result => result.IsHandled)
+            .Retry(1, Backoff.None);
+
+        var execution = shield.ExecuteAsync(_ => new ValueTask<BlockingAsyncDisposableResult>(
+            Interlocked.Increment(ref attempts) == 1 ? handled : final)).AsTask();
+
+        await handled.DisposalStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(attempts).IsEqualTo(1);
+        handled.AllowDisposal();
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(ReferenceEquals(result, final)).IsTrue();
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(handled.AsyncDisposeCount).IsEqualTo(1);
+        await Assert.That(handled.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Untyped_Hedge_Disposes_Cancelled_Loser_And_Preserves_Winner()
+    {
+        var loser = new DisposableResult(isHandled: false);
+        var winner = new DisposableResult(isHandled: false);
+        var primaryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        var shield = Shield.Hedge(1, TimeSpan.Zero);
+
+        var result = await shield.ExecuteAsync(async token =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                primaryStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return loser;
+                }
+            }
+
+            await primaryStarted.Task;
+            return winner;
+        });
+
+        await loser.Disposed.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(ReferenceEquals(result, winner)).IsTrue();
+        await Assert.That(loser.DisposeCount).IsEqualTo(1);
+        await Assert.That(winner.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Hedge_Disposes_Handled_Result_When_Superseded()
+    {
+        var handled = new DisposableResult(isHandled: true);
+        var winner = new DisposableResult(isHandled: false);
+        var releases = new[]
+        {
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+        };
+        var allStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        var shield = Shield.For<DisposableResult>()
+            .WhenResult(static result => result.IsHandled)
+            .Hedge(1, TimeSpan.Zero);
+
+        var execution = shield.ExecuteAsync(async _ =>
+        {
+            var attempt = Interlocked.Increment(ref attempts) - 1;
+            if (attempt == 1)
+            {
+                allStarted.TrySetResult();
+            }
+
+            await releases[attempt].Task;
+            return attempt == 0 ? handled : winner;
+        }).AsTask();
+
+        await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releases[0].SetResult();
+        await Task.Yield();
+        releases[1].SetResult();
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(ReferenceEquals(result, winner)).IsTrue();
+        await Assert.That(handled.DisposeCount).IsEqualTo(1);
+        await Assert.That(winner.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Hedge_Does_Not_Dispose_A_Loser_Sharing_The_Winner_Instance()
+    {
+        var shared = new DisposableResult(isHandled: false);
+        var shield = Shield.Hedge(1, TimeSpan.Zero);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<DisposableResult>(shared));
+
+        await Assert.That(ReferenceEquals(result, shared)).IsTrue();
+        await Assert.That(shared.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Hedge_ActionGenerator_Disposes_All_NonSelected_Original_Results()
+    {
+        var primaryLoser = new DisposableResult(isHandled: false);
+        var firstOriginal = new DisposableResult(isHandled: false);
+        var secondOriginal = new DisposableResult(isHandled: false);
+        var generatedWinner = new DisposableResult(isHandled: false);
+        var attempts = 0;
+        var shield = Shield.For<DisposableResult>().Hedge(options =>
+        {
+            options.MaxHedgedAttempts = 1;
+            options.Delay = TimeSpan.Zero;
+            options.ActionGenerator = hedge => async token =>
+            {
+                _ = await hedge.OriginalAction(token);
+                _ = await hedge.OriginalAction(token);
+                return generatedWinner;
+            };
+        });
+
+        var result = await shield.ExecuteAsync(async token =>
+        {
+            switch (Interlocked.Increment(ref attempts))
+            {
+                case 1:
+                    try
+                    {
+                        await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return primaryLoser;
+                    }
+
+                    break;
+                case 2:
+                    return firstOriginal;
+                case 3:
+                    return secondOriginal;
+            }
+
+            throw new InvalidOperationException("Unexpected attempt.");
+        });
+
+        await primaryLoser.Disposed.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(ReferenceEquals(result, generatedWinner)).IsTrue();
+        await Assert.That(firstOriginal.DisposeCount).IsEqualTo(1);
+        await Assert.That(secondOriginal.DisposeCount).IsEqualTo(1);
+        await Assert.That(primaryLoser.DisposeCount).IsEqualTo(1);
+        await Assert.That(generatedWinner.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Disposal_Failure_Is_Reported_Without_Changing_The_Outcome()
+    {
+        var failure = new IOException("dispose");
+        var handled = new AsyncDisposableResult(isHandled: true, failure);
+        var final = new AsyncDisposableResult(isHandled: false);
+        CallbackErrorEvent? reported = null;
+        Action<CallbackErrorEvent> handler = item => reported = item;
+        KevlarDiagnostics.OnCallbackError += handler;
+
+        try
+        {
+            var attempts = 0;
+            var shield = Shield.For<AsyncDisposableResult>()
+                .WhenResult(static result => result.IsHandled)
+                .Retry(1, Backoff.None);
+
+            var result = await shield.ExecuteAsync(_ => new ValueTask<AsyncDisposableResult>(
+                Interlocked.Increment(ref attempts) == 1 ? handled : final));
+
+            await Assert.That(ReferenceEquals(result, final)).IsTrue();
+            await Assert.That(reported?.Kind).IsEqualTo(CallbackErrorKind.ResultDisposal);
+            await Assert.That(ReferenceEquals(reported?.Exception, failure)).IsTrue();
+        }
+        finally
+        {
+            KevlarDiagnostics.OnCallbackError -= handler;
+        }
+    }
+
+    private sealed class DisposableResult(bool isHandled) : IDisposable
+    {
+        private readonly TaskCompletionSource _disposed = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _disposeCount;
+
+        public bool IsHandled { get; } = isHandled;
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public Task Disposed => _disposed.Task;
+
+        public void Dispose()
+        {
+            if (Interlocked.Increment(ref _disposeCount) == 1)
+            {
+                _disposed.TrySetResult();
+            }
+        }
+    }
+
+    private sealed class AsyncDisposableResult(bool isHandled, Exception? failure = null)
+        : IDisposable, IAsyncDisposable
+    {
+        private int _asyncDisposeCount;
+        private int _disposeCount;
+
+        public bool IsHandled { get; } = isHandled;
+
+        public int AsyncDisposeCount => Volatile.Read(ref _asyncDisposeCount);
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public void Dispose() => Interlocked.Increment(ref _disposeCount);
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _asyncDisposeCount);
+            return failure is null ? default : ValueTask.FromException(failure);
+        }
+    }
+
+    private sealed class BlockingAsyncDisposableResult(bool isHandled)
+        : IDisposable, IAsyncDisposable
+    {
+        private readonly TaskCompletionSource _allowDisposal = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _disposalStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _asyncDisposeCount;
+        private int _disposeCount;
+
+        public bool IsHandled { get; } = isHandled;
+
+        public int AsyncDisposeCount => Volatile.Read(ref _asyncDisposeCount);
+
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+        public Task DisposalStarted => _disposalStarted.Task;
+
+        public void AllowDisposal() => _allowDisposal.TrySetResult();
+
+        public void Dispose() => Interlocked.Increment(ref _disposeCount);
+
+        public async ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _asyncDisposeCount);
+            _disposalStarted.TrySetResult();
+            await _allowDisposal.Task;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- dispose superseded retry and hedge results, preferring `IAsyncDisposable` and preserving the selected terminal result
- keep hedge action-generator contexts alive through async cleanup and avoid disposing shared winner instances
- report isolated cleanup failures as `CallbackErrorKind.ResultDisposal`; remove obsolete HTTP retry disposal compensation
- document ownership and add typed, untyped, async, failure, action-generator, shared-instance, HTTP, and allocation coverage

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m`
- logging tests on net8.0 and net10.0
- allocation tests on net8.0 and net10.0
- API docs, docs site, changelog, doc snippets, and packed public API verification

Closes #336