### PR TITLE
feat(fallback): permit sync delegates

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
@@ -33,6 +33,10 @@ public class FallbackBenchmarks
             7,
             static options => options.OnFallback = static async _ => await Task.Yield());
 
+    private static readonly Shield<int> KevlarSynchronousDelegate = Shield.For<int>()
+        .When<InvalidOperationException>()
+        .Fallback(static _ => new ValueTask<int>(7));
+
     private static readonly ResiliencePipeline<int> PollyFallback = new ResiliencePipelineBuilder<int>()
         .AddFallback(new FallbackStrategyOptions<int>
         {
@@ -49,6 +53,10 @@ public class FallbackBenchmarks
 
     [BenchmarkCategory("Triggered"), Benchmark(Baseline = true)]
     public ValueTask<int> Kevlar_Triggered() => KevlarFallback.ExecuteAsync(static _ => throw PrimaryError);
+
+    [BenchmarkCategory("SynchronousTriggered"), Benchmark]
+    public int Kevlar_SynchronousDelegate_Triggered() =>
+        KevlarSynchronousDelegate.Execute(static _ => throw PrimaryError);
 
     [BenchmarkCategory("Triggered"), Benchmark]
     public ValueTask<int> Polly_Triggered() => PollyFallback.ExecuteAsync(static ValueTask<int> (_) => throw PrimaryError);

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -364,11 +364,11 @@ Disable it project-wide with `dotnet_diagnostic.KEV011.severity = none`.
 
 ## KEV012: async configuration with synchronous Execute
 
-Every strategy hook returns `ValueTask`, and Kevlar never blocks the calling thread on one: under
-synchronous `Execute`, a hook that does not complete synchronously throws `NotSupportedException`
-at that call. `KEV012` reports the statically visible form — an `async` lambda, an `async`
-anonymous method, or a method group naming an `async` method assigned to a hook of a shield that
-is then passed to `Execute`:
+Every strategy hook and fallback recovery delegate returns `ValueTask`, and Kevlar never blocks the
+calling thread on one: under synchronous `Execute`, a delegate that does not complete synchronously
+throws `NotSupportedException` at that call. `KEV012` reports the statically visible form — an
+`async` lambda, an `async` anonymous method, or a method group naming an `async` method assigned to
+a hook or fallback recovery on a shield that is then passed to `Execute`:
 
 ```csharp
 #pragma warning disable KEV012 // Deliberately demonstrates the unsafe form.
@@ -393,10 +393,10 @@ var value = shield.Execute(static _ => 42);
 ```
 
 The rule recognizes hook assignments in a configuration lambda on the same fluent chain or through
-a stable local alias. It also recognizes `Fallback` recovery delegates and `UseRateLimiter`
-adapters, whose runtime contracts are async-only. Configuration lambdas are inspected only on known
-Kevlar strategy factories, so a custom extension that merely inspects genuine Kevlar options remains
-clean.
+a stable local alias. It also recognizes `Fallback` recovery delegates that are statically `async`.
+`UseRateLimiter` adapters remain async-only. Configuration lambdas are inspected only on known
+Kevlar strategy factories, so a custom extension that merely inspects genuine Kevlar options
+remains clean.
 
 The analyzer does not guess through fields, parameters, local delegates, or opaque factories; the
 runtime guard still protects those cases. `ExecuteAsync` and configurations whose hooks complete

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -67,19 +67,20 @@ rejected statically, before the action runs:
 
 | Pipeline configuration | Synchronous `Execute` behavior |
 |---|---|
-| Empty shield, fixed timeout, constant fallback, or hooks that complete synchronously | Runs on the calling thread |
+| Empty shield, fixed timeout, constant fallback, or hooks and fallback delegates that complete synchronously | Runs on the calling thread |
 | Retry delay, queued rate limit, or queued concurrency limit | Blocks the calling thread until the delay or queue admission completes |
 | `TimeoutGenerator`, `BreakDurationGenerator`, or `DelayGenerator` returning a completed `ValueTask` | Invokes the generator inline; no async transition is introduced |
 | Any hook or generator that returns an incomplete `ValueTask`, including `ChaosBehaviorOptions.Behavior` | Throws `NotSupportedException` at that call; use `ExecuteAsync` or make the hook complete synchronously |
+| A fallback recovery delegate that returns an incomplete `ValueTask` | Throws `NotSupportedException` at that call; use `ExecuteAsync` or make the delegate complete synchronously |
 | `CircuitBreakerMonitor.Isolate()` / `Reset()` with an `OnStateChanged` hook that yields | Blocks until the observer completes; the observer runs on the thread pool |
 | Multi-attempt hedging | Throws `NotSupportedException` before the action runs |
-| A `ValueTask`-returning fallback recovery delegate or any `UseRateLimiter` adapter | Throws `NotSupportedException` before the action runs; use `ExecuteAsync` |
+| Any `UseRateLimiter` adapter | Throws `NotSupportedException` before the action runs; use `ExecuteAsync` |
 | Custom strategy returning an incomplete `ValueTask` | Blocks at the execution boundary; custom code must avoid capturing a single-threaded `SynchronizationContext` |
 
 [`KEV012`](analyzers.md#kev012-async-configuration-with-synchronous-execute) reports `async`
-delegates assigned to hooks of a shield that is passed to `Execute`. A shield obtained from a field,
-parameter, or opaque factory may still contain such a hook, so the runtime guard remains
-authoritative.
+delegates assigned to hooks or fallback recovery on a shield that is passed to `Execute`. A shield
+obtained from a field, parameter, or opaque factory may still contain such a delegate, so the
+runtime guard remains authoritative.
 
 ## Zero-closure hot paths
 

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -705,6 +705,7 @@ Classic Polly v7 concepts translate as follows:
 | Polly v7 | Kevlar |
 |---|---|
 | `Policy.Handle<T>().WaitAndRetryAsync(...)` | `Shield.When<T>().Retry(...)` |
+| `Policy.Handle<T>().Fallback(...)` / `FallbackAsync(...)` | `Shield.When<T>().Fallback(...)`; a completed `ValueTask` recovery runs inline under synchronous `Execute` |
 | `AddPolicyHandler(policy)` | build a shield, then `AddShield(shield)` |
 | `AddTransientHttpErrorPolicy(...)` / `HandleTransientHttpError()` | `HttpShield.WhenTransient()` followed by strategies |
 | `CircuitBreakerAsync(n, duration)` | `CircuitBreaker(consecutiveFailures: n, breakDuration: duration)` |

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -170,6 +170,10 @@ fallback, the delegate receives the timeout scope's token and must observe it to
 total budget. If the fallback is outside the timeout, timeout cleanup completes first and the
 fallback receives the restored caller token.
 
+A fallback delegate that returns a completed `ValueTask` runs inline under synchronous `Execute`.
+One that remains incomplete throws `NotSupportedException` at that call; use `ExecuteAsync` for
+asynchronous recovery.
+
 ## Placement
 
 Fallback is usually **outermost** — the last line of defence after retries and breakers have given up:

--- a/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
+++ b/src/Kevlar.Analyzers/PipelineHazardAnalyzer.cs
@@ -8271,8 +8271,15 @@ public sealed class PipelineHazardAnalyzer : DiagnosticAnalyzer
 
         if (method.Name == "Fallback")
         {
-            memberName = "Fallback recovery delegate";
-            return true;
+            foreach (var argument in invocation.Arguments)
+            {
+                if (argument.Parameter?.Name == "fallback"
+                    && IsAsynchronousDelegateValue(argument.Value))
+                {
+                    memberName = "Fallback recovery delegate";
+                    return true;
+                }
+            }
         }
 
         if (method.Name == "UseRateLimiter")

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -18,7 +18,22 @@ internal abstract class OutcomeJudge
     /// </summary>
     public virtual string? Description => null;
 
-    public abstract bool ShouldHandle<T>(
+    public bool ShouldHandle<T>(
+        in Outcome<T> outcome,
+        KevlarContext? context,
+        int attempt,
+        int strategyIndex)
+    {
+        if (outcome.Exception is { } exception
+            && SynchronousExecutionGuard.IsRejection(exception))
+        {
+            return false;
+        }
+
+        return ShouldHandleCore(in outcome, context, attempt, strategyIndex);
+    }
+
+    protected abstract bool ShouldHandleCore<T>(
         in Outcome<T> outcome,
         KevlarContext? context,
         int attempt,
@@ -45,7 +60,7 @@ internal abstract class OutcomeJudge
 
     private sealed class DefaultJudge : OutcomeJudge
     {
-        public override bool ShouldHandle<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
+        protected override bool ShouldHandleCore<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
             outcome.Exception is { } exception && IsOrdinaryError(exception);
 
         private static bool IsOrdinaryError(Exception exception) =>
@@ -74,7 +89,7 @@ internal sealed class ExceptionJudge : OutcomeJudge
 
     public override string? Description => _description;
 
-    public override bool ShouldHandle<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
+    protected override bool ShouldHandleCore<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
         outcome.Exception is { } exception && _predicate(exception);
 }
 
@@ -99,7 +114,7 @@ internal sealed class ContextExceptionJudge : OutcomeJudge
 
     public override bool IsContextAware => true;
 
-    public override bool ShouldHandle<T>(
+    protected override bool ShouldHandleCore<T>(
         in Outcome<T> outcome,
         KevlarContext? context,
         int attempt,
@@ -150,7 +165,7 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
 
     public override bool IsContextAware => _contextPredicate is not null;
 
-    public override bool ShouldHandle<T>(
+    protected override bool ShouldHandleCore<T>(
         in Outcome<T> outcome,
         KevlarContext? context,
         int attempt,

--- a/src/Kevlar/Internal/SynchronousExecutionGuard.cs
+++ b/src/Kevlar/Internal/SynchronousExecutionGuard.cs
@@ -6,6 +6,8 @@ namespace Kevlar.Internal;
 /// </summary>
 internal static class SynchronousExecutionGuard
 {
+    private static readonly object RejectionMarker = new();
+
     /// <summary>
     /// Throws when <paramref name="pending"/> is still running and the execution is synchronous.
     /// A completed (successful or faulted) hook is left for the caller to observe.
@@ -39,10 +41,15 @@ internal static class SynchronousExecutionGuard
     internal static NotSupportedException CreateException(KevlarContext context, string hookName)
     {
         var shield = context.ShieldName is { Length: > 0 } name ? $" on shield '{name}'" : string.Empty;
-        return new NotSupportedException(
+        var exception = new NotSupportedException(
             $"Synchronous execution does not support {hookName} completing asynchronously{shield}. " +
             "Use ExecuteAsync instead of Execute, or make the callback complete synchronously.");
+        exception.Data[RejectionMarker] = true;
+        return exception;
     }
+
+    internal static bool IsRejection(Exception exception) =>
+        exception.Data.Contains(RejectionMarker);
 
     private static void Observe(Task abandoned) =>
         _ = abandoned.ContinueWith(

--- a/src/Kevlar/Internal/SynchronousExecutionGuard.cs
+++ b/src/Kevlar/Internal/SynchronousExecutionGuard.cs
@@ -6,8 +6,6 @@ namespace Kevlar.Internal;
 /// </summary>
 internal static class SynchronousExecutionGuard
 {
-    private static readonly object RejectionMarker = new();
-
     /// <summary>
     /// Throws when <paramref name="pending"/> is still running and the execution is synchronous.
     /// A completed (successful or faulted) hook is left for the caller to observe.
@@ -41,15 +39,13 @@ internal static class SynchronousExecutionGuard
     internal static NotSupportedException CreateException(KevlarContext context, string hookName)
     {
         var shield = context.ShieldName is { Length: > 0 } name ? $" on shield '{name}'" : string.Empty;
-        var exception = new NotSupportedException(
+        return new SynchronousExecutionRejectionException(
             $"Synchronous execution does not support {hookName} completing asynchronously{shield}. " +
             "Use ExecuteAsync instead of Execute, or make the callback complete synchronously.");
-        exception.Data[RejectionMarker] = true;
-        return exception;
     }
 
     internal static bool IsRejection(Exception exception) =>
-        exception.Data.Contains(RejectionMarker);
+        exception is SynchronousExecutionRejectionException;
 
     private static void Observe(Task abandoned) =>
         _ = abandoned.ContinueWith(
@@ -57,4 +53,7 @@ internal static class SynchronousExecutionGuard
             CancellationToken.None,
             TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
+
+    private sealed class SynchronousExecutionRejectionException(string message)
+        : NotSupportedException(message);
 }

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -362,8 +362,7 @@ public static class ShieldExtensions
         return shield.Append(new VoidFallbackStrategy(
             fallback,
             shield.JudgeOrDefault,
-            null,
-            fallbackIsAsync: true));
+            null));
     }
 
     /// <summary>
@@ -389,7 +388,6 @@ public static class ShieldExtensions
             fallback,
             judge,
             options.OnFallback,
-            fallbackIsAsync: true,
             hasHandlingOverride: options.HasHandlingOverride,
             telemetryName: options.Name));
     }
@@ -407,8 +405,7 @@ public static class ShieldExtensions
         return shield.Append(new VoidFallbackStrategy(
             (_, token) => fallback(token),
             shield.JudgeOrDefault,
-            null,
-            fallbackIsAsync: true));
+            null));
     }
 
     /// <summary>
@@ -434,7 +431,6 @@ public static class ShieldExtensions
             (_, token) => fallback(token),
             judge,
             options.OnFallback,
-            fallbackIsAsync: true,
             hasHandlingOverride: options.HasHandlingOverride,
             telemetryName: options.Name));
     }

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -309,8 +309,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
         Append(new FallbackStrategy<TResult>(
             (_, _) => new ValueTask<TResult>(fallbackValue),
             JudgeOrDefault,
-            null,
-            fallbackIsAsync: false));
+            null));
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
     /// <remarks>Runs and awaits <see cref="FallbackOptions{TResult}.OnFallback"/> before recovery. Notification failures are reported and recovery continues.</remarks>
