### PR TITLE
fix(handling)!: isolate predicate failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
-### Changed
-
-- **Breaking:** exceptions from every handling predicate are treated as not handled, leaving the
-  original execution outcome unchanged. Failures are reported through
-  `CallbackErrorKind.HandlingPredicate`, `kevlar.callback_errors`, telemetry, and logging.
-
 ## [1.0.0] - 2026-08-27
 
 Kevlar 1.0 establishes the stable Shield API: composable retry, timeout, circuit-breaker,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** exceptions from every handling predicate are treated as not handled, leaving the
+  original execution outcome unchanged. Failures are reported through
+  `CallbackErrorKind.HandlingPredicate`, `kevlar.callback_errors`, telemetry, and logging.
+
 ## [1.0.0] - 2026-08-27
 
 Kevlar 1.0 establishes the stable Shield API: composable retry, timeout, circuit-breaker,

--- a/docs/api/.manifest
+++ b/docs/api/.manifest
@@ -32,6 +32,7 @@
   "Kevlar.CallbackErrorKind.ConcurrencyLimitRejected": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.Custom": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.Fallback": "Kevlar.CallbackErrorKind.yml",
+  "Kevlar.CallbackErrorKind.HandlingPredicate": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.Hedge": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.RateLimitRejected": "Kevlar.CallbackErrorKind.yml",
   "Kevlar.CallbackErrorKind.ResultDisposal": "Kevlar.CallbackErrorKind.yml",

--- a/docs/api/.manifest
+++ b/docs/api/.manifest
@@ -21,6 +21,7 @@
   "Kevlar.BackoffKind.Linear": "Kevlar.BackoffKind.yml",
   "Kevlar.BackoffKind.None": "Kevlar.BackoffKind.yml",
   "Kevlar.CallbackErrorEvent": "Kevlar.CallbackErrorEvent.yml",
+  "Kevlar.CallbackErrorEvent.AttemptNumber": "Kevlar.CallbackErrorEvent.yml",
   "Kevlar.CallbackErrorEvent.Exception": "Kevlar.CallbackErrorEvent.yml",
   "Kevlar.CallbackErrorEvent.Kind": "Kevlar.CallbackErrorEvent.yml",
   "Kevlar.CallbackErrorEvent.ShieldName": "Kevlar.CallbackErrorEvent.yml",

--- a/docs/api/Kevlar.CallbackErrorEvent.yml
+++ b/docs/api/Kevlar.CallbackErrorEvent.yml
@@ -5,6 +5,7 @@ items:
   id: CallbackErrorEvent
   parent: Kevlar
   children:
+  - Kevlar.CallbackErrorEvent.AttemptNumber
   - Kevlar.CallbackErrorEvent.Exception
   - Kevlar.CallbackErrorEvent.Kind
   - Kevlar.CallbackErrorEvent.ShieldName
@@ -124,6 +125,29 @@ items:
       type: System.Int32
     content.vb: Public ReadOnly Property StrategyIndex As Integer
   overload: Kevlar.CallbackErrorEvent.StrategyIndex*
+- uid: Kevlar.CallbackErrorEvent.AttemptNumber
+  commentId: P:Kevlar.CallbackErrorEvent.AttemptNumber
+  id: AttemptNumber
+  parent: Kevlar.CallbackErrorEvent
+  langs:
+  - csharp
+  - vb
+  name: AttemptNumber
+  nameWithType: CallbackErrorEvent.AttemptNumber
+  fullName: Kevlar.CallbackErrorEvent.AttemptNumber
+  type: Property
+  assemblies:
+  - Kevlar
+  namespace: Kevlar
+  summary: Gets the zero-based execution attempt number.
+  example: []
+  syntax:
+    content: public int AttemptNumber { get; }
+    parameters: []
+    return:
+      type: System.Int32
+    content.vb: Public ReadOnly Property AttemptNumber As Integer
+  overload: Kevlar.CallbackErrorEvent.AttemptNumber*
 - uid: Kevlar.CallbackErrorEvent.Exception
   commentId: P:Kevlar.CallbackErrorEvent.Exception
   id: Exception
@@ -430,6 +454,13 @@ references:
   nameWithType.vb: Integer
   fullName.vb: Integer
   name.vb: Integer
+- uid: Kevlar.CallbackErrorEvent.AttemptNumber*
+  commentId: Overload:Kevlar.CallbackErrorEvent.AttemptNumber
+  isExternal: true
+  href: Kevlar.CallbackErrorEvent.html#Kevlar_CallbackErrorEvent_AttemptNumber
+  name: AttemptNumber
+  nameWithType: CallbackErrorEvent.AttemptNumber
+  fullName: Kevlar.CallbackErrorEvent.AttemptNumber
 - uid: Kevlar.CallbackErrorEvent.Exception*
   commentId: Overload:Kevlar.CallbackErrorEvent.Exception
   isExternal: true

--- a/docs/api/Kevlar.CallbackErrorKind.yml
+++ b/docs/api/Kevlar.CallbackErrorKind.yml
@@ -10,6 +10,7 @@ items:
   - Kevlar.CallbackErrorKind.ConcurrencyLimitRejected
   - Kevlar.CallbackErrorKind.Custom
   - Kevlar.CallbackErrorKind.Fallback
+  - Kevlar.CallbackErrorKind.HandlingPredicate
   - Kevlar.CallbackErrorKind.Hedge
   - Kevlar.CallbackErrorKind.RateLimitRejected
   - Kevlar.CallbackErrorKind.ResultDisposal
