### PR TITLE
feat(http): surface unsafe replay suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ services.AddHttpClient("api")
 
 The standard shield has a 30-second total timeout, three jittered retries that honour
 `Retry-After`, a circuit breaker, and a 10-second timeout per attempt. You can configure every
-part or supply your own shield. `Kevlar.Extensions.DependencyInjection` adds named,
+part or supply your own shield. POST, PATCH, and custom methods remain single-attempt unless you
+explicitly enable replay for operations that are safe to repeat. `Kevlar.Extensions.DependencyInjection` adds named,
 configuration-bound shields and `IKevlarRegistry`.
 
 ## Packages

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -83,7 +83,9 @@ using var serviceProvider = services.BuildServiceProvider();
 ```
 
 `AddShield` registers a reusable named shield. `AddStandardShield` installs a production HTTP
-pipeline with total and per-attempt timeouts, retry, and circuit breaker. Continue with
+pipeline with total and per-attempt timeouts, retry, and circuit breaker. POST, PATCH, and custom
+methods remain single-attempt unless replay is explicitly enabled for an operation that is safe to
+repeat. Continue with
 [Dependency injection](dependency-injection.md) or [HTTP resilience](http.md) to resolve and
 customize them. Registration extensions live in `Microsoft.Extensions.DependencyInjection`, so
 ASP.NET Core projects get them through implicit usings without importing a Kevlar package namespace.

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -363,8 +363,11 @@ actually idempotent. If method or content cannot be replayed safely, retry and h
 single-attempt: the original response is returned or the original exception is rethrown without a
 retry delay or callback. Other stages, including timeout, circuit breaker, and concurrency limiting,
 still observe that attempt. A multi-attempt shield reports this decision once as the
-`attempts_suppressed` telemetry event and Information log 1009, with reason `replay_disabled`,
-`unsafe_method`, or `non_replayable_content`. The `kevlar.http.replay_suppressed` counter carries the
+`attempts_suppressed` telemetry event and log 1009, with reason `replay_disabled`, `unsafe_method`,
+or `non_replayable_content`. The first `unsafe_method` suppression for a client is a Warning that
+names the handler-wide and per-request opt-ins; later unsafe-method suppressions and other reasons
+are Information. Telemetry uses the matching Warning or Information severity. The
+`kevlar.http.replay_suppressed` counter carries the
 same bounded reason in `kevlar.suppression.reason`. `HttpRequestReplayException` is reserved for
 configuration failures such as a null factory result or content exceeding the requested buffer
 limit. Timeouts and caller cancellation flow to every attempt and request factory.

--- a/docs/docs/logging.md
+++ b/docs/docs/logging.md
@@ -70,7 +70,7 @@ registered `ILoggerFactory`. Explicit `WithLogging` calls remain local to that s
 | 1006 | rate-limit rejection | Warning |
 | 1007 | concurrency-limit rejection | Warning |
 | 1008 | callback error | Error |
-| 1009 | HTTP attempts suppressed | Information |
+| 1009 | HTTP attempts suppressed | Warning for the first unsafe-method suppression per client; Information otherwise |
 | 1010 | timeout cancellation ignored | Warning |
 
 Structured state includes the applicable subset of `ShieldName`, `StrategyIndex`, `AttemptNumber`,

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -415,6 +415,7 @@ required.
 | Hedging | 1 additional attempt (2 total); delay 2 s | 1 additional attempt (2 total); delay 1 s |
 | Concurrency | permit limit 1,000; queue limit 0 | maximum concurrency 10; queue limit 0 |
 | Standard HTTP retry | 3 retries; exponential from 2 s; decorrelated jitter; no delay cap | 3 retries; exponential from 250 ms; equal jitter; 10 s cap; honours `Retry-After` |
+| Standard HTTP unsafe methods | POST, PATCH, DELETE, and custom methods are retried by default | POST, PATCH, and custom methods remain single-attempt unless `AllowUnsafeMethodReplay`, per-request `AllowReplay`, or a `RequestFactory` opts in |
 | Standard HTTP circuit breaker | failure ratio 0.1; minimum throughput 100; sampling 30 s; break 5 s | failure ratio 0.5; minimum throughput 10; sampling 30 s; break 15 s |
 | Standard HTTP concurrency | permit limit 1,000; queue limit 0 | no limiter unless `ConcurrencyLimit` is configured |
 | Chaos | enabled; injection rate 0.001 | disabled; injection rate 1 |

--- a/docs/docs/thread-safety.md
+++ b/docs/docs/thread-safety.md
@@ -15,6 +15,7 @@ execution-scoped objects that must remain owned by one operation.
 | `CircuitBreakerMonitor` | Thread-safe and bindable to multiple circuit breakers. `StateChanged` notifications are serialized per breaker; different breakers may publish concurrently. |
 | `KevlarContext`, `KevlarProperties` | Execution-scoped and not safe for caller-created concurrent access. Do not retain them after the delegate or callback returns. Hedge attempts receive detached property containers, but mutable values stored inside them remain the caller's responsibility. |
 | `IKevlarRegistry`, `IShieldProvider` | Thread-safe singleton services. Registry lookups return immutable snapshots. Reloading names expose only a keyed provider; query it or the registry once per operation. |
+| `ShieldDelegatingHandler` | Thread-safe for concurrent requests. Replay state is request-scoped; the first unsafe-method suppression warning is coordinated atomically per handler. |
 | `ExecutionProbe`, `TelemetryRecorder` | Thread-safe test observers. Their snapshot collections are immutable copies; dispose `TelemetryRecorder` to detach its listener. |
 | Custom `Strategy` implementations | One instance may be used by every concurrent execution and composed shield. Implementations must synchronize mutable state and must not retain a pooled `KevlarContext`. |
 

--- a/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
+++ b/src/Kevlar.Extensions.Http/ShieldDelegatingHandler.cs
@@ -13,6 +13,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
     private readonly ReloadingHttpShieldPipeline? _reloadingPipeline;
     private readonly Func<HttpRequestMessage, ValueTask<Shield<HttpResponseMessage>>>? _shieldSelector;
     private readonly Func<Shield<HttpResponseMessage>, Shield<HttpResponseMessage>>? _requestShieldDecorator;
+    private int _unsafeMethodSuppressionReported;
 
     /// <summary>Creates the handler with safe no-buffer replay defaults.</summary>
     public ShieldDelegatingHandler(Shield<HttpResponseMessage> shield)
@@ -134,6 +135,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             request,
             pipeline.Options,
             requestOptions).ConfigureAwait(false);
+        var reportSuppression = !replay.CanReplay && !selectedShield.InvokesContinuationAtMostOnce;
         var execution = new RequestExecution(
             this,
             request,
@@ -141,7 +143,7 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             requestOptions,
             replay.CanReplay,
             replay.SuppressionReason,
-            reportSuppression: !replay.CanReplay && !selectedShield.InvokesContinuationAtMostOnce,
+            reportSuppression,
             executionCancellationToken: executionCancellationToken);
         try
         {
@@ -262,6 +264,10 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
         return request => new ValueTask<Shield<HttpResponseMessage>>(shieldSelector(request));
     }
 
+    private bool ShouldWarnOnSuppression(string reason) =>
+        reason == "unsafe_method"
+        && Interlocked.CompareExchange(ref _unsafeMethodSuppressionReported, 1, 0) == 0;
+
     private Task<HttpResponseMessage> BaseSendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken) =>
@@ -380,7 +386,12 @@ public sealed class ShieldDelegatingHandler : DelegatingHandler
             if (_reportSuppression
                 && Interlocked.Exchange(ref _suppressionReported, 1) == 0)
             {
-                KevlarMetrics.HttpReplaySuppressed(context, _suppressionReason!);
+                KevlarMetrics.HttpReplaySuppressed(
+                    context,
+                    _suppressionReason!,
+                    _handler.ShouldWarnOnSuppression(_suppressionReason!)
+                        ? KevlarTelemetrySeverity.Warning
+                        : KevlarTelemetrySeverity.Information);
             }
 
             var cancellationToken = context.CancellationToken;

--- a/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
+++ b/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
@@ -327,6 +327,7 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
                     WarningLoggerMessages.UnsafeMethodAttemptsSuppressed(
                         logger,
                         telemetryEvent.ShieldName,
+                        telemetryEvent.SuppressionReason,
                         suppressedRequestMethod,
                         suppressedRequestUri);
                 }

--- a/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
+++ b/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
@@ -321,12 +321,24 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
                 _ = telemetryEvent.Context.Properties.TryGet(
                     HttpRequestUriKey,
                     out string? suppressedRequestUri);
-                LoggerMessages.AttemptsSuppressed(
-                    logger,
-                    telemetryEvent.ShieldName,
-                    telemetryEvent.SuppressionReason,
-                    suppressedRequestMethod,
-                    suppressedRequestUri);
+                if (telemetryEvent.Severity == KevlarTelemetrySeverity.Warning
+                    && telemetryEvent.SuppressionReason == "unsafe_method")
+                {
+                    WarningLoggerMessages.UnsafeMethodAttemptsSuppressed(
+                        logger,
+                        telemetryEvent.ShieldName,
+                        suppressedRequestMethod,
+                        suppressedRequestUri);
+                }
+                else
+                {
+                    LoggerMessages.AttemptsSuppressed(
+                        logger,
+                        telemetryEvent.ShieldName,
+                        telemetryEvent.SuppressionReason,
+                        suppressedRequestMethod,
+                        suppressedRequestUri);
+                }
                 break;
         }
     }
@@ -493,7 +505,9 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
             case "attempts_suppressed":
                 kind = KevlarLogEventKind.AttemptsSuppressed;
                 eventId = new EventId(1009, "AttemptsSuppressed");
-                level = LogLevel.Information;
+                level = telemetryEvent.Severity == KevlarTelemetrySeverity.Warning
+                    ? LogLevel.Warning
+                    : LogLevel.Information;
                 return true;
             case "rejection" when telemetryEvent.RejectionKind is "rate_limit" or "rate_limiter_adapter":
                 kind = KevlarLogEventKind.RateLimitRejected;

--- a/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
+++ b/src/Kevlar.Extensions.Logging/LoggingTelemetryListener.cs
@@ -321,8 +321,7 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
                 _ = telemetryEvent.Context.Properties.TryGet(
                     HttpRequestUriKey,
                     out string? suppressedRequestUri);
-                if (telemetryEvent.Severity == KevlarTelemetrySeverity.Warning
-                    && telemetryEvent.SuppressionReason == "unsafe_method")
+                if (IsFirstUnsafeMethodSuppression(in telemetryEvent))
                 {
                     WarningLoggerMessages.UnsafeMethodAttemptsSuppressed(
                         logger,
@@ -439,13 +438,31 @@ internal sealed class LoggingTelemetryListener(LoggingRegistration registration)
                 _ = telemetryEvent.Context.Properties.TryGet(
                     HttpRequestUriKey,
                     out string? suppressedRequestUri);
-                logger.Log(level, eventId,
-                    "Shield {ShieldName} suppressed additional HTTP attempts because {SuppressionReason}; request {RequestMethod} {RequestUri}",
-                    telemetryEvent.ShieldName, telemetryEvent.SuppressionReason,
-                    suppressedRequestMethod, suppressedRequestUri);
+                if (IsFirstUnsafeMethodSuppression(in telemetryEvent))
+                {
+                    logger.Log(level, eventId,
+                        WarningLoggerMessages.UnsafeMethodAttemptsSuppressedFormat,
+                        telemetryEvent.ShieldName, telemetryEvent.SuppressionReason,
+                        suppressedRequestMethod, suppressedRequestUri);
+                }
+                else
+                {
+                    logger.Log(level, eventId,
+                        "Shield {ShieldName} suppressed additional HTTP attempts because {SuppressionReason}; request {RequestMethod} {RequestUri}",
+                        telemetryEvent.ShieldName, telemetryEvent.SuppressionReason,
+                        suppressedRequestMethod, suppressedRequestUri);
+                }
                 break;
         }
     }
+
+    private static bool IsFirstUnsafeMethodSuppression(
+        in KevlarTelemetryEvent telemetryEvent) =>
+        telemetryEvent.Severity == KevlarTelemetrySeverity.Warning
+        && string.Equals(
+            telemetryEvent.SuppressionReason,
+            "unsafe_method",
+            StringComparison.Ordinal);
 
     private static CircuitState CircuitStateFromRejection(
         in KevlarTelemetryEvent telemetryEvent) =>

--- a/src/Kevlar.Extensions.Logging/WarningLoggerMessages.cs
+++ b/src/Kevlar.Extensions.Logging/WarningLoggerMessages.cs
@@ -4,8 +4,14 @@ namespace Kevlar.Extensions.Logging;
 
 internal static partial class WarningLoggerMessages
 {
+    public const string UnsafeMethodAttemptsSuppressedFormat =
+        "Shield {ShieldName} suppressed additional HTTP attempts because {SuppressionReason}; " +
+        "unsafe method {RequestMethod} {RequestUri}; opt in with " +
+        "ShieldHttpHandlerOptions.AllowUnsafeMethodReplay or " +
+        "KevlarHttp.GetRequestOptions(request).AllowReplay";
+
     [LoggerMessage(EventId = 1009, EventName = "AttemptsSuppressed", Level = LogLevel.Warning,
-        Message = "Shield {ShieldName} suppressed additional HTTP attempts because {SuppressionReason}; unsafe method {RequestMethod} {RequestUri}; opt in with ShieldHttpHandlerOptions.AllowUnsafeMethodReplay or KevlarHttp.GetRequestOptions(request).AllowReplay",
+        Message = UnsafeMethodAttemptsSuppressedFormat,
         SkipEnabledCheck = true)]
     public static partial void UnsafeMethodAttemptsSuppressed(
         ILogger logger,

--- a/src/Kevlar.Extensions.Logging/WarningLoggerMessages.cs
+++ b/src/Kevlar.Extensions.Logging/WarningLoggerMessages.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+
+namespace Kevlar.Extensions.Logging;
+
+internal static partial class WarningLoggerMessages
+{
+    [LoggerMessage(EventId = 1009, EventName = "AttemptsSuppressed", Level = LogLevel.Warning,
+        Message = "Shield {ShieldName} suppressed additional HTTP attempts for unsafe method {RequestMethod} {RequestUri}; opt in with ShieldHttpHandlerOptions.AllowUnsafeMethodReplay or KevlarHttp.GetRequestOptions(request).AllowReplay",
+        SkipEnabledCheck = true)]
+    public static partial void UnsafeMethodAttemptsSuppressed(
+        ILogger logger,
+        string? shieldName,
+        string? requestMethod,
+        string? requestUri);
+}

--- a/src/Kevlar.Extensions.Logging/WarningLoggerMessages.cs
+++ b/src/Kevlar.Extensions.Logging/WarningLoggerMessages.cs
@@ -5,11 +5,12 @@ namespace Kevlar.Extensions.Logging;
 internal static partial class WarningLoggerMessages
 {
     [LoggerMessage(EventId = 1009, EventName = "AttemptsSuppressed", Level = LogLevel.Warning,
-        Message = "Shield {ShieldName} suppressed additional HTTP attempts for unsafe method {RequestMethod} {RequestUri}; opt in with ShieldHttpHandlerOptions.AllowUnsafeMethodReplay or KevlarHttp.GetRequestOptions(request).AllowReplay",
+        Message = "Shield {ShieldName} suppressed additional HTTP attempts because {SuppressionReason}; unsafe method {RequestMethod} {RequestUri}; opt in with ShieldHttpHandlerOptions.AllowUnsafeMethodReplay or KevlarHttp.GetRequestOptions(request).AllowReplay",
         SkipEnabledCheck = true)]
     public static partial void UnsafeMethodAttemptsSuppressed(
         ILogger logger,
         string? shieldName,
+        string? suppressionReason,
         string? requestMethod,
         string? requestUri);
 }

--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -330,7 +330,10 @@ internal static class KevlarMetrics
             rejectionKind: kind);
     }
 
-    public static void HttpReplaySuppressed(KevlarContext context, string reason)
+    public static void HttpReplaySuppressed(
+        KevlarContext context,
+        string reason,
+        KevlarTelemetrySeverity severity = KevlarTelemetrySeverity.Information)
     {
 #if NET8_0_OR_GREATER
         if (HttpReplaySuppressions.Enabled)
@@ -349,7 +352,7 @@ internal static class KevlarMetrics
             context,
             strategyName: "HTTP",
             eventName: "attempts_suppressed",
-            KevlarTelemetrySeverity.Information,
+            severity,
             context.StrategyIndex,
             context.AttemptNumber,
             isSuccess: true,

--- a/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
+++ b/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
@@ -98,6 +98,8 @@ public class IntegrationTests
         await Assert.That(transport.Attempts).IsEqualTo(2);
         await Assert.That(suppressions.Length).IsEqualTo(2);
         await Assert.That(suppressions[0].Level).IsEqualTo(LogLevel.Warning);
+        await Assert.That(suppressions[0].GetStructuredStateValue("SuppressionReason"))
+            .IsEqualTo("unsafe_method");
         await Assert.That(suppressions[0].Message).Contains("AllowUnsafeMethodReplay");
         await Assert.That(suppressions[0].Message).Contains("KevlarHttp.GetRequestOptions");
         await Assert.That(suppressions[1].Level).IsEqualTo(LogLevel.Information);

--- a/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
+++ b/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
@@ -63,6 +63,52 @@ public class IntegrationTests
 
     [Test]
     [NotInParallel]
+    public async Task Unsafe_Method_First_Suppression_Warns_Then_Uses_Information()
+    {
+        var logs = new FakeLoggerProvider();
+        var telemetry = new List<KevlarTelemetrySeverity>();
+        using var subscription = KevlarDiagnostics.Listen(new CallbackTelemetryListener(telemetryEvent =>
+        {
+            if (telemetryEvent.EventName == "attempts_suppressed"
+                && telemetryEvent.SuppressionReason == "unsafe_method")
+            {
+                telemetry.Add(telemetryEvent.Severity);
+            }
+        }));
+        var transport = new SequenceHandler(
+            HttpStatusCode.ServiceUnavailable,
+            HttpStatusCode.ServiceUnavailable);
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddProvider(logs));
+        services.AddKevlarLogging();
+        services.AddHttpClient("unsafe-method")
+            .ConfigurePrimaryHttpMessageHandler(() => transport)
+            .AddShield(HttpShield.WhenTransient().Retry(1, Backoff.None));
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("unsafe-method");
+        using var firstRequest = new HttpRequestMessage(HttpMethod.Post, "https://example.test/first");
+        using var secondRequest = new HttpRequestMessage(HttpMethod.Post, "https://example.test/second");
+
+        using var firstResponse = await client.SendAsync(firstRequest);
+        using var secondResponse = await client.SendAsync(secondRequest);
+
+        var suppressions = logs.Collector.GetSnapshot()
+            .Where(record => record.Id == new EventId(1009, "AttemptsSuppressed"))
+            .ToArray();
+        await Assert.That(transport.Attempts).IsEqualTo(2);
+        await Assert.That(suppressions.Length).IsEqualTo(2);
+        await Assert.That(suppressions[0].Level).IsEqualTo(LogLevel.Warning);
+        await Assert.That(suppressions[0].Message).Contains("AllowUnsafeMethodReplay");
+        await Assert.That(suppressions[0].Message).Contains("KevlarHttp.GetRequestOptions");
+        await Assert.That(suppressions[1].Level).IsEqualTo(LogLevel.Information);
+        await Assert.That(telemetry).IsEquivalentTo([
+            KevlarTelemetrySeverity.Warning,
+            KevlarTelemetrySeverity.Information,
+        ]);
+    }
+
+    [Test]
+    [NotInParallel]
     public async Task AddKevlarLogging_Applies_To_Named_And_Reloading_Shields()
     {
         var logs = new FakeLoggerProvider();

--- a/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
+++ b/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
@@ -111,6 +111,35 @@ public class IntegrationTests
 
     [Test]
     [NotInParallel]
+    public async Task Unsafe_Method_Guidance_Survives_Severity_Override()
+    {
+        var logs = new FakeLoggerProvider();
+        var transport = new SequenceHandler(HttpStatusCode.ServiceUnavailable);
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddProvider(logs));
+        services.AddKevlarLogging(options =>
+            options.SeverityProvider = _ => LogLevel.Information);
+        services.AddHttpClient("unsafe-method-override")
+            .ConfigurePrimaryHttpMessageHandler(() => transport)
+            .AddShield(HttpShield.WhenTransient().Retry(1, Backoff.None));
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>()
+            .CreateClient("unsafe-method-override");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/unsafe");
+
+        using var response = await client.SendAsync(request);
+
+        var suppression = logs.Collector.GetSnapshot()
+            .Single(record => record.Id == new EventId(1009, "AttemptsSuppressed"));
+        await Assert.That(suppression.Level).IsEqualTo(LogLevel.Information);
+        await Assert.That(suppression.GetStructuredStateValue("SuppressionReason"))
+            .IsEqualTo("unsafe_method");
+        await Assert.That(suppression.Message).Contains("AllowUnsafeMethodReplay");
+        await Assert.That(suppression.Message).Contains("KevlarHttp.GetRequestOptions");
+    }
+
+    [Test]
+    [NotInParallel]
     public async Task AddKevlarLogging_Applies_To_Named_And_Reloading_Shields()
     {
         var logs = new FakeLoggerProvider();


### PR DESCRIPTION
Closes #387

## Summary

- warn on the first unsafe-method replay suppression per HTTP handler, then log later suppressions at Information
- publish matching Warning/Information severity through the existing `attempts_suppressed` telemetry event
- name `AllowUnsafeMethodReplay` and the per-request `AllowReplay` opt-in in the warning
- document replay-safe defaults in README, getting started, HTTP, logging, migration, and thread-safety guidance

## Validation

- `dotnet build Kevlar.slnx -c Release --no-restore`
- `Kevlar.Tests` net10/net8: 1283/1249 passed
- `Kevlar.Extensions.Logging.Tests` net10/net8: 49/49 passed
- `Kevlar.IntegrationTests`: 171 passed
- `scripts/Verify-Docs.ps1`
- `scripts/Build-ApiDocs.ps1 -SkipBuild` and `scripts/Verify-ApiDocs.ps1`
- `scripts/Verify-DocSnippets.ps1` with uniquely versioned local packages: 209 snippets compiled and executed on net8/net10
- `npm run build`