@@ -329,7 +328,6 @@ public sealed class Shield<TResult> : IShieldLifecycle
             (_, _) => new ValueTask<TResult>(fallbackValue),
             judge,
             options.OnFallback,
-            fallbackIsAsync: false,
             hasHandlingOverride: options.HasHandlingOverride,
             telemetryName: options.Name));
     }
@@ -341,8 +339,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
         return Append(new FallbackStrategy<TResult>(
             (_, context) => fallback(context.CancellationToken),
             JudgeOrDefault,
-            null,
-            fallbackIsAsync: true));
+            null));
     }
 
     /// <summary>Replaces handled outcomes with the result of <paramref name="fallback"/> and configures notifications.</summary>
@@ -365,7 +362,6 @@ public sealed class Shield<TResult> : IShieldLifecycle
             (_, context) => fallback(context.CancellationToken),
             judge,
             options.OnFallback,
-            fallbackIsAsync: true,
             hasHandlingOverride: options.HasHandlingOverride,
             telemetryName: options.Name));
     }
@@ -377,8 +373,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
         return Append(new FallbackStrategy<TResult>(
             (outcome, context) => fallback(outcome, context.CancellationToken),
             JudgeOrDefault,
-            null,
-            fallbackIsAsync: true));
+            null));
     }
 
     /// <summary>
