### PR TITLE
fix(packaging): version analyzer asset path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           dotnet-version: |
+            7.0.x
             8.0.x
             10.0.x
 
@@ -236,6 +237,13 @@ jobs:
         env:
           PACKAGE_VERSION: ${{ steps.gitversion.outputs.semVer }}
         run: ./scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/release -Version $env:PACKAGE_VERSION
+
+      - name: Verify analyzer compatibility with .NET 7 SDK
+        if: matrix.os == 'ubuntu-latest'
+        shell: pwsh
+        env:
+          PACKAGE_VERSION: ${{ steps.gitversion.outputs.semVer }}
+        run: ./scripts/Verify-AnalyzerCompatibility.ps1 -PackagesPath artifacts/package/release -Version $env:PACKAGE_VERSION
 
       - name: Validate Renovate configuration
         if: matrix.os == 'ubuntu-latest'

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -10,9 +10,9 @@ required. They report diagnostics only; Kevlar does not install code fixes or ID
 ## Toolchain compatibility
 
 Kevlar's analyzers reference Microsoft.CodeAnalysis 4.8.0. Use Visual Studio 2022 17.8 or later,
-or the .NET 8.0.100 SDK or later. An older compiler can report `CS9057` because the analyzer was
-built against a newer compiler; projects that treat warnings as errors will then fail their build.
-Updating the compiler host is the preferred fix.
+or the .NET 8.0.100 SDK or later to run them. The package places them in its `roslyn4.8` analyzer
+band, so older compiler hosts skip them instead of reporting `CS9057`; the Kevlar runtime library
+remains available. Update the compiler host when those projects should also run Kevlar's analyzers.
 
 ## Disabling analyzers
 

--- a/scripts/Verify-AnalyzerCompatibility.ps1
+++ b/scripts/Verify-AnalyzerCompatibility.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$PackagesPath,
+
+    [Parameter(Mandatory)]
+    [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+
+$resolvedPackagesPath = (Resolve-Path -LiteralPath $PackagesPath).Path
+$sdkVersion = dotnet --list-sdks |
+    ForEach-Object { ($_ -split '\s+', 2)[0] } |
+    Where-Object { $_ -match '^7\.' } |
+    Sort-Object { [Version]$_ } -Descending |
+    Select-Object -First 1
+if (-not $sdkVersion)
+{
+    throw 'A .NET 7 SDK is required for the pre-Roslyn-4.8 analyzer compatibility check.'
+}
+
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) "kevlar-analyzer-compat-$([Guid]::NewGuid().ToString('N'))"
+$utf8 = [Text.UTF8Encoding]::new($false)
+$previousNuGetPackages = $env:NUGET_PACKAGES
+
+try
+{
+    New-Item -ItemType Directory -Path $testRoot | Out-Null
+    $env:NUGET_PACKAGES = Join-Path $testRoot 'packages'
+    [IO.File]::WriteAllText(
+        (Join-Path $testRoot 'global.json'),
+        (@{
+            sdk = @{
+                version = $sdkVersion
+                rollForward = 'disable'
+            }
+        } | ConvertTo-Json -Depth 2),
+        $utf8)
+
+    $project = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Kevlar" Version="$Version" />
+  </ItemGroup>
+</Project>
+"@
+    [IO.File]::WriteAllText((Join-Path $testRoot 'AnalyzerCompatibility.csproj'), $project, $utf8)
+    [IO.File]::WriteAllText(
+        (Join-Path $testRoot 'Program.cs'),
+        "using System;`nusing Kevlar;`n`nConsole.WriteLine(Shield.Empty);`n",
+        $utf8)
+
+    $escapedPackagesPath = [Security.SecurityElement]::Escape($resolvedPackagesPath)
+    $nugetConfig = @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local-packages" value="$escapedPackagesPath" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@
+    $nugetConfigPath = Join-Path $testRoot 'NuGet.config'
+    [IO.File]::WriteAllText($nugetConfigPath, $nugetConfig, $utf8)
+
+    Push-Location $testRoot
+    try
+    {
+        $selectedSdk = dotnet --version
+        if ($selectedSdk -ne $sdkVersion)
+        {
+            throw "Expected .NET SDK $sdkVersion, got $selectedSdk."
+        }
+
+        dotnet restore AnalyzerCompatibility.csproj --configfile $nugetConfigPath
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Analyzer compatibility restore failed with exit code $LASTEXITCODE."
+        }
+
+        $buildOutput = @(dotnet build AnalyzerCompatibility.csproj -c Release --no-restore -warnaserror 2>&1)
+        $buildOutput | Write-Host
+        if ($buildOutput -match 'CS9057')
+        {
+            throw 'The pre-Roslyn-4.8 compiler attempted to load the Kevlar analyzer (CS9057).'
+        }
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Analyzer compatibility build failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally
+    {
+        Pop-Location
+    }
+}
+finally
+{
+    if ($null -eq $previousNuGetPackages)
+    {
+        Remove-Item Env:NUGET_PACKAGES -ErrorAction SilentlyContinue
+    }
+    else
+    {
+        $env:NUGET_PACKAGES = $previousNuGetPackages
+    }
+
+    if (Test-Path -LiteralPath $testRoot)
+    {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}

--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -104,7 +104,7 @@ function Get-ExpectedSymbolAssets([string]$PackageId)
     if ($PackageId -eq 'Kevlar')
     {
         $assets += @(
-            'analyzers/dotnet/cs/Kevlar.Analyzers.pdb'
+            'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.pdb'
         )
     }
 
@@ -548,10 +548,10 @@ foreach ($packageId in $expectedDependencies.Keys)
         if ($packageId -eq 'Kevlar')
         {
             Assert-Set "$packageId analyzer assets" `
-                ($entries | Where-Object { $_ -like 'analyzers/dotnet/cs/*' }) `
+                ($entries | Where-Object { $_ -match '^analyzers/' }) `
                 @(
-                    'analyzers/dotnet/cs/Kevlar.Analyzers.dll',
-                    'analyzers/dotnet/cs/Kevlar.Analyzers.pdb'
+                    'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.dll',
+                    'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.pdb'
                 )
         }
         elseif ($entries | Where-Object { $_ -match '^analyzers/' })

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -29,11 +29,11 @@
   <ItemGroup>
     <None Include="$(ArtifactsPath)\bin\Kevlar.Analyzers\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.dll"
           Pack="true"
-          PackagePath="analyzers/dotnet/cs"
+          PackagePath="analyzers/dotnet/roslyn4.8/cs"
           Visible="false" />
     <None Include="$(ArtifactsPath)\bin\Kevlar.Analyzers\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.pdb"
           Pack="true"
-          PackagePath="analyzers/dotnet/cs"
+          PackagePath="analyzers/dotnet/roslyn4.8/cs"
           Visible="false" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- pack `Kevlar.Analyzers` under the `roslyn4.8` analyzer band
- make package verification reject legacy or unexpected analyzer assets
- add a .NET 7 SDK consumer smoke that treats warnings as errors and fails on CS9057
- document automatic analyzer skipping on older compiler hosts

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/green397 -Version 0.0.0-local`
- [x] `pwsh scripts/Verify-AnalyzerCompatibility.ps1 -PackagesPath artifacts/package/green397 -Version 0.0.0-local`
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m --zero-tests-policy strict`
- [x] `pwsh scripts/Verify-Repo.ps1`
- [x] `pwsh scripts/Verify-Docs.ps1`

Closes #397
