### PR TITLE
refactor(analyzers): make config hints opt-in

### DIFF
--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -33,21 +33,35 @@ The analyzers report only hazards that are provable from the current expression 
 initializer. They do not guess what a factory method returns or follow a local that is reassigned.
 Generated code is ignored.
 
-| Rule | Severity | Hazard |
-|---|---|---|
-| `KEV001` | Warning | execution delegate ignores its `CancellationToken` |
-| `KEV002` | Warning | known multi-attempt hedging pipeline is passed to synchronous `Execute` |
-| `KEV003` | Warning | inner fallback makes retry, hedging, or circuit breaker unreachable |
-| `KEV004` | Warning | stateful shield or partition provider is constructed for one execution |
-| `KEV005` | Warning | void fallback is executed with a result-returning delegate |
-| `KEV006` | Warning | hedging is added to an untyped shield, whose action must be idempotent |
-| `KEV007` | Warning | handling clause never reaches a reactive strategy |
-| `KEV008` | Warning | fluent chaining result is discarded as a statement |
-| `KEV009` | Info | strategy inherits a handling clause declared earlier in the chain |
-| `KEV010` | Info | default-result clause is written for a value type, whose default is usually valid |
-| `KEV011` | Info | reactive strategy relies on implicit default handling, which includes programming errors |
-| `KEV012` | Warning | a delegate that completes asynchronously is assigned to a hook of a shield passed to synchronous `Execute` |
-| `KEV014` | Warning | a pooled event context is captured by deferred work |
+## Enabling stricter configuration hints
+
+`KEV009`, `KEV010`, and `KEV011` are opt-in informational design hints. Enable whichever checks
+match your team's conventions in `.editorconfig`:
+
+```ini
+[*.cs]
+dotnet_diagnostic.KEV009.severity = suggestion
+dotnet_diagnostic.KEV010.severity = suggestion
+dotnet_diagnostic.KEV011.severity = suggestion
+```
+
+The warning-level safety rules remain enabled by default.
+
+| Rule | Severity | Default | Hazard |
+|---|---|---|---|
+| `KEV001` | Warning | On | execution delegate ignores its `CancellationToken` |
+| `KEV002` | Warning | On | known multi-attempt hedging pipeline is passed to synchronous `Execute` |
+| `KEV003` | Warning | On | inner fallback makes retry, hedging, or circuit breaker unreachable |
+| `KEV004` | Warning | On | stateful shield or partition provider is constructed for one execution |
+| `KEV005` | Warning | On | void fallback is executed with a result-returning delegate |
+| `KEV006` | Warning | On | hedging is added to an untyped shield, whose action must be idempotent |
+| `KEV007` | Warning | On | handling clause never reaches a reactive strategy |
+| `KEV008` | Warning | On | fluent chaining result is discarded as a statement |
+| `KEV009` | Info | Off | strategy inherits a handling clause declared earlier in the chain |
+| `KEV010` | Info | Off | default-result clause is written for a value type, whose default is usually valid |
+| `KEV011` | Info | Off | reactive strategy relies on implicit default handling, which includes programming errors |
+| `KEV012` | Warning | On | a delegate that completes asynchronously is assigned to a hook of a shield passed to synchronous `Execute` |
+| `KEV014` | Warning | On | a pooled event context is captured by deferred work |
 
 ## KEV001: ignored execution cancellation
 