@@ -228,6 +229,26 @@ items:
   example: []
   syntax:
     content: ResultDisposal = 9
+    return:
+      type: Kevlar.CallbackErrorKind
+- uid: Kevlar.CallbackErrorKind.HandlingPredicate
+  commentId: F:Kevlar.CallbackErrorKind.HandlingPredicate
+  id: HandlingPredicate
+  parent: Kevlar.CallbackErrorKind
+  langs:
+  - csharp
+  - vb
+  name: HandlingPredicate
+  nameWithType: CallbackErrorKind.HandlingPredicate
+  fullName: Kevlar.CallbackErrorKind.HandlingPredicate
+  type: Field
+  assemblies:
+  - Kevlar
+  namespace: Kevlar
+  summary: A handling-clause or strategy handling predicate.
+  example: []
+  syntax:
+    content: HandlingPredicate = 10
     return:
       type: Kevlar.CallbackErrorKind
 references:

--- a/docs/api/Kevlar.HandlingClause.yml
+++ b/docs/api/Kevlar.HandlingClause.yml
@@ -49,6 +49,10 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: Returns whether <code class="paramref">outcome</code> is a handled failure.
+  remarks: >-
+    This context-free overload cannot report predicate failures through execution diagnostics.
+
+    Reactive strategies should use the overload that accepts <xref href="Kevlar.KevlarContext" data-throw-if-not-resolved="false"></xref>.
   example: []
   syntax:
     content: public bool ShouldHandle<T>(in Outcome<T> outcome)
@@ -374,6 +378,14 @@ references:
   name: System
   nameWithType: System
   fullName: System
+- uid: Kevlar.KevlarContext
+  commentId: T:Kevlar.KevlarContext
+  parent: Kevlar
+  isExternal: true
+  href: Kevlar.KevlarContext.html
+  name: KevlarContext
+  nameWithType: KevlarContext
+  fullName: Kevlar.KevlarContext
 - uid: Kevlar.HandlingClause.ShouldHandle*
   commentId: Overload:Kevlar.HandlingClause.ShouldHandle
   isExternal: true
@@ -450,14 +462,6 @@ references:
   - name: " "
   - name: T
   - name: )
-- uid: Kevlar.KevlarContext
-  commentId: T:Kevlar.KevlarContext
-  parent: Kevlar
-  isExternal: true
-  href: Kevlar.KevlarContext.html
-  name: KevlarContext
-  nameWithType: KevlarContext
-  fullName: Kevlar.KevlarContext
 - uid: System.Int32
   commentId: T:System.Int32
   parent: System

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -220,11 +220,15 @@ per-strategy override.
 
 Every predicate shape follows the same failure contract. If an exception, result, or context-aware
 predicate throws, that predicate is treated as not handled and later alternatives are still
-evaluated. The original execution outcome remains unchanged. Kevlar reports the predicate exception
-through `KevlarDiagnostics.OnCallbackError` with `CallbackErrorKind.HandlingPredicate`, the
-`kevlar.callback_errors` counter with `kevlar.callback.kind=handling_predicate`, telemetry, and
-structured logging. Predicate failures therefore stay visible without changing retry, breaker,
-hedge, or fallback behavior.
+evaluated. The original execution outcome remains unchanged. During shield execution, Kevlar
+reports the predicate exception through `KevlarDiagnostics.OnCallbackError` with
+`CallbackErrorKind.HandlingPredicate`, the `kevlar.callback_errors` counter with
+`kevlar.callback.kind=handling_predicate`, telemetry, and structured logging. Predicate failures
+therefore stay visible without changing retry, breaker, hedge, or fallback behavior.
+
+The context-free `HandlingClause.ShouldHandle(in outcome)` overload has no active execution and
+cannot emit execution diagnostics. Custom reactive strategies should pass their active
+`KevlarContext` to the context-aware overload, as shown below.
 
 ## Per-strategy overrides
 

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -216,8 +216,15 @@ await contextual.ExecuteWithContextAsync(
 On `Shield<TResult>`, context-aware predicates receive `HandlingEvent<TResult>`. Its typed
 `Outcome` exposes either the exception or result without boxing. Use the
 `HandlesExceptionWithContext` and `HandlesResultWithContext` option properties for a local
-per-strategy override. A context-aware predicate that throws is reported through `Trace` and treated as not
-handled, so it cannot replace the execution's real outcome.
+per-strategy override.
+
+Every predicate shape follows the same failure contract. If an exception, result, or context-aware
+predicate throws, that predicate is treated as not handled and later alternatives are still
+evaluated. The original execution outcome remains unchanged. Kevlar reports the predicate exception
+through `KevlarDiagnostics.OnCallbackError` with `CallbackErrorKind.HandlingPredicate`, the
+`kevlar.callback_errors` counter with `kevlar.callback.kind=handling_predicate`, telemetry, and
+structured logging. Predicate failures therefore stay visible without changing retry, breaker,
+hedge, or fallback behavior.
 
 ## Per-strategy overrides
 

--- a/src/Kevlar.Testing/TelemetryRecorder.cs
+++ b/src/Kevlar.Testing/TelemetryRecorder.cs
@@ -198,6 +198,7 @@ public sealed class TelemetryRecorder : IDisposable, IKevlarTelemetryListener
         CallbackKind.CallbackError,
         item.ShieldName,
         strategyIndex: item.StrategyIndex,
+        attemptNumber: item.AttemptNumber,
         exception: item.Exception,
         errorKind: item.Kind));
 

