### PR TITLE
feat(fallback)!: handle rejections by default

### DIFF
--- a/docs/api/Kevlar.FallbackOptions-1.yml
+++ b/docs/api/Kevlar.FallbackOptions-1.yml
@@ -34,6 +34,12 @@ items:
     factory. Notification failures are reported through <xref href="Kevlar.KevlarDiagnostics.OnCallbackError" data-throw-if-not-resolved="false"></xref>
 
     and do not skip recovery.
+
+    Without an ambient clause or local handling override, fallback handles ordinary exceptions and
+
+    <xref href="Kevlar.ExecutionRejectedException" data-throw-if-not-resolved="false"></xref> instances while letting cancellation and fatal runtime
+
+    exceptions propagate.
   example: []
   syntax:
     content: public sealed class FallbackOptions<TResult>
@@ -296,6 +302,14 @@ references:
   name: OnCallbackError
   nameWithType: KevlarDiagnostics.OnCallbackError
   fullName: Kevlar.KevlarDiagnostics.OnCallbackError
+- uid: Kevlar.ExecutionRejectedException
+  commentId: T:Kevlar.ExecutionRejectedException
+  parent: Kevlar
+  isExternal: true
+  href: Kevlar.ExecutionRejectedException.html
+  name: ExecutionRejectedException
+  nameWithType: ExecutionRejectedException
+  fullName: Kevlar.ExecutionRejectedException
 - uid: Kevlar
   commentId: N:Kevlar
   isExternal: true

--- a/docs/api/Kevlar.FallbackOptions.yml
+++ b/docs/api/Kevlar.FallbackOptions.yml
@@ -27,6 +27,12 @@ items:
     awaits <xref href="Kevlar.FallbackOptions.OnFallback" data-throw-if-not-resolved="false"></xref>, and then runs the recovery action. Notification failures
 
     are reported through <xref href="Kevlar.KevlarDiagnostics.OnCallbackError" data-throw-if-not-resolved="false"></xref> and do not skip recovery.
+
+    Without an ambient clause or local handling override, fallback handles ordinary exceptions and
+
+    <xref href="Kevlar.ExecutionRejectedException" data-throw-if-not-resolved="false"></xref> instances while letting cancellation and fatal runtime
+
+    exceptions propagate.
   example: []
   syntax:
     content: public sealed class FallbackOptions
@@ -183,6 +189,14 @@ references:
   name: OnCallbackError
   nameWithType: KevlarDiagnostics.OnCallbackError
   fullName: Kevlar.KevlarDiagnostics.OnCallbackError
+- uid: Kevlar.ExecutionRejectedException
+  commentId: T:Kevlar.ExecutionRejectedException
+  parent: Kevlar
+  isExternal: true
+  href: Kevlar.ExecutionRejectedException.html
+  name: ExecutionRejectedException
+  nameWithType: ExecutionRejectedException
+  fullName: Kevlar.ExecutionRejectedException
 - uid: Kevlar
   commentId: N:Kevlar
   isExternal: true

--- a/docs/docs/analyzers.md
+++ b/docs/docs/analyzers.md
@@ -342,9 +342,10 @@ term available. `KEV010` is disabled by default and can be enabled through the
 
 ## KEV011: implicit default handling
 