@@ -292,9 +306,9 @@ never flagged and never end the inherited span. A strategy that sets `HandlesExc
 `HandlesResult` in its own options has opted out of the ambient clause and is not flagged either.
 The rule follows one fluent chain and a stable local, and stops at `Wrap`/`Compose` boundaries.
 
-Because it is `Info`, `KEV009` never fails a build, including under `TreatWarningsAsErrors`. Turn it
-off entirely with `dotnet_diagnostic.KEV009.severity = none` in `.editorconfig` if the ambient model
-is already second nature to your team.
+`KEV009` is disabled by default. Enable it through the
+[stricter configuration hints](#enabling-stricter-configuration-hints) when the extra editor signal
+fits your team's conventions.
 
 ## KEV010: default-result clause on a value type
 
@@ -323,8 +337,8 @@ var shield = Shield.For<string>().WhenResultIsNull().Retry(3);
 
 The rule reads `TResult` from the shield being configured. `Nullable<T>` results are left alone —
 their default *is* the missing value — and so is generic code, where `default(TResult)` is the only
-term available. Like `KEV009`, `KEV010` is `Info` and never fails a build; silence it per site with
-a pragma or project-wide with `dotnet_diagnostic.KEV010.severity = none`.
+term available. `KEV010` is disabled by default and can be enabled through the
+[stricter configuration hints](#enabling-stricter-configuration-hints).
 
 ## KEV011: implicit default handling
 
@@ -351,16 +365,14 @@ A local `HandlesException` or `HandlesResult` override also makes the policy exp
 does not report proactive strategies, an explicit `WithDefaultHandling()` reset, or opaque configuration
 that the analyzer cannot prove still uses the default.
 
-`KEV011` is an informational design hint, not a warning. Keep the default when it is deliberate,
-and suppress the hint at that site with a reason:
+`KEV011` is an opt-in informational design hint, not a warning. After enabling it, keep the default
+when it is deliberate and suppress the hint at that site with a reason:
 
 ```csharp
 #pragma warning disable KEV011 // This boundary deliberately retries every ordinary exception.
 var shield = Shield.Retry(3);
 #pragma warning restore KEV011
 ```
-
-Disable it project-wide with `dotnet_diagnostic.KEV011.severity = none`.
 
 ## KEV012: async configuration with synchronous Execute
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -33,11 +33,6 @@ exponential with equal jitter, starting at 250 ms and capped at 30 seconds. Alwa
 cancellation token passed to your delegate; timeout and hedging strategies use it to stop
 abandoned work.
 
-Bundled analyzer conventions: name the execution token `_` only for genuinely uncancellable work;
-otherwise pass it through. Plain `Retry(3)` also raises an informational diagnostic; narrow
-handling or set [`dotnet_diagnostic.KEV011.severity = none`](analyzers.md#kev011-implicit-default-handling)
-when broad default handling is deliberate.
-
 Shields are immutable and thread-safe. Build one and reuse it. Reuse also preserves state: calls
 through the same shield share circuit-breaker and limiter state.
 

--- a/src/Kevlar.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Kevlar.Analyzers/AnalyzerReleases.Shipped.md
@@ -15,8 +15,8 @@ KEV005 | Configuration | Warning | Void fallback is used with a result-returning
 KEV006 | Reliability | Warning | Hedging on an untyped Shield requires an idempotent action
 KEV007 | Configuration | Warning | Handling clause never reaches a reactive strategy
 KEV008 | Configuration | Warning | Fluent chaining result is discarded as a statement
-KEV009 | Configuration | Info | Strategy inherits a handling clause declared earlier in the chain
-KEV010 | Configuration | Info | Default-result clause handles a value type's default
-KEV011 | Configuration | Info | Reactive strategy uses implicit default handling
+KEV009 | Configuration | Disabled | Strategy inherits a handling clause declared earlier in the chain
+KEV010 | Configuration | Disabled | Default-result clause handles a value type's default
+KEV011 | Configuration | Disabled | Reactive strategy uses implicit default handling
 KEV012 | Reliability | Warning | Asynchronous strategy configuration requires ExecuteAsync
 KEV014 | Reliability | Warning | Pooled event context is captured by deferred work

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -156,7 +156,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         messageFormat: "This strategy inherits the handling clause declared earlier in the chain ('{0}'); only those exceptions or results count toward it. Declare a new clause, or call 'WithDefaultHandling()' first, to give it different handling.",
         category: "Configuration",
         defaultSeverity: DiagnosticSeverity.Info,
-        isEnabledByDefault: true,
+        isEnabledByDefault: false,
         description: "A handling clause stays ambient for every reactive strategy chained after it until a new clause replaces it, WithDefaultHandling resets it, or Wrap/Compose seals it. That is by design; this diagnostic makes the inherited span visible at the strategies that silently pick the clause up.",
         helpLinkUri: AnalyzerHelpLink.Create("KEV009", "inherited-handling-clause"));
 
@@ -167,7 +167,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         messageFormat: "'{0}' handles 'default({1})', which for a value type — 0, false, an empty struct — is as often a legitimate result as a failure. Confirm that is intended, or select the failing results with 'WhenResult'/'OrResult'.",
         category: "Configuration",
         defaultSeverity: DiagnosticSeverity.Info,
-        isEnabledByDefault: true,
+        isEnabledByDefault: false,
         description: "WhenResultIsDefault and OrResultIsDefault were named for reference types, where default(TResult) is null and a missing value is usually the failure. On a value type the same clause treats a zero, a false, or an empty struct as a failure worth retrying, hedging, or falling back from. Reference-type shields can say so explicitly with WhenResultIsNull and OrResultIsNull.",
         helpLinkUri: AnalyzerHelpLink.Create("KEV010", "default-result-clause-on-a-value-type"));
 
@@ -178,7 +178,7 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
         messageFormat: "'{0}' uses Kevlar's default handling, which includes programming errors. Declare a When clause or local HandlesException override when only expected failures should be handled.",
         category: "Configuration",
         defaultSeverity: DiagnosticSeverity.Info,
-        isEnabledByDefault: true,
+        isEnabledByDefault: false,
         description: "Without an explicit handling clause, reactive strategies handle ordinary exceptions, including programming errors such as ArgumentException and InvalidOperationException. This hint makes that implicit policy visible so transient-failure pipelines can narrow it deliberately.",
         helpLinkUri: AnalyzerHelpLink.Create("KEV011", "implicit-default-handling"));
 

--- a/tests/Kevlar.Analyzers.Tests/AnalyzerMetadataTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/AnalyzerMetadataTests.cs
@@ -56,7 +56,13 @@ public class AnalyzerMetadataTests
             await Assert.That(rules[informationalRule].DefaultSeverity).IsEqualTo(DiagnosticSeverity.Info);
         }
 
-        await Assert.That(rules.Values.All(static rule => rule.IsEnabledByDefault)).IsTrue();
+        var optInRuleIds = new[] { "KEV009", "KEV010", "KEV011" };
+        await Assert.That(rules.Values
+            .Where(rule => optInRuleIds.Contains(rule.Id, StringComparer.Ordinal))
+            .All(static rule => !rule.IsEnabledByDefault)).IsTrue();
+        await Assert.That(rules.Values
+            .Where(rule => !optInRuleIds.Contains(rule.Id, StringComparer.Ordinal))
+            .All(static rule => rule.IsEnabledByDefault)).IsTrue();
         await Assert.That(rules.Values.All(static rule =>
             !string.IsNullOrWhiteSpace(rule.Title.ToString())
             && !string.IsNullOrWhiteSpace(rule.MessageFormat.ToString())
@@ -119,10 +125,14 @@ public class AnalyzerMetadataTests
             .Concat(new PipelineHazardAnalyzer().SupportedDiagnostics)
             .Single(rule => rule.Id == ruleId);
 
+        var isOptIn = ruleId is "KEV009" or "KEV010" or "KEV011";
+        var shippedSeverity = isOptIn ? "Disabled" : severity.ToString();
+
         await Assert.That(shippedRule[1]).IsEqualTo(category);
-        await Assert.That(shippedRule[2]).IsEqualTo(severity.ToString());
+        await Assert.That(shippedRule[2]).IsEqualTo(shippedSeverity);
         await Assert.That(descriptor.Category).IsEqualTo(shippedRule[1]);
-        await Assert.That(descriptor.DefaultSeverity.ToString()).IsEqualTo(shippedRule[2]);
+        await Assert.That(descriptor.DefaultSeverity).IsEqualTo(severity);
+        await Assert.That(descriptor.IsEnabledByDefault).IsEqualTo(!isOptIn);
     }
 
     private static string FindRepositoryRoot()

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -12,6 +12,20 @@ namespace Kevlar.Analyzers.Tests;
 public class PipelineHazardAnalyzerTests
 {
     [Test]
+    public async Task OptIn_Configuration_Hints_Are_Disabled_By_Default()
+    {
+        var diagnostics = await AnalyzeBodyAsync("""
+            _ = Shield.For<int>()
+                .WhenResultIsDefault()
+                .Retry(1)
+                .CircuitBreaker(2, TimeSpan.FromSeconds(1));
+            _ = Shield.Retry(1);
+            """);
+
+        await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
     public async Task KEV014_Allows_Event_Use_After_Await_In_Awaited_Hooks()
     {
         var callbacks = new[]
@@ -6474,7 +6488,7 @@ public class PipelineHazardAnalyzerTests
             "var outer = Shield.When<InvalidOperationException>().Retry(1); _ = outer.CircuitBreaker(2, TimeSpan.FromSeconds(1));",
         };
 
-        await AssertEachAsync(cases, "KEV009", DiagnosticSeverity.Info, "KEV010");
+        await AssertEachOptInAsync(cases, "KEV009", DiagnosticSeverity.Info);
     }
 
     [Test]
@@ -6488,7 +6502,7 @@ public class PipelineHazardAnalyzerTests
                 .CircuitBreaker(2, TimeSpan.FromSeconds(1))
                 .RateLimit(10, TimeSpan.FromSeconds(1))
                 .RetryForever(Backoff.None);
-            """);
+            """, enabledRuleIds: ["KEV009"]);
 
         // The retry states the clause at its own call site; the breaker and the forever-retry
         // inherit it across the timeout and rate limit, which carry no clause of their own.
@@ -6526,7 +6540,8 @@ public class PipelineHazardAnalyzerTests
         {
             var diagnostics = await AnalyzeBodyAsync(
                 body,
-                "private static Shield CreateShield() => Shield.When<InvalidOperationException>().Retry(1);");
+                "private static Shield CreateShield() => Shield.When<InvalidOperationException>().Retry(1);",
+                enabledRuleIds: ["KEV009"]);
             await Assert.That(diagnostics).IsEmpty();
         }
     }
@@ -6535,12 +6550,12 @@ public class PipelineHazardAnalyzerTests
     public async Task KEV009_Diagnostic_Contract_And_Suppression_Are_Exact()
     {
         const string body = "_ = Shield.When<InvalidOperationException>().Retry(1).CircuitBreaker(2, TimeSpan.FromSeconds(1));";
-        var diagnostics = await AnalyzeBodyAsync(body);
+        var diagnostics = await AnalyzeBodyAsync(body, enabledRuleIds: ["KEV009"]);
         var suppressed = await AnalyzeBodyAsync($"""
             #pragma warning disable KEV009 // The inherited clause is deliberate here.
             {body}
             #pragma warning restore KEV009
-            """);
+            """, enabledRuleIds: ["KEV009"]);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         var diagnostic = diagnostics[0];
@@ -6572,7 +6587,7 @@ public class PipelineHazardAnalyzerTests
             "var clause = Shield.For<int>().WhenResultIsDefault(); _ = clause.Retry(1);",
         };
 
-        await AssertEachAsync(cases, "KEV010", DiagnosticSeverity.Info);
+        await AssertEachOptInAsync(cases, "KEV010", DiagnosticSeverity.Info);
     }
 
     [Test]
@@ -6593,7 +6608,8 @@ public class PipelineHazardAnalyzerTests
             var diagnostics = await AnalyzeBodyAsync(
                 body,
                 // Generic code has no result to name but default(T), so the clause is all it can write.
-                "private static Shield<T> Build<T>() => Shield.For<T>().WhenResultIsDefault().Retry(1);");
+                "private static Shield<T> Build<T>() => Shield.For<T>().WhenResultIsDefault().Retry(1);",
+                enabledRuleIds: ["KEV010"]);
             await Assert.That(diagnostics).IsEmpty();
         }
     }
@@ -6602,12 +6618,12 @@ public class PipelineHazardAnalyzerTests
     public async Task KEV010_Diagnostic_Contract_And_Suppression_Are_Exact()
     {
         const string body = "_ = Shield.For<int>().WhenResultIsDefault().Retry(1);";
-        var diagnostics = await AnalyzeBodyAsync(body);
+        var diagnostics = await AnalyzeBodyAsync(body, enabledRuleIds: ["KEV010"]);
         var suppressed = await AnalyzeBodyAsync($"""
             #pragma warning disable KEV010 // Zero really is the failure here.
             {body}
             #pragma warning restore KEV010
-            """);
+            """, enabledRuleIds: ["KEV010"]);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         var diagnostic = diagnostics[0];
@@ -6639,7 +6655,7 @@ public class PipelineHazardAnalyzerTests
 
         foreach (var body in cases)
         {
-            var diagnostics = await AnalyzeBodyAsync(body, enableImplicitDefaultHandlingRule: true);
+            var diagnostics = await AnalyzeBodyAsync(body, enabledRuleIds: ["KEV011"]);
             await AssertRuleAsync(Without(diagnostics, "KEV006"), "KEV011", DiagnosticSeverity.Info);
         }
     }
@@ -6659,7 +6675,7 @@ public class PipelineHazardAnalyzerTests
 
         foreach (var body in cases)
         {
-            var diagnostics = await AnalyzeBodyAsync(body, enableImplicitDefaultHandlingRule: true);
+            var diagnostics = await AnalyzeBodyAsync(body, enabledRuleIds: ["KEV011"]);
             await Assert.That(Without(diagnostics, "KEV009")).IsEmpty();
         }
     }
@@ -6668,12 +6684,12 @@ public class PipelineHazardAnalyzerTests
     public async Task KEV011_Diagnostic_Contract_And_Suppression_Are_Exact()
     {
         const string body = "_ = Shield.Retry(3);";
-        var diagnostics = await AnalyzeBodyAsync(body, enableImplicitDefaultHandlingRule: true);
+        var diagnostics = await AnalyzeBodyAsync(body, enabledRuleIds: ["KEV011"]);
         var suppressed = await AnalyzeBodyAsync($"""
             #pragma warning disable KEV011 // Retrying all ordinary errors is deliberate.
             {body}
             #pragma warning restore KEV011
-            """, enableImplicitDefaultHandlingRule: true);
+            """, enabledRuleIds: ["KEV011"]);
 
         await Assert.That(diagnostics.Length).IsEqualTo(1);
         var diagnostic = diagnostics[0];
@@ -6973,6 +6989,18 @@ public class PipelineHazardAnalyzerTests
         }
     }
 
+    private static async Task AssertEachOptInAsync(
+        IEnumerable<string> cases,
+        string expectedRule,
+        DiagnosticSeverity expectedSeverity)
+    {
+        foreach (var body in cases)
+        {
+            var diagnostics = await AnalyzeBodyAsync(body, enabledRuleIds: [expectedRule]);
+            await AssertRuleAsync(diagnostics, expectedRule, expectedSeverity);
+        }
+    }
+
     private static async Task AssertEachAsync(
         IEnumerable<string> cases,
         string expectedRule,
@@ -7014,7 +7042,7 @@ public class PipelineHazardAnalyzerTests
         string members = "",
         bool isGenerated = false,
         string assemblyName = "PipelineHazardAnalyzerTestSubject",
-        bool enableImplicitDefaultHandlingRule = false) =>
+        ImmutableArray<string> enabledRuleIds = default) =>
         AnalyzeSourceAsync($$"""
             public class TestSubject
             {
@@ -7025,18 +7053,18 @@ public class PipelineHazardAnalyzerTests
                     {{body}}
                 }
             }
-            """, isGenerated, assemblyName: assemblyName, enableImplicitDefaultHandlingRule: enableImplicitDefaultHandlingRule);
+            """, isGenerated, assemblyName: assemblyName, enabledRuleIds: enabledRuleIds);
 
     private static async Task<ImmutableArray<Diagnostic>> AnalyzeSourceAsync(
         string declarations,
         bool isGenerated = false,
         bool allowCompilationErrors = false,
         string assemblyName = "PipelineHazardAnalyzerTestSubject",
-        bool enableImplicitDefaultHandlingRule = false,
-        MetadataReference? additionalReference = null)
+        MetadataReference? additionalReference = null,
+        ImmutableArray<string> enabledRuleIds = default)
     {
-        var source = CreateSource(declarations, isGenerated, enableImplicitDefaultHandlingRule);
-        var compilation = CreateCompilation(source, assemblyName, additionalReference);
+        var source = CreateSource(declarations, isGenerated);
+        var compilation = CreateCompilation(source, assemblyName, additionalReference, enabledRuleIds);
         var errors = compilation.GetDiagnostics().Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
         if (!allowCompilationErrors && errors.Length > 0)
         {
@@ -7070,10 +7098,8 @@ public class PipelineHazardAnalyzerTests
 
     private static string CreateSource(
         string declarations,
-        bool isGenerated = false,
-        bool enableImplicitDefaultHandlingRule = false) =>
+        bool isGenerated = false) =>
         (isGenerated ? "// <auto-generated/>\n" : string.Empty)
-        + (enableImplicitDefaultHandlingRule ? string.Empty : "#pragma warning disable KEV011\n")
         + $$"""
             using System;
             using System.Threading;
@@ -7088,7 +7114,8 @@ public class PipelineHazardAnalyzerTests
     private static CSharpCompilation CreateCompilation(
         string source,
         string assemblyName = "PipelineHazardAnalyzerTestSubject",
-        MetadataReference? additionalReference = null)
+        MetadataReference? additionalReference = null,
+        ImmutableArray<string> enabledRuleIds = default)
     {
         var references = GetMetadataReferences();
         if (additionalReference is not null)
@@ -7096,11 +7123,18 @@ public class PipelineHazardAnalyzerTests
             references = references.Append(additionalReference);
         }
 
+        var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        if (!enabledRuleIds.IsDefaultOrEmpty)
+        {
+            compilationOptions = (CSharpCompilationOptions)compilationOptions
+                .WithSyntaxTreeOptionsProvider(new EditorConfigOptionsProvider(enabledRuleIds));
+        }
+
         return CSharpCompilation.Create(
             assemblyName,
-            [CSharpSyntaxTree.ParseText(source)],
+            [CSharpSyntaxTree.ParseText(source, path: GetTestPath("TestSubject.cs"))],
             references,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            compilationOptions);
     }
 
     private static MetadataReference CreateMetadataReference(string declarations)
@@ -7133,4 +7167,48 @@ public class PipelineHazardAnalyzerTests
         compilation
             .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new PipelineHazardAnalyzer()))
             .GetAnalyzerDiagnosticsAsync();
+
+    private sealed class EditorConfigOptionsProvider : SyntaxTreeOptionsProvider
+    {
+        private readonly AnalyzerConfigSet _configSet;
+
+        public EditorConfigOptionsProvider(ImmutableArray<string> enabledRuleIds)
+        {
+            var settings = string.Join(
+                "\n",
+                enabledRuleIds.Select(static ruleId =>
+                    $"dotnet_diagnostic.{ruleId}.severity = suggestion"));
+            var editorConfig = AnalyzerConfig.Parse(
+                $$"""
+                root = true
+
+                [*.cs]
+                {{settings}}
+                """,
+                GetTestPath(".editorconfig"));
+            _configSet = AnalyzerConfigSet.Create(new[] { editorConfig });
+        }
+
+        public override GeneratedKind IsGenerated(
+            SyntaxTree tree,
+            CancellationToken cancellationToken) => GeneratedKind.Unknown;
+
+        public override bool TryGetDiagnosticValue(
+            SyntaxTree tree,
+            string diagnosticId,
+            CancellationToken cancellationToken,
+            out ReportDiagnostic severity) =>
+            _configSet.GetOptionsForSourcePath(tree.FilePath)
+                .TreeOptions
+                .TryGetValue(diagnosticId, out severity);
+
+        public override bool TryGetGlobalDiagnosticValue(
+            string diagnosticId,
+            CancellationToken cancellationToken,
+            out ReportDiagnostic severity) =>
+            _configSet.GlobalConfigOptions.TreeOptions.TryGetValue(diagnosticId, out severity);
+    }
+
+    private static string GetTestPath(string fileName) =>
+        Path.Combine(Path.GetPathRoot(AppContext.BaseDirectory)!, fileName);
 }


### PR DESCRIPTION
## Summary
- disable KEV009, KEV010, and KEV011 by default while retaining Info severity when enabled
- test opt-in behavior through a parsed `.editorconfig`
- document strict-hint enablement and remove page-one muting guidance

## Test plan
- [x] `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (297 passed)
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/issue396 -Version 0.0.0-issue396 -NoImplicitUsings`
- [x] `npm run build --prefix docs`

Closes #396