@@ -404,7 +399,6 @@ public sealed class Shield<TResult> : IShieldLifecycle
             (outcome, context) => fallback(outcome, context.CancellationToken),
             judge,
             options.OnFallback,
-            fallbackIsAsync: true,
             hasHandlingOverride: options.HasHandlingOverride,
             telemetryName: options.Name));
     }

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -11,13 +11,11 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
     private readonly OutcomeJudge _judge;
     private readonly Func<FallbackEvent<TResult>, ValueTask>? _onFallback;
     private readonly string _telemetryName;
-    private readonly bool _fallbackIsAsync;
 
     public FallbackStrategy(
         Func<Outcome<TResult>, KevlarContext, ValueTask<TResult>> fallback,
         OutcomeJudge judge,
         Func<FallbackEvent<TResult>, ValueTask>? onFallback,
-        bool fallbackIsAsync,
         bool hasHandlingOverride = false,
         string? telemetryName = null)
     {
@@ -25,7 +23,6 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
         _judge = judge;
         _onFallback = onFallback;
         _telemetryName = telemetryName ?? "Fallback";
-        _fallbackIsAsync = fallbackIsAsync;
         HasHandlingOverride = hasHandlingOverride;
     }
 
@@ -34,9 +31,6 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
     internal override bool HasHandlingOverride { get; }
 
     internal override bool IsFallback => true;
