### PR TITLE
docs: add practical resilience guides

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/ConcurrencyLimitBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/ConcurrencyLimitBenchmarks.cs
@@ -30,7 +30,7 @@ public class ConcurrencyLimitBenchmarks
     [BenchmarkCategory("Uncontended"), Benchmark]
     public ValueTask<int> Polly_Uncontended() => PollyConcurrency.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("Uncontended"), Benchmark]
+    [BenchmarkCategory("Uncontended"), Benchmark(Description = "Kevlar concurrency limiter with hooks")]
     public ValueTask<int> Kevlar_WithHooks_Uncontended() =>
         KevlarConcurrencyWithHooks.ExecuteAsync(static _ => new ValueTask<int>(42));
 }

--- a/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
@@ -53,7 +53,9 @@ public class FallbackBenchmarks
     [BenchmarkCategory("Triggered"), Benchmark]
     public ValueTask<int> Polly_Triggered() => PollyFallback.ExecuteAsync(static ValueTask<int> (_) => throw PrimaryError);
 
-    [BenchmarkCategory("Notifications"), Benchmark(Baseline = true)]
+    [BenchmarkCategory("Notifications"), Benchmark(
+        Baseline = true,
+        Description = "Kevlar fallback without notification")]
     public ValueTask<int> Kevlar_NoNotification() => KevlarFallback.ExecuteAsync(static _ => throw PrimaryError);
 
     [BenchmarkCategory("Notifications"), Benchmark]

--- a/benchmarks/Kevlar.Benchmarks/OverheadBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/OverheadBenchmarks.cs
@@ -47,7 +47,9 @@ public class OverheadBenchmarks
         PollyEmpty.ExecuteAsync(static (s, _) => new ValueTask<int>(s), _state);
 
     /// <summary>Executes a state-passing no-throw call through an empty Kevlar pipeline.</summary>
-    [BenchmarkCategory("EmptyOutcomeState"), Benchmark(Baseline = true)]
+    [BenchmarkCategory("EmptyOutcomeState"), Benchmark(
+        Baseline = true,
+        Description = "Kevlar empty shield outcome with caller state")]
     public ValueTask<Outcome<int>> Kevlar_EmptyOutcomeState() =>
         KevlarEmpty.ExecuteOutcomeAsync(_state, static (s, _) => new ValueTask<int>(s));
 

--- a/benchmarks/Kevlar.Benchmarks/PipelineBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/PipelineBenchmarks.cs
@@ -89,7 +89,9 @@ public class PipelineBenchmarks
     public ValueTask<int> Polly_TokenBucketRatioFiveStrategyChain() =>
         PollyDeep.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("TokenBucketRatioFiveStrategyChainSync"), Benchmark(Baseline = true)]
+    [BenchmarkCategory("TokenBucketRatioFiveStrategyChainSync"), Benchmark(
+        Baseline = true,
+        Description = "Kevlar five-strategy synchronous chain")]
     public int Kevlar_TokenBucketRatioFiveStrategyChainSync() =>
         KevlarDeep.Execute(static _ => 42);
 

--- a/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/RateLimitBenchmarks.cs
@@ -63,7 +63,7 @@ public class RateLimitBenchmarks
     public ValueTask<int> Polly_TokenBucketUncontended() =>
         PollyRateLimit.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("TokenBucketUncontended"), Benchmark]
+    [BenchmarkCategory("TokenBucketUncontended"), Benchmark(Description = "Kevlar token bucket with hooks")]
     public ValueTask<int> Kevlar_WithHooks_Uncontended() =>
         KevlarRateLimitWithHooks.ExecuteAsync(static _ => new ValueTask<int>(42));
 

--- a/benchmarks/Kevlar.Benchmarks/TimeoutBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/TimeoutBenchmarks.cs
@@ -39,7 +39,7 @@ public class TimeoutBenchmarks
     [BenchmarkCategory("HappyPath"), Benchmark]
     public ValueTask<int> Polly_HappyPath() => PollyTimeout.ExecuteAsync(static _ => new ValueTask<int>(42));
 