-A retry, circuit breaker, hedge, or fallback without an explicit clause uses Kevlar's
-[default handling](handling-failures.md#the-default). That default excludes cancellation,
-fail-fast rejections, and fatal runtime failures, but it still includes programming errors such as
+A retry, circuit breaker, hedge, or fallback without an explicit clause uses its
+[default handling](handling-failures.md#the-default). Retry, circuit breaker, and hedge exclude
+cancellation, fail-fast rejections, and fatal runtime failures; fallback additionally handles
+fail-fast rejections. Every strategy default still includes programming errors such as
 `ArgumentException`, `InvalidOperationException`, and `NullReferenceException`:
 
 ```csharp

--- a/docs/docs/composition.md
+++ b/docs/docs/composition.md
@@ -123,9 +123,10 @@ Shield
     .Fallback(...);                // fallback reacts to TimeoutExceededException only
 ```
 
-`Wrap` and `Compose` are scope boundaries. A reactive strategy added afterwards uses Kevlar's
-default handling—ordinary exceptions, excluding cancellation, Kevlar's fail-fast rejections, and
-fatal runtime failures—unless the new expression declares a clause locally:
+`Wrap` and `Compose` are scope boundaries. A reactive strategy added afterwards uses its default
+handling unless the new expression declares a clause locally. Retry, circuit breaker, and hedge
+exclude cancellation, Kevlar's fail-fast rejections, and fatal runtime failures; fallback also
+handles fail-fast rejections:
 
 ```csharp
 var apiDefaults = Shield.When<HttpRequestException>().Retry(3);

--- a/docs/docs/exceptions.md
+++ b/docs/docs/exceptions.md
@@ -11,11 +11,12 @@ fault, or reports a testing assertion failure.
 ## Reference
 
 The **default clause** column says whether a reactive strategy handles the exception when no custom
-[`When` clause](handling-failures.md) is present. The default handles ordinary errors but excludes
-`OperationCanceledException`, fail-fast execution rejections, and fatal runtime exceptions. A
-timeout remains handled because the delegate ran and produced a recoverable attempt failure. Use an
-explicit clause to include an excluded rejection or narrow the ordinary errors handled by a retry,
-breaker, hedge, or fallback.
+[`When` clause](handling-failures.md) is present. Retry, circuit breaker, and hedge handle ordinary
+errors but exclude `OperationCanceledException`, fail-fast execution rejections, and fatal runtime
+exceptions. Fallback additionally handles `ExecutionRejectedException` so it can recover an outer
+breaker or limiter without opting retry into the same rejection. A timeout remains handled because
+the delegate ran and produced a recoverable attempt failure. An explicit ambient clause or local
+handling override replaces the strategy default.
 
 | Exception | Thrown by | Properties | Base class | Catch pattern | Default clause |
 |---|---|---|---|---|---|
@@ -24,10 +25,10 @@ breaker, hedge, or fallback.
 | `ExecutionRejectedException` | Abstract base for execution rejections | `RetryAfter` estimates when execution may be attempted again; inherited `InnerException` carries a cause when known. | `KevlarException` | `catch (ExecutionRejectedException e)` | N/A |
 | `KevlarProxyException` | Internal bookkeeping for adapter-owned exception proxies | `OriginalException` is the failure exposed to handling clauses, public outcomes, and adapter callers; inherited `InnerException` preserves the same cause. | `Exception` | Catch `OriginalException`'s concrete type, such as `RpcException`. | N/A |
 | `TimeoutExceededException` | Timeout | `Timeout` is the winning budget; a strategy-produced timeout carries the delegate's cancellation exception in inherited `InnerException`. | `KevlarException` | `catch (TimeoutExceededException e) when (e.Timeout == budget)` | Yes |
-| `CircuitOpenException` | Circuit breaker | Inherited `RetryAfter` is the remaining break duration; `IsIsolated` distinguishes manual isolation; inherited `InnerException` is the last failure when known. | `ExecutionRejectedException` | `catch (CircuitOpenException e) when (e.RetryAfter is { } delay)` | No |
-| `RateLimitExceededException` | Rate limit | Inherited `RetryAfter` estimates when a permit may become available. | `ExecutionRejectedException` | `catch (RateLimitExceededException e) when (e.RetryAfter is { } delay)` | No |
-| `RateLimiterAdapterRejectedException` | System.Threading.RateLimiting adapter | Inherited `RetryAfter` is copied from rejected lease metadata when supplied. | `ExecutionRejectedException` | `catch (RateLimiterAdapterRejectedException e) when (e.RetryAfter is { } delay)` | No |
-| `ConcurrencyLimitExceededException` | Concurrency limit | Inherited `RetryAfter` and `InnerException` are `null`; the rejection means both execution and queue capacity are full. | `ExecutionRejectedException` | `catch (ConcurrencyLimitExceededException)` | No |
+| `CircuitOpenException` | Circuit breaker | Inherited `RetryAfter` is the remaining break duration; `IsIsolated` distinguishes manual isolation; inherited `InnerException` is the last failure when known. | `ExecutionRejectedException` | `catch (CircuitOpenException e) when (e.RetryAfter is { } delay)` | Fallback only |
+| `RateLimitExceededException` | Rate limit | Inherited `RetryAfter` estimates when a permit may become available. | `ExecutionRejectedException` | `catch (RateLimitExceededException e) when (e.RetryAfter is { } delay)` | Fallback only |
+| `RateLimiterAdapterRejectedException` | System.Threading.RateLimiting adapter | Inherited `RetryAfter` is copied from rejected lease metadata when supplied. | `ExecutionRejectedException` | `catch (RateLimiterAdapterRejectedException e) when (e.RetryAfter is { } delay)` | Fallback only |
+| `ConcurrencyLimitExceededException` | Concurrency limit | Inherited `RetryAfter` and `InnerException` are `null`; the rejection means both execution and queue capacity are full. | `ExecutionRejectedException` | `catch (ConcurrencyLimitExceededException)` | Fallback only |
 | `HttpRequestReplayException` | HTTP request replay and endpoint routing | Inherited `InnerException` is the content failure when serialization or buffering caused the replay failure. | `InvalidOperationException` | `catch (HttpRequestReplayException e)` | Yes |
 | `ChaosInjectedException` | Chaos fault injection | Inherited `InnerException` is populated only when the configured injected fault wraps a cause. | `Exception` | `catch (ChaosInjectedException e)` | Yes |
 | `ShieldAssertionException` | Kevlar.Testing assertions and bounded waits | Inherited `InnerException` is `null`; `Message` explains the failed assertion or unmet condition. | `Exception` | `catch (ShieldAssertionException e)` | Yes |

--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -115,9 +115,10 @@ editor.
 
 ### Reset to default handling
 
-Call `WithDefaultHandling()` to clear the ambient clause. Reactive strategies chained after it return to
-Kevlar's default handling: ordinary exceptions, excluding cancellation, Kevlar's fail-fast
-rejections, and fatal runtime failures.
+Call `WithDefaultHandling()` to clear the ambient clause. Reactive strategies chained after it return
+to their defaults: retry, circuit breaker, and hedge handle ordinary exceptions while excluding
+cancellation, Kevlar's fail-fast rejections, and fatal runtime failures; fallback additionally
+handles fail-fast rejections.
 
 ```csharp
 var shield = Shield

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -44,8 +44,9 @@ Console.WriteLine(shield);
 // [when HttpRequestException | TimeoutExceededException] Retry(3, no delay) → CircuitBreaker(5 consecutive, break 30s)
 ```
 
-Shields that use only the default handling—ordinary exceptions, excluding cancellation, Kevlar's
-fail-fast rejections, and fatal runtime failures—print exactly as before, with no prefix.
+Shields that use only strategy defaults print exactly as before, with no prefix. Retry, circuit
+breaker, and hedge defaults exclude cancellation, Kevlar's fail-fast rejections, and fatal runtime
+failures; fallback additionally handles fail-fast rejections.
 
 ## Metrics
 

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -104,10 +104,11 @@ Polly handling predicate. Retry callback counters map directly:
 |---|---|
 | `OnRetryArguments.AttemptNumber` is zero-based (`0` before the first retry) | `RetryEvent.AttemptNumber` is zero-based (`0` before the first retry) |
 
-Polly's default predicate handles every exception except `OperationCanceledException`. Kevlar also
-lets execution-rejection exceptions and fatal runtime exceptions propagate by default. Use an
-explicit clause when a shield intentionally recovers `CircuitOpenException`,
-`RateLimitExceededException`, or `ConcurrencyLimitExceededException`.
+Polly's default predicate handles every exception except `OperationCanceledException`. Kevlar's
+retry, circuit-breaker, and hedging defaults also let execution-rejection exceptions and fatal
+runtime exceptions propagate. Fallback is the terminal recovery strategy, so its default additionally
+handles `CircuitOpenException`, `RateLimitExceededException`, and
+`ConcurrencyLimitExceededException`.
 
 ## Context and properties
 
@@ -684,6 +685,10 @@ accepts `RateLimiter`, `PartitionedRateLimiter<KevlarContext>`, or a custom leas
   `Wrap` and `Compose` seal clauses at composition boundaries.
 - **Fallback ordering fails fast.** Kevlar rejects a fallback placed inside a retry, hedge, or
   breaker when both share the same clause; Polly builds that ineffective order silently.
+- **Fallback handles execution rejections by default.** An outer fallback in
+  `Shield.For<T>().FallbackTo(...).Retry(3).CircuitBreaker(...)` recovers an open circuit or limiter
+  rejection. Retry, circuit breaker, and hedging still let `ExecutionRejectedException` propagate
+  unless an explicit handling clause opts in.
 - **Hook exceptions never propagate.** Polly lets a strategy-hook exception fail the execution.
   Kevlar reports hook failures without replacing the protected outcome. Observe them through
   `KevlarDiagnostics.OnCallbackError`, structured logging from `AddKevlarLogging`, or

--- a/docs/docs/strategies/fallback.md
+++ b/docs/docs/strategies/fallback.md
@@ -154,9 +154,9 @@ var http = Shield.For<HttpResponseMessage>()
 
 If the fallback delegate itself throws, that exception becomes the pipeline's outcome — fallbacks don't get fallbacks.
 
-As with every reactive strategy, the default clause bypasses cancellation, Kevlar's fail-fast
-rejections, and fatal runtime failures. An excluded exception can be recovered explicitly when
-that is intentional:
+Fallback's default clause handles ordinary exceptions and Kevlar's fail-fast execution rejections.
+It still bypasses cancellation and fatal runtime failures. An excluded exception can be recovered
+explicitly when that is intentional:
 
 ```csharp
 var shield = Shield.For<Config>()
@@ -180,14 +180,15 @@ Fallback is usually **outermost** — the last line of defence after retries and
 
 ```csharp
 var shield = Shield.For<Quote>()
-    .When<HttpRequestException>()
-    .Or<CircuitOpenException>()      // catch the breaker's rejection too
     .FallbackTo(Quote.Unavailable)
     .Retry(3)
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 ```
 
-Note the clause: to fall back when the circuit is open, the fallback's handling clause must include `CircuitOpenException`.
+The fallback recovers `CircuitOpenException` by default. Retry and circuit breaker continue to let
+execution rejections propagate, so an open circuit does not trigger unnecessary retries. An
+ambient `When` clause or local fallback handling override replaces this default instead of adding
+to it.
 
 The same outermost rule applies to hedging: an outer fallback runs once after every hedge attempt
 has produced a handled outcome. A fallback inside a hedge with the same clause is rejected because

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -11,6 +11,16 @@ internal abstract class OutcomeJudge
     /// <summary>The default: handle ordinary errors, but not cancellation, rejections, or fatal exceptions.</summary>
     public static readonly OutcomeJudge Default = new DefaultJudge();
 
+    /// <summary>The fallback default: also handle execution rejections, but not cancellation or fatal exceptions.</summary>
+    public static readonly OutcomeJudge FallbackDefault = new FallbackDefaultJudge();
+
+    internal static bool FallbackHandlesEveryOutcomeHandledBy(
+        OutcomeJudge fallbackJudge,
+        OutcomeJudge outerJudge) =>
+        ReferenceEquals(fallbackJudge, outerJudge)
+        || (ReferenceEquals(fallbackJudge, FallbackDefault)
+            && ReferenceEquals(outerJudge, Default));
+
     /// <summary>
     /// A human-readable rendering of the clause — the terms the caller wrote, joined with
     /// <c>" | "</c> — for pipeline descriptions. <see langword="null"/> when the clause adds
@@ -87,20 +97,27 @@ internal abstract class OutcomeJudge
         return false;
     }
 
+    private static bool IsOrdinaryError(Exception exception) =>
+        exception is not (
+            OperationCanceledException
+            or ExecutionRejectedException
+            or OutOfMemoryException
+            or InsufficientExecutionStackException
+            or StackOverflowException
+            or ThreadAbortException
+            or AccessViolationException);
+
     private sealed class DefaultJudge : OutcomeJudge
     {
         protected override bool ShouldHandleCore<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
             outcome.Exception is { } exception && IsOrdinaryError(exception);
+    }
 
-        private static bool IsOrdinaryError(Exception exception) =>
-            exception is not (
-                OperationCanceledException
-                or ExecutionRejectedException
-                or OutOfMemoryException
-                or InsufficientExecutionStackException
-                or StackOverflowException
-                or ThreadAbortException
-                or AccessViolationException);
+    private sealed class FallbackDefaultJudge : OutcomeJudge
+    {
+        protected override bool ShouldHandleCore<T>(in Outcome<T> outcome, KevlarContext? context, int attempt, int strategyIndex) =>
+            outcome.Exception is { } exception
+            && (exception is ExecutionRejectedException || IsOrdinaryError(exception));
     }
 }
 

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -62,6 +62,11 @@ public sealed class Shield : IShieldLifecycle
 
     internal OutcomeJudge JudgeOrDefault => Ambient ?? OutcomeJudge.Default;
 