-
-    protected internal override string? SynchronousExecutionUnsupportedReason =>
-        _fallbackIsAsync ? "Fallback recovery delegate" : null;
 
     Type? IFallbackStrategyInspection.ResultType => typeof(TResult);
 
@@ -105,6 +99,14 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
         try
         {
             var execution = fallback(outcome, context);
+            if (context.IsSynchronous)
+            {
+                SynchronousExecutionGuard.ThrowIfIncomplete(
+                    in execution,
+                    context,
+                    "FallbackOptions<TResult> recovery delegate");
+            }
+
             return execution.IsCompletedSuccessfully
                 ? new ValueTask<Outcome<T>>(Outcome<T>.FromResult(execution.Result))
                 : AwaitFallbackAsync(execution);
@@ -150,13 +152,11 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
     private readonly OutcomeJudge _judge;
     private readonly Func<FallbackEvent, ValueTask>? _onFallback;
     private readonly string _telemetryName;
-    private readonly bool _fallbackIsAsync;
 
     public VoidFallbackStrategy(
         Func<Exception, CancellationToken, ValueTask> fallback,
         OutcomeJudge judge,
         Func<FallbackEvent, ValueTask>? onFallback,
-        bool fallbackIsAsync,
         bool hasHandlingOverride = false,
         string? telemetryName = null)
     {
@@ -164,7 +164,6 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
         _judge = judge;
         _onFallback = onFallback;
         _telemetryName = telemetryName ?? "Fallback";
-        _fallbackIsAsync = fallbackIsAsync;
         HasHandlingOverride = hasHandlingOverride;
     }
 
@@ -173,9 +172,6 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
     internal override bool HasHandlingOverride { get; }
 
     internal override bool IsFallback => true;
-
-    protected internal override string? SynchronousExecutionUnsupportedReason =>
-        _fallbackIsAsync ? "Fallback recovery delegate" : null;
 
     Type? IFallbackStrategyInspection.ResultType => null;
 
@@ -217,7 +213,16 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
 
         try
         {
-            await _fallback(exception, context.CancellationToken).ConfigureAwait(false);
+            var fallback = _fallback(exception, context.CancellationToken);
+            if (context.IsSynchronous)
+            {
+                SynchronousExecutionGuard.ThrowIfIncomplete(
+                    in fallback,
+                    context,
+                    "FallbackOptions recovery delegate");
+            }
+
+            await fallback.ConfigureAwait(false);
             return Outcome<T>.FromResult(default!);
         }
         catch (Exception fallbackFailure)

--- a/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
+++ b/tests/Kevlar.Analyzers.Tests/PipelineHazardAnalyzerTests.cs
@@ -6705,7 +6705,10 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Retry(options => options.OnRetry = async _ => await Task.Yield()).ExecuteWithContext(static _ => 1);",
             "_ = Shield.Retry(options => options.OnRetry = async _ => await Task.Yield()).ExecuteOutcome(static _ => 1);",
             "_ = Shield.Empty.UseRateLimiter((System.Threading.RateLimiting.RateLimiter)null!, options => options.OnRejected = async _ => await Task.Yield()).Execute(_ => 1);",
-            "_ = Shield.For<int>().Fallback(static _ => ValueTask.FromResult(0)).Execute(_ => 1);",
+            "_ = Shield.For<int>().Fallback(async _ => { await Task.Yield(); return 0; }).Execute(_ => 1);",
+            "_ = Shield.For<int>().Fallback(async (_, _) => { await Task.Yield(); return 0; }).Execute(_ => 1);",
+            "Shield.Fallback(async _ => await Task.Yield()).Execute(static _ => { });",
+            "Shield.When<InvalidOperationException>().Fallback(async (_, _) => await Task.Yield()).Execute(static _ => { });",
             "_ = Shield.Empty.UseRateLimiter((System.Threading.RateLimiting.RateLimiter)null!).Execute(_ => 1);",
             "_ = ChaosShield.Behavior(options => { options.Enabled = true; options.Behavior = async _ => await Task.Yield(); }).Execute(_ => 1);",
             "_ = ChaosShield.Behavior(options => { options.Enabled = false; if (DateTime.UtcNow.Ticks > 0) { options.Enabled = true; } options.Behavior = async _ => await Task.Yield(); }).Execute(_ => 1);",
@@ -6726,6 +6729,11 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Retry(options => options.OnRetry = RetryAsync).Execute(_ => 1);",
             members: "private static async ValueTask RetryAsync(RetryEvent item) => await Task.Yield();");
         await AssertRuleAsync(asyncMethodGroup, "KEV012");