-    [BenchmarkCategory("HappyPath"), Benchmark]
+    [BenchmarkCategory("HappyPath"), Benchmark(Description = "Kevlar timeout with synchronous generator")]
     public ValueTask<int> Kevlar_SynchronousGenerator_HappyPath() =>
         KevlarGeneratedTimeout.ExecuteAsync(static _ => new ValueTask<int>(42));
 

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -1,0 +1,95 @@
+# Cookbook
+
+These recipes are starting points, not universal defaults. Choose handling predicates from the
+failure contract of the dependency, keep total budgets bounded, and share a shield only when its
+state should also be shared.
+
+## Resilient HTTP client
+
+Use the standard HTTP pipeline for an idempotent dependency. It owns total and per-attempt timeout,
+retry, circuit-breaker, and response-disposal behavior:
+
+```csharp
+using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+services.AddHttpClient("catalog", client =>
+    client.BaseAddress = new Uri("https://catalog.example"))
+    .AddStandardShield(options =>
+    {
+        options.TotalTimeout.Timeout = TimeSpan.FromSeconds(15);
+        options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(3);
+        options.Retry.MaxRetries = 2;
+        options.Retry.Backoff = Backoff.Exponential(
+            TimeSpan.FromMilliseconds(200),
+            maxDelay: TimeSpan.FromSeconds(2));
+    });
+```
+
+Keep unsafe HTTP methods single-attempt unless the application has an idempotency contract. For
+dynamic configuration, use the configuration-backed overload described in [HTTP resilience](http.md).
+
+## Database query with recovery value
+
+The fallback is outermost, so it can recover after retry, breaker, and timeout have finished. The
+handling clause is explicit: programming and authentication failures are not retried or replaced.
+
+```csharp
+var databaseShield = Shield.For<int>()
+    .When<TimeoutExceededException>()
+    .Or<IOException>()
+    .FallbackTo(-1)
+    .Retry(3, Backoff.Exponential(
+        TimeSpan.FromMilliseconds(100),
+        maxDelay: TimeSpan.FromSeconds(1)))
+    .CircuitBreaker(
+        consecutiveFailures: 5,
+        breakDuration: TimeSpan.FromSeconds(30))
+    .Timeout(TimeSpan.FromSeconds(2));
+
+var rowCount = await databaseShield.ExecuteAsync(
+    static async cancellationToken =>
+    {
+        await Task.Delay(TimeSpan.FromMilliseconds(1), cancellationToken);
+        return 42;
+    },
+    cancellationToken);
+```
+
+Treat `-1` as a deliberate degraded result and surface it to callers and telemetry; do not make a
+fallback indistinguishable from fresh data.
+
+## Queue consumer with dead-letter fallback
+
+For an idempotent message handler, place dead-letter publication outside the retrying work. The
+fallback runs only after the inner policies cannot deliver the message:
+
+```csharp
+var consumerShield = Shield
+    .When<MessagingException>()
+    .Or<TimeoutExceededException>()
+    .Fallback((exception, token) => deadLetter.PublishAsync(exception, token))
+    .Retry(3, Backoff.Exponential(
+        TimeSpan.FromMilliseconds(250),
+        maxDelay: TimeSpan.FromSeconds(5)))
+    .CircuitBreaker(
+        consecutiveFailures: 10,
+        breakDuration: TimeSpan.FromSeconds(20))
+    .Timeout(TimeSpan.FromSeconds(10));
+
+await consumerShield.ExecuteAsync(
+    token => bus.PublishAsync(message, token),
+    cancellationToken);
+```
+
+The broker's visibility timeout must exceed the total Kevlar budget. Make the handler idempotent,
+because a process crash after the side effect but before broker acknowledgement can still cause
+redelivery.
+
+## Choosing order
+
+Read chains from left to right as outermost to innermost. Put total timeout and fallback outside the
+work they must observe; put per-attempt timeout inside retry. A circuit breaker usually sits outside
+retry when one exhausted call should count once, and inside retry when each failed attempt should
+contribute. Confirm the resulting tree with `shield.Describe()` and the
+[composition guide](composition.md).

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -1,0 +1,81 @@
+# Glossary
+
+Kevlar uses a small vocabulary consistently across strategies, diagnostics, and documentation.
+These definitions are conceptual; links point to the API or guide where the behavior becomes
+concrete.
+
+## Ambient handling
+
+The exception and result predicates currently inherited by strategies added to a fluent chain.
+Calling `When...` starts an ambient handling clause; `Or...` extends it. Each reactive strategy
+captures the clause that exists when that strategy is added. See [Handling failures](handling-failures.md).
+
+## Proactive strategy
+
+A strategy that acts before an operation produces an outcome. Timeouts, rate limits, concurrency
+limits, and hedging are proactive: they budget, admit, or schedule work. They do not need an
+exception or result predicate to decide whether to start.
+
+## Reactive strategy
+
+A strategy that reacts after an attempt produces an exception or handled result. Retry, circuit
+breaker, and fallback are reactive. Their handling clause defines which outcomes affect them;
+unhandled outcomes pass through unchanged.
+
+## Outcome
+
+A success value or an exception represented without throwing between pipeline layers. Public
+`Outcome` and `Outcome<T>` APIs support no-throw execution; ordinary `Execute...` methods throw the
+terminal exception only at the caller boundary.
+
+## Strategy
+
+One resilience behavior in a shield. A fluent chain builds an immutable linked sequence of
+strategies. The first strategy added is outermost, so it observes everything performed by the
+strategies added after it.
+
+## Shield
+
+An immutable, thread-safe resilience pipeline. `Shield` protects operations without results;
+`Shield<T>` can also judge results. A built shield may be safely shared when callers should share
+breaker, limiter, or retry-related state.
+
+## Judge
+
+To evaluate an exception or result against a handling predicate. Benchmark descriptions use
+“judging” for this predicate cost; it does not imply throwing or changing the outcome.
+
+## Seal
+
+To end inheritance of an ambient handling clause across a composition boundary. `Wrap` and
+`Compose` seal the wrapped pipeline: strategies appended afterward return to default handling until
+another `When...` clause is declared. Sealing prevents a caller's clause from silently changing a
+library-owned pipeline.
+
+## Attempt
+
+One invocation of the protected delegate. Retries and hedges create additional attempts. Retry
+counts use additional-attempt semantics: `Retry(3)` permits the original plus three retries. Event
+models document their own attempt-number convention.
+
+## Terminal outcome
+
+The value or exception selected after every strategy finishes. Superseded retry results and losing
+hedge results are pipeline-owned and disposed; the selected terminal result remains caller-owned.
+
+## Operation key
+
+A bounded diagnostic label carried by `KevlarContext`. It identifies an operation within a named
+shield without changing strategy state. Avoid unbounded values such as request IDs.
+
+## Snapshot
+
+An immutable view captured at a defined boundary. Options and routing collections are snapshotted
+when documented, and testing snapshots copy live state so later executions cannot mutate an
+assertion already obtained.
+
+## Partition
+
+Independent strategy state selected by a key through [`PartitionedShield`](partitioning.md). Partitions isolate
+tenants or endpoints while sharing one pipeline definition; capacity and eviction keep retained
+state bounded. See [Partitioning](partitioning.md).

