### PR TITLE
fix(http): snapshot handler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Pipelines stay immutable, allocation-conscious, observable, and explicit about e
 
 ### Changed
 
+- HTTP handler replay and routing options are snapshotted when a pipeline is registered or created.
+  Later mutations no longer alter live handlers; configuration reload remains the explicit update
+  path and publishes a fresh complete snapshot.
 - `TimeoutExceededException` now derives directly from `KevlarException`. It no longer counts as
   an `ExecutionRejectedException`: fail-fast rejections mean the delegate did not run, while a
   timeout means it ran and exceeded its budget.

--- a/docs/api/Kevlar.Extensions.Http.HttpEndpointRoutingOptions.yml
+++ b/docs/api/Kevlar.Extensions.Http.HttpEndpointRoutingOptions.yml
@@ -21,6 +21,7 @@ items:
   - Kevlar.Extensions.Http
   namespace: Kevlar.Extensions.Http
   summary: Configures alternate authorities for retry and hedge attempts.
+  remarks: The endpoint list and scalar values are snapshotted with the handler options.
   example: []
   syntax:
     content: public sealed class HttpEndpointRoutingOptions

--- a/docs/api/Kevlar.Extensions.Http.ShieldHttpHandlerOptions.yml
+++ b/docs/api/Kevlar.Extensions.Http.ShieldHttpHandlerOptions.yml
@@ -22,6 +22,10 @@ items:
   - Kevlar.Extensions.Http
   namespace: Kevlar.Extensions.Http
   summary: Configures safe request replay and optional endpoint routing.
+  remarks: >-
+    Values are snapshotted when the handler pipeline is registered or created. Later mutations do
+
+    not reconfigure that pipeline; use a configuration-backed reloading registration for updates.
   example: []
   syntax:
     content: public sealed class ShieldHttpHandlerOptions

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -413,6 +413,12 @@ is cached by authority, so circuit-breaker and limiter state stays isolated per 
 endpoint-local shield single-attempt (breaker, limiter, timeout); put retry or hedging in the outer
 shield so every additional send goes through safe replay and routing.
 
+Handler options are setup objects. `ShieldDelegatingHandler` snapshots their scalar values,
+delegates, routing values, and endpoint list when the handler pipeline is created; the direct
+`AddShield(shield, options)` overload snapshots at registration. Mutating those source objects later
+does not reconfigure existing handlers. Use a configuration-backed standard registration when
+runtime changes are required; each valid reload publishes a fresh complete pipeline snapshot.
+
 ## Behaviour notes
 
 - **Superseded responses are handler-owned.** The handler disposes failed retry responses and losing hedge responses, including a loser that completes after the winner. A custom `OnRetry` response-disposal hook is unnecessary with `ShieldDelegatingHandler`; the hook that `HttpShield.Standard()` installs stays safe because `HttpResponseMessage.Dispose` is idempotent. The selected response remains caller-owned.

--- a/docs/docs/thread-safety.md
+++ b/docs/docs/thread-safety.md
@@ -24,10 +24,12 @@ Options and configuration definitions are mutable setup objects. Do not mutate o
 instance concurrently. Fluent factories read and validate them while building a strategy; later
 changes do not reconfigure an already-built shield.
 
-HTTP handler options are the exception: `ShieldDelegatingHandler(shield, options)` and the
-`IHttpClientBuilder.AddShield(...)` options overloads retain the exact `ShieldHttpHandlerOptions`
-instance supplied directly or by the options factory. Treat it as immutable after handoff;
-mutating it can change live replay or routing behavior, and racing mutations are unsafe.
+HTTP handler options follow the same snapshot rule. `ShieldDelegatingHandler(shield, options)`
+copies replay settings, routing settings, delegates, and the endpoint list when it is created. The
+direct `IHttpClientBuilder.AddShield(shield, options)` overload snapshots at registration; an
+options factory is read once for each handler pipeline it creates. Later mutations do not affect an
+existing pipeline. Configuration-backed standard registrations publish a fresh complete snapshot
+after a valid reload.
 
 The following public mutable types follow that rule:
 