+
+        var asyncFallbackMethodGroup = await AnalyzeBodyAsync(
+            "_ = Shield.For<int>().When<Exception>().Fallback(RecoverAsync).Execute(_ => 1);",
+            members: "private static async ValueTask<int> RecoverAsync(CancellationToken token) { await Task.Yield(); return 0; }");
+        await AssertRuleAsync(asyncFallbackMethodGroup, "KEV012");
 
         var additionalOptionShapes = new[]
         {
@@ -6767,6 +6775,10 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.RateLimit(options => options.OnRejected = static _ => default).Execute(_ => 1);",
             "_ = Shield.ConcurrencyLimit(options => options.OnRejected = static _ => default).Execute(_ => 1);",
             "_ = Shield.For<int>().FallbackTo(0, options => options.OnFallback = static _ => default).Execute(_ => 1);",
+            "_ = Shield.For<int>().Fallback(static _ => ValueTask.FromResult(0)).Execute(_ => 1);",
+            "_ = Shield.For<int>().Fallback(static (_, _) => new ValueTask<int>(0)).Execute(_ => 1);",
+            "Shield.Fallback(static _ => ValueTask.CompletedTask).Execute(static _ => { });",
+            "Shield.When<InvalidOperationException>().Fallback(static (_, _) => default).Execute(static _ => { });",
             "_ = ChaosShield.Behavior(options => { options.Enabled = true; options.Behavior = static _ => ValueTask.CompletedTask; }).Execute(_ => 1);",
             "_ = Shield.Retry(options => { options.MaxRetries = 0; options.OnRetry = async _ => await Task.Yield(); }).Execute(_ => 1);",
             "_ = Shield.Retry(options => { options.DelayGenerator = async _ => { await Task.Yield(); return null; }; options.MaxRetries = 0; }).Execute(_ => 1);",
@@ -6794,6 +6806,11 @@ public class PipelineHazardAnalyzerTests
             "_ = Shield.Retry(options => options.OnRetry = Retry).Execute(_ => 1);",
             members: "private static ValueTask Retry(RetryEvent item) => ValueTask.CompletedTask;");
         await Assert.That(methodGroup).IsEmpty();
