### PR TITLE
docs: define stable support commitments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Kevlar currently has one primary maintainer. Keep the default explicit so GitHub routes every
+# change, including new paths, for owner review.
+* @thomhurst
+
+# Security and release automation are called out for visibility even though the default applies.
+/SECURITY.md @thomhurst
+/.github/workflows/ @thomhurst
+/scripts/ @thomhurst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Pipelines stay immutable, allocation-conscious, observable, and explicit about e
 
 ### Changed
 
+- The support policy commits target-framework removals to major releases, gives obsolete APIs at
+  least one minor release before removal, provides six months of previous-major security overlap,
+  and documents dependency floors, package lockstep, cadence, maintenance, and roadmap ownership.
 - HTTP handler replay and routing options are snapshotted when a pipeline is registered or created.
   Later mutations no longer alter live handlers; configuration reload remains the explicit update
   path and publishes a fresh complete snapshot.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,18 @@
 
 ## Supported versions
 
-Security fixes are provided for the latest stable minor release in the current major line.
-Pre-release builds and older major lines may receive a fix at the maintainers' discretion.
+Security fixes are provided for the latest stable minor release in the current major line. After a
+new major version reaches general availability, the previous major remains supported for six
+months. Older minors within a supported major must upgrade to that major's latest minor.
+Pre-release builds are not supported.
 
 | Version | Security support |
 |---|---|
 | Latest `1.x` | Supported |
 | Older `1.x` | Upgrade to the latest `1.x` |
 | `0.x` and previews | Not supported |
+
+When `2.0` is released, this table will include the exact date on which `1.x` security support ends.
 
 ## Reporting a vulnerability
 

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -4,6 +4,22 @@ sidebar_position: 29
 
 # Support policy
 
+## Target frameworks and compatibility
+
+Removing a target framework from a stable package is a breaking change and happens only in a new
+major version. Kevlar may add target frameworks in a minor release when doing so does not change
+the behavior or dependency graph of existing targets. A framework reaching end of support from its
+vendor does not by itself remove that target from an existing Kevlar major line.
+
+Public API removals also require a new major version. When a safe migration exists, an API is
+marked `[Obsolete]` for at least one minor release before it is removed. Security, legal, or
+platform constraints may require faster action; release notes will identify any such exception and
+its migration path.
+
+Behavioral fixes can ship in patch releases when they restore documented intent. Minor releases
+may add compatible APIs and diagnostics. Release notes call out changes that could affect unusual
+or implementation-dependent usage.
+
 ## Minimum dependency versions
 
 Kevlar keeps shipped dependency floors compatible with .NET 8-era applications. These are minimum
@@ -45,3 +61,29 @@ Upgrade these packages together. If package versions are managed centrally, assi
 the coupled package set. A partial upgrade fails restore with `NU1608` instead of allowing a mixed
 version deployment that could fail at runtime. `Kevlar.Chaos` uses only public APIs and is not part
 of this lockstep set.