--- a/src/Kevlar/CallbackErrorEvent.cs
+++ b/src/Kevlar/CallbackErrorEvent.cs
@@ -8,12 +8,14 @@ public readonly struct CallbackErrorEvent
         string source,
         string? shieldName,
         int strategyIndex,
+        int attemptNumber,
         Exception exception)
     {
         Kind = kind;
         Source = source;
         ShieldName = shieldName;
         StrategyIndex = strategyIndex;
+        AttemptNumber = attemptNumber;
         Exception = exception;
     }
 
@@ -28,6 +30,9 @@ public readonly struct CallbackErrorEvent
 
     /// <summary>Gets the zero-based strategy position in the shield.</summary>
     public int StrategyIndex { get; }
+
+    /// <summary>Gets the zero-based execution attempt number.</summary>
+    public int AttemptNumber { get; }
 
     /// <summary>Gets the isolated exception.</summary>
     public Exception Exception { get; }

--- a/src/Kevlar/CallbackErrorKind.cs
+++ b/src/Kevlar/CallbackErrorKind.cs
@@ -32,4 +32,7 @@ public enum CallbackErrorKind
 
     /// <summary>Disposal of a superseded result.</summary>
     ResultDisposal,
+
+    /// <summary>A handling-clause or strategy handling predicate.</summary>
+    HandlingPredicate,
 }

--- a/src/Kevlar/HandlingClause.cs
+++ b/src/Kevlar/HandlingClause.cs
@@ -21,6 +21,10 @@ public readonly struct HandlingClause
     internal OutcomeJudge Judge => _judge ?? OutcomeJudge.Default;
 
     /// <summary>Returns whether <paramref name="outcome"/> is a handled failure.</summary>
+    /// <remarks>
+    /// This context-free overload cannot report predicate failures through execution diagnostics.
+    /// Reactive strategies should use the overload that accepts <see cref="KevlarContext"/>.
+    /// </remarks>
     public bool ShouldHandle<T>(in Outcome<T> outcome) =>
         Judge.ShouldHandle(in outcome, context: null, attempt: 0, strategyIndex: -1);
 

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -993,6 +993,7 @@ internal static class KevlarMetrics
         CallbackErrorKind.RateLimitRejected => "rate_limit_rejected",
         CallbackErrorKind.Custom => "custom",
         CallbackErrorKind.ResultDisposal => "result_disposal",
+        CallbackErrorKind.HandlingPredicate => "handling_predicate",
         _ => throw new ArgumentOutOfRangeException(nameof(kind)),
     };
 

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -44,18 +44,41 @@ internal abstract class OutcomeJudge
 
     public virtual bool IsContextAware => false;
 
-    protected internal static void ReportPredicateFailure(Exception exception)
+    private static void ReportPredicateFailure(
+        Exception exception,
+        KevlarContext? context)
     {
-        try
+        if (context is not null)
         {
-            System.Diagnostics.Trace.TraceError(
-                "Kevlar handling predicate failed and was treated as not handled: {0}",
-                exception);
+            KevlarDiagnostics.ReportCallbackError(
+                CallbackErrorKind.HandlingPredicate,
+                context,
+                exception,
+                "HandlingPredicate");
         }
-        catch
+    }
+
+    protected static bool EvaluatePredicates<T>(
+        Func<T, bool>[] predicates,
+        T value,
+        KevlarContext? context)
+    {
+        foreach (var predicate in predicates)
         {
-            // Diagnostics must not change the protected execution's outcome.
+            try
+            {
+                if (predicate(value))
+                {
+                    return true;
+                }
+            }
+            catch (Exception exception)
+            {
+                ReportPredicateFailure(exception, context);
+            }
         }
+
+        return false;
     }
 
     private sealed class DefaultJudge : OutcomeJudge
@@ -78,35 +101,52 @@ internal abstract class OutcomeJudge
 /// <summary>Handles outcomes whose exception matches a caller-supplied predicate.</summary>
 internal sealed class ExceptionJudge : OutcomeJudge
 {
-    private readonly Func<Exception, bool> _predicate;
+    private readonly Func<Exception, bool>[] _predicates;
     private readonly string? _description;
 
     public ExceptionJudge(Func<Exception, bool> predicate, string? description = null)
+        : this([predicate], description)
     {
-        _predicate = predicate;
+    }
+
+    public ExceptionJudge(Func<Exception, bool>[] predicates, string? description = null)
+    {
+        _predicates = predicates;
         _description = description;
     }
 
     public override string? Description => _description;
 
     protected override bool ShouldHandleCore<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
-        outcome.Exception is { } exception && _predicate(exception);
+        outcome.Exception is { } exception
+        && EvaluatePredicates(_predicates, exception, context);
 }
 
 /// <summary>Handles exceptions using the active execution and strategy context.</summary>
 internal sealed class ContextExceptionJudge : OutcomeJudge
 {
-    private readonly Func<Exception, bool>? _exceptionPredicate;
-    private readonly Func<HandlingEvent, bool> _predicate;
+    private readonly Func<Exception, bool>[] _exceptionPredicates;
+    private readonly Func<HandlingEvent, bool>[] _contextPredicates;
     private readonly string? _description;
 
     public ContextExceptionJudge(
         Func<Exception, bool>? exceptionPredicate,
         Func<HandlingEvent, bool> predicate,
         string? description = null)
+        : this(
+            exceptionPredicate is null ? [] : [exceptionPredicate],
+            [predicate],
+            description)
     {
-        _exceptionPredicate = exceptionPredicate;
-        _predicate = predicate;
+    }
+
+    public ContextExceptionJudge(
+        Func<Exception, bool>[] exceptionPredicates,
+        Func<HandlingEvent, bool>[] contextPredicates,
+        string? description = null)
+    {
+        _exceptionPredicates = exceptionPredicates;
+        _contextPredicates = contextPredicates;
         _description = description;
     }
 
@@ -120,22 +160,12 @@ internal sealed class ContextExceptionJudge : OutcomeJudge
         int attempt,
         int strategyIndex) =>
         outcome.Exception is { } exception