+
+        var fallbackMethodGroup = await AnalyzeBodyAsync(
+            "_ = Shield.For<int>().When<Exception>().Fallback(Recover).Execute(_ => 1);",
+            members: "private static ValueTask<int> Recover(CancellationToken token) => new(0);");
+        await Assert.That(fallbackMethodGroup).IsEmpty();
     }
 
     [Test]

--- a/tests/Kevlar.Tests/SyncExecutionTests.cs
+++ b/tests/Kevlar.Tests/SyncExecutionTests.cs
@@ -234,79 +234,84 @@ public class SyncExecutionTests
     }
 
     [Test]
-    public async Task Sync_Execute_Rejects_Forwarded_Async_Fallback_Recovery_Before_Invoking_The_Action()
+    public async Task Sync_Execute_Rejects_Fallback_Recovery_That_Does_Not_Complete_Synchronously()
     {
-        var actionInvoked = false;
-        var typed = Shield.For<int>().Fallback(static token => RecoverAsync(token));
-        var untyped = Shield.Empty.Fallback(static token => RecoverVoidAsync(token));
-        Exception? typedException = null;
-        Exception? untypedException = null;
+        var typedGate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var untypedGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionInvocations = 0;
+        var typed = Shield.For<int>().Fallback(_ => new ValueTask<int>(typedGate.Task));
+        var untyped = Shield.Empty.Fallback(_ => new ValueTask(untypedGate.Task));
 
         var previous = SynchronizationContext.Current;
         try
         {
             SynchronizationContext.SetSynchronizationContext(new NonPumpingSynchronizationContext());
-            try
-            {
-                _ = typed.Execute(_ =>
+            var typedException = await Assert.That(() => typed.Execute(_ =>
                 {
-                    actionInvoked = true;
+                    actionInvocations++;
                     throw new InvalidOperationException();
-                });
-            }
-            catch (Exception exception)
-            {
-                typedException = exception;
-            }
+                }))
+                .Throws<NotSupportedException>();
+            var untypedException = await Assert.That(() => untyped.Execute(_ =>
+                {
+                    actionInvocations++;
+                    throw new InvalidOperationException();
+                }))
+                .Throws<NotSupportedException>();
 
-            try
-            {
-                untyped.Execute(_ =>
-                {
-                    actionInvoked = true;
-                    throw new InvalidOperationException();
-                });
-            }
-            catch (Exception exception)
-            {
-                untypedException = exception;
-            }
+            await Assert.That(typedException!.Message).Contains("FallbackOptions<TResult>");
+            await Assert.That(untypedException!.Message).Contains("FallbackOptions");
+            await Assert.That(actionInvocations).IsEqualTo(2);
         }
         finally
         {
             SynchronizationContext.SetSynchronizationContext(previous);
+            typedGate.TrySetResult(42);
+            untypedGate.TrySetResult();
         }
-
-        await Assert.That(typedException).IsTypeOf<NotSupportedException>();
-        await Assert.That(untypedException).IsTypeOf<NotSupportedException>();
-        await Assert.That(typedException!.Message).Contains("Fallback recovery delegate");
-        await Assert.That(untypedException!.Message).Contains("Fallback recovery delegate");
-        await Assert.That(actionInvoked).IsFalse();
     }
 
     [Test]