--- a/docs/docs/grpc.md
+++ b/docs/docs/grpc.md
@@ -20,7 +20,6 @@ gRPC status handling is opt-in. `GrpcShield.WhenTransient()` handles `RpcExcepti
 
 It does not retry `Cancelled`, validation failures, authentication failures, or other statuses.
 
-<!-- doc-test-ignore: requires an application-generated gRPC client and channel -->
 ```csharp
 using Grpc.Core.Interceptors;
 using Kevlar;
@@ -40,8 +39,10 @@ The final response or `RpcException` remains the caller's result. Superseded ret
 
 Use `ShieldStreamingClientInterceptor` for server-streaming, client-streaming, and duplex calls:
 
-<!-- doc-test-ignore: requires an application-generated gRPC client and channel -->
 ```csharp
+using Grpc.Core.Interceptors;
+using Kevlar.Extensions.Grpc;
+
 var streamingShield = Shield.Timeout(TimeSpan.FromSeconds(5));
 var client = new Orders.OrdersClient(
     channel.Intercept(new ShieldStreamingClientInterceptor(streamingShield)));
@@ -55,8 +56,10 @@ The interceptor uses explicit progress boundaries:
 
 When server-stream establishment needs retry or hedging and later reads still need a timeout, supply separate shields:
 
-<!-- doc-test-ignore: requires an application-generated gRPC client and channel -->
 ```csharp
+using Grpc.Core.Interceptors;
+using Kevlar.Extensions.Grpc;
+
 var establishment = GrpcShield.WhenTransient().Retry(2, Backoff.None);
 var operations = Shield.Timeout(TimeSpan.FromSeconds(3));
 var interceptor = new ShieldStreamingClientInterceptor(establishment, operations);
