### PR TITLE
feat(timeout): report ignored cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Pipelines stay immutable, allocation-conscious, observable, and explicit about e
   strategies, and void fallbacks that do not need the handled exception.
 - Circuit-open, rate-limit, concurrency-limit, and timeout failures expose conventional public
   exception constructors while retaining strategy-specific metadata.
+- Timeout strategies emit `timeout_ignored` telemetry, a structured Warning log, and a
+  `kevlar.timeouts` measurement with `outcome=ignored` when a delegate completes after ignoring
+  timeout cancellation; the delegate's outcome remains unchanged and `OnTimeout` is not invoked.
 
 ### Changed
 

--- a/docs/api/.manifest
+++ b/docs/api/.manifest
@@ -402,6 +402,7 @@
   "Kevlar.Extensions.Logging.KevlarLogEventKind.RateLimitRejected": "Kevlar.Extensions.Logging.KevlarLogEventKind.yml",
   "Kevlar.Extensions.Logging.KevlarLogEventKind.Retry": "Kevlar.Extensions.Logging.KevlarLogEventKind.yml",
   "Kevlar.Extensions.Logging.KevlarLogEventKind.Timeout": "Kevlar.Extensions.Logging.KevlarLogEventKind.yml",
+  "Kevlar.Extensions.Logging.KevlarLogEventKind.TimeoutIgnored": "Kevlar.Extensions.Logging.KevlarLogEventKind.yml",
   "Kevlar.Extensions.Logging.KevlarLoggingOptions": "Kevlar.Extensions.Logging.KevlarLoggingOptions.yml",
   "Kevlar.Extensions.Logging.KevlarLoggingOptions.#ctor": "Kevlar.Extensions.Logging.KevlarLoggingOptions.yml",
   "Kevlar.Extensions.Logging.KevlarLoggingOptions.IncludeScopes": "Kevlar.Extensions.Logging.KevlarLoggingOptions.yml",

--- a/docs/api/Kevlar.Extensions.Logging.KevlarLogEventKind.yml
+++ b/docs/api/Kevlar.Extensions.Logging.KevlarLogEventKind.yml
@@ -15,6 +15,7 @@ items:
   - Kevlar.Extensions.Logging.KevlarLogEventKind.RateLimitRejected
   - Kevlar.Extensions.Logging.KevlarLogEventKind.Retry
   - Kevlar.Extensions.Logging.KevlarLogEventKind.Timeout
+  - Kevlar.Extensions.Logging.KevlarLogEventKind.TimeoutIgnored
   langs:
   - csharp
   - vb
@@ -228,6 +229,26 @@ items:
   example: []
   syntax:
     content: AttemptsSuppressed = 9
+    return:
+      type: Kevlar.Extensions.Logging.KevlarLogEventKind
+- uid: Kevlar.Extensions.Logging.KevlarLogEventKind.TimeoutIgnored
+  commentId: F:Kevlar.Extensions.Logging.KevlarLogEventKind.TimeoutIgnored
+  id: TimeoutIgnored
+  parent: Kevlar.Extensions.Logging.KevlarLogEventKind
+  langs:
+  - csharp
+  - vb
+  name: TimeoutIgnored
+  nameWithType: KevlarLogEventKind.TimeoutIgnored
+  fullName: Kevlar.Extensions.Logging.KevlarLogEventKind.TimeoutIgnored
+  type: Field
+  assemblies:
+  - Kevlar.Extensions.Logging
+  namespace: Kevlar.Extensions.Logging
+  summary: An execution completed after ignoring timeout cancellation.
+  example: []
+  syntax:
+    content: TimeoutIgnored = 10
     return:
       type: Kevlar.Extensions.Logging.KevlarLogEventKind
 references:

--- a/docs/api/Kevlar.KevlarDiagnostics.yml
+++ b/docs/api/Kevlar.KevlarDiagnostics.yml
@@ -36,7 +36,11 @@ items:
 
     <ul><li><code>kevlar.executions</code> — completed public execution calls, including empty shields and
 