-        && ((_exceptionPredicate?.Invoke(exception) ?? false)
-            || (context is not null
-                && InvokeSafely(new HandlingEvent(exception, context, attempt, strategyIndex))));
-
-    private bool InvokeSafely(HandlingEvent handlingEvent)
-    {
-        try
-        {
-            return _predicate(handlingEvent);
-        }
-        catch (Exception exception)
-        {
-            ReportPredicateFailure(exception);
-            return false;
-        }
-    }
+        && (EvaluatePredicates(_exceptionPredicates, exception, context)
+            || context is not null
+            && EvaluatePredicates(
+                _contextPredicates,
+                new HandlingEvent(exception, context, attempt, strategyIndex),
+                context));
 }
 
 /// <summary>
@@ -144,9 +174,9 @@ internal sealed class ContextExceptionJudge : OutcomeJudge
 /// </summary>
 internal sealed class TypedJudge<TResult> : OutcomeJudge
 {
-    private readonly Func<Exception, bool>? _exceptionPredicate;
-    private readonly Func<TResult, bool>? _resultPredicate;
-    private readonly Func<HandlingEvent<TResult>, bool>? _contextPredicate;
+    private readonly Func<Exception, bool>[] _exceptionPredicates;
+    private readonly Func<TResult, bool>[] _resultPredicates;
+    private readonly Func<HandlingEvent<TResult>, bool>[] _contextPredicates;
     private readonly string? _description;
 
     public TypedJudge(
@@ -154,16 +184,29 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
         Func<TResult, bool>? resultPredicate,
         string? description = null,
         Func<HandlingEvent<TResult>, bool>? contextPredicate = null)
+        : this(
+            exceptionPredicate is null ? [] : [exceptionPredicate],
+            resultPredicate is null ? [] : [resultPredicate],
+            description,
+            contextPredicate is null ? [] : [contextPredicate])
     {
-        _exceptionPredicate = exceptionPredicate;
-        _resultPredicate = resultPredicate;
-        _contextPredicate = contextPredicate;
+    }
+
+    public TypedJudge(
+        Func<Exception, bool>[] exceptionPredicates,
+        Func<TResult, bool>[] resultPredicates,
+        string? description = null,
+        Func<HandlingEvent<TResult>, bool>[]? contextPredicates = null)
+    {
+        _exceptionPredicates = exceptionPredicates;
+        _resultPredicates = resultPredicates;
+        _contextPredicates = contextPredicates ?? [];
         _description = description;
     }
 
     public override string? Description => _description;
 
-    public override bool IsContextAware => _contextPredicate is not null;
+    public override bool IsContextAware => _contextPredicates.Length != 0;
 
     protected override bool ShouldHandleCore<T>(
         in Outcome<T> outcome,
@@ -171,34 +214,30 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
         int attempt,
         int strategyIndex)
     {
-        if (_contextPredicate is not null && context is not null && typeof(T) == typeof(TResult))
+        if (_contextPredicates.Length != 0 && context is not null && typeof(T) == typeof(TResult))
         {
             var typedOutcome = Unsafe.As<Outcome<T>, Outcome<TResult>>(
                 ref Unsafe.AsRef(in outcome));
-            try
+            if (EvaluatePredicates(
+                _contextPredicates,
+                new HandlingEvent<TResult>(typedOutcome, context, attempt, strategyIndex),
+                context))
             {
-                if (_contextPredicate(new HandlingEvent<TResult>(typedOutcome, context, attempt, strategyIndex)))
-                {
-                    return true;
-                }
-            }
-            catch (Exception predicateException)
-            {
-                ReportPredicateFailure(predicateException);
+                return true;
             }
         }
 
         if (outcome.Exception is { } exception)
         {
-            return _exceptionPredicate?.Invoke(exception) ?? false;
+            return EvaluatePredicates(_exceptionPredicates, exception, context);
         }
 
-        if (_resultPredicate is null || typeof(T) != typeof(TResult))
+        if (_resultPredicates.Length == 0 || typeof(T) != typeof(TResult))
         {
             return false;
         }
 
-        var predicate = (Func<T, bool>)(object)_resultPredicate;
-        return predicate(outcome.Result!);
+        var predicates = (Func<T, bool>[])(object)_resultPredicates;
+        return EvaluatePredicates(predicates, outcome.Result!, context);
     }
 }

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -46,7 +46,9 @@ internal abstract class OutcomeJudge
 
     private static void ReportPredicateFailure(
         Exception exception,
-        KevlarContext? context)
+        KevlarContext? context,
+        int attempt,
+        int strategyIndex)
     {
         if (context is not null)
         {
@@ -54,14 +56,18 @@ internal abstract class OutcomeJudge
                 CallbackErrorKind.HandlingPredicate,
                 context,
                 exception,
-                "HandlingPredicate");
+                "HandlingPredicate",
+                attemptNumber: attempt,
+                strategyIndex: strategyIndex);
         }
     }
 
     protected static bool EvaluatePredicates<T>(
         Func<T, bool>[] predicates,
         T value,
-        KevlarContext? context)
+        KevlarContext? context,
+        int attempt,
+        int strategyIndex)
     {
         foreach (var predicate in predicates)
         {
@@ -74,7 +80,7 @@ internal abstract class OutcomeJudge
             }
             catch (Exception exception)
             {
-                ReportPredicateFailure(exception, context);
+                ReportPredicateFailure(exception, context, attempt, strategyIndex);
             }
         }
 
