### PR TITLE
docs(packaging): add package-specific readmes

### DIFF
--- a/scripts/Verify-DocSnippets.ps1
+++ b/scripts/Verify-DocSnippets.ps1
@@ -21,6 +21,10 @@ $changelogPath = Join-Path $repositoryRoot 'CHANGELOG.md'
 $documentPaths = @(
     (Join-Path $repositoryRoot 'README.md')
     $changelogPath
+    Get-ChildItem (Join-Path $repositoryRoot 'src') -Directory |
+        ForEach-Object { Join-Path $_.FullName 'README.md' } |
+        Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+        Sort-Object
     Get-ChildItem (Join-Path $repositoryRoot 'docs/docs') -Recurse -File -Include '*.md', '*.mdx' |
         Sort-Object FullName |
         ForEach-Object FullName
@@ -47,6 +51,12 @@ foreach ($packageId in $requiredPackages)
     if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf))
     {
         throw "Documented package '$packageId' was not packed at '$packagePath'."
+    }
+
+    $packageReadmePath = Join-Path $repositoryRoot "src/$packageId/README.md"
+    if (-not (Test-Path -LiteralPath $packageReadmePath -PathType Leaf))
+    {
+        throw "Documented package '$packageId' has no package-specific README at '$packageReadmePath'."
     }
 }
 

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -448,6 +448,15 @@ foreach ($packageId in $expectedDependencies.Keys)
             $readmeReader.Dispose()
         }
 
+        $packageReadmePath = Join-Path $repositoryRoot "src/$packageId/README.md"
+        if (-not (Test-Path -LiteralPath $packageReadmePath -PathType Leaf))
+        {
+            throw "$packageId has no package-specific README at '$packageReadmePath'."
+        }
+
+        $expectedReadme = Get-Content -LiteralPath $packageReadmePath -Raw
+        Assert-Equal "$packageId README contents" $embeddedReadme $expectedReadme
+
         if ($embeddedReadme -match '\]\((?!https?://|#|mailto:)[^)]+\)')
         {
             throw "$packageId README contains a relative Markdown link: '$($Matches[0])'."

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildProjectDirectory)\README.md" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)..\icon.png" Pack="true" PackagePath="\" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />

--- a/src/Kevlar.Chaos/README.md
+++ b/src/Kevlar.Chaos/README.md
@@ -1,0 +1,23 @@
+# Kevlar.Chaos
+
+Opt-in chaos strategies for Kevlar inject controlled latency, exceptions, results, or custom
+behavior with explicit blast-radius controls.
+
+```shell
+dotnet add package Kevlar.Chaos
+```
+
+```csharp
+using Kevlar.Chaos;
+
+var latency = ChaosShield.Latency(options =>
+{
+    options.Enabled = true;
+    options.Delay = TimeSpan.FromMilliseconds(250);
+    options.InjectionRate = 0.02;
+    options.Environment = "staging";
+});
+```
+
+See the [chaos engineering guide](https://thomhurst.github.io/Kevlar/docs/chaos) for deterministic
+runs, operation scopes, safety controls, and telemetry.

--- a/src/Kevlar.Extensions.DependencyInjection/README.md
+++ b/src/Kevlar.Extensions.DependencyInjection/README.md
@@ -1,0 +1,21 @@
+# Kevlar.Extensions.DependencyInjection
+
+Register immutable named Kevlar shields with `Microsoft.Extensions.DependencyInjection`, then
+resolve them through keyed services or `IKevlarRegistry`.
+
+```shell
+dotnet add package Kevlar.Extensions.DependencyInjection
+```
+
+```csharp
+using Kevlar;
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddShield(
+    "catalog",
+    Shield.Timeout(TimeSpan.FromSeconds(10)).Retry(3));
+```
+
+See the [dependency-injection guide](https://thomhurst.github.io/Kevlar/docs/dependency-injection)
+for factories, configuration reload, partitioning, and registry behavior.

--- a/src/Kevlar.Extensions.Grpc/README.md
+++ b/src/Kevlar.Extensions.Grpc/README.md
@@ -1,0 +1,19 @@
+# Kevlar.Extensions.Grpc
+
+Protect asynchronous unary and streaming gRPC client calls with Kevlar interceptors, transient
+status helpers, cancellation safety, and named-shield registration.
+
+```shell
+dotnet add package Kevlar.Extensions.Grpc
+```
+
+```csharp
+using Kevlar.Extensions.Grpc;
+
+var shield = GrpcShield.WhenTransient()
+    .Retry(3)
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+```
+
+See the [gRPC integration guide](https://thomhurst.github.io/Kevlar/docs/grpc) for interceptor
+registration, streaming progress boundaries, deadlines, and replay safety.

--- a/src/Kevlar.Extensions.Http/README.md
+++ b/src/Kevlar.Extensions.Http/README.md
@@ -1,0 +1,19 @@
+# Kevlar.Extensions.Http
+
+Add Kevlar resilience to `HttpClientFactory` with request replay controls, transient-fault
+handling, `Retry-After` support, and a production-ready standard pipeline.
+
+```shell
+dotnet add package Kevlar.Extensions.Http
+```
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddHttpClient("catalog")
+    .AddStandardShield();
+```
+
+See the [HTTP integration guide](https://thomhurst.github.io/Kevlar/docs/http) for pipeline
+defaults, request replay safety, hedging, routing, and configuration reload.

--- a/src/Kevlar.Extensions.Logging/README.md
+++ b/src/Kevlar.Extensions.Logging/README.md
@@ -1,0 +1,21 @@
+# Kevlar.Extensions.Logging
+
+Map Kevlar strategy events to stable, structured `Microsoft.Extensions.Logging` events without
+replacing strategy callbacks.
+
+```shell
+dotnet add package Kevlar.Extensions.Logging
+```
+
+```csharp
+using Kevlar;
+using Kevlar.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+var shield = Shield.Retry(3)
+    .WithName("catalog")
+    .WithLogging(NullLogger.Instance);
+```
+
+See the [structured logging guide](https://thomhurst.github.io/Kevlar/docs/logging) for event IDs,
+severity mapping, scopes, throttling, and result formatting.

--- a/src/Kevlar.Extensions.RateLimiting/README.md
+++ b/src/Kevlar.Extensions.RateLimiting/README.md
@@ -1,0 +1,27 @@
+# Kevlar.Extensions.RateLimiting
+
+Adapt `System.Threading.RateLimiting` instances, partitioned limiters, or custom asynchronous lease
+acquisition into Kevlar shields.
+
+```shell
+dotnet add package Kevlar.Extensions.RateLimiting
+```
+
+```csharp
+using Kevlar;
+using Kevlar.Extensions.RateLimiting;
+using System.Threading.RateLimiting;
+
+using var limiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+{
+    PermitLimit = 100,
+    Window = TimeSpan.FromSeconds(1),
+    QueueLimit = 0,
+    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+});
+
+var shield = Shield.Empty.UseRateLimiter(limiter);
+```
+
+See the [rate-limiting guide](https://thomhurst.github.io/Kevlar/docs/strategies/rate-limit) for
+ownership, rejection metadata, partitioning, and custom lease acquisition.

--- a/src/Kevlar.Testing/README.md
+++ b/src/Kevlar.Testing/README.md
@@ -1,0 +1,22 @@
+# Kevlar.Testing
+
+Inspect shield pipelines, assert strategy order, snapshot live state, capture telemetry, and drive
+time deterministically without depending on one test framework.
+
+```shell
+dotnet add package Kevlar.Testing
+```
+
+```csharp
+using Kevlar;
+using Kevlar.Testing;
+
+var shield = Shield.Timeout(TimeSpan.FromSeconds(10)).Retry(3);
+
+shield.GetDescriptor()
+    .AssertStrategyOrder(StrategyKind.Timeout, StrategyKind.Retry)
+    .AssertContainsSingle<RetryStrategyDescriptor>();
+```
+
+See the [testing guide](https://thomhurst.github.io/Kevlar/docs/testing) for descriptors,
+assertions, state snapshots, execution probes, fake time, and `TelemetryRecorder`.

--- a/src/Kevlar/README.md
+++ b/src/Kevlar/README.md
@@ -1,0 +1,20 @@
+# Kevlar
+
+Kevlar is an allocation-conscious resilience library for .NET. Compose retries, timeouts, circuit
+breakers, hedging, fallbacks, rate limits, and concurrency limits through one immutable `Shield` API.
+
+```shell
+dotnet add package Kevlar
+```
+
+```csharp
+using Kevlar;
+
+var shield = Shield
+    .Timeout(TimeSpan.FromSeconds(30))
+    .Retry(3)
+    .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
+```
+
+Start with the [Kevlar getting-started guide](https://thomhurst.github.io/Kevlar/docs/getting-started)
+or browse the [API reference](https://thomhurst.github.io/Kevlar/api/index.html).


### PR DESCRIPTION
## Summary
- add package-specific NuGet README content for all eight packable projects
- pack each project's README at the nupkg root
- compile package README snippets and verify embedded content matches source

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/readme -Version 0.0.0-local`
- [x] `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/readme-snippets -Version 0.0.0-issue399 -NoImplicitUsings`
- [x] `npm run build --prefix docs`

Closes #399