-    pre-cancelled calls; attributes <code>kevlar.shield.name</code>, <code>kevlar.execution.outcome</code> (<code>success</code>/<code>failure</code>)</li><li><code>kevlar.retries</code> — retry attempts; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.timeouts</code> — executions cancelled by a timeout strategy; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.hedges</code> — extra hedged attempts launched; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.fallbacks</code> — outcomes replaced by a fallback; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.rejections</code> — fail-fast rejections; attributes <code>kevlar.shield.name</code>, <code>kevlar.rejection.type</code> (<code>circuit_open</code>/<code>rate_limit</code>/<code>rate_limiter_adapter</code>/<code>concurrency_limit</code>)</li><li><code>kevlar.http.replay_suppressed</code> — HTTP requests whose configured additional attempts
+    pre-cancelled calls; attributes <code>kevlar.shield.name</code>, <code>kevlar.execution.outcome</code> (<code>success</code>/<code>failure</code>)</li><li><code>kevlar.retries</code> — retry attempts; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.timeouts</code> — executions cancelled by a timeout strategy, including delegates
+
+    that complete after ignoring cancellation; attributes <code>kevlar.shield.name</code> and optional
+
+    <code>outcome</code> (<code>ignored</code>)</li><li><code>kevlar.hedges</code> — extra hedged attempts launched; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.fallbacks</code> — outcomes replaced by a fallback; attribute <code>kevlar.shield.name</code></li><li><code>kevlar.rejections</code> — fail-fast rejections; attributes <code>kevlar.shield.name</code>, <code>kevlar.rejection.type</code> (<code>circuit_open</code>/<code>rate_limit</code>/<code>rate_limiter_adapter</code>/<code>concurrency_limit</code>)</li><li><code>kevlar.http.replay_suppressed</code> — HTTP requests whose configured additional attempts
 
     were disabled for replay safety; attributes <code>kevlar.shield.name</code> and
 

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -70,9 +70,10 @@ registered `ILoggerFactory`. Explicit `WithLogging` calls remain local to that s
 | 1007 | concurrency-limit rejection | Warning |
 | 1008 | callback error | Error |
 | 1009 | HTTP attempts suppressed | Information |
+| 1010 | timeout cancellation ignored | Warning |
 
 Structured state includes the applicable subset of `ShieldName`, `StrategyIndex`, `Attempt`,
