### PR TITLE
docs: require explicit DI imports in snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ state-sharing rules.
 `Kevlar.Extensions.Http` provides a ready-to-use `HttpClientFactory` pipeline:
 
 ```csharp
-using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddHttpClient("api")
     .AddStandardShield();

--- a/docs/docs/dependency-injection.md
+++ b/docs/docs/dependency-injection.md
@@ -123,6 +123,7 @@ dotnet add package Microsoft.Extensions.Configuration.Json
 
 ```csharp
 using Kevlar.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 var configuration = new ConfigurationBuilder()
     .SetBasePath(Directory.GetCurrentDirectory())
@@ -148,6 +149,7 @@ Configuration cannot reorder that chain — the order is what makes a definition
 
 ```csharp
 using Kevlar.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 var configuration = new ConfigurationBuilder()
     .SetBasePath(Directory.GetCurrentDirectory())
@@ -203,6 +205,7 @@ schema. The options name and shield name are the same; a change for another name
 ```csharp
 using Kevlar;
 using Kevlar.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 public sealed class CatalogResilienceOptions
 {
@@ -225,6 +228,8 @@ Named shields are also registered as keyed services, so you can skip the registr
 
 <!-- doc-test-declaration -->
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+
 public sealed class GitHubClient([FromKeyedServices("github")] Shield shield)
 {
     public Shield Resilience { get; } = shield;

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -39,6 +39,7 @@ Customize those stages without rebuilding the pipeline:
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddHttpClient("api")
     .AddStandardShield(options =>
@@ -74,6 +75,7 @@ For dependency-aware setup, use the service-provider overload:
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddSingleton(new ConcurrencyLimitOptions
 {
@@ -99,6 +101,7 @@ change token fires:
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 var configuration = new ConfigurationBuilder()
     .AddInMemoryCollection(new Dictionary<string, string?>
@@ -132,6 +135,7 @@ and delegates can deliberately override bound values:
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 var configuration = new ConfigurationBuilder()
     .AddInMemoryCollection(new Dictionary<string, string?>
@@ -167,6 +171,7 @@ Hedging uses the same reload contract. Its keys follow the nested
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 var configuration = new ConfigurationBuilder()
     .AddInMemoryCollection(new Dictionary<string, string?>
@@ -188,6 +193,7 @@ services.AddHttpClient("routed")
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddHttpClient("api")
     .AddShield(
@@ -255,6 +261,7 @@ var shield = HttpShield.WhenTransient()
 ```csharp
 using Kevlar.Extensions.DependencyInjection;
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddHttpClient("api")
     .AddShield(sp => sp.GetRequiredService<IKevlarRegistry>()
@@ -295,6 +302,7 @@ selector; `ShieldName` is metadata for selectors and has no global lookup behavi
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 var readShield = HttpShield.WhenTransient().Retry(3);
 var writeShield = HttpShield.WhenTransient().Retry(0);
@@ -311,6 +319,7 @@ directly:
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 var tenantShields = new PartitionedShield<string, HttpResponseMessage>(
     _ => HttpShield.WhenTransient()
@@ -366,6 +375,7 @@ Hedge against the request's own authority without registration-time routing conf
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddHttpClient("hedged")
     .AddStandardHedgeShield();
@@ -376,6 +386,7 @@ attempt 2, and so on across alternate authorities instead, configure endpoints e
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddHttpClient("routed")
     .AddStandardHedgeShield(options =>
@@ -407,6 +418,7 @@ For a fully custom endpoint-aware pipeline, compose the outer and endpoint shiel
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 var routing = new HttpEndpointRoutingOptions
 {

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -45,6 +45,8 @@ configuration independently with a one-second monotonic window.
 through Kevlar's integration packages:
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+
 services.AddKevlarLogging(options =>
 {
     options.IncludeScopes = true;

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -54,6 +54,8 @@ Kevlar publishes core metrics through a `System.Diagnostics.Metrics.Meter` named
 Register the core meter with OpenTelemetry:
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+
 services.AddOpenTelemetry().WithMetrics(metrics => metrics
     .AddMeter(KevlarDiagnostics.MeterName));
 ```
@@ -62,6 +64,7 @@ Applications that reference the optional `Kevlar.Chaos` package can register its
 
 ```csharp
 using Kevlar.Chaos;
+using Microsoft.Extensions.DependencyInjection;
 
 services.AddOpenTelemetry().WithMetrics(metrics => metrics
     .AddMeter(ChaosDiagnostics.MeterName));

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -211,6 +211,8 @@ Use the `onCompleted` overload of `ExecuteWithContextAsync` to copy final
 Polly registers builders and resolves them through `ResiliencePipelineProvider<TKey>`:
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+
 var pollyServices = new ServiceCollection();
 pollyServices.AddResiliencePipeline("catalog", static builder => builder.AddRetry(
     new RetryStrategyOptions { MaxRetryAttempts = 3 }));
@@ -224,6 +226,7 @@ Kevlar registers built shields and resolves them through `IKevlarRegistry` or ke
 
 ```csharp
 using Kevlar.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 var kevlarServices = new ServiceCollection();
 kevlarServices.AddShield("catalog", Shield.Retry(3));
@@ -253,12 +256,16 @@ before the service provider is built. Both providers expose non-throwing lookup 
 The standard handlers have corresponding `IHttpClientBuilder` extensions:
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+
 var pollyHttpServices = new ServiceCollection();
 pollyHttpServices.AddHttpClient("catalog")
     .AddStandardResilienceHandler(options => options.Retry.MaxRetryAttempts = 3);
 ```
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+
 var kevlarHttpServices = new ServiceCollection();
 kevlarHttpServices.AddHttpClient("catalog")
     .AddStandardShield(options => options.Retry.MaxRetries = 3);
@@ -278,6 +285,7 @@ Like Polly's standard handler, Kevlar hedges against the request's own authority
 
 ```csharp
 using Kevlar.Extensions.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 var kevlarHedgeServices = new ServiceCollection();
 kevlarHedgeServices.AddHttpClient("hedged-catalog")
@@ -309,6 +317,8 @@ var telemetryPipeline = new ResiliencePipelineBuilder()
 Kevlar publishes `System.Diagnostics.Metrics` instruments from the `Kevlar` meter:
 
 ```csharp
+using Microsoft.Extensions.DependencyInjection;
+
 var telemetryServices = new ServiceCollection();
 telemetryServices.AddOpenTelemetry()
     .WithMetrics(metrics => metrics.AddMeter(KevlarDiagnostics.MeterName));
@@ -319,6 +329,7 @@ decorate a shield directly or register it once for every DI, reloading, and HTTP
 
 ```csharp
 using Kevlar.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
 var loggedShield = Shield.Retry(3)
     .WithLogging(logger);

--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -323,7 +323,6 @@ $usingStatements = @(
     'using System.Threading;'
     'using System.Threading.Tasks;'
     'using Kevlar;'
-    'using Microsoft.Extensions.DependencyInjection;'
     'using Microsoft.Extensions.Configuration;'
     'using Microsoft.Extensions.Time.Testing;'
     'using Microsoft.Extensions.Logging;'


### PR DESCRIPTION
## Summary
- fix README `AddStandardShield` namespace import
- remove hidden DI import from snippet verifier
- add explicit DI imports to affected documentation fences

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release -p:Version=0.0.398`
- [x] `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 0.0.398 -NoImplicitUsings`
- [x] `pwsh scripts/Verify-Docs.ps1`
- [x] `npm run build --prefix docs`

Closes #398