@@ -80,7 +83,6 @@ A Kevlar operation timeout is not an idle-stream timer. Use the gRPC deadline wh
 
 The package integrates with `Grpc.Net.ClientFactory` and the existing Kevlar registry:
 
-<!-- doc-test-ignore: requires an application-generated gRPC client -->
 ```csharp
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Grpc;

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -138,6 +138,34 @@ its `Events` property and `WaitForEventCountAsync`. Kevlar intentionally does no
 `ActivitySource` spans: use the metrics and listener hook to enrich the tracing system already owned
 by the application or transport.
 
+For applications that want one span per Kevlar event, bridge the listener into an application-owned
+`ActivitySource`. Keep tags bounded and copy everything needed during the callback because the
+context is pooled:
+
+<!-- doc-test-declaration: split-before=using var activitySource -->
+```csharp
+using System.Diagnostics;
+
+sealed class KevlarActivityListener(ActivitySource source) : IKevlarTelemetryListener
+{
+    public void OnEvent(in KevlarTelemetryEvent item)
+    {
+        using var activity = source.StartActivity(
+            $"kevlar.{item.EventName}",
+            ActivityKind.Internal);
+        activity?.SetTag("kevlar.shield.name", item.ShieldName);
+        activity?.SetTag("kevlar.strategy.name", item.StrategyName);
+        activity?.SetTag("kevlar.attempt.number", item.AttemptNumber);
+    }
+}
+
+using var activitySource = new ActivitySource("Catalog.Resilience");
+using var tracingSubscription = KevlarDiagnostics.Listen(new KevlarActivityListener(activitySource));
+```
+
+If the protected transport already creates a client span, prefer adding events or tags to that span
+instead of creating a second overlapping duration span.
+
 The state gauges are observable instruments sampled only when the metrics reader collects them. They read the strategies' existing synchronized state instead of publishing from execution paths, so enabling state metrics adds no state-publication locks or listener callbacks to each execution. Listener failures therefore remain confined to collection. Gauges aggregate by shield name and carry a bounded `kevlar.strategy.index` attribute (the strategy's zero-based pipeline position), so independent stateful strategies in one named pipeline remain distinct. Shared strategies expose up to 64 observed name/index aliases; additional aliases are omitted to bound memory and series growth. Registrations hold strategy instances weakly and discard collected registrations during observation, so telemetry does not keep an abandoned shield alive.
 
 This executable example verifies a completed execution with `MeterListener`:

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -12,6 +12,58 @@ Kevlar's design keeps the happy path cheap:
 - **Strategy chains are prebuilt linked nodes** — no per-call graph construction, no LINQ, no boxing of results on the success path.
 - **`ValueTask` end to end** — synchronous completions (cache hits, fast paths) never allocate a `Task`.
 
+## Tune budgets before mechanics
+
+Start with dependency behavior, not nanoseconds. Set one total latency budget, decide how much of it
+each attempt may consume, then fit retry delays and attempt count inside the remainder. A pipeline
+that can schedule work after the caller's useful deadline wastes more capacity than a small
+allocation ever will. Keep `HttpClient.Timeout` disabled when the standard HTTP shield owns total
+and attempt timeouts.
+
+Retries multiply load during an incident. Use bounded exponential backoff and jitter, cap additional
+attempts, and combine retry with a circuit breaker when persistent faults should fail fast. Hedging
+trades extra load for tail-latency reduction; reserve it for idempotent operations and measure the
+loser rate before increasing parallel attempts.
+
+## Share state deliberately
+
+Breaker, limiter, and partition state lives in strategy instances. Reuse one shield when callers
+should coordinate; build separate shields when isolation matters. Avoid constructing a stateful
+pipeline per request, because that both allocates and prevents its history from becoming useful.
+For tenant or endpoint isolation, prefer a bounded [`PartitionedShield`](partitioning.md) over an unbounded dictionary
+of shields.
+
+## Keep hot call sites allocation-conscious
+
+Use state-passing overloads with a `static` callback when profiling shows closure allocation at a
+high-volume call site:
+
+```csharp
+var result = await shield.ExecuteAsync(
+    client,
+    static (activeClient, token) => activeClient.GetUserAsync(1, token),
+    cancellationToken);
+```
+
+Return an already-completed `ValueTask` for synchronous work. Do not wrap naturally asynchronous
+I/O merely to force synchronous completion, and do not pool application objects until a profile
+shows they dominate cost. Clear code around a network boundary is normally worth more than saving
+a handful of bytes.
+
+## Diagnose before changing
+
+| Symptom | First checks |
+|---|---|
+| Rising p95 with low dependency latency | queue depth, limiter saturation, retry delays, total-timeout position |
+| Traffic spike during dependency failure | retry count, jitter, breaker threshold, hedge loser rate |
+| Breaker never opens | shield lifetime, handling predicates, result handling, partition key |
+| Growing memory | unbounded partition keys, per-request pipeline construction, retained result bodies |
+| Unexpected allocations | captured lambdas, yielding hooks, exception-heavy paths, HTTP content buffering |
+
+Use application traces and metrics to identify the expensive path, then reproduce it with a focused
+benchmark. Compare distributions and allocation counts across multiple runs; a single timing from a
+shared machine is not a tuning decision.
+
 ## Benchmarks
 
 The [Benchmarks](benchmarks.md) page compares Kevlar against Polly v8 across every strategy — happy paths, failure paths, and composed pipelines. It is regenerated automatically from CI runs, so the numbers there always reflect the current code.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -5,6 +5,8 @@ const sidebars: SidebarsConfig = {
     'intro',
     'getting-started',
     'polly-migration',
+    'glossary',
+    'cookbook',
     'handling-failures',
     'exceptions',
     {

--- a/samples/ChaosTesting/README.md
+++ b/samples/ChaosTesting/README.md
@@ -1,3 +1,9 @@
 # Chaos-enabled integration smoke
 
 This deterministic smoke confines a single injected fault to one operation, then verifies that retry recovers and the real action runs exactly once. Run `dotnet run --project samples/ChaosTesting -f net10.0`; add `-- --smoke` for CI.
+
+The injection decision is controlled rather than random, making the program suitable for automated
+tests and local debugging. Notice that chaos is composed inside retry: the injected failure becomes
+the first handled attempt, then the real operation succeeds. Keep chaos disabled by default in
+production, scope experiments narrowly, and emit enough telemetry to distinguish injected failures
+from genuine dependency faults.

--- a/samples/ConsoleRetry/README.md
+++ b/samples/ConsoleRetry/README.md
@@ -1,3 +1,9 @@
 # Console retry
 
 A minimal console application retries two transient failures with zero backoff and verifies that the third attempt recovers. Run `dotnet run --project samples/ConsoleRetry -f net10.0`; add `-- --smoke` when using the repository smoke convention.
+
+Start here when learning Kevlar's fluent pipeline order. The sample declares the handled exception,
+adds retry, and keeps the protected delegate cancellation-aware. `Backoff.None` makes the example
+deterministic and fast; production code should normally select bounded constant or exponential
+backoff with jitter. Change the retry count or remove the handling clause to see how the terminal
+exception changes.

--- a/samples/GrpcClient/README.md
+++ b/samples/GrpcClient/README.md
@@ -1,3 +1,8 @@
 # gRPC client
 
 This sample wraps a `CallInvoker` with `ShieldUnaryClientInterceptor` and proves that transient `Unavailable` results are retried before returning `pong`. Run `dotnet run --project samples/GrpcClient -f net10.0`; generated clients use the same interceptor registration shown in the gRPC guide.
+
+The transport is an in-process stub, so no server, TLS certificate, or generated protobuf client is
+required. Focus on the interceptor boundary: each retry creates a new unary call while preserving
+the request and call options. In a real application, apply multiple attempts only to idempotent
+operations and keep the gRPC deadline large enough for the complete retry budget.

--- a/samples/PartitionedWorker/README.md
+++ b/samples/PartitionedWorker/README.md
@@ -1,3 +1,9 @@
 # Partitioned worker
 
 This worker-style console application retains one bounded shield per tenant and proves that two tenants retry independently. Run `dotnet run --project samples/PartitionedWorker -f net10.0`; add `-- --smoke` for CI-style execution.
+
+Use this pattern when one global breaker or retry history would let a noisy tenant affect every
+other tenant. The partition key selects isolated strategy state, while `PartitionedShieldOptions`
+bounds retained entries so cardinality cannot grow forever. The sample uses two fixed tenant names;
+production callers should choose stable, low-cardinality keys and observe eviction when traffic is
+highly dynamic.

--- a/samples/WebApi/Program.cs
+++ b/samples/WebApi/Program.cs
@@ -35,6 +35,24 @@ builder.Services.AddHttpClient("downstream")
     });
 
 await using var app = builder.Build();
+app.MapGet("/orders", async (IHttpClientFactory clientFactory, CancellationToken cancellationToken) =>
+{
+    var endpointClient = clientFactory.CreateClient("downstream");
+    using var endpointResponse = await endpointClient.GetAsync("https://sample.invalid/orders", cancellationToken);
+    return Results.Ok(new
+    {
+        Status = endpointResponse.StatusCode,
+        Attempts = Volatile.Read(ref attempts),
+        Retries = Interlocked.Read(ref retries),
+    });
+});
+
+if (!args.Contains("--smoke", StringComparer.Ordinal))
+{
+    await app.RunAsync();
+    return;
+}
+
 var client = app.Services.GetRequiredService<IHttpClientFactory>().CreateClient("downstream");
 using var response = await client.GetAsync("https://sample.invalid/orders");
 var provider = app.Services.GetRequiredKeyedService<IShieldProvider>("background-jobs");

--- a/samples/WebApi/README.md
+++ b/samples/WebApi/README.md
@@ -1,3 +1,10 @@
 # ASP.NET Core, DI, HTTP, and metrics
 
-This headless ASP.NET Core sample registers a named shield, protects an `HttpClientFactory` client with `AddStandardShield`, registers the Kevlar meter with OpenTelemetry, and verifies two retries against an in-process flaky handler. Run `dotnet run --project samples/WebApi -f net10.0 -- --smoke`.
+This ASP.NET Core sample registers a named shield, protects an `HttpClientFactory` client with
+`AddStandardShield`, and exports the Kevlar meter through OpenTelemetry. Its `/orders` minimal API
+endpoint calls an in-process flaky handler that fails twice before recovering.
+
+Run `dotnet run --project samples/WebApi -f net10.0`, then request `/orders` from the address printed
+by ASP.NET Core. For a headless verification, add `-- --smoke`; that path performs the same resilient
+downstream call, asserts three attempts and two retry measurements, prints the result, and exits.
+The sample intentionally keeps transport local so it needs no external service.

--- a/scripts/Verify-Docs.ps1
+++ b/scripts/Verify-Docs.ps1
@@ -34,7 +34,7 @@ $documents = Get-ChildItem -LiteralPath $resolvedDocsPath -Recurse -File |
 $visibleDocuments = [System.Collections.Generic.List[object]]::new()
 $errors = [System.Collections.Generic.List[string]]::new()
 
-if ($sidebarSource -notmatch "'getting-started',\s*'polly-migration',\s*'handling-failures'")
+if ($sidebarSource -notmatch "'getting-started',\s*'polly-migration'")
 {
     $errors.Add("Documentation sidebar must place 'polly-migration' immediately after 'getting-started'.")
 }
@@ -229,6 +229,60 @@ $dependencyInjectionSource = Get-Content -LiteralPath (Join-Path $resolvedDocsPa
 if ($dependencyInjectionSource.Contains('builder.Configuration', [StringComparison]::Ordinal))
 {
     $errors.Add('dependency-injection.md must define IConfiguration explicitly instead of relying on an undefined builder.Configuration.')
+}
+
+foreach ($requiredPage in @('glossary.md', 'cookbook.md'))
+{
+    if (-not (Test-Path -LiteralPath (Join-Path $resolvedDocsPath $requiredPage)))
+    {
+        $errors.Add("Required documentation page '$requiredPage' is missing.")
+    }
+}
+
+$webApiProgram = Get-Content -LiteralPath (Join-Path $repositoryRoot 'samples/WebApi/Program.cs') -Raw
+if (-not $webApiProgram.Contains('.MapGet(', [StringComparison]::Ordinal))
+{
+    $errors.Add('samples/WebApi must map a minimal API endpoint with MapGet.')
+}
+
+foreach ($sampleDirectory in Get-ChildItem (Join-Path $repositoryRoot 'samples') -Directory)
+{
+    $sampleReadme = Join-Path $sampleDirectory.FullName 'README.md'
+    if (-not (Test-Path -LiteralPath $sampleReadme))
+    {
+        continue
+    }
+
+    $wordCount = @((Get-Content -LiteralPath $sampleReadme -Raw) -split '\s+' | Where-Object { $_ }).Count
+    if ($wordCount -lt 70)
+    {
+        $errors.Add("Sample README '$($sampleDirectory.Name)' must contain at least 70 words; found $wordCount.")
+    }
+}
+
+$benchmarkDescriptions = [ordered]@{
+    'OverheadBenchmarks.cs' = 'Kevlar_EmptyOutcomeState'
+    'TimeoutBenchmarks.cs' = 'Kevlar_SynchronousGenerator_HappyPath'
+    'ConcurrencyLimitBenchmarks.cs' = 'Kevlar_WithHooks_Uncontended'
+    'RateLimitBenchmarks.cs' = 'Kevlar_WithHooks_Uncontended'
+    'FallbackBenchmarks.cs' = 'Kevlar_NoNotification'
+    'PipelineBenchmarks.cs' = 'Kevlar_TokenBucketRatioFiveStrategyChainSync'
+}
+foreach ($entry in $benchmarkDescriptions.GetEnumerator())
+{
+    $benchmarkPath = Join-Path $repositoryRoot "benchmarks/Kevlar.Benchmarks/$($entry.Key)"
+    $benchmarkSource = Get-Content -LiteralPath $benchmarkPath -Raw
+    $pattern = '(?s)\[[^\]]*Benchmark\([^\]]*Description\s*=\s*"[^"]+"[^\]]*\)\]\s*public\s+[^\r\n]+\s+{0}\s*\(' -f [regex]::Escape($entry.Value)
+    if (-not [regex]::IsMatch($benchmarkSource, $pattern))
+    {
+        $errors.Add("Benchmark '$($entry.Value)' in '$($entry.Key)' must declare Benchmark.Description.")
+    }
+}
+
+$grpcSource = Get-Content -LiteralPath (Join-Path $resolvedDocsPath 'grpc.md') -Raw
+if ($grpcSource.Contains('doc-test-ignore', [StringComparison]::Ordinal))
+{
+    $errors.Add('grpc.md snippets must compile against the documentation test client instead of using doc-test-ignore.')
 }
 
 foreach ($document in $documents)

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -15,6 +15,9 @@
     <PackageReference Include="Kevlar.Extensions.Logging" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.RateLimiting" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Testing" VersionOverride="$(KevlarPackageVersion)" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
@@ -28,6 +31,7 @@
 
   <ItemGroup>
     <Compile Include="$(GeneratedSnippetsPath)" Link="GeneratedSnippets.g.cs" />
+    <Protobuf Include="Protos\orders.proto" GrpcServices="Client" />
   </ItemGroup>
 
 </Project>

--- a/tests/Kevlar.DocTests/Program.cs
+++ b/tests/Kevlar.DocTests/Program.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Grpc.Net.Client;
 using Kevlar;
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Http;
@@ -42,6 +43,7 @@ internal abstract class SnippetContext
     protected static readonly StubClient client = new();
     protected static readonly HttpClient httpClient = new(new StubHttpHandler());
     protected static readonly HttpClient http = httpClient;
+    protected static readonly GrpcChannel channel = GrpcChannel.ForAddress("https://grpc.example.test");
     protected static readonly IServiceCollection services = new ServiceCollection();
     protected static readonly IKevlarRegistry registry = null!;
     protected static readonly StubBuilder builder = new();

--- a/tests/Kevlar.DocTests/Protos/orders.proto
+++ b/tests/Kevlar.DocTests/Protos/orders.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option csharp_namespace = "Kevlar.DocTests";
+
+package kevlar.docs;
+
+service Orders {
+  rpc GetOrder (OrderRequest) returns (OrderReply);
+  rpc WatchOrders (OrderRequest) returns (stream OrderReply);
+}
+
+message OrderRequest {
+  int32 id = 1;
+}
+
+message OrderReply {
+  int32 id = 1;
+}


### PR DESCRIPTION
## Summary
- add glossary and practical HTTP/database/queue cookbook pages
- turn WebApi into a runnable minimal API and expand all sample READMEs
- add actionable performance and ActivitySource guidance
- compile every gRPC snippet using a generated documentation test client
- add readable BenchmarkDotNet descriptions for raw benchmark method names

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet build samples/Samples.slnx -c Release -warnaserror`
- `pwsh scripts/Run-SampleSmokes.ps1`
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/packages/issue351 -Version 0.0.0-issue351.20260827`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/packages/issue351 -Version 0.0.0-issue351.20260827 -NoImplicitUsings`
- `npm run build` (from `docs/`)

Closes #351