-`Delay`, `Duration`, `Outcome`, `FromState`, `ToState`, `RetryAfter`, `CallbackKind`, and
+`Delay`, `Duration`, `Elapsed`, `Outcome`, `FromState`, `ToState`, `RetryAfter`, `CallbackKind`, and
 `SuppressionReason`. HTTP retry and suppression events also include `RequestMethod` and `RequestUri`;
 the URI omits query and fragment data.
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -71,7 +71,7 @@ services.AddOpenTelemetry().WithMetrics(metrics => metrics
 |---|---|---|---|---|---|
 | `kevlar.executions` | Counter | `{execution}` | `net8.0` | completed public execution calls, including empty shields and pre-cancelled calls | `kevlar.shield.name`, `kevlar.execution.outcome` (`success`/`failure`) |
 | `kevlar.retries` | Counter | `{retry}` | `net8.0` | retry attempts | `kevlar.shield.name` |
-| `kevlar.timeouts` | Counter | `{timeout}` | `net8.0` | executions cancelled by a timeout strategy | `kevlar.shield.name` |
+| `kevlar.timeouts` | Counter | `{timeout}` | `net8.0` | executions cancelled by a timeout strategy, including delegates that complete after ignoring cancellation | `kevlar.shield.name`, optional `outcome` (`ignored`) |
 | `kevlar.hedges` | Counter | `{hedge}` | `net8.0` | extra hedged attempts launched | `kevlar.shield.name` |
 | `kevlar.fallbacks` | Counter | `{fallback}` | `net8.0` | outcomes replaced by a fallback | `kevlar.shield.name` |
 | `kevlar.rejections` | Counter | `{rejection}` | `net8.0` | fail-fast rejections | `kevlar.shield.name`, `kevlar.rejection.type` (`circuit_open`/`rate_limit`/`rate_limiter_adapter`/`concurrency_limit`) |
@@ -106,7 +106,7 @@ Every strategy options type has an optional `Name`. When unset, telemetry uses t
 name such as `Retry`; when set, the configured value becomes `kevlar.strategy.name`. Keep strategy
 names bounded just like shield names.
 
-Built-in `kevlar.event.name` values are `execution_attempt`, `retry`, `timeout`, `hedge`,
+Built-in `kevlar.event.name` values are `execution_attempt`, `retry`, `timeout`, `timeout_ignored`, `hedge`,
 `fallback`, `rejection`, `circuit_opened`, `circuit_half_opened`, `circuit_closed`, and
 `circuit_isolated`; the HTTP integration also emits `attempts_suppressed`. `Kevlar.Chaos`
 additionally emits `chaos_latency`, `chaos_fault`,

--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -41,7 +41,9 @@ Internally, the timeout strategy swaps `context.CancellationToken` for a linked 
 
 Two behaviours worth knowing:
 
-- If your delegate completes successfully *despite* the token firing, the result is still delivered.
+- If your delegate completes *despite* the token firing, its result or non-cancellation exception is
+  still delivered. Kevlar emits a `timeout_ignored` Warning event containing the elapsed duration,
+  increments `kevlar.timeouts` with `outcome=ignored`, and does not invoke `OnTimeout`.
 - Cancellation from your own outer token is **not** reported as a timeout — it propagates as a normal `OperationCanceledException`.
 
 ## Cancellation arbitration

--- a/src/Kevlar.Extensions.Logging/KevlarLogEventKind.cs
+++ b/src/Kevlar.Extensions.Logging/KevlarLogEventKind.cs
@@ -32,4 +32,7 @@ public enum KevlarLogEventKind
 
     /// <summary>HTTP replay safety disabled configured additional attempts.</summary>
     AttemptsSuppressed,
+
+    /// <summary>An execution completed after ignoring timeout cancellation.</summary>
+    TimeoutIgnored,
 }

--- a/src/Kevlar.Extensions.Logging/LoggerMessages.cs
+++ b/src/Kevlar.Extensions.Logging/LoggerMessages.cs
@@ -128,4 +128,15 @@ internal static partial class LoggerMessages
         string? suppressionReason,
         string? requestMethod,
         string? requestUri);
+
+    [LoggerMessage(EventId = 1010, EventName = "TimeoutIgnored", Level = LogLevel.Warning,
+        Message = "Shield {ShieldName} strategy {StrategyIndex} completed after ignoring timeout cancellation for {Elapsed}; outcome {Outcome}",
+        SkipEnabledCheck = true)]
+    public static partial void TimeoutIgnored(
+        ILogger logger,
+        string? shieldName,
+        int strategyIndex,
+        TimeSpan elapsed,
+        string outcome,
+        Exception? exception);
 }

--- a/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
+++ b/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
@@ -258,6 +258,11 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
                 LoggerMessages.Timeout(logger, telemetryEvent.ShieldName, telemetryEvent.StrategyIndex,
                     telemetryEvent.Duration, outcome, telemetryEvent.Exception);
                 break;
+            case KevlarLogEventKind.TimeoutIgnored:
+                LoggerMessages.TimeoutIgnored(logger, telemetryEvent.ShieldName,
+                    telemetryEvent.StrategyIndex, telemetryEvent.Duration, outcome,
+                    telemetryEvent.Exception);
+                break;
             case KevlarLogEventKind.CircuitState:
                 if (telemetryEvent.ToState == CircuitState.Open)
                 {
@@ -355,6 +360,12 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
                     telemetryEvent.ShieldName, telemetryEvent.StrategyIndex,
                     telemetryEvent.Duration, outcome);
                 break;
