### PR TITLE
fix(packaging): pin coupled Kevlar packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,9 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
 
 ### Fixed
 
+- Coupled satellite packages exact-pin their `Kevlar` dependencies. Partial upgrades of
+  dependency injection, logging, and gRPC packages fail restore with `NU1608` instead of risking
+  runtime failures from incompatible internals.
 - Circuit-breaker monitors and testing snapshots report `HalfOpen` as soon as break duration
   elapses. Stale outcomes cannot alter newer state generations, and exceptions that opened a
   circuit are released when it closes or resets.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
           Condition="'$(PinKevlarDependencyVersion)' == 'true'">
     <ItemGroup>
       <_ProjectReferencesWithVersions Update="@(_ProjectReferencesWithVersions)"
-                                      Condition="'%(Filename)' == 'Kevlar'">
+                                      Condition="$([System.String]::Copy('%(Filename)').StartsWith('Kevlar'))">
         <ProjectVersion>[%(_ProjectReferencesWithVersions.ProjectVersion)]</ProjectVersion>
       </_ProjectReferencesWithVersions>
     </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Kevlar, you build an immutable `Shield`, reuse it, and use it with ordinary sync
 dotnet add package Kevlar
 ```
 
+Install all coupled `Kevlar.*` packages at the same version. Their exact NuGet dependencies reject
+partial upgrades early; see the [package lockstep policy](https://thomhurst.github.io/Kevlar/docs/support-policy#kevlar-package-lockstep).
+
 ```csharp
 using Kevlar;
 

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -31,3 +31,16 @@ application. Test-only and build-only dependencies are not part of this package 
 Package verification rejects accidental dependency floors above major version 8, except for the
 documented gRPC and Reservoir version lines. Raising a floor is a compatibility decision and must
 be called out in release notes.