+    internal OutcomeJudge FallbackJudgeOrDefault =>
+        Ambient is null || ReferenceEquals(Ambient, OutcomeJudge.Default)
+            ? OutcomeJudge.FallbackDefault
+            : Ambient;
+
     internal TimeProvider TimeOrSystem => Time ?? TimeProvider.System;
 
     /// <summary>
@@ -867,7 +872,9 @@ public sealed class Shield : IShieldLifecycle
             for (var j = 0; j < i; j++)
             {
                 var outer = strategies[j];
-                if (!outer.IsFallback && ReferenceEquals(outer.ReactiveJudge, fallbackJudge))
+                if (!outer.IsFallback
+                    && outer.ReactiveJudge is { } outerJudge
+                    && OutcomeJudge.FallbackHandlesEveryOutcomeHandledBy(fallbackJudge, outerJudge))
                 {
                     throw new InvalidOperationException(
                         $"This chain places Fallback inside {outer.Describe()} with the same handling clause, " +

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -361,7 +361,7 @@ public static class ShieldExtensions
         Throw.IfNull(fallback, nameof(fallback));
         return shield.Append(new VoidFallbackStrategy(
             fallback,
-            shield.JudgeOrDefault,
+            shield.FallbackJudgeOrDefault,
             null));
     }
 
@@ -383,7 +383,7 @@ public static class ShieldExtensions
         var judge = HandlingOverride.Resolve(
             options.HandlesException,
             options.HandlesExceptionWithContext,
-            shield.JudgeOrDefault);
+            shield.FallbackJudgeOrDefault);
         return shield.Append(new VoidFallbackStrategy(
             fallback,
             judge,
@@ -404,7 +404,7 @@ public static class ShieldExtensions
         Throw.IfNull(shield, nameof(shield));
         return shield.Append(new VoidFallbackStrategy(
             (_, token) => fallback(token),
-            shield.JudgeOrDefault,
+            shield.FallbackJudgeOrDefault,
             null));
     }
 
@@ -426,7 +426,7 @@ public static class ShieldExtensions
         var judge = HandlingOverride.Resolve(
             options.HandlesException,
             options.HandlesExceptionWithContext,
-            shield.JudgeOrDefault);
+            shield.FallbackJudgeOrDefault);
         return shield.Append(new VoidFallbackStrategy(
             (_, token) => fallback(token),
             judge,

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -67,6 +67,11 @@ public sealed class Shield<TResult> : IShieldLifecycle
 
     internal OutcomeJudge JudgeOrDefault => Ambient ?? OutcomeJudge.Default;
 
+    internal OutcomeJudge FallbackJudgeOrDefault =>
+        Ambient is null || ReferenceEquals(Ambient, OutcomeJudge.Default)
+            ? OutcomeJudge.FallbackDefault
+            : Ambient;
+
     internal TimeProvider TimeOrSystem => Time ?? TimeProvider.System;
 
     // ── Handling clauses ────────────────────────────────────────────────────────────────
@@ -308,7 +313,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
     public Shield<TResult> FallbackTo(TResult fallbackValue) =>
         Append(new FallbackStrategy<TResult>(
             (_, _) => new ValueTask<TResult>(fallbackValue),
-            JudgeOrDefault,
+            FallbackJudgeOrDefault,
             null));
 
     /// <summary>Replaces handled outcomes with <paramref name="fallbackValue"/> and configures notifications.</summary>
@@ -323,7 +328,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
             options.HandlesResult,
             options.HandlesExceptionWithContext,
             options.HandlesResultWithContext,
-            JudgeOrDefault);
+            FallbackJudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (_, _) => new ValueTask<TResult>(fallbackValue),
             judge,
@@ -338,7 +343,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
         Throw.IfNull(fallback, nameof(fallback));
         return Append(new FallbackStrategy<TResult>(
             (_, context) => fallback(context.CancellationToken),
-            JudgeOrDefault,
+            FallbackJudgeOrDefault,
             null));
     }
 
@@ -357,7 +362,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
             options.HandlesResult,
             options.HandlesExceptionWithContext,
             options.HandlesResultWithContext,
-            JudgeOrDefault);
+            FallbackJudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (_, context) => fallback(context.CancellationToken),
             judge,