@@ -119,7 +125,7 @@ internal sealed class ExceptionJudge : OutcomeJudge
 
     protected override bool ShouldHandleCore<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
         outcome.Exception is { } exception
-        && EvaluatePredicates(_predicates, exception, context);
+        && EvaluatePredicates(_predicates, exception, context, attempt, strategyIndex);
 }
 
 /// <summary>Handles exceptions using the active execution and strategy context.</summary>
@@ -160,12 +166,19 @@ internal sealed class ContextExceptionJudge : OutcomeJudge
         int attempt,
         int strategyIndex) =>
         outcome.Exception is { } exception
-        && (EvaluatePredicates(_exceptionPredicates, exception, context)
+        && (EvaluatePredicates(
+                _exceptionPredicates,
+                exception,
+                context,
+                attempt,
+                strategyIndex)
             || context is not null
             && EvaluatePredicates(
                 _contextPredicates,
                 new HandlingEvent(exception, context, attempt, strategyIndex),
-                context));
+                context,
+                attempt,
+                strategyIndex));
 }
 
 /// <summary>
@@ -221,7 +234,9 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
             if (EvaluatePredicates(
                 _contextPredicates,
                 new HandlingEvent<TResult>(typedOutcome, context, attempt, strategyIndex),
-                context))
+                context,
+                attempt,
+                strategyIndex))
             {
                 return true;
             }
@@ -229,7 +244,12 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
 
         if (outcome.Exception is { } exception)
         {
-            return EvaluatePredicates(_exceptionPredicates, exception, context);
+            return EvaluatePredicates(
+                _exceptionPredicates,
+                exception,
+                context,
+                attempt,
+                strategyIndex);
         }
 
         if (_resultPredicates.Length == 0 || typeof(T) != typeof(TResult))
@@ -238,6 +258,11 @@ internal sealed class TypedJudge<TResult> : OutcomeJudge
         }
 
         var predicates = (Func<T, bool>[])(object)_resultPredicates;
-        return EvaluatePredicates(predicates, outcome.Result!, context);
+        return EvaluatePredicates(
+            predicates,
+            outcome.Result!,
+            context,
+            attempt,
+            strategyIndex);
     }
 }

--- a/src/Kevlar/KevlarDiagnostics.cs
+++ b/src/Kevlar/KevlarDiagnostics.cs
@@ -85,7 +85,37 @@ public static class KevlarDiagnostics
         CallbackErrorKind kind,
         KevlarContext context,
         Exception exception,