--- a/src/Kevlar.Extensions.Http/HttpEndpointRoutingOptions.cs
+++ b/src/Kevlar.Extensions.Http/HttpEndpointRoutingOptions.cs
@@ -1,6 +1,7 @@
 namespace Kevlar.Extensions.Http;
 
 /// <summary>Configures alternate authorities for retry and hedge attempts.</summary>
+/// <remarks>The endpoint list and scalar values are snapshotted with the handler options.</remarks>
 public sealed class HttpEndpointRoutingOptions
 {
     /// <summary>The available endpoint authorities. At least one is required when routing is enabled.</summary>

--- a/src/Kevlar.Extensions.Http/HttpShieldPipeline.cs
+++ b/src/Kevlar.Extensions.Http/HttpShieldPipeline.cs
@@ -11,13 +11,18 @@ internal sealed class HttpShieldPipeline
         ShieldHttpHandlerOptions options)
     {
         Policy = policy ?? throw new ArgumentNullException(nameof(policy));
-        Options = options ?? throw new ArgumentNullException(nameof(options));
-        ValidateOptions(options);
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        Options = new HttpShieldPipelineOptions(options);
+        ValidateOptions(Options);
     }
 
     public Shield<HttpResponseMessage> Policy { get; }
 
-    public ShieldHttpHandlerOptions Options { get; }
+    public HttpShieldPipelineOptions Options { get; }
 
     public Shield<HttpResponseMessage>? GetEndpointShield(
         Uri endpoint,
@@ -91,7 +96,7 @@ internal sealed class HttpShieldPipeline
             .ToArray();
     }
 
-    private static void ValidateOptions(ShieldHttpHandlerOptions options)
+    private static void ValidateOptions(HttpShieldPipelineOptions options)
     {
         if (!Enum.IsDefined(typeof(HttpContentReplayPolicy), options.ContentReplayPolicy))
         {
@@ -113,7 +118,7 @@ internal sealed class HttpShieldPipeline
             throw new ArgumentOutOfRangeException(nameof(options), "The endpoint selection mode is invalid.");
         }
 
-        if (routing.Endpoints.Count == 0)
+        if (routing.Endpoints.Length == 0)
         {
             throw new ArgumentException("Routing requires at least one endpoint.", nameof(options));
         }

--- a/src/Kevlar.Extensions.Http/HttpShieldPipelineOptions.cs
+++ b/src/Kevlar.Extensions.Http/HttpShieldPipelineOptions.cs
@@ -1,0 +1,42 @@
+namespace Kevlar.Extensions.Http;
+
+internal sealed class HttpShieldPipelineOptions
+{
+    public HttpShieldPipelineOptions(ShieldHttpHandlerOptions source)
+    {
+        ContentReplayPolicy = source.ContentReplayPolicy;
+        MaximumBufferSize = source.MaximumBufferSize;
+        AllowUnsafeMethodReplay = source.AllowUnsafeMethodReplay;
+        RequestFactory = source.RequestFactory;
+        Routing = source.Routing is null ? null : new RoutingSnapshot(source.Routing);
+    }
+
+    public HttpContentReplayPolicy ContentReplayPolicy { get; }
+
+    public long MaximumBufferSize { get; }
+
+    public bool AllowUnsafeMethodReplay { get; }
+
+    public Func<HttpRequestMessage, int, CancellationToken, ValueTask<HttpRequestMessage>>? RequestFactory { get; }
+
+    public RoutingSnapshot? Routing { get; }
+
+    internal sealed class RoutingSnapshot
+    {
+        public RoutingSnapshot(HttpEndpointRoutingOptions source)
+        {
+            Endpoints = source.Endpoints.ToArray();
+            SelectionMode = source.SelectionMode;
+            Seed = source.Seed;
+            ShieldFactory = source.ShieldFactory;
+        }
+
+        public HttpEndpoint[] Endpoints { get; }
+
+        public HttpEndpointSelectionMode SelectionMode { get; }
+
+        public int Seed { get; }
+
+        public Func<Uri, Shield<HttpResponseMessage>>? ShieldFactory { get; }
+    }
+}

--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -158,7 +158,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
 
     private static async ValueTask<bool> CanReplayAsync(
         HttpRequestMessage request,
-        ShieldHttpHandlerOptions options,
+        HttpShieldPipelineOptions options,
         KevlarRequestOptions? requestOptions)
     {
         if (requestOptions?.AllowReplay == false)
@@ -296,7 +296,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             _endpointOrder = pipeline.CreateEndpointOrder();
         }
 
-        private ShieldHttpHandlerOptions Options => _pipeline.Options;
+        private HttpShieldPipelineOptions Options => _pipeline.Options;
 
         public void InitializeProperties(KevlarProperties properties)
         {

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -50,10 +50,11 @@ public static class ShieldHttpClientBuilderExtensions
             throw new ArgumentNullException(nameof(options));
         }
 
+        var optionsSnapshot = Snapshot(options);
         return builder.AddHttpMessageHandler(services =>
             new ShieldDelegatingHandler(
                 Decorate(services, shield, builder.Name),
-                options,
+                optionsSnapshot,
                 CreateDecorator(services, builder.Name)));
     }
 