-    public async Task Sync_Execute_Rejects_Async_Shaped_Fallback_Even_When_It_Completes_Synchronously()
+    public async Task Sync_Execute_Runs_Fallback_Recovery_That_Completes_Synchronously()
     {
+        var untypedFallbackInvoked = false;
         var typed = Shield.For<int>().Fallback(static _ => new ValueTask<int>(42));
-        var untyped = Shield.Empty.Fallback(static _ => ValueTask.CompletedTask);
+        var untyped = Shield.Empty.Fallback(_ =>
+        {
+            untypedFallbackInvoked = true;
+            return ValueTask.CompletedTask;
+        });
 
-        await Assert.That(() => typed.Execute(_ => throw new InvalidOperationException()))
-            .Throws<NotSupportedException>();
-        await Assert.That(() => untyped.Execute(_ => throw new InvalidOperationException()))
-            .Throws<NotSupportedException>();
+        var result = typed.Execute(_ => throw new InvalidOperationException());
+        untyped.Execute(_ => throw new InvalidOperationException());
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(untypedFallbackInvoked).IsTrue();
     }
 
-    private static async ValueTask<int> RecoverAsync(CancellationToken cancellationToken)
+    [Test]
+    public async Task Sync_ExecuteOutcome_Captures_Incomplete_Fallback_Recovery()
     {
-        await Task.Yield();
-        cancellationToken.ThrowIfCancellationRequested();
-        return 42;
-    }
+        var typedGate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var untypedGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var typed = Shield.For<int>().Fallback(_ => new ValueTask<int>(typedGate.Task));
+        var untyped = Shield.Empty.Fallback(_ => new ValueTask(untypedGate.Task));
 
-    private static async ValueTask RecoverVoidAsync(CancellationToken cancellationToken)
-    {
-        await Task.Yield();
-        cancellationToken.ThrowIfCancellationRequested();
+        try
+        {
+            var typedOutcome = typed.ExecuteOutcome(_ => throw new InvalidOperationException());
+            var untypedOutcome = untyped.ExecuteOutcome(_ => throw new InvalidOperationException());
+
+            await Assert.That(typedOutcome.Exception).IsTypeOf<NotSupportedException>();
+            await Assert.That(untypedOutcome.Exception).IsTypeOf<NotSupportedException>();
+            await Assert.That(typedOutcome.Exception!.Message).Contains("FallbackOptions<TResult>");
+            await Assert.That(untypedOutcome.Exception!.Message).Contains("FallbackOptions");
+        }
+        finally
+        {
+            typedGate.TrySetResult(42);
+            untypedGate.TrySetResult();
+        }
     }
 
     [Test]

--- a/tests/Kevlar.Tests/SyncExecutionTests.cs
+++ b/tests/Kevlar.Tests/SyncExecutionTests.cs
@@ -315,6 +315,83 @@ public class SyncExecutionTests
     }
 
     [Test]