+
+## Kevlar package lockstep
+
+Packages that consume Kevlar internals must use the same version as `Kevlar`. NuGet exact-version
+dependencies enforce this for `Kevlar.Testing`, `Kevlar.Extensions.Http`,
+`Kevlar.Extensions.RateLimiting`, `Kevlar.Extensions.DependencyInjection`, and
+`Kevlar.Extensions.Logging`. `Kevlar.Extensions.Grpc` is also coupled through dependency injection,
+so it exact-pins both `Kevlar` and `Kevlar.Extensions.DependencyInjection`.
+
+Upgrade these packages together. If package versions are managed centrally, assign one version to
+the coupled package set. A partial upgrade fails restore with `NU1608` instead of allowing a mixed
+version deployment that could fail at runtime. `Kevlar.Chaos` uses only public APIs and is not part
+of this lockstep set.

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -338,6 +338,17 @@ $expectedDependencies = @{
 $expectedPackageIds = @(& (Join-Path $PSScriptRoot 'Get-PackablePackageIds.ps1') -RepositoryRoot $repositoryRoot)
 Assert-Set 'package dependency table IDs' @($expectedDependencies.Keys) $expectedPackageIds
 
+[xml]$kevlarProject = Get-Content -LiteralPath (Join-Path $repositoryRoot 'src/Kevlar/Kevlar.csproj') -Raw
+$internalsVisibleToPackages = @($kevlarProject.SelectNodes(
+        "/Project/ItemGroup/InternalsVisibleTo") |
+    ForEach-Object { $_.GetAttribute('Include') } |
+    Where-Object { $expectedPackageIds -contains $_ })
+$exactPinnedPackageIds = @(
+    $internalsVisibleToPackages
+    # gRPC ships against DI, which is coupled to Kevlar internals and must move in lockstep.
+    'Kevlar.Extensions.Grpc'
+) | Sort-Object -Unique
+
 $expectedDependencyVersions = @{}
 foreach ($dependencyId in @(
     'Microsoft.Bcl.TimeProvider',
@@ -467,8 +478,8 @@ foreach ($packageId in $expectedDependencies.Keys)
                         ($dependency.GetAttribute('include') -split ',') `
                         @('Runtime', 'Compile', 'Native', 'ContentFiles', 'Analyzers', 'BuildTransitive')
                 }
-                if ($dependencyId -eq 'Kevlar' -and
-                    $packageId -in @('Kevlar.Testing', 'Kevlar.Extensions.RateLimiting'))
+                if ($dependencyId -like 'Kevlar*' -and
+                    $packageId -in $exactPinnedPackageIds)
                 {
                     Assert-Equal `
                         "$packageId $framework Kevlar dependency version" `
@@ -709,8 +720,10 @@ try
     $skewNugetConfig = $nugetConfig.Replace($escapedPackageDirectory, $escapedSkewFeed)
     $skewNugetConfigPath = Join-Path $temporaryRoot 'NuGet.Skew.Config'
     Write-TextFile $skewNugetConfigPath $skewNugetConfig
-    $skewConsumerDirectory = Join-Path $temporaryRoot 'version-skew'
-    $skewConsumerProject = @"
+    foreach ($satellitePackageId in $exactPinnedPackageIds)
+    {
+        $skewConsumerDirectory = Join-Path $temporaryRoot "version-skew-$satellitePackageId"
+        $skewConsumerProject = @"
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -718,26 +731,27 @@ try
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Kevlar" Version="$skewVersion" />
-    <PackageReference Include="Kevlar.Testing" Version="$Version" />
+    <PackageReference Include="$satellitePackageId" Version="$Version" />
   </ItemGroup>
 </Project>
 "@
-    $skewConsumerProjectPath = Join-Path $skewConsumerDirectory 'VersionSkew.csproj'
-    Write-TextFile $skewConsumerProjectPath $skewConsumerProject
-    $skewRestoreOutput = (& dotnet restore `
-        $skewConsumerProjectPath `
-        --configfile $skewNugetConfigPath `
-        --no-cache `
-        --force-evaluate 2>&1 | Out-String)
-    if ($LASTEXITCODE -eq 0)
-    {
-        throw "NuGet accepted Kevlar.Testing $Version with incompatible Kevlar $skewVersion.`n$skewRestoreOutput"
-    }
+        $skewConsumerProjectPath = Join-Path $skewConsumerDirectory 'VersionSkew.csproj'
+        Write-TextFile $skewConsumerProjectPath $skewConsumerProject
+        $skewRestoreOutput = (& dotnet restore `
+            $skewConsumerProjectPath `
+            --configfile $skewNugetConfigPath `
+            --no-cache `
+            --force-evaluate 2>&1 | Out-String)
+        if ($LASTEXITCODE -eq 0)
+        {
+            throw "NuGet accepted $satellitePackageId $Version with incompatible Kevlar $skewVersion.`n$skewRestoreOutput"
+        }
 
-    if ($skewRestoreOutput -notmatch '\bNU1608\b' -or
-        $skewRestoreOutput -notmatch [regex]::Escape("Kevlar.Testing $Version"))
-    {
-        throw "Version-skew restore did not report the expected exact-dependency conflict.`n$skewRestoreOutput"
+        if ($skewRestoreOutput -notmatch '\bNU1608\b' -or
+            $skewRestoreOutput -notmatch [regex]::Escape("$satellitePackageId $Version"))
+        {
+            throw "$satellitePackageId version-skew restore did not report the expected exact-dependency conflict.`n$skewRestoreOutput"
+        }
     }
 
     $runtimeProgram = @'

--- a/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
+++ b/src/Kevlar.Extensions.DependencyInjection/Kevlar.Extensions.DependencyInjection.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <Description>Microsoft.Extensions.DependencyInjection integration for Kevlar: named shield registration and the IKevlarRegistry.</Description>
     <PackageTags>resilience;dependency-injection;kevlar</PackageTags>
+    <PinKevlarDependencyVersion>true</PinKevlarDependencyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
+++ b/src/Kevlar.Extensions.Grpc/Kevlar.Extensions.Grpc.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <Description>gRPC client integration for Kevlar: unary and streaming interceptors, transient status helpers, cancellation safety, and named-shield DI registration.</Description>
     <PackageTags>resilience;grpc;client;interceptor;kevlar</PackageTags>
+    <PinKevlarDependencyVersion>true</PinKevlarDependencyVersion>
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)' == 'net10.0'">true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Kevlar.Extensions.Logging/Kevlar.Extensions.Logging.csproj
+++ b/src/Kevlar.Extensions.Logging/Kevlar.Extensions.Logging.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <Description>Microsoft.Extensions.Logging integration for Kevlar strategy events.</Description>
     <PackageTags>resilience;logging;kevlar</PackageTags>
+    <PinKevlarDependencyVersion>true</PinKevlarDependencyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- exact-pin every shipped package coupled to Kevlar internals
- derive package verification from the core `InternalsVisibleTo` declarations
- reject every coupled mixed-version restore and document lockstep upgrades

## Validation
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/packages/issue-334-green -Version 0.0.0-local`
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-Changelog.ps1`
- `npm ci` (from `docs/`)
- `npm run build` (from `docs/`)

Closes #334