--- a/src/Kevlar.Extensions.Http/ShieldHttpHandlerOptions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpHandlerOptions.cs
@@ -1,6 +1,10 @@
 namespace Kevlar.Extensions.Http;
 
 /// <summary>Configures safe request replay and optional endpoint routing.</summary>
+/// <remarks>
+/// Values are snapshotted when the handler pipeline is registered or created. Later mutations do
+/// not reconfigure that pipeline; use a configuration-backed reloading registration for updates.
+/// </remarks>
 public sealed class ShieldHttpHandlerOptions
 {
     /// <summary>The request-content replay policy. The default never buffers caller content.</summary>

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -366,6 +366,34 @@ public class HttpConfigurationReloadTests
     }
 
     [Test]
+    public async Task Reload_Replaces_The_Handler_Endpoint_Snapshot()
+    {
+        var configuration = BuildConfiguration(
+            ("Retry:MaxRetries", "0"),
+            ("Handler:Routing:Endpoints:0:Uri", "https://first.example"));
+        var hosts = new List<string>();
+        var transport = new FuncHandler((request, _) =>
+        {
+            hosts.Add(request.RequestUri!.Host);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        using var services = CreateStandardServices(configuration, transport);
+        var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+
+        using (await client.GetAsync("https://origin.example/"))
+        {
+        }
+
+        configuration["Handler:Routing:Endpoints:0:Uri"] = "https://second.example";
+        configuration.Reload();
+        using (await client.GetAsync("https://origin.example/"))
+        {
+        }
+
+        await Assert.That(hosts).IsEquivalentTo(["first.example", "second.example"]);
+    }
+
+    [Test]
     public async Task Configuration_Bound_RetryAfter_Survives_Reload()
     {
         var configuration = BuildConfiguration(
@@ -662,6 +690,82 @@ public class HttpConfigurationReloadTests
             .Throws<InvalidOperationException>();
 
         await Assert.That(creations).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Direct_Registration_Snapshots_Handler_Options()
+    {
+        var hosts = new List<string>();
+        var transport = new FuncHandler((request, _) =>
+        {
+            hosts.Add(request.RequestUri!.Host);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+        var routing = new HttpEndpointRoutingOptions();
+        routing.Endpoints.Add(new HttpEndpoint(new Uri("https://original.example")));
+        var options = new ShieldHttpHandlerOptions { Routing = routing };
+        var services = new ServiceCollection();
+        services.AddHttpClient("client")
+            .ConfigurePrimaryHttpMessageHandler(() => transport)
+            .AddShield(HttpShield.WhenTransient().Retry(0, Backoff.None), options);
+
+        routing.Endpoints.Clear();
+        routing.Endpoints.Add(new HttpEndpoint(new Uri("https://mutated.example")));
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+        using var response = await client.GetAsync("https://origin.example/");
+
+        await Assert.That(hosts).IsEquivalentTo(["original.example"]);
+    }
+
+    [Test]
+    public async Task Handler_Options_Are_Snapshotted_At_Construction()
+    {
+        Func<HttpRequestMessage, int, CancellationToken, ValueTask<HttpRequestMessage>> requestFactory =
+            static (request, _, _) => new(new HttpRequestMessage(request.Method, request.RequestUri));
+        Func<Uri, Shield<HttpResponseMessage>> shieldFactory =
+            static _ => HttpShield.WhenTransient().Retry(0, Backoff.None);
+        var endpoint = new HttpEndpoint(new Uri("https://original.example"), weight: 2);
+        var routing = new HttpEndpointRoutingOptions
+        {
+            SelectionMode = HttpEndpointSelectionMode.Weighted,
+            Seed = 17,
+            ShieldFactory = shieldFactory,
+        };
+        routing.Endpoints.Add(endpoint);
+        var options = new ShieldHttpHandlerOptions
+        {
+            ContentReplayPolicy = HttpContentReplayPolicy.Buffer,
+            MaximumBufferSize = 2048,
+            AllowUnsafeMethodReplay = true,
+            RequestFactory = requestFactory,
+            Routing = routing,
+        };
+        var pipeline = new HttpShieldPipeline(
+            HttpShield.WhenTransient().Retry(0, Backoff.None),
+            options);
+
+        options.ContentReplayPolicy = HttpContentReplayPolicy.NoBuffer;
+        options.MaximumBufferSize = 4096;
+        options.AllowUnsafeMethodReplay = false;
+        options.RequestFactory = null;
+        routing.SelectionMode = HttpEndpointSelectionMode.Ordered;
+        routing.Seed = 23;
+        routing.ShieldFactory = null;
+        routing.Endpoints.Clear();
+        routing.Endpoints.Add(new HttpEndpoint(new Uri("https://mutated.example")));
+        options.Routing = new HttpEndpointRoutingOptions();
+
+        await Assert.That(pipeline.Options.ContentReplayPolicy)
+            .IsEqualTo(HttpContentReplayPolicy.Buffer);
+        await Assert.That(pipeline.Options.MaximumBufferSize).IsEqualTo(2048);
+        await Assert.That(pipeline.Options.AllowUnsafeMethodReplay).IsTrue();
+        await Assert.That(ReferenceEquals(pipeline.Options.RequestFactory, requestFactory)).IsTrue();
+        await Assert.That(pipeline.Options.Routing!.SelectionMode)
+            .IsEqualTo(HttpEndpointSelectionMode.Weighted);
+        await Assert.That(pipeline.Options.Routing.Seed).IsEqualTo(17);
+        await Assert.That(ReferenceEquals(pipeline.Options.Routing.ShieldFactory, shieldFactory)).IsTrue();
+        await Assert.That(pipeline.Options.Routing.Endpoints).IsEquivalentTo([endpoint]);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- snapshot replay scalars, delegates, routing values, and endpoints into immutable handler-pipeline options
- freeze the direct `AddShield(shield, options)` overload at registration while preserving per-handler option factories
- keep configuration reload as the explicit update path and document the contract

Closes #332

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m` (1,199 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (1,230 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (166 passed)
- allocation suites on .NET 8 and .NET 10
- `pwsh scripts/Build-ApiDocs.ps1`
- docs, API-doc, and changelog verification
- packed package snippets on .NET 8 and .NET 10 (184 each)
- `npm run build`

Snapshot allocation occurs only during registration/pipeline construction; request execution reads immutable fields and the materialized endpoint array.