+    public async Task Sync_Incomplete_Typed_Fallback_Bypasses_Outer_Retry()
+    {
+        var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionInvocations = 0;
+        var shield = Shield.For<int>()
+            .Retry(1, Backoff.None)
+            .When<InvalidOperationException>()
+            .Fallback(_ => new ValueTask<int>(gate.Task));
+
+        try
+        {
+            await Assert.That(() => shield.Execute(_ =>
+                Interlocked.Increment(ref actionInvocations) == 1
+                    ? throw new InvalidOperationException()
+                    : 42))
+                .Throws<NotSupportedException>();
+            await Assert.That(actionInvocations).IsEqualTo(1);
+        }
+        finally
+        {
+            gate.TrySetResult(42);
+        }
+    }
+
+    [Test]
+    public async Task Sync_Incomplete_Fallback_Bypasses_Explicit_Outer_Retry()
+    {
+        var gate = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionInvocations = 0;
+        var shield = Shield.For<int>()
+            .When<NotSupportedException>()
+            .Retry(1, Backoff.None)
+            .When<InvalidOperationException>()
+            .Fallback(_ => new ValueTask<int>(gate.Task));
+
+        try
+        {
+            await Assert.That(() => shield.Execute(_ =>
+                Interlocked.Increment(ref actionInvocations) == 1
+                    ? throw new InvalidOperationException()
+                    : 42))
+                .Throws<NotSupportedException>();
+            await Assert.That(actionInvocations).IsEqualTo(1);
+        }
+        finally
+        {
+            gate.TrySetResult(42);
+        }
+    }
+
+    [Test]
+    public async Task Sync_Incomplete_Void_Fallback_Bypasses_Outer_Retry()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var actionInvocations = 0;
+        var shield = Shield.Retry(1, Backoff.None)
+            .When<InvalidOperationException>()
+            .Fallback(_ => new ValueTask(gate.Task));
+
+        try
+        {
+            await Assert.That(() => shield.Execute(_ =>
+            {
+                if (Interlocked.Increment(ref actionInvocations) == 1)
+                {
+                    throw new InvalidOperationException();
+                }
+            })).Throws<NotSupportedException>();
+            await Assert.That(actionInvocations).IsEqualTo(1);
+        }
+        finally
+        {
+            gate.TrySetResult();
+        }
+    }
+
+    [Test]
     public async Task Extension_Strategy_Can_Reject_Synchronous_Execution()
     {
         var actionInvoked = false;

--- a/tests/Kevlar.Tests/SynchronousHookGuardTests.cs
+++ b/tests/Kevlar.Tests/SynchronousHookGuardTests.cs
@@ -422,10 +422,8 @@ public class SynchronousHookGuardTests
     // ---- FallbackOptions.OnFallback (void fallback) ----
 
     [Test]
-    public async Task Void_Fallback_Recovery_Is_Rejected_Statically_Before_OnFallback_Runs()
+    public async Task Void_Fallback_Recovery_And_OnFallback_Complete_Synchronously_Under_Execute()
     {
-        // Every void fallback recovery delegate is ValueTask-shaped and stays statically rejected
-        // under synchronous execution, so FallbackOptions.OnFallback never gets a chance to run there.
         var observed = 0;
         var shield = Shield.Fallback(
             static _ => default,
@@ -435,12 +433,9 @@ public class SynchronousHookGuardTests
                 return default;
             });
 
-        var exception = await Assert.That(() => shield.Execute(_ => throw new InvalidOperationException()))
-            .Throws<NotSupportedException>();
+        shield.Execute(_ => throw new InvalidOperationException());
 
-        await Assert.That(exception!.Message).Contains("Fallback recovery delegate");
-        await Assert.That(exception.Message).DoesNotContain("FallbackOptions.OnFallback");
-        await Assert.That(observed).IsEqualTo(0);
+        await Assert.That(observed).IsEqualTo(1);
     }
 
     // ---- FallbackOptions<TResult>.OnFallback ----

--- a/tests/Kevlar.Tests/VoidFallbackTests.cs
+++ b/tests/Kevlar.Tests/VoidFallbackTests.cs
@@ -177,7 +177,7 @@ public class VoidFallbackTests
     }
 
     [Test]
-    public async Task Async_Shaped_Void_Fallback_Is_Rejected_Synchronously()
+    public async Task Completed_Void_Fallback_Runs_Synchronously()
     {
         var fallbackRan = false;
         var shield = Shield.When<InvalidOperationException>().Fallback((_, _) =>
@@ -186,10 +186,9 @@ public class VoidFallbackTests
             return default;
         });
 
-        await Assert.That(() => shield.Execute(_ => throw new InvalidOperationException()))
-            .Throws<NotSupportedException>();
+        shield.Execute(_ => throw new InvalidOperationException());
 
-        await Assert.That(fallbackRan).IsFalse();
+        await Assert.That(fallbackRan).IsTrue();
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- run completed typed and void fallback `ValueTask` recovery delegates inline under synchronous `Execute`
- reject only incomplete recovery at the call site through `SynchronousExecutionGuard`, naming `FallbackOptions`
- teach KEV012 to report statically async fallback recovery delegates and document the sync/migration contract
- add runtime, analyzer, and benchmark coverage

## Validation

- `dotnet build Kevlar.slnx -c Release` (0 warnings)
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m` (1,247 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (1,282 passed after final rebase)
- `dotnet run --project tests/Kevlar.Analyzers.Tests -c Release --no-build -- --timeout 5m` (297 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (171 passed)
- `scripts/Verify-Docs.ps1`
- `scripts/Verify-DocSnippets.ps1 -NoImplicitUsings` (208 compiled and executed twice)
- `scripts/Verify-Repo.ps1`
- `npm ci` and `npm run build` under `docs`

## Benchmark

`FallbackBenchmarks.Kevlar_Triggered` before/after: 1.323 us / 200 B -> 1.309 us / 200 B. The new synchronous delegate case measures 1.337 us / 200 B. No material regression; allocations unchanged.

Closes #400