@@ -372,7 +377,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
         Throw.IfNull(fallback, nameof(fallback));
         return Append(new FallbackStrategy<TResult>(
             (outcome, context) => fallback(outcome, context.CancellationToken),
-            JudgeOrDefault,
+            FallbackJudgeOrDefault,
             null));
     }
 
@@ -394,7 +399,7 @@ public sealed class Shield<TResult> : IShieldLifecycle
             options.HandlesResult,
             options.HandlesExceptionWithContext,
             options.HandlesResultWithContext,
-            JudgeOrDefault);
+            FallbackJudgeOrDefault);
         return Append(new FallbackStrategy<TResult>(
             (outcome, context) => fallback(outcome, context.CancellationToken),
             judge,

--- a/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptions.cs
@@ -5,6 +5,9 @@ namespace Kevlar;
 /// After a failure is selected for recovery, Kevlar records the fallback metric, invokes and
 /// awaits <see cref="OnFallback"/>, and then runs the recovery action. Notification failures
 /// are reported through <see cref="KevlarDiagnostics.OnCallbackError"/> and do not skip recovery.
+/// Without an ambient clause or local handling override, fallback handles ordinary exceptions and
+/// <see cref="ExecutionRejectedException"/> instances while letting cancellation and fatal runtime
+/// exceptions propagate.
 /// </remarks>
 public sealed class FallbackOptions
 {

--- a/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackOptionsOfT.cs
@@ -9,6 +9,9 @@ namespace Kevlar;
 /// and awaits <see cref="OnFallback"/>, and then runs the recovery
 /// factory. Notification failures are reported through <see cref="KevlarDiagnostics.OnCallbackError"/>
 /// and do not skip recovery.
+/// Without an ambient clause or local handling override, fallback handles ordinary exceptions and
+/// <see cref="ExecutionRejectedException"/> instances while letting cancellation and fatal runtime
+/// exceptions propagate.
 /// </remarks>
 public sealed class FallbackOptions<TResult>
 {

--- a/tests/Kevlar.Tests/DefaultHandlingTests.cs
+++ b/tests/Kevlar.Tests/DefaultHandlingTests.cs
@@ -101,20 +101,74 @@ public class DefaultHandlingTests
     }
 
     [Test]
-    public async Task Default_Fallback_Does_Not_Catch_Rejections_But_Explicit_Clause_Does()
+    public async Task Default_Fallback_Catches_Kevlar_Rejections()
     {
-        var defaultFallback = Shield.For<int>().FallbackTo(42);
-        var explicitFallback = Shield.For<int>()
-            .When<KevlarException>()
-            .FallbackTo(42);
+        Exception[] rejections =
+        [
+            new CircuitOpenException(TimeSpan.FromSeconds(1), isIsolated: false, lastException: null),
+            new RateLimitExceededException(TimeSpan.FromSeconds(1)),
+            new ConcurrencyLimitExceededException(),
+        ];
+        var shield = Shield.For<int>().FallbackTo(42);
 
-        var unhandled = await defaultFallback.ExecuteOutcomeAsync(_ =>
-            throw new RateLimitExceededException(retryAfter: null));
-        var handled = await explicitFallback.ExecuteAsync(_ =>
+        foreach (var rejection in rejections)
+        {
+            var result = await shield.ExecuteAsync(_ => throw rejection);
+
+            await Assert.That(result).IsEqualTo(42);
+        }
+
+        var explicitlyNarrowFallback = Shield.For<int>()
+            .When<InvalidOperationException>()
+            .FallbackTo(42);
+        var unhandled = await explicitlyNarrowFallback.ExecuteOutcomeAsync(_ =>
             throw new RateLimitExceededException(retryAfter: null));
 
         await Assert.That(unhandled.Exception).IsTypeOf<RateLimitExceededException>();
-        await Assert.That(handled).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Void_Default_Fallback_Catches_Kevlar_Rejections()
+    {
+        var recovered = false;
+        var shield = Shield.Fallback((_, _) =>
+        {
+            recovered = true;
+            return default;
+        });
+
+        await shield.ExecuteAsync(_ => throw new ConcurrencyLimitExceededException());
+
+        await Assert.That(recovered).IsTrue();
+    }
+
+    [Test]
+    public async Task Default_Fallback_Recovers_Open_Circuit_Without_Retrying_Rejection()
+    {
+        var retries = 0;
+        var shield = Shield.For<int>()
+            .FallbackTo(42)
+            .Retry(options =>
+            {
+                options.MaxRetries = 1;
+                options.Backoff = Backoff.None;
+                options.OnRetry = _ =>
+                {
+                    retries++;
+                    return default;
+                };
+            })
+            .CircuitBreaker(
+                consecutiveFailures: 1,
+                breakDuration: TimeSpan.FromMinutes(1));
+
+        var first = await shield.ExecuteAsync(_ => throw new InvalidOperationException());
+        retries = 0;
+        var second = await shield.ExecuteAsync(_ => new ValueTask<int>(1));
+
+        await Assert.That(first).IsEqualTo(42);
+        await Assert.That(second).IsEqualTo(42);
+        await Assert.That(retries).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Kevlar.Tests/DocsConsistencyTests.cs
+++ b/tests/Kevlar.Tests/DocsConsistencyTests.cs
@@ -231,6 +231,18 @@ public partial class DocsConsistencyTests
         await Assert.That(migrationGuide).Contains("TelemetryRecorder");
     }
 
+    [Test]
+    public async Task Migration_Guide_Documents_Fallback_Rejection_Handling()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var migrationGuide = await File.ReadAllTextAsync(
+            Path.Combine(repositoryRoot, "docs", "docs", "polly-migration.md"));
+
+        await Assert.That(migrationGuide).Contains("**Fallback handles execution rejections by default.**");
+        await Assert.That(migrationGuide).Contains("CircuitOpenException");
+        await Assert.That(migrationGuide).Contains("FallbackTo(...).Retry(3).CircuitBreaker(...)");
+    }
+
     private static Dictionary<string, ExceptionDocRow> ReadExceptionRows()
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/tests/Kevlar.Tests/DocsConsistencyTests.cs
+++ b/tests/Kevlar.Tests/DocsConsistencyTests.cs
@@ -71,7 +71,11 @@ public partial class DocsConsistencyTests
         foreach (var exception in exceptions)
         {
             var outcome = Outcome<int>.FromException(exception);
-            var expected = OutcomeJudge.Default.ShouldHandle(in outcome) ? "Yes" : "No";
+            var expected = OutcomeJudge.Default.ShouldHandle(in outcome)
+                ? "Yes"
+                : OutcomeJudge.FallbackDefault.ShouldHandle(in outcome)
+                    ? "Fallback only"
+                    : "No";
             await Assert.That(rows[exception.GetType().Name].DefaultClause).IsEqualTo(expected);
         }
     }


### PR DESCRIPTION
Closes #388

## Summary
- give fallback a dedicated default outcome judge that handles `ExecutionRejectedException`
- preserve retry, circuit-breaker, and hedge rejection defaults
- retain fallback ordering validation when its broader default covers an outer default clause
- document the Polly migration behavior and fallback option contract

## Validation
- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build --framework net8.0 -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -c Release --no-build --framework net10.0 -- --timeout 5m`
- `pwsh scripts/Verify-ApiDocs.ps1`
- `pwsh scripts/Verify-Docs.ps1`