+            case KevlarLogEventKind.TimeoutIgnored:
+                logger.Log(level, eventId, telemetryEvent.Exception,
+                    "Shield {ShieldName} strategy {StrategyIndex} completed after ignoring timeout cancellation for {Elapsed}; outcome {Outcome}",
+                    telemetryEvent.ShieldName, telemetryEvent.StrategyIndex,
+                    telemetryEvent.Duration, outcome);
+                break;
             case KevlarLogEventKind.CircuitState:
                 if (telemetryEvent.ToState == CircuitState.Open)
                 {
@@ -445,6 +456,11 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
             case "timeout":
                 kind = KevlarLogEventKind.Timeout;
                 eventId = new EventId(1002, "Timeout");
+                level = LogLevel.Warning;
+                return true;
+            case "timeout_ignored":
+                kind = KevlarLogEventKind.TimeoutIgnored;
+                eventId = new EventId(1010, "TimeoutIgnored");
                 level = LogLevel.Warning;
                 return true;
             case "circuit_opened":

--- a/src/Kevlar.Extensions.Logging/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Logging/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Kevlar.Extensions.Logging.KevlarLogEventKind.TimeoutIgnored = 10 -> Kevlar.Extensions.Logging.KevlarLogEventKind

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -206,6 +206,38 @@ internal static class KevlarMetrics
             duration: timeout);
     }
 
