### PR TITLE
docs: explain hook exception isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ stateful strategies: calls made through the same shield share its circuit breake
   [BenchmarkDotNet results](https://thomhurst.github.io/Kevlar/docs/benchmarks).
 - **Production concerns are built in.** Shields support `TimeProvider`, describe their own pipeline,
   publish metrics through the `Kevlar` meter, and can emit structured `ILogger` events through
-  `Kevlar.Extensions.Logging`. Built-in analyzers catch cancellation and pipeline mistakes at
-  compile time.
+  `Kevlar.Extensions.Logging`. Hook exceptions never replace the protected outcome; observe them
+  through `KevlarDiagnostics.OnCallbackError`, logging, or `Kevlar.Testing.TelemetryRecorder`.
+  Built-in analyzers catch cancellation and pipeline mistakes at compile time.
 
 The core package targets `netstandard2.0`, `net8.0`, and `net10.0`.
 

--- a/docs/docs/chaos.md
+++ b/docs/docs/chaos.md
@@ -125,7 +125,9 @@ var behavior = ChaosShield.Behavior(options =>
 awaited before the injection proceeds, and `return default;` suffices for synchronous work. The
 event identifies the injection kind, effective rate and sample, operation, environment, and
 `KevlarContext`. The context is pooled: copy values inside the callback rather than retaining the
-context or event.
+context or event. Hook exceptions follow the shared
+[callback-failure contract](observability.md#callback-failures): Kevlar reports them without
+replacing the injected outcome.
 
 On .NET 8+, the `Kevlar.Chaos` meter publishes the `kevlar.chaos.injections` counter. Its tags are
 `kevlar.chaos.kind` plus the available `kevlar.shield.name`, `kevlar.chaos.operation`, and

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -287,6 +287,10 @@ through `KevlarDiagnostics.OnCallbackError`, increments `kevlar.callback_errors`
 Each diagnostics subscriber is isolated too: one throwing subscriber cannot prevent later
 subscribers from receiving the error.
 
+This differs from Polly, where a strategy-hook exception propagates to the caller. During migration,
+use `KevlarDiagnostics.OnCallbackError`, `AddKevlarLogging`, or `TelemetryRecorder` in tests to keep
+hook failures visible. See [semantic differences](polly-migration.md#semantic-differences).
+
 `CallbackErrorEvent` is detached from the pooled execution context. It carries the callback kind,
 stable source, shield name, strategy index, and original exception, so it can safely be retained or
 queued. Satellite integrations use `CallbackErrorKind.Custom` and identify their callback through

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -672,6 +672,10 @@ accepts `RateLimiter`, `PartitionedRateLimiter<KevlarContext>`, or a custom leas
   `Wrap` and `Compose` seal clauses at composition boundaries.
 - **Fallback ordering fails fast.** Kevlar rejects a fallback placed inside a retry, hedge, or
   breaker when both share the same clause; Polly builds that ineffective order silently.
+- **Hook exceptions never propagate.** Polly lets a strategy-hook exception fail the execution.
+  Kevlar reports hook failures without replacing the protected outcome. Observe them through
+  `KevlarDiagnostics.OnCallbackError`, structured logging from `AddKevlarLogging`, or
+  `TelemetryRecorder` in tests. See [callback failures](observability.md#callback-failures).
 - **Unhandled circuit outcomes are neutral.** Current Kevlar, like Polly, neither records an
   unhandled exception as a breaker failure nor resets prior consecutive failures.
 - **State is by instance.** Both libraries share breaker and limiter state only when the same built

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -150,8 +150,9 @@ transition currently being delivered. Use `ResetAsync()` and `IsolateAsync()` wh
 may yield so the calling thread is not blocked; these methods await every bound breaker in binding
 order. If an observer throws,
 later observers still run and the circuit keeps its new, usable state. Observer failures are
-reported through `KevlarDiagnostics.OnCallbackError` and never replace an execution outcome or
-block a transition.
+reported through `KevlarDiagnostics.OnCallbackError` under the shared
+[callback-failure contract](../observability.md#callback-failures) and never replace an execution
+outcome or block a transition.
 
 ## Share the circuit deliberately
 

--- a/docs/docs/strategies/concurrency-limit.md
+++ b/docs/docs/strategies/concurrency-limit.md
@@ -41,7 +41,8 @@ Total capacity is `MaxConcurrency + QueueLimit`. Anything beyond that fails **im
 For an actual rejection, Kevlar records the rejection counter, awaits `OnRejected`, then surfaces
 `ConcurrencyLimitExceededException`. Observable limiter gauges report the current state at the next
 metrics collection. The event includes the configured concurrency/queue limits, strategy index, and
-`KevlarContext`. Callback failures are reported through `KevlarDiagnostics.OnCallbackError`, and
+`KevlarContext`. Under the shared [callback-failure contract](../observability.md#callback-failures),
+failures are reported through `KevlarDiagnostics.OnCallbackError`, and
 `ConcurrencyLimitExceededException` remains the rejection outcome. A hook that completes
 synchronously works with synchronous `Execute`; one that yields throws `NotSupportedException`
 there and must run through `ExecuteAsync`.

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -91,9 +91,10 @@ callback to `options.OnFallback` as shown above.
 
 The `FallbackEvent<T>` carries the failure that triggered it as a typed `Outcome<T>` — `Outcome.Exception` when an exception was handled, `Outcome.Result` when a result value was. No casting, no boxing.
 
-`OnFallback` is awaited before the fallback value or factory runs. Callback failures are reported
-through `KevlarDiagnostics.OnCallbackError`; they do not replace the protected outcome or skip
-recovery. Fallback factory failures are preserved as the pipeline outcome.
+`OnFallback` is awaited before the fallback value or factory runs. Under the shared
+[callback-failure contract](../observability.md#callback-failures), failures are reported through
+`KevlarDiagnostics.OnCallbackError`; they do not replace the protected outcome or skip recovery.
+Fallback factory failures are preserved as the pipeline outcome.
 
 ## Notifications
 

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -122,7 +122,7 @@ flags untyped `Hedge(...)` for exactly this reason.
 
 - Losing attempts are cancelled through their token (use the token you're handed!).
 - Caller cancellation prevents any later hedge delegate from running, even when it races a completed stagger delay or occurs inside `DelayGenerator` or `OnHedge`. A cancellation already observable at the launch boundary suppresses callbacks.
-- Launch ordering is the awaited `DelayGenerator` (while the previous attempt is pending), then awaited `OnHedge`, action generation, metrics, then the selected operation. Callback failures are reported through `KevlarDiagnostics.OnCallbackError` and do not suppress the launch. Generator failures preserve their exception identity, cancel in-flight attempts, and are not counted as launched hedges.
+- Launch ordering is the awaited `DelayGenerator` (while the previous attempt is pending), then awaited `OnHedge`, action generation, metrics, then the selected operation. Under the shared [callback-failure contract](../observability.md#callback-failures), hook failures are reported through `KevlarDiagnostics.OnCallbackError` and do not suppress the launch. Generator failures preserve their exception identity, cancel in-flight attempts, and are not counted as launched hedges.
 - Each attempt gets a forked context — `Properties` are copied at launch time, so attempts don't see each other's writes.
 - Callback contexts are pooled. Do not retain them after the returned `ValueTask` completes; a generated action's isolated context remains valid until that attempt completes.
 - Callbacks and generators run without a strategy lock. They may re-enter the same shield, and concurrent shield executions may invoke them concurrently; keep captured state thread-safe.

--- a/docs/docs/strategies/rate-limit.md
+++ b/docs/docs/strategies/rate-limit.md
@@ -138,10 +138,11 @@ With `QueueLimit > 0`, up to that many executions reserve a future permit and **
 
 For an actual rejection, Kevlar records rejection metrics, awaits `OnRejected`, then surfaces
 `RateLimitExceededException`. The event includes `RetryAfter`, the configured
-permit/window/burst/queue values, the strategy index, and `KevlarContext`. Callback failures are
-reported through `KevlarDiagnostics.OnCallbackError`, and `RateLimitExceededException` remains the
-rejection outcome. Queued cancellation is cancellation, not rejection, so it does not invoke the
-hook. A hook that completes synchronously works with synchronous `Execute`; one that yields throws
+permit/window/burst/queue values, the strategy index, and `KevlarContext`. Under the shared
+[callback-failure contract](../observability.md#callback-failures), failures are reported through
+`KevlarDiagnostics.OnCallbackError`, and `RateLimitExceededException` remains the rejection outcome.
+Queued cancellation is cancellation, not rejection, so it does not invoke the hook. A hook that
+completes synchronously works with synchronous `Execute`; one that yields throws
 `NotSupportedException` there and must run through `ExecuteAsync`.
 
 Callback contexts are pooled. Do not retain `RateLimitRejectedEvent.Context` after the returned

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -117,6 +117,8 @@ Both hooks return `ValueTask`. A hook that completes synchronously (`return defa
 costs nothing extra and works with synchronous `Execute`. A hook that yields is awaited by
 `ExecuteAsync`; reached through synchronous `Execute`, it throws `NotSupportedException` at that
 call. See [synchronous execution compatibility](../executing.md#synchronous-execution-compatibility).
+Notification-hook exceptions follow the shared [callback-failure contract](../observability.md#callback-failures):
+they are reported and never replace the protected outcome.
 
 `RetryOptions` and `RetryOptions<T>` are standalone sibling types. Both expose the same
 `MaxRetries`, `Backoff`, and `MaxDelay` settings, while their callback properties use distinct

--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -90,9 +90,10 @@ Invalid `TimeoutOptions` values—and invalid durations returned by `TimeoutGene
 offending value.
 
 After a timeout wins, Kevlar records timeout metrics, restores the caller token, disposes timer state,
-then awaits `OnTimeout`. Callback exceptions and cancellations are reported through
-`KevlarDiagnostics.OnCallbackError`; `TimeoutExceededException` remains the outcome. Hooks may run
-concurrently when a shield is reused, so callbacks must be thread-safe and must not assume
+then awaits `OnTimeout`. Callback exceptions and cancellations follow the shared
+[callback-failure contract](../observability.md#callback-failures): they are reported through
+`KevlarDiagnostics.OnCallbackError`, and `TimeoutExceededException` remains the outcome. Hooks may
+run concurrently when a shield is reused, so callbacks must be thread-safe and must not assume
 serialization.
 
 `TimeoutGenerator` and `OnTimeout` both return `ValueTask`. A hook that completes synchronously

--- a/tests/Kevlar.Tests/DocsConsistencyTests.cs
+++ b/tests/Kevlar.Tests/DocsConsistencyTests.cs
@@ -218,6 +218,19 @@ public partial class DocsConsistencyTests
         }
     }
 
+    [Test]
+    public async Task Migration_Guide_Documents_Hook_Exception_Isolation()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var migrationGuide = await File.ReadAllTextAsync(
+            Path.Combine(repositoryRoot, "docs", "docs", "polly-migration.md"));
+
+        await Assert.That(migrationGuide).Contains("**Hook exceptions never propagate.**");
+        await Assert.That(migrationGuide).Contains("KevlarDiagnostics.OnCallbackError");
+        await Assert.That(migrationGuide).Contains("AddKevlarLogging");
+        await Assert.That(migrationGuide).Contains("TelemetryRecorder");
+    }
+
     private static Dictionary<string, ExceptionDocRow> ReadExceptionRows()
     {
         var repositoryRoot = FindRepositoryRoot();


### PR DESCRIPTION
## Summary
- document Kevlar hook-exception isolation as a Polly semantic difference
- link callback-failure guidance from every built-in strategy hook page and Chaos
- add a migration-guide documentation contract test

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m`
- [x] `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0-issue402 -NoImplicitUsings`
- [x] `npm ci` and `npm run build` from `docs/`

Closes #402