+
+## Security support
+
+Security fixes target the latest stable minor release in the current major line. After a new major
+version reaches general availability, the previous major continues receiving security fixes for
+six months. Older minors in a supported major must upgrade to that major's latest minor to receive
+the fix. Pre-release builds are not supported. See the repository
+[security policy](https://github.com/thomhurst/Kevlar/blob/main/SECURITY.md) for the current matrix
+and private reporting process.
+
+## Release cadence
+
+Patch releases ship as needed for correctness and security. While a major line is active, minor
+releases are targeted roughly monthly; this is a planning target, not a service-level agreement.
+Major releases are intentionally rare and include migration guidance for breaking changes.
+
+## Maintenance and roadmap
+
+Kevlar is currently maintained by one primary maintainer, [@thomhurst](https://github.com/thomhurst).
+`CODEOWNERS` routes repository changes for review but does not provide maintainer redundancy or a
+response-time guarantee. Organizations that require multi-maintainer governance should account for
+that bus-factor risk in adoption decisions.
+
+The public issue tracker and GitHub milestones are the roadmap. An issue or milestone expresses
+intent, not a delivery commitment; released packages and this support policy are the authoritative
+compatibility contract.

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -352,6 +352,8 @@ $exactPinnedPackageIds = @(
 $expectedDependencyVersions = @{}
 foreach ($dependencyId in @(
     'Microsoft.Bcl.AsyncInterfaces',
+    'Grpc.Core.Api',
+    'Grpc.Net.ClientFactory',
     'Microsoft.Bcl.TimeProvider',
     'Microsoft.Extensions.Configuration.Abstractions',
     'Microsoft.Extensions.DependencyInjection.Abstractions',
@@ -362,7 +364,9 @@ foreach ($dependencyId in @(
     'Microsoft.Extensions.Primitives',
     'Microsoft.Extensions.TimeProvider.Testing',
     'Reservoir',
-    'System.Threading.RateLimiting'))
+    'System.Runtime.CompilerServices.Unsafe',
+    'System.Threading.RateLimiting',
+    'System.Threading.Tasks.Extensions'))
 {
     $expectedDependencyVersions[$dependencyId] =
         (Get-CentralPackageVersion $centralPackages $dependencyId) -replace ',\s*', ', '
@@ -372,6 +376,7 @@ $packageFiles = @(Get-ChildItem -LiteralPath $packageDirectory -Filter '*.nupkg'
 Assert-Set 'package IDs' ($packageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) $expectedPackageIds
 $symbolPackageFiles = @(Get-ChildItem -LiteralPath $packageDirectory -Filter '*.snupkg' -File)
 Assert-Set 'symbol package IDs' ($symbolPackageFiles.BaseName | ForEach-Object { $_ -replace "\.$([regex]::Escape($Version))$", '' }) $expectedPackageIds
+$actualExternalDependencyPackages = @{}
 
 foreach ($packageId in $expectedDependencies.Keys)
 {
@@ -459,6 +464,18 @@ foreach ($packageId in $expectedDependencies.Keys)
             foreach ($dependency in $dependencies)
             {
                 $dependencyId = $dependency.GetAttribute('id')
+                if (-not $dependencyId.StartsWith('Kevlar', [StringComparison]::Ordinal))
+                {
+                    if (-not $actualExternalDependencyPackages.ContainsKey($dependencyId))
+                    {
+                        $actualExternalDependencyPackages[$dependencyId] =
+                            [System.Collections.Generic.HashSet[string]]::new(
+                                [StringComparer]::Ordinal)
+                    }
+
+                    $actualExternalDependencyPackages[$dependencyId].Add($packageId) | Out-Null
+                }
+
                 Assert-ShippedDependencyFloor `
                     -DependencyId $dependencyId `
                     -DependencyVersion $dependency.GetAttribute('version') `
@@ -602,6 +619,45 @@ foreach ($packageId in $expectedDependencies.Keys)
     {
         $symbolArchive.Dispose()
     }
+}
+
+$supportPolicyPath = Join-Path $repositoryRoot 'docs/docs/support-policy.md'
+$documentedDependencyFloors = @{}
+foreach ($line in Get-Content -LiteralPath $supportPolicyPath)
+{
+    if ($line -notmatch '^\|\s*`(?<id>[^`]+)`\s*\|\s*`(?<version>[^`]+)`\s*\|(?<packages>[^|]+)\|$')
+    {
+        continue
+    }
+
+    $dependencyId = $Matches.id
+    if ($documentedDependencyFloors.ContainsKey($dependencyId))
+    {
+        throw "Support policy contains duplicate dependency floor '$dependencyId'."
+    }
+
+    $documentedDependencyFloors[$dependencyId] = [pscustomobject]@{
+        Version = $Matches.version
+        Packages = @(
+            [regex]::Matches($Matches.packages, '`(?<package>Kevlar(?:\.[^`]+)?)`') |
+                ForEach-Object { $_.Groups['package'].Value })
+    }
+}
+
+Assert-Set `
+    'support-policy dependency floor IDs' `
+    @($documentedDependencyFloors.Keys) `
+    @($actualExternalDependencyPackages.Keys)
+foreach ($dependencyId in $actualExternalDependencyPackages.Keys)
+{
+    Assert-Equal `
+        "support-policy $dependencyId minimum version" `
+        $documentedDependencyFloors[$dependencyId].Version `
+        $expectedDependencyVersions[$dependencyId]
+    Assert-Set `
+        "support-policy $dependencyId shipped-by packages" `
+        $documentedDependencyFloors[$dependencyId].Packages `
+        @($actualExternalDependencyPackages[$dependencyId])
 }
 
 $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "kevlar-package-consumers-$([guid]::NewGuid().ToString('N'))"

--- a/tests/Kevlar.Tests/ResultDisposalTests.cs
+++ b/tests/Kevlar.Tests/ResultDisposalTests.cs
@@ -153,6 +153,7 @@ public class ResultDisposalTests
         releases[1].SetResult();
         var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
 
+        await handled.Disposed.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(ReferenceEquals(result, winner)).IsTrue();
         await Assert.That(handled.DisposeCount).IsEqualTo(1);
         await Assert.That(winner.DisposeCount).IsEqualTo(0);


### PR DESCRIPTION
## Summary

- commit target-framework removals to major releases and give obsolete APIs at least one minor before removal
- provide six months of previous-major security overlap and document release cadence, maintenance, bus factor, and roadmap ownership
- add CODEOWNERS and enforce that the published dependency-floor table matches produced nuspecs

## Motivation

Make the compatibility and maintenance promises behind Kevlar 1.0 concrete and mechanically protect the documented dependency floors from drift.

Closes #341

## Validation

- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-Changelog.ps1`
- `npm ci && npm run build` from `docs/`
- `dotnet pack Kevlar.slnx -c Release -p:Version=0.0.0-local`
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version 0.0.0-local`