+    public static void TimeoutIgnored(
+        KevlarContext context,
+        string strategyName,
+        TimeSpan elapsed,
+        bool isSuccess,
+        Exception? exception)
+    {
+#if NET8_0_OR_GREATER
+        if (Timeouts.Enabled)
+        {
+            var tags = NameTags(context.ShieldName);
+            tags.Add("outcome", "ignored");
+            Timeouts.Add(1, tags);
+        }
+#endif
+        if (!KevlarTelemetry.IsEventEnabled(context))
+        {
+            return;
+        }
+
+        KevlarTelemetry.Record(
+            context,
+            strategyName,
+            eventName: "timeout_ignored",
+            KevlarTelemetrySeverity.Warning,
+            context.StrategyIndex,
+            context.AttemptNumber,
+            isSuccess,
+            exception,
+            duration: elapsed);
+    }
+
     public static void Hedge(
         KevlarContext context,
         string strategyName,

--- a/src/Kevlar/KevlarDiagnostics.cs
+++ b/src/Kevlar/KevlarDiagnostics.cs
@@ -15,7 +15,9 @@ namespace Kevlar;
 /// <item><c>kevlar.executions</c> — completed public execution calls, including empty shields and
 /// pre-cancelled calls; attributes <c>kevlar.shield.name</c>, <c>kevlar.execution.outcome</c> (<c>success</c>/<c>failure</c>)</item>
 /// <item><c>kevlar.retries</c> — retry attempts; attribute <c>kevlar.shield.name</c></item>
-/// <item><c>kevlar.timeouts</c> — executions cancelled by a timeout strategy; attribute <c>kevlar.shield.name</c></item>
+/// <item><c>kevlar.timeouts</c> — executions cancelled by a timeout strategy, including delegates
+/// that complete after ignoring cancellation; attributes <c>kevlar.shield.name</c> and optional
+/// <c>outcome</c> (<c>ignored</c>)</item>
 /// <item><c>kevlar.hedges</c> — extra hedged attempts launched; attribute <c>kevlar.shield.name</c></item>
 /// <item><c>kevlar.fallbacks</c> — outcomes replaced by a fallback; attribute <c>kevlar.shield.name</c></item>
 /// <item><c>kevlar.rejections</c> — fail-fast rejections; attributes <c>kevlar.shield.name</c>, <c>kevlar.rejection.type</c> (<c>circuit_open</c>/<c>rate_limit</c>/<c>rate_limiter_adapter</c>/<c>concurrency_limit</c>)</item>

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -102,6 +102,7 @@ internal sealed class TimeoutStrategy : Strategy
             : CancellationTokenSource.CreateLinkedTokenSource(priorToken);
         ITimer? timer = null;
         ValueTask<Outcome<T>> execution;
+        var startedAt = context.TimeProvider.GetTimestamp();
 
         try
         {
@@ -139,14 +140,19 @@ internal sealed class TimeoutStrategy : Strategy
 
         if (!execution.IsCompletedSuccessfully)
         {
-            return AwaitAsync(execution, context, priorToken, timeoutSource, timer, timeout);
+            return AwaitAsync(execution, context, priorToken, timeoutSource, timer, timeout, startedAt);
         }
 
         var outcome = execution.Result;
         if (outcome.Exception is not OperationCanceledException cancellationException)
         {
-            Cleanup(context, priorToken, timeoutSource, timer);
-            return new ValueTask<Outcome<T>>(outcome);
+            return new ValueTask<Outcome<T>>(CompleteNonCancellation(
+                outcome,
+                context,
+                priorToken,
+                timeoutSource,
+                timer,
+                startedAt));
         }
 
         return CompleteCancellationAsync(
@@ -165,7 +171,8 @@ internal sealed class TimeoutStrategy : Strategy
         CancellationToken priorToken,
         CancellationTokenSource timeoutSource,
         ITimer? timer,
-        TimeSpan timeout)
+        TimeSpan timeout,
+        long startedAt)
     {
         Outcome<T> outcome;
 
@@ -181,8 +188,13 @@ internal sealed class TimeoutStrategy : Strategy
 
         if (outcome.Exception is not OperationCanceledException cancellationException)
         {
-            Cleanup(context, priorToken, timeoutSource, timer);
-            return outcome;
+            return CompleteNonCancellation(
+                outcome,
+                context,
+                priorToken,
+                timeoutSource,
+                timer,
+                startedAt);
         }
 
         return await CompleteCancellationAsync(
@@ -193,6 +205,32 @@ internal sealed class TimeoutStrategy : Strategy
             timeoutSource,
             timer,
             timeout).ConfigureAwait(false);
+    }
+
+    private Outcome<T> CompleteNonCancellation<T>(
+        Outcome<T> outcome,
+        KevlarContext context,
+        CancellationToken priorToken,
+        CancellationTokenSource timeoutSource,
+        ITimer? timer,
+        long startedAt)
+    {
+        context.CancellationToken = priorToken;
+        timer?.Dispose();
+        var timeoutIgnored = !priorToken.IsCancellationRequested && timeoutSource.IsCancellationRequested;
+        timeoutSource.Dispose();
+
+        if (timeoutIgnored)
+        {
+            KevlarMetrics.TimeoutIgnored(
+                context,
+                _telemetryName,
+                context.TimeProvider.GetElapsedTime(startedAt),
+                outcome.IsSuccess,
+                outcome.Exception);
+        }
+
+        return outcome;
     }
 
     private static void Cleanup(

--- a/tests/Kevlar.Extensions.Logging.Tests/LoggingTests.cs
+++ b/tests/Kevlar.Extensions.Logging.Tests/LoggingTests.cs
@@ -91,6 +91,37 @@ public class LoggingTests
 
     [Test]
     [NotInParallel]
+    public async Task Ignored_Timeout_Logs_Elapsed_Duration_At_Warning()
+    {
+        var logger = new FakeLogger();
+        var timeProvider = new FakeTimeProvider();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Timeout(TimeSpan.FromSeconds(1))
+            .WithTimeProvider(timeProvider)
+            .WithLogging(logger);
+
+        var execution = shield.ExecuteAsync(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            return 42;
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        release.SetResult();
+
+        await Assert.That(await execution.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(42);
+        var record = logger.Collector.GetSnapshot().Single();
+        await Assert.That(record.Id).IsEqualTo(new EventId(1010, "TimeoutIgnored"));
+        await Assert.That(record.Level).IsEqualTo(LogLevel.Warning);
+        await Assert.That(record.GetStructuredStateValue("Elapsed")).IsEqualTo(TimeSpan.FromSeconds(2).ToString());
+        await Assert.That(record.GetStructuredStateValue("Outcome")).IsEqualTo("success");
+    }
+
+    [Test]
+    [NotInParallel]
     public async Task Breaker_Opened_Logs_Error_With_State_And_Break_Duration()
     {
         var logger = new FakeLogger();

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -684,6 +684,35 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Ignored_Timeouts_Are_Counted_With_Their_Outcome()
+    {
+        using var listener = new KevlarMeterListener();
+        var timeProvider = new FakeTimeProvider();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shield = Shield.Timeout(TimeSpan.FromSeconds(1))
+            .WithName("metrics-timeouts-ignored")
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            return 42;
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        release.SetResult();
+
+        await Assert.That(await execution.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(42);
+        await Assert.That(listener.Total(
+            "kevlar.timeouts",
+            "metrics-timeouts-ignored",
+            ("outcome", "ignored"))).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Timeout_Telemetry_Uses_The_Surfaced_Exception()
     {
         using var meterListener = new KevlarMeterListener();

--- a/tests/Kevlar.Tests/TimeoutArbitrationTests.cs
+++ b/tests/Kevlar.Tests/TimeoutArbitrationTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Time.Testing;
+
 namespace Kevlar.Tests;
 
 public class TimeoutArbitrationTests
@@ -295,6 +297,50 @@ public class TimeoutArbitrationTests
     }
 
     [Test]
+    public async Task Ignored_Timeout_Emits_Elapsed_Telemetry_Without_OnTimeout()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutEvents = 0;
+        KevlarTelemetryEvent observed = default;
+        using var subscription = KevlarDiagnostics.Listen(new CallbackTelemetryListener(telemetryEvent =>
+        {
+            if (telemetryEvent.EventName == "timeout_ignored"
+                && telemetryEvent.ShieldName == "timeout-ignored-telemetry")
+            {
+                observed = telemetryEvent;
+            }
+        }));
+        var shield = Shield.Timeout(options =>
+        {
+            options.Timeout = TimeSpan.FromSeconds(1);
+            options.OnTimeout = _ => { timeoutEvents++; return default; };
+        })
+            .WithName("timeout-ignored-telemetry")
+            .WithTimeProvider(timeProvider);
+
+        var execution = shield.ExecuteAsync(async _ =>
+        {
+            started.SetResult();
+            await release.Task;
+            return 42;
+        }).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+        release.SetResult();
+        var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(observed.EventName).IsEqualTo("timeout_ignored");
+        await Assert.That(observed.Severity).IsEqualTo(KevlarTelemetrySeverity.Warning);
+        await Assert.That(observed.Duration).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(observed.IsSuccess).IsTrue();
+        await Assert.That(timeoutEvents).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Outer_Strategy_Sees_Caller_Token_After_Success_And_Timeout()
     {
         var timeProvider = new ManualTimeProvider();
@@ -472,6 +518,12 @@ public class TimeoutArbitrationTests
             ((TaskCompletionSource)state!).TrySetResult(), cancelled);
         await cancelled.Task;
         throw new OperationCanceledException("wrapped without token");
+    }
+
+    private sealed class CallbackTelemetryListener(Action<KevlarTelemetryEvent> callback)
+        : IKevlarTelemetryListener
+    {
+        public void OnEvent(in KevlarTelemetryEvent telemetryEvent) => callback(telemetryEvent);
     }
 
     private sealed class ManualTimeProvider : TimeProvider


### PR DESCRIPTION
When a cooperative timeout fires but the delegate completes with a non-cancellation outcome, emit a `timeout_ignored` Warning event with elapsed time while preserving the delegate outcome and skipping `OnTimeout`.

Also counts `kevlar.timeouts` with `outcome=ignored` and adds structured logging event 1010 (`TimeoutIgnored`).

Validation:
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -f net10.0 -c Release --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -f net8.0 -c Release --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Extensions.Logging.Tests -f net10.0 -c Release --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Extensions.Logging.Tests -f net8.0 -c Release --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m`
- allocation gates on net8.0 and net10.0
- API, changelog, docs, 198 snippets, and Docusaurus build

Closes #345