-        string source)
+        string source) =>
+        ReportCallbackErrorCore(
+            kind,
+            context,
+            exception,
+            source,
+            context?.AttemptNumber ?? 0,
+            context?.StrategyIndex ?? -1);
+
+    internal static void ReportCallbackError(
+        CallbackErrorKind kind,
+        KevlarContext context,
+        Exception exception,
+        string source,
+        int attemptNumber,
+        int strategyIndex) =>
+        ReportCallbackErrorCore(
+            kind,
+            context,
+            exception,
+            source,
+            attemptNumber,
+            strategyIndex);
+
+    private static void ReportCallbackErrorCore(
+        CallbackErrorKind kind,
+        KevlarContext context,
+        Exception exception,
+        string source,
+        int attemptNumber,
+        int strategyIndex)
     {
         if (context is null)
         {
@@ -118,8 +148,8 @@ public static class KevlarDiagnostics
                 strategyName: "Callback",
                 eventName: "callback_error",
                 KevlarTelemetrySeverity.Error,
-                context.StrategyIndex,
-                context.AttemptNumber,
+                strategyIndex,
+                attemptNumber,
                 isSuccess: false,
                 exception,
                 callbackKind: kind,
@@ -134,7 +164,8 @@ public static class KevlarDiagnostics
             kind,
             source,
             context.ShieldName,
-            context.StrategyIndex,
+            strategyIndex,
+            attemptNumber,
             exception);
         var handlers = OnCallbackError;
         if (handlers is null)

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 static Kevlar.Strategy.InvokeGenerator<TEvent, TResult>(System.Func<TEvent, System.Threading.Tasks.ValueTask<TResult>>! generator, TEvent callbackEvent, Kevlar.KevlarContext! context, string! hookName) -> System.Threading.Tasks.ValueTask<TResult>
 Kevlar.CallbackErrorKind.HandlingPredicate = 10 -> Kevlar.CallbackErrorKind
+Kevlar.CallbackErrorEvent.AttemptNumber.get -> int
 Kevlar.KevlarTelemetryEvent.IsCancelled.get -> bool
 Kevlar.KevlarTelemetryEvent.IsWinner.get -> bool
 abstract Kevlar.KevlarMetricEnricher.Enrich(in Kevlar.KevlarMetricEnrichmentContext context) -> void

--- a/src/Kevlar/PublicAPI.Unshipped.txt
+++ b/src/Kevlar/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 static Kevlar.Strategy.InvokeGenerator<TEvent, TResult>(System.Func<TEvent, System.Threading.Tasks.ValueTask<TResult>>! generator, TEvent callbackEvent, Kevlar.KevlarContext! context, string! hookName) -> System.Threading.Tasks.ValueTask<TResult>
+Kevlar.CallbackErrorKind.HandlingPredicate = 10 -> Kevlar.CallbackErrorKind
 Kevlar.KevlarTelemetryEvent.IsCancelled.get -> bool
 Kevlar.KevlarTelemetryEvent.IsWinner.get -> bool
 abstract Kevlar.KevlarMetricEnricher.Enrich(in Kevlar.KevlarMetricEnrichmentContext context) -> void

--- a/src/Kevlar/ShieldBuilder.cs
+++ b/src/Kevlar/ShieldBuilder.cs
@@ -201,10 +201,10 @@ public sealed class ShieldBuilder
     {
         var description = DescribeHelper.Clause(_clauseTerms);
         OutcomeJudge judge = _contextPredicates.Length == 0
-            ? new ExceptionJudge(Combine(_predicates), description)
+            ? new ExceptionJudge(_predicates, description)
             : new ContextExceptionJudge(
-                _predicates.Length == 0 ? null : Combine(_predicates),
-                CombineContexts(_contextPredicates),
+                _predicates,
+                _contextPredicates,
                 description);
         return new Shield(
             _parent.Strategies,
@@ -236,64 +236,5 @@ public sealed class ShieldBuilder
         Array.Copy(source, appended, source.Length);
         appended[source.Length] = item;
         return appended;
-    }
-
-    internal static Func<Exception, bool> Combine(Func<Exception, bool>[] predicates)
-    {
-        if (predicates.Length == 0)
-        {
-            throw new InvalidOperationException("No handling clauses were added.");
-        }
-
-        if (predicates.Length == 1)
-        {
-            return predicates[0];
-        }
-
-        return exception =>
-        {
-            foreach (var predicate in predicates)
-            {
-                if (predicate(exception))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        };
-    }
-
-    private static Func<HandlingEvent, bool> CombineContexts(Func<HandlingEvent, bool>[] predicates)
-    {
-        if (predicates.Length == 1)
-        {
-            return predicates[0];
-        }
-
-        return handling =>
-            EvaluateContextPredicates(predicates, handling);
-    }
-
-    internal static bool EvaluateContextPredicates<TEvent>(
-        Func<TEvent, bool>[] predicates,
-        TEvent handling)
-    {
-        foreach (var predicate in predicates)
-        {
-            try
-            {
-                if (predicate(handling))
-                {
-                    return true;
-                }
-            }
-            catch (Exception exception)
-            {
-                OutcomeJudge.ReportPredicateFailure(exception);
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Kevlar/ShieldBuilderOfT.cs
+++ b/src/Kevlar/ShieldBuilderOfT.cs
@@ -218,15 +218,11 @@ public sealed class ShieldBuilder<TResult>
     /// </summary>
     private Shield<TResult> Seal()
     {
-        var exceptionPredicate = _exceptionPredicates.Length == 0
-            ? null
-            : ShieldBuilder.Combine(_exceptionPredicates);
-        var resultPredicate = CombineResults(_resultPredicates);
         var judge = new TypedJudge<TResult>(
-            exceptionPredicate,
-            resultPredicate,
+            _exceptionPredicates,
+            _resultPredicates,
             DescribeHelper.Clause(_clauseTerms),
-            CombineContexts(_contextPredicates));
+            _contextPredicates);
         return new Shield<TResult>(
             _parent.Strategies,
             judge,
@@ -272,46 +268,4 @@ public sealed class ShieldBuilder<TResult>
             _resultPredicates,
             ShieldBuilder.Append(_contextPredicates, predicate),
             ShieldBuilder.Append(_clauseTerms, clauseTerm));
-
-    private static Func<TResult, bool>? CombineResults(Func<TResult, bool>[] predicates)
-    {
-        if (predicates.Length == 0)
-        {
-            return null;
-        }
-
-        if (predicates.Length == 1)
-        {
-            return predicates[0];
-        }
-
-        return result =>
-        {
-            foreach (var predicate in predicates)
-            {
-                if (predicate(result))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        };
-    }
-
-    private static Func<HandlingEvent<TResult>, bool>? CombineContexts(
-        Func<HandlingEvent<TResult>, bool>[] predicates)
-    {
-        if (predicates.Length == 0)
-        {
-            return null;
-        }
-
-        if (predicates.Length == 1)
-        {
-            return predicates[0];
-        }
-
-        return handling => ShieldBuilder.EvaluateContextPredicates(predicates, handling);
-    }
 }

--- a/tests/Kevlar.Tests/CallbackFailureTests.cs
+++ b/tests/Kevlar.Tests/CallbackFailureTests.cs
@@ -6,6 +6,90 @@ public class CallbackFailureTests
 {
     [Test]
     [NotInParallel]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Throwing_Handling_Predicate_Is_Reported_Without_Replacing_The_Outcome(
+        bool contextAware)
+    {
+        var predicateFailure = new IOException("predicate");
+        var executionFailure = new ArgumentException("execution");
+        var shieldName = $"predicate-{Guid.NewGuid():N}";
+        var reported = new List<CallbackErrorEvent>();
+        var measurements = new List<(string Kind, string Source)>();
+        Action<CallbackErrorEvent> handler = reported.Add;
+        using var listener = CreateCallbackErrorListener(shieldName, measurements);
+        KevlarDiagnostics.OnCallbackError += handler;
+
+        try
+        {
+            var shield = contextAware
+                ? Shield.WhenContext((HandlingEvent _) => throw predicateFailure)
+                    .Retry(1, Backoff.None)
+                : Shield.When(_ => throw predicateFailure)
+                    .Retry(1, Backoff.None);
+            shield = shield.WithName(shieldName);
+
+            var thrown = await Assert.That(async () => await shield.ExecuteAsync<int>(
+                _ => throw executionFailure)).Throws<ArgumentException>();
+
+            await Assert.That(thrown).IsSameReferenceAs(executionFailure);
+            await Assert.That(reported).HasSingleItem();
+            await Assert.That(reported[0].Kind).IsEqualTo(CallbackErrorKind.HandlingPredicate);
+            await Assert.That(reported[0].Source).IsEqualTo("HandlingPredicate");
+            await Assert.That(reported[0].Exception).IsSameReferenceAs(predicateFailure);
+            await Assert.That(measurements)
+                .IsEquivalentTo([("handling_predicate", "HandlingPredicate")]);
+        }
+        finally
+        {
+            KevlarDiagnostics.OnCallbackError -= handler;
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Throwing_Result_Predicate_Is_Reported_Without_Replacing_The_Result(
+        bool contextAware)
+    {
+        var predicateFailure = new IOException("predicate");
+        var shieldName = $"result-predicate-{Guid.NewGuid():N}";
+        var reported = new List<CallbackErrorEvent>();
+        var measurements = new List<(string Kind, string Source)>();
+        Action<CallbackErrorEvent> handler = reported.Add;
+        using var listener = CreateCallbackErrorListener(shieldName, measurements);
+        KevlarDiagnostics.OnCallbackError += handler;
+
+        try
+        {
+            var shield = contextAware
+                ? Shield.For<int>()
+                    .WhenResultContext((HandlingEvent<int> _) => throw predicateFailure)
+                    .FallbackTo(-1)
+                : Shield.For<int>()
+                    .WhenResult(_ => throw predicateFailure)
+                    .FallbackTo(-1);
+            shield = shield.WithName(shieldName);
+
+            var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+            await Assert.That(result).IsEqualTo(42);
+            await Assert.That(reported).HasSingleItem();
+            await Assert.That(reported[0].Kind).IsEqualTo(CallbackErrorKind.HandlingPredicate);
+            await Assert.That(reported[0].Source).IsEqualTo("HandlingPredicate");
+            await Assert.That(reported[0].Exception).IsSameReferenceAs(predicateFailure);
+            await Assert.That(measurements)
+                .IsEquivalentTo([("handling_predicate", "HandlingPredicate")]);
+        }
+        finally
+        {
+            KevlarDiagnostics.OnCallbackError -= handler;
+        }
+    }
+
+    [Test]
+    [NotInParallel]
     public async Task Throwing_Callback_Is_Reported_Without_Changing_Successful_Outcome()
     {
         var callbackFailure = new IOException("callback");

--- a/tests/Kevlar.Tests/CallbackFailureTests.cs
+++ b/tests/Kevlar.Tests/CallbackFailureTests.cs
@@ -1,9 +1,38 @@
 using System.Diagnostics.Metrics;
+using Kevlar.Testing;
 
 namespace Kevlar.Tests;
 
 public class CallbackFailureTests
 {
+    [Test]
+    [NotInParallel]
+    public async Task Public_HandlingClause_Reports_Explicit_Evaluation_Metadata()
+    {
+        const int attemptNumber = 3;
+        const int strategyIndex = 7;
+        using var recorder = new TelemetryRecorder(
+            captureMetrics: false,
+            captureCallbackErrors: true);
+        var predicateFailure = new IOException("predicate");
+        var shield = Shield.WhenContext((HandlingEvent _) => throw predicateFailure)
+            .Use(clause => new HandlingClauseProbeStrategy(
+                clause,
+                attemptNumber,
+                strategyIndex));
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        var callback = recorder.Callbacks.Single();
+        await Assert.That(callback.ErrorKind).IsEqualTo(CallbackErrorKind.HandlingPredicate);
+        await Assert.That(callback.AttemptNumber).IsEqualTo(attemptNumber);
+        await Assert.That(callback.StrategyIndex).IsEqualTo(strategyIndex);
+        var telemetry = recorder.Events.Single(item => item.EventName == "callback_error");
+        await Assert.That(telemetry.AttemptNumber).IsEqualTo(attemptNumber);
+        await Assert.That(telemetry.StrategyIndex).IsEqualTo(strategyIndex);
+    }
+
     [Test]
     [NotInParallel]
     [Arguments(false)]
@@ -319,5 +348,20 @@ public class CallbackFailureTests
         });
         listener.Start();
         return listener;
+    }
+
+    private sealed class HandlingClauseProbeStrategy(
+        HandlingClause clause,
+        int attemptNumber,
+        int strategyIndex) : Strategy
+    {
+        public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(
+            Continuation<T, TState> next,
+            KevlarContext context)
+        {
+            var failed = Outcome<T>.FromException(new InvalidOperationException("probe"));
+            _ = clause.ShouldHandle(in failed, context, attemptNumber, strategyIndex);
+            return next.InvokeAsync(context);
+        }
     }
 }

--- a/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerDynamicOptionsTests.cs
@@ -533,7 +533,7 @@ public class CircuitBreakerDynamicOptionsTests
     }
 
     [Test]
-    public async Task Configured_Breaker_Returns_Synchronous_Processing_Failure_As_Faulted_ValueTask()
+    public async Task Configured_Breaker_Preserves_Operation_Failure_When_Predicate_Throws()
     {
         var predicateFailure = new InvalidOperationException("predicate");
         var shield = Shield.When(_ => throw predicateFailure).CircuitBreaker(options =>
@@ -554,9 +554,10 @@ public class CircuitBreakerDynamicOptionsTests
             var execution = strategy.ExecuteAsync(continuation, context);
 
             await Assert.That(execution.IsCompleted).IsTrue();
-            await Assert.That(execution.IsCompletedSuccessfully).IsFalse();
-            var thrown = await Assert.That(async () => await execution).Throws<InvalidOperationException>();
-            await Assert.That(ReferenceEquals(thrown, predicateFailure)).IsTrue();
+            await Assert.That(execution.IsCompletedSuccessfully).IsTrue();
+            var outcome = await execution;
+            await Assert.That(outcome.Exception).IsTypeOf<ApplicationException>();
+            await Assert.That(outcome.Exception).IsNotSameReferenceAs(predicateFailure);
         }
         finally
         {

--- a/tests/Kevlar.Tests/CompositionContractTests.cs
+++ b/tests/Kevlar.Tests/CompositionContractTests.cs
@@ -240,22 +240,52 @@ public class CompositionContractTests
     }
 
     [Test]
-    public async Task Predicate_Failure_Surfaces_The_Original_Instance()
+    public async Task Predicate_Failure_Preserves_The_Execution_Failure()
     {
         var predicateFailure = new InvalidOperationException("predicate failed");
+        var executionFailure = new ArgumentException("execution failed");
         var shield = Shield.When(_ => throw predicateFailure).Retry(1, Backoff.None);
-        Exception? caught = null;
+        var attempts = 0;
 
-        try
+        var thrown = await Assert.That(async () => await shield.ExecuteAsync<int>(_ =>
         {
-            await shield.ExecuteAsync<int>(_ => throw new ArgumentException());
-        }
-        catch (Exception exception)
-        {
-            caught = exception;
-        }
+            attempts++;
+            throw executionFailure;
+        })).Throws<ArgumentException>();
 
-        await Assert.That(ReferenceEquals(caught, predicateFailure)).IsTrue();
+        await Assert.That(thrown).IsSameReferenceAs(executionFailure);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Predicate_Failure_Does_Not_Skip_Later_Exception_Alternative()
+    {
+        var attempts = 0;
+        var shield = Shield
+            .When(_ => throw new InvalidOperationException("predicate"))
+            .Or<ArgumentException>()
+            .Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(
+            ++attempts == 1 ? throw new ArgumentException("execution") : 42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Predicate_Failure_Does_Not_Skip_Later_Result_Alternative()
+    {
+        var attempts = 0;
+        var shield = Shield.For<int>()
+            .WhenResult(_ => throw new InvalidOperationException("predicate"))
+            .OrResult(static result => result == 1)
+            .Retry(1, Backoff.None);
+
+        var result = await shield.ExecuteAsync(_ => new ValueTask<int>(++attempts));
+
+        await Assert.That(result).IsEqualTo(2);
+        await Assert.That(attempts).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
+++ b/tests/Kevlar.Tests/ContextAwarePredicateTests.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace Kevlar.Tests;
 
 public class ContextAwarePredicateTests
@@ -345,30 +343,6 @@ public class ContextAwarePredicateTests
     }
 
     [Test]
-    [NotInParallel]
-    public async Task Trace_Listener_Exception_Does_Not_Replace_Execution_Failure()
-    {
-        var listener = new ThrowingTraceListener();
-        Trace.Listeners.Add(listener);
-
-        try
-        {
-            var shield = Shield.WhenContext((HandlingEvent _) => throw new DivideByZeroException("predicate"))
-                .Retry(1, Backoff.None);
-            var executionFailure = new InvalidOperationException("execution");
-
-            var thrown = await Assert.That(async () => await shield.ExecuteAsync<int>(
-                _ => throw executionFailure)).Throws<InvalidOperationException>();
-
-            await Assert.That(thrown).IsSameReferenceAs(executionFailure);
-        }
-        finally
-        {
-            Trace.Listeners.Remove(listener);
-        }
-    }
-
-    [Test]
     public async Task Predicate_Exception_Does_Not_Skip_Later_Context_Alternative()
     {
         var alternatives = 0;
@@ -390,13 +364,6 @@ public class ContextAwarePredicateTests
 
         await Assert.That(attempts).IsEqualTo(2);
         await Assert.That(alternatives).IsEqualTo(1);
-    }
-
-    private sealed class ThrowingTraceListener : TraceListener
-    {
-        public override void Write(string? message) => throw new InvalidOperationException("listener");
-
-        public override void WriteLine(string? message) => throw new InvalidOperationException("listener");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- treat exceptions from every handling predicate shape as not handled, preserving the protected outcome
- report predicate failures through `CallbackErrorKind.HandlingPredicate`, telemetry, logging, and `kevlar.callback_errors`
- continue evaluating later handling alternatives after one predicate throws
- document the breaking semantic and regenerate API metadata

## Test plan
- [x] `dotnet build Kevlar.slnx -c Release`
- [x] `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m` (1251 passed)
- [x] `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (1285 passed)
- [x] `dotnet run --project tests/Kevlar.Extensions.Logging.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (48 passed)
- [x] `dotnet run --project tests/Kevlar.Testing.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (61 passed)
- [x] `pwsh scripts/Build-ApiDocs.ps1`
- [x] `pwsh scripts/Verify-ApiDocs.ps1`
- [x] `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/verify -Version 0.0.0-local` (LF checkout; all gates passed)

Closes #401