### PR TITLE
fix(http)!: make hedge limiter optional

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/HttpStandardHedgeBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/HttpStandardHedgeBenchmarks.cs
@@ -27,6 +27,7 @@ public class HttpStandardHedgeBenchmarks
             .ConfigurePrimaryHttpMessageHandler(static () => new SuccessHandler())
             .AddStandardHedgeShield(static options =>
             {
+                options.Routing = new HttpEndpointRoutingOptions();
                 options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.invalid")));
                 options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.invalid")));
             });
@@ -71,7 +72,6 @@ public class HttpStandardHedgeBenchmarks
         var routing = new HttpEndpointRoutingOptions
         {
             ShieldFactory = static _ => HttpShield.WhenTransient()
-                .ConcurrencyLimit(10)
                 .CircuitBreaker(options =>
                 {
                     options.FailureRatio = 0.5;

--- a/docs/api/Kevlar.Extensions.Http.StandardHedgeShieldOptions.yml
+++ b/docs/api/Kevlar.Extensions.Http.StandardHedgeShieldOptions.yml
@@ -121,10 +121,13 @@ items:
   assemblies:
   - Kevlar.Extensions.Http
   namespace: Kevlar.Extensions.Http
-  summary: Configures the concurrency limiter applied independently to each endpoint.
+  summary: >-
+    Optionally configures a concurrency limiter applied independently to each endpoint. The
+
+    limiter is disabled when this property is <a href="https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/null">null</a>.
   example: []
   syntax:
-    content: public ConcurrencyLimitOptions ConcurrencyLimit { get; set; }
+    content: public ConcurrencyLimitOptions? ConcurrencyLimit { get; set; }
     parameters: []
     return:
       type: Kevlar.ConcurrencyLimitOptions
@@ -220,12 +223,12 @@ items:
   - Kevlar.Extensions.Http
   namespace: Kevlar.Extensions.Http
   summary: >-
-    Optionally configures endpoint authorities and their ordering. When empty, hedged attempts
+    Optionally configures endpoint authorities and their ordering. When <a href="https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/null">null</a>,
 
-    use the request's own authority.
+    hedged attempts use the request's own authority in their natural order.
   example: []
   syntax:
-    content: public HttpEndpointRoutingOptions Routing { get; set; }
+    content: public HttpEndpointRoutingOptions? Routing { get; set; }
     parameters: []
     return:
       type: Kevlar.Extensions.Http.HttpEndpointRoutingOptions

--- a/docs/api/Microsoft.Extensions.DependencyInjection.ShieldHttpClientBuilderExtensions.yml
+++ b/docs/api/Microsoft.Extensions.DependencyInjection.ShieldHttpClientBuilderExtensions.yml
@@ -430,7 +430,7 @@ items:
   summary: >-
     Adds one shared standard pipeline that hedges against the request's authority: total timeout,
 
-    hedging, per-authority concurrency limit and circuit breaker, then per-attempt timeout.
+    hedging, per-authority circuit breaker, then per-attempt timeout.
   example: []
   syntax:
     content: public static IHttpClientBuilder AddStandardHedgeShield(this IHttpClientBuilder builder)
@@ -459,7 +459,7 @@ items:
   summary: >-
     Adds one shared standard pipeline with optional endpoint routing: total timeout, hedging,
 
-    per-authority concurrency limit and circuit breaker, then per-attempt timeout.
+    optional per-authority concurrency limit, circuit breaker, then per-attempt timeout.
   example: []
   syntax:
     content: public static IHttpClientBuilder AddStandardHedgeShield(this IHttpClientBuilder builder, Action<StandardHedgeShieldOptions> configure)

--- a/docs/api/Microsoft.Extensions.DependencyInjection.ShieldHttpClientBuilderExtensions.yml
+++ b/docs/api/Microsoft.Extensions.DependencyInjection.ShieldHttpClientBuilderExtensions.yml
@@ -430,7 +430,7 @@ items:
   summary: >-
     Adds one shared standard pipeline that hedges against the request's authority: total timeout,
 
-    hedging, per-authority circuit breaker, then per-attempt timeout.
+    hedging, optional per-authority concurrency limit, circuit breaker, then per-attempt timeout.
   example: []
   syntax:
     content: public static IHttpClientBuilder AddStandardHedgeShield(this IHttpClientBuilder builder)

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -167,7 +167,8 @@ state. `HttpClientFactory` handler rotation reuses the current snapshot and does
 service-provider callback. The application service provider owns the reload subscription.
 
 Hedging uses the same reload contract. Its keys follow the nested
-`StandardHedgeShieldOptions` shape, and `Routing:Endpoints` is required:
+`StandardHedgeShieldOptions` shape. `Routing` is optional; without it, attempts keep the request's
+authority:
 
 ```csharp
 using Kevlar.Extensions.Http;
@@ -394,9 +395,12 @@ using Microsoft.Extensions.DependencyInjection;
 services.AddHttpClient("routed")
     .AddStandardHedgeShield(options =>
     {
+        options.Routing = new HttpEndpointRoutingOptions
+        {
+            SelectionMode = HttpEndpointSelectionMode.Weighted,
+        };
         options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://api-a.example"), weight: 3));
         options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://api-b.example"), weight: 1));
-        options.Routing.SelectionMode = HttpEndpointSelectionMode.Weighted;
         options.Hedge.MaxHedgedAttempts = 1;
         options.Hedge.Delay = TimeSpan.FromMilliseconds(500);
         options.Hedge.DelayGenerator = hedge => new(hedge.Elapsed < TimeSpan.FromSeconds(1)
@@ -406,10 +410,10 @@ services.AddHttpClient("routed")
 ```
 
 `AddStandardHedgeShield` installs a 30s total timeout and one additional hedged attempt (two total).
-Each authority gets its own 10-concurrent/zero-queue limiter, 50%-over-30s circuit breaker (minimum
-10 attempts, 15s break), and 10s attempt timeout. Configure those defaults through
-`TotalTimeout.Timeout`, `Hedge`, `ConcurrencyLimit`, `CircuitBreaker`, and
-`AttemptTimeout.Timeout`.
+Each authority gets its own 50%-over-30s circuit breaker (minimum 10 attempts, 15s break) and 10s
+attempt timeout. No concurrency limiter is installed by default. Set `ConcurrencyLimit` to a new
+`ConcurrencyLimitOptions` instance to add an authority-local limiter; configure the remaining
+defaults through `TotalTimeout.Timeout`, `Hedge`, `CircuitBreaker`, and `AttemptTimeout.Timeout`.
 
 Request replay is configured through `Handler` (`ContentReplayPolicy`, `MaxBufferSize`,
 `AllowUnsafeMethodReplay`, and `RequestFactory`); alternate endpoint authorities and ordering are
@@ -460,7 +464,7 @@ runtime changes are required; each valid reload publishes a fresh complete pipel
 - **Redirects remain transport-owned.** Each Kevlar attempt begins with the original absolute URI (or its routed authority). Normal `HttpClientHandler` redirect policy runs inside that attempt.
 - **Named-client state survives handler rotation.** Service-provider `AddShield` registrations and all standard registrations build or resolve one pipeline for that named client registration. Fixed-shield overloads already share their shield instance; request-selector overloads intentionally select a shield per request. Service-provider factories run once against the application provider, and circuit breakers, concurrency limiters, and endpoint caches are not multiplied when `HttpClientFactory` rotates handlers.
 - **Configuration-backed state is replaced, not mutated.** Only a valid configuration reload publishes a fresh complete pipeline. Handler rotation reuses the current snapshot, and requests already executing retain the snapshot they captured at send start.
-- **Standard hedging state is authority-local.** `AddStandardHedgeShield` creates one limiter and breaker per request authority or configured endpoint authority and preserves those instances across handler rotation until configuration reload replaces the pipeline.
+- **Standard hedging state is authority-local.** `AddStandardHedgeShield` creates one breaker and, when configured, one limiter per request authority or configured endpoint authority and preserves those instances across handler rotation until configuration reload replaces the pipeline.
 - **Per-handler state remains explicit.** When fresh state for every handler lifetime is intentional, register `ShieldDelegatingHandler` directly with `AddHttpMessageHandler` and construct the shield inside that low-level handler factory.
 - **Compose with other handlers normally.** The Kevlar handler is a regular `DelegatingHandler`; ordering relative to your own handlers follows the usual `AddHttpMessageHandler` rules.
 

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -418,7 +418,7 @@ required.
 | Standard HTTP retry | 3 retries; exponential from 2 s; decorrelated jitter; no delay cap | 3 retries; exponential from 250 ms; equal jitter; 10 s cap; honours `Retry-After` |
 | Standard HTTP unsafe methods | POST, PATCH, DELETE, and custom methods are retried by default | POST, PATCH, and custom methods remain single-attempt unless `AllowUnsafeMethodReplay`, per-request `AllowReplay`, or a `RequestFactory` opts in |
 | Standard HTTP circuit breaker | failure ratio 0.1; minimum throughput 100; sampling 30 s; break 5 s | failure ratio 0.5; minimum throughput 10; sampling 30 s; break 15 s |
-| Standard HTTP concurrency | permit limit 1,000; queue limit 0 | no limiter unless `ConcurrencyLimit` is configured |
+| Standard HTTP and hedging concurrency | permit limit 1,000; queue limit 0 | no limiter unless `ConcurrencyLimit` is configured |
 | Chaos | enabled; injection rate 0.001 | disabled; injection rate 1 |
 
 The standard HTTP and chaos differences are executable contracts:
@@ -430,6 +430,7 @@ using Kevlar.Extensions.Http;
 
 var pollyHttpDefaults = new HttpStandardResilienceOptions();
 var kevlarHttpDefaults = new StandardHttpShieldOptions();
+var kevlarHedgeDefaults = new StandardHedgeShieldOptions();
 var pollyChaosDefaults = new Polly.Simmy.Fault.ChaosFaultStrategyOptions();
 var kevlarChaosDefaults = new ChaosFaultOptions();
 
@@ -442,6 +443,8 @@ if (pollyHttpDefaults.Retry.MaxDelay is not null
     || kevlarHttpDefaults.CircuitBreaker.SamplingWindow != TimeSpan.FromSeconds(30)
     || kevlarHttpDefaults.CircuitBreaker.BreakDuration != TimeSpan.FromSeconds(15)
     || kevlarHttpDefaults.ConcurrencyLimit is not null
+    || kevlarHedgeDefaults.ConcurrencyLimit is not null
+    || kevlarHedgeDefaults.Routing is not null
     || !pollyChaosDefaults.Enabled
     || pollyChaosDefaults.InjectionRate != 0.001
     || kevlarChaosDefaults.Enabled

--- a/src/Kevlar.Extensions.Http/PublicAPI.Shipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Shipped.txt
@@ -51,13 +51,13 @@ Kevlar.Extensions.Http.StandardHedgeShieldOptions.AttemptTimeout.get -> Kevlar.T
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.AttemptTimeout.set -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.CircuitBreaker.get -> Kevlar.CircuitBreakerOptions<System.Net.Http.HttpResponseMessage!>!
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.CircuitBreaker.set -> void
-Kevlar.Extensions.Http.StandardHedgeShieldOptions.ConcurrencyLimit.get -> Kevlar.ConcurrencyLimitOptions!
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.ConcurrencyLimit.get -> Kevlar.ConcurrencyLimitOptions?
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.ConcurrencyLimit.set -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.Handler.get -> Kevlar.Extensions.Http.ShieldHttpHandlerOptions!
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.Handler.set -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.Hedge.get -> Kevlar.HedgeOptions<System.Net.Http.HttpResponseMessage!>!
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.Hedge.set -> void
-Kevlar.Extensions.Http.StandardHedgeShieldOptions.Routing.get -> Kevlar.Extensions.Http.HttpEndpointRoutingOptions!
+Kevlar.Extensions.Http.StandardHedgeShieldOptions.Routing.get -> Kevlar.Extensions.Http.HttpEndpointRoutingOptions?
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.Routing.set -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.StandardHedgeShieldOptions() -> void
 Kevlar.Extensions.Http.StandardHedgeShieldOptions.TotalTimeout.get -> Kevlar.TimeoutOptions!

--- a/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
+++ b/src/Kevlar.Extensions.Http/ShieldHttpClientBuilderExtensions.cs
@@ -395,14 +395,14 @@ public static class ShieldHttpClientBuilderExtensions
 
     /// <summary>
     /// Adds one shared standard pipeline that hedges against the request's authority: total timeout,
-    /// hedging, per-authority concurrency limit and circuit breaker, then per-attempt timeout.
+    /// hedging, optional per-authority concurrency limit, circuit breaker, then per-attempt timeout.
     /// </summary>
     public static IHttpClientBuilder AddStandardHedgeShield(this IHttpClientBuilder builder) =>
         AddStandardHedgeShield(builder, static _ => { });
 
     /// <summary>
     /// Adds one shared standard pipeline with optional endpoint routing: total timeout, hedging,
-    /// per-authority concurrency limit and circuit breaker, then per-attempt timeout.
+    /// optional per-authority concurrency limit, circuit breaker, then per-attempt timeout.
     /// </summary>
     public static IHttpClientBuilder AddStandardHedgeShield(
         this IHttpClientBuilder builder,
@@ -569,7 +569,9 @@ public static class ShieldHttpClientBuilderExtensions
 
     private static ShieldHttpHandlerOptions CreateHandlerOptions(StandardHedgeShieldOptions options)
     {
-        if (!Enum.IsDefined(typeof(HttpEndpointSelectionMode), options.Routing.SelectionMode))
+        var configuredRouting = options.Routing;
+        if (configuredRouting is not null
+            && !Enum.IsDefined(typeof(HttpEndpointSelectionMode), configuredRouting.SelectionMode))
         {
             throw new ArgumentOutOfRangeException(nameof(options), "The endpoint selection mode is invalid.");
         }
@@ -584,20 +586,20 @@ public static class ShieldHttpClientBuilderExtensions
             throw new ArgumentOutOfRangeException(nameof(options), "MaxBufferSize must be positive.");
         }
 
-        if (options.Routing.Endpoints.Any(static endpoint => endpoint is null))
+        if (configuredRouting?.Endpoints.Any(static endpoint => endpoint is null) is true)
         {
             throw new ArgumentException("Endpoints cannot contain null.", nameof(options));
         }
 
-        var routing = new HttpEndpointRoutingOptions
+        var routing = new HttpEndpointRoutingOptions { ShieldFactory = CreateEndpointShieldFactory(options) };
+        if (configuredRouting is not null)
         {
-            SelectionMode = options.Routing.SelectionMode,
-            Seed = options.Routing.Seed,
-            ShieldFactory = CreateEndpointShieldFactory(options),
-        };
-        foreach (var endpoint in options.Routing.Endpoints)
-        {
-            routing.Endpoints.Add(endpoint);
+            routing.SelectionMode = configuredRouting.SelectionMode;
+            routing.Seed = configuredRouting.Seed;
+            foreach (var endpoint in configuredRouting.Endpoints)
+            {
+                routing.Endpoints.Add(endpoint);
+            }
         }
 
         return new ShieldHttpHandlerOptions
@@ -613,15 +615,20 @@ public static class ShieldHttpClientBuilderExtensions
     private static Func<Uri, Shield<HttpResponseMessage>> CreateEndpointShieldFactory(
         StandardHedgeShieldOptions options)
     {
-        var concurrencyLimit = Clone(options.ConcurrencyLimit);
+        var concurrencyLimit = options.ConcurrencyLimit is null
+            ? null
+            : Clone(options.ConcurrencyLimit);
         var circuitBreaker = Clone(options.CircuitBreaker);
         var attemptTimeout = Clone(options.AttemptTimeout);
 
         Shield<HttpResponseMessage> CreateEndpointShield(Uri _)
         {
-            var shield = HttpShield.WhenTransient()
-                .ConcurrencyLimit(target => Copy(concurrencyLimit, target))
-                .CircuitBreaker(target => Copy(circuitBreaker, target));
+            var shield = concurrencyLimit is null
+                ? HttpShield.WhenTransient()
+                    .CircuitBreaker(target => Copy(circuitBreaker, target))
+                : HttpShield.WhenTransient()
+                    .ConcurrencyLimit(target => Copy(concurrencyLimit, target))
+                    .CircuitBreaker(target => Copy(circuitBreaker, target));
             return IsDisabled(attemptTimeout)
                 ? shield
                 : shield.Timeout(target => Copy(attemptTimeout, target));
@@ -635,14 +642,12 @@ public static class ShieldHttpClientBuilderExtensions
     {
         if (options.TotalTimeout is null
             || options.Hedge is null
-            || options.ConcurrencyLimit is null
             || options.CircuitBreaker is null
             || options.AttemptTimeout is null
-            || options.Handler is null
-            || options.Routing is null)
+            || options.Handler is null)
         {
             throw new ArgumentException(
-                "StandardHedgeShieldOptions nested options cannot be null.",
+                "StandardHedgeShieldOptions required nested options cannot be null.",
                 nameof(options));
         }
     }

--- a/src/Kevlar.Extensions.Http/StandardHedgeShieldOptions.cs
+++ b/src/Kevlar.Extensions.Http/StandardHedgeShieldOptions.cs
@@ -12,8 +12,11 @@ public sealed class StandardHedgeShieldOptions
     /// <summary>Configures hedged attempts. Defaults to one additional attempt after one second.</summary>
     public HedgeOptions<HttpResponseMessage> Hedge { get; set; } = new();
 
-    /// <summary>Configures the concurrency limiter applied independently to each endpoint.</summary>
-    public ConcurrencyLimitOptions ConcurrencyLimit { get; set; } = new();
+    /// <summary>
+    /// Optionally configures a concurrency limiter applied independently to each endpoint. The
+    /// limiter is disabled when this property is <see langword="null"/>.
+    /// </summary>
+    public ConcurrencyLimitOptions? ConcurrencyLimit { get; set; }
 
     /// <summary>
     /// Configures the circuit breaker applied independently to each endpoint. Defaults to a 50%
@@ -37,8 +40,8 @@ public sealed class StandardHedgeShieldOptions
     public ShieldHttpHandlerOptions Handler { get; set; } = new();
 
     /// <summary>
-    /// Optionally configures endpoint authorities and their ordering. When empty, hedged attempts
-    /// use the request's own authority.
+    /// Optionally configures endpoint authorities and their ordering. When <see langword="null"/>,
+    /// hedged attempts use the request's own authority in their natural order.
     /// </summary>
-    public HttpEndpointRoutingOptions Routing { get; set; } = new();
+    public HttpEndpointRoutingOptions? Routing { get; set; }
 }

--- a/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
@@ -32,11 +32,11 @@ internal static class StandardHttpConfigurationBinder
         RejectLegacyKey(configuration, "MaxAttempts", "Hedge:MaxHedgedAttempts");
         BindTimeout(configuration, nameof(options.TotalTimeout), options.TotalTimeout);
         BindHedge(configuration.GetSection(nameof(options.Hedge)), options.Hedge);
-        BindConcurrencyLimit(configuration.GetSection(nameof(options.ConcurrencyLimit)), options.ConcurrencyLimit);
+        BindConcurrencyLimit(configuration.GetSection(nameof(options.ConcurrencyLimit)), options);
         BindCircuitBreaker(configuration.GetSection(nameof(options.CircuitBreaker)), options.CircuitBreaker);
         BindTimeout(configuration, nameof(options.AttemptTimeout), options.AttemptTimeout);
         BindHandler(configuration.GetSection(nameof(options.Handler)), options.Handler);
-        BindRouting(configuration.GetSection(nameof(options.Routing)), options.Routing);
+        BindRouting(configuration.GetSection(nameof(options.Routing)), options);
 
         ValidateHedge(configuration, options);
         return options;
@@ -158,11 +158,18 @@ internal static class StandardHttpConfigurationBinder
 
     private static void BindConcurrencyLimit(
         IConfiguration section,
-        ConcurrencyLimitOptions options)
+        StandardHedgeShieldOptions standard)
     {
+        if (!section.GetChildren().Any())
+        {
+            return;
+        }
+
+        var options = standard.ConcurrencyLimit ?? new ConcurrencyLimitOptions();
         RejectLegacyKey(section, "MaxQueue", nameof(options.QueueLimit));
         SetInt(section, nameof(options.MaxConcurrency), value => options.MaxConcurrency = value);
         SetInt(section, nameof(options.QueueLimit), value => options.QueueLimit = value);
+        standard.ConcurrencyLimit = options;
     }
 
     private static void BindHandler(
@@ -191,6 +198,20 @@ internal static class StandardHttpConfigurationBinder
         SetEnum<HttpEndpointSelectionMode>(section, nameof(options.SelectionMode), value => options.SelectionMode = value);
         SetInt(section, nameof(options.Seed), value => options.Seed = value);
         BindEndpoints(section.GetSection(nameof(options.Endpoints)), options.Endpoints);
+    }
+
+    private static void BindRouting(
+        IConfiguration section,
+        StandardHedgeShieldOptions standard)
+    {
+        if (!section.GetChildren().Any())
+        {
+            return;
+        }
+
+        var options = standard.Routing ?? new HttpEndpointRoutingOptions();
+        BindRouting(section, options);
+        standard.Routing = options;
     }
 
     private static void BindEndpoints(IConfiguration section, IList<HttpEndpoint> endpoints)
@@ -294,14 +315,21 @@ internal static class StandardHttpConfigurationBinder
             IsValidStandardTimeout(options.AttemptTimeout),
             TimeoutSection(configuration, nameof(options.AttemptTimeout)),
             "must be positive or Timeout.InfiniteTimeSpan");
-        Ensure(options.ConcurrencyLimit.MaxConcurrency > 0, configuration.GetSection("ConcurrencyLimit:MaxConcurrency"), "must be positive");
-        Ensure(options.ConcurrencyLimit.QueueLimit >= 0, configuration.GetSection("ConcurrencyLimit:QueueLimit"), "must not be negative");
+        if (options.ConcurrencyLimit is { } concurrency)
+        {
+            Ensure(concurrency.MaxConcurrency > 0, configuration.GetSection("ConcurrencyLimit:MaxConcurrency"), "must be positive");
+            Ensure(concurrency.QueueLimit >= 0, configuration.GetSection("ConcurrencyLimit:QueueLimit"), "must not be negative");
+        }
+
         ValidateCircuitBreaker(configuration.GetSection(nameof(options.CircuitBreaker)), options.CircuitBreaker);
         Ensure(options.Handler.MaxBufferSize > 0, configuration.GetSection("Handler:MaxBufferSize"), "must be positive");
-        Ensure(
-            options.Routing.Endpoints.Count > 0,
-            configuration.GetSection("Routing:Endpoints"),
-            "must contain at least one endpoint");
+        if (options.Routing is { } routing)
+        {
+            Ensure(
+                routing.Endpoints.Count > 0,
+                configuration.GetSection("Routing:Endpoints"),
+                "must contain at least one endpoint");
+        }
     }
 
     private static void ValidateCircuitBreaker(

--- a/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
+++ b/tests/Kevlar.Extensions.Logging.Tests/IntegrationTests.cs
@@ -370,6 +370,7 @@ public class IntegrationTests
                 options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
                 options.CircuitBreaker.ConsecutiveFailures = 1;
                 options.CircuitBreaker.FailureRatio = null;
+                options.Routing = new HttpEndpointRoutingOptions();
                 options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://endpoint.test")));
             });
         using var provider = services.BuildServiceProvider();

--- a/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpReplayTests.cs
@@ -839,8 +839,8 @@ public class HttpReplayTests
         });
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.Hedge.Delay = Timeout.InfiniteTimeSpan;
             options.CircuitBreaker.ConsecutiveFailures = 1;
             options.CircuitBreaker.FailureRatio = null;
@@ -879,8 +879,8 @@ public class HttpReplayTests
         });
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.Hedge.Delay = Timeout.InfiniteTimeSpan;
             options.AttemptTimeout.Timeout = TimeSpan.FromMilliseconds(20);
         });
@@ -904,8 +904,8 @@ public class HttpReplayTests
         });
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.Hedge.Delay = TimeSpan.Zero;
             options.TotalTimeout.Timeout = TimeSpan.FromMinutes(1);
             options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
@@ -931,8 +931,8 @@ public class HttpReplayTests
         });
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.Hedge.Delay = TimeSpan.Zero;
             options.TotalTimeout.Timeout = TimeSpan.FromSeconds(1);
             options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
@@ -959,8 +959,8 @@ public class HttpReplayTests
         });
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.Hedge.Delay = Timeout.InfiniteTimeSpan;
             options.Handler.ContentReplayPolicy = HttpContentReplayPolicy.Buffer;
             options.Handler.AllowUnsafeMethodReplay = true;
@@ -986,8 +986,8 @@ public class HttpReplayTests
             new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = failedContent }));
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.Hedge.Delay = Timeout.InfiniteTimeSpan;
         });
         using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
@@ -1001,6 +1001,99 @@ public class HttpReplayTests
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
         await Assert.That(transport.Attempts).IsEqualTo(1);
         await Assert.That(failedContent.DisposeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Standard_Hedge_Default_Does_Not_Limit_One_Authority()
+    {
+        const int requestCount = 50;
+        var allStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = 0;
+        var transport = new RecordingHandler(async (_, _, cancellationToken) =>
+        {
+            if (Interlocked.Increment(ref started) == requestCount)
+            {
+                allStarted.TrySetResult();
+            }
+
+            await release.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var services = CreateStandardHedgeServices(transport, options =>
+        {
+            options.Hedge.MaxHedgedAttempts = 0;
+            options.TotalTimeout.Timeout = TimeSpan.FromMinutes(1);
+            options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
+        var requests = Enumerable.Range(0, requestCount)
+            .Select(index => client.GetAsync($"https://origin.example/{index}"))
+            .ToArray();
+
+        try
+        {
+            await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        var responses = await Task.WhenAll(requests);
+        foreach (var response in responses)
+        {
+            response.Dispose();
+        }
+
+        await Assert.That(started).IsEqualTo(requestCount);
+    }
+
+    [Test]
+    public async Task Standard_Hedge_Configured_Concurrency_Limit_Rejects_Overflow()
+    {
+        var twoStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = 0;
+        var transport = new RecordingHandler(async (_, _, cancellationToken) =>
+        {
+            if (Interlocked.Increment(ref started) == 2)
+            {
+                twoStarted.TrySetResult();
+            }
+
+            await release.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var services = CreateStandardHedgeServices(transport, options =>
+        {
+            options.Hedge.MaxHedgedAttempts = 0;
+            options.ConcurrencyLimit = new ConcurrencyLimitOptions
+            {
+                MaxConcurrency = 2,
+                QueueLimit = 0,
+            };
+            options.TotalTimeout.Timeout = TimeSpan.FromMinutes(1);
+            options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
+        });
+        using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
+        var first = client.GetAsync("https://origin.example/first");
+        var second = client.GetAsync("https://origin.example/second");
+
+        await twoStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        try
+        {
+            await Assert.That(async () => await client.GetAsync("https://origin.example/third"))
+                .Throws<ConcurrencyLimitExceededException>();
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+
+        using var firstResponse = await first;
+        using var secondResponse = await second;
+        await Assert.That(started).IsEqualTo(2);
     }
 
     [Test]
@@ -1022,11 +1115,14 @@ public class HttpReplayTests
         });
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example")));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example")));
             options.Hedge.Delay = Timeout.InfiniteTimeSpan;
-            options.ConcurrencyLimit.MaxConcurrency = 1;
-            options.ConcurrencyLimit.QueueLimit = 0;
+            options.ConcurrencyLimit = new ConcurrencyLimitOptions
+            {
+                MaxConcurrency = 1,
+                QueueLimit = 0,
+            };
             options.TotalTimeout.Timeout = TimeSpan.FromMinutes(1);
             options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
         });
@@ -1056,10 +1152,10 @@ public class HttpReplayTests
         });
         using var services = CreateStandardHedgeServices(transport, options =>
         {
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example"), 5));
-            options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example"), 1));
-            options.Routing.SelectionMode = HttpEndpointSelectionMode.Weighted;
-            options.Routing.Seed = 1729;
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://first.example"), 5));
+            options.Routing!.Endpoints.Add(new HttpEndpoint(new Uri("https://second.example"), 1));
+            options.Routing!.SelectionMode = HttpEndpointSelectionMode.Weighted;
+            options.Routing!.Seed = 1729;
             options.Hedge.MaxHedgedAttempts = 0;
         });
         using var client = services.GetRequiredService<IHttpClientFactory>().CreateClient("standard-hedge");
@@ -1341,7 +1437,11 @@ public class HttpReplayTests
         var services = new ServiceCollection();
         services.AddHttpClient("standard-hedge")
             .ConfigurePrimaryHttpMessageHandler(() => transport)
-            .AddStandardHedgeShield(configure);
+            .AddStandardHedgeShield(options =>
+            {
+                options.Routing = new HttpEndpointRoutingOptions();
+                configure(options);
+            });
         return services.BuildServiceProvider();
     }
 

--- a/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpResilienceTests.cs
@@ -230,6 +230,7 @@ public class HttpResilienceTests
             .AddHttpClient("hedged-backend")
             .AddStandardHedgeShield(options =>
             {
+                options.Routing = new HttpEndpointRoutingOptions();
                 options.Routing.Endpoints.Add(new HttpEndpoint(new Uri(failing.Url)));
                 options.Routing.Endpoints.Add(new HttpEndpoint(new Uri(healthy.Url)));
                 options.Hedge.Delay = Timeout.InfiniteTimeSpan;
@@ -317,6 +318,7 @@ public class HttpResilienceTests
             .AddHttpClient("adaptive-hedge")
             .AddStandardHedgeShield(options =>
             {
+                options.Routing = new HttpEndpointRoutingOptions();
                 options.Routing.Endpoints.Add(new HttpEndpoint(new Uri(slow.Url)));
                 options.Routing.Endpoints.Add(new HttpEndpoint(new Uri(healthy.Url)));
                 options.Hedge.Delay = TimeSpan.FromMinutes(1);

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -206,19 +206,38 @@ public class HttpConfigurationReloadTests
         await Assert.That(bound.Hedge.MaxHedgedAttempts).IsEqualTo(3);
         await Assert.That(bound.Hedge.Delay).IsEqualTo(TimeSpan.FromMilliseconds(250));
         await Assert.That(bound.AttemptTimeout.Timeout).IsEqualTo(TimeSpan.FromSeconds(2));
-        await Assert.That(bound.ConcurrencyLimit.MaxConcurrency).IsEqualTo(4);
-        await Assert.That(bound.ConcurrencyLimit.QueueLimit).IsEqualTo(5);
+        await Assert.That(bound.ConcurrencyLimit).IsNotNull();
+        await Assert.That(bound.ConcurrencyLimit!.MaxConcurrency).IsEqualTo(4);
+        await Assert.That(bound.ConcurrencyLimit!.QueueLimit).IsEqualTo(5);
         await Assert.That(bound.CircuitBreaker.ConsecutiveFailures).IsEqualTo(2);
         await Assert.That(bound.CircuitBreaker.FailureRatio).IsNull();
         await Assert.That(bound.CircuitBreaker.MinimumThroughput).IsEqualTo(6);
         await Assert.That(bound.CircuitBreaker.SamplingWindow).IsEqualTo(TimeSpan.FromSeconds(8));
         await Assert.That(bound.CircuitBreaker.BreakDuration).IsEqualTo(TimeSpan.FromSeconds(4));
-        await Assert.That(bound.Routing.SelectionMode).IsEqualTo(HttpEndpointSelectionMode.Weighted);
-        await Assert.That(bound.Routing.Seed).IsEqualTo(9);
+        await Assert.That(bound.Routing).IsNotNull();
+        await Assert.That(bound.Routing!.SelectionMode).IsEqualTo(HttpEndpointSelectionMode.Weighted);
+        await Assert.That(bound.Routing!.Seed).IsEqualTo(9);
         await Assert.That(bound.Handler.ContentReplayPolicy).IsEqualTo(HttpContentReplayPolicy.Buffer);
         await Assert.That(bound.Handler.MaxBufferSize).IsEqualTo(8192);
         await Assert.That(bound.Handler.AllowUnsafeMethodReplay).IsTrue();
-        await Assert.That(bound.Routing.Endpoints.Single().Uri.Host).IsEqualTo("one.example");
+        await Assert.That(bound.Routing!.Endpoints.Single().Uri.Host).IsEqualTo("one.example");
+    }
+
+    [Test]
+    public async Task Hedge_Section_Leaves_Optional_Stages_Null_When_Absent()
+    {
+        var configuration = BuildConfiguration(("Hedge:MaxHedgedAttempts", "0"));
+        StandardHedgeShieldOptions? bound = null;
+        var services = new ServiceCollection();
+        services.AddHttpClient("client")
+            .AddStandardHedgeShield(configuration, (_, options) => bound = options);
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+
+        await Assert.That(bound).IsNotNull();
+        await Assert.That(bound!.ConcurrencyLimit).IsNull();
+        await Assert.That(bound.Routing).IsNull();
     }
 
     [Test]
@@ -788,7 +807,9 @@ public class HttpConfigurationReloadTests
             })
             .AddStandardHedgeShield(options =>
             {
-                options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://example.test")));
+                var routing = new HttpEndpointRoutingOptions();
+                routing.Endpoints.Add(new HttpEndpoint(new Uri("https://example.test")));
+                options.Routing = routing;
                 options.CircuitBreaker.ConsecutiveFailures = 1;
                 options.CircuitBreaker.FailureRatio = null;
                 options.CircuitBreaker.BreakDuration = TimeSpan.FromDays(1);

--- a/tests/Kevlar.Tests/HttpContractTests.cs
+++ b/tests/Kevlar.Tests/HttpContractTests.cs
@@ -257,7 +257,10 @@ public class HttpContractTests
             .AddHttpClient("standard-hedge-timeout", client =>
                 client.Timeout = TimeSpan.FromMilliseconds(10))
             .AddStandardHedgeShield(options =>
-                options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://example.test"))))
+            {
+                options.Routing = new HttpEndpointRoutingOptions();
+                options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://example.test")));
+            })
             .Services
             .BuildServiceProvider();
         using var client = services.GetRequiredService<IHttpClientFactory>()
@@ -289,8 +292,7 @@ public class HttpContractTests
             .AddHttpClient("standard-hedge-descriptor")
             .ConfigurePrimaryHttpMessageHandler(() => new DelegateHandler(
                 (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK))))
-            .AddStandardHedgeShield(options =>
-                options.Routing.Endpoints.Add(new HttpEndpoint(new Uri("https://example.test"))))
+            .AddStandardHedgeShield()
             .Services
             .BuildServiceProvider();
         using var client = services.GetRequiredService<IHttpClientFactory>()
@@ -306,18 +308,15 @@ public class HttpContractTests
             .IsEquivalentTo([StrategyKind.Timeout, StrategyKind.Hedge]);
         await Assert.That(endpoint.Strategies.Select(strategy => strategy.Kind))
             .IsEquivalentTo(
-                [StrategyKind.ConcurrencyLimit, StrategyKind.CircuitBreaker, StrategyKind.Timeout]);
+                [StrategyKind.CircuitBreaker, StrategyKind.Timeout]);
 
         var totalTimeout = (TimeoutStrategyDescriptor)outer.Strategies[0];
         var hedge = (HedgeStrategyDescriptor)outer.Strategies[1];
-        var concurrency = (ConcurrencyLimitStrategyDescriptor)endpoint.Strategies[0];
-        var circuitBreaker = (CircuitBreakerStrategyDescriptor)endpoint.Strategies[1];
-        var attemptTimeout = (TimeoutStrategyDescriptor)endpoint.Strategies[2];
+        var circuitBreaker = (CircuitBreakerStrategyDescriptor)endpoint.Strategies[0];
+        var attemptTimeout = (TimeoutStrategyDescriptor)endpoint.Strategies[1];
         await Assert.That(totalTimeout.Timeout).IsEqualTo(TimeSpan.FromSeconds(30));
         await Assert.That(hedge.MaxHedgedAttempts).IsEqualTo(1);
         await Assert.That(hedge.Delay).IsEqualTo(TimeSpan.FromSeconds(1));
-        await Assert.That(concurrency.MaxConcurrency).IsEqualTo(10);
-        await Assert.That(concurrency.QueueLimit).IsEqualTo(0);
         await Assert.That(circuitBreaker.FailureRatio).IsEqualTo(0.5);
         await Assert.That(circuitBreaker.MinimumThroughput).IsEqualTo(10);
         await Assert.That(circuitBreaker.SamplingWindow).IsEqualTo(TimeSpan.FromSeconds(30));
@@ -328,11 +327,9 @@ public class HttpContractTests
     [Test]
     [Arguments("TotalTimeout")]
     [Arguments("Hedge")]
-    [Arguments("ConcurrencyLimit")]
     [Arguments("CircuitBreaker")]
     [Arguments("AttemptTimeout")]
     [Arguments("Handler")]
-    [Arguments("Routing")]
     public async Task Standard_Hedge_Null_Nested_Option_Throws(string propertyName)
     {
         var builder = new ServiceCollection().AddHttpClient("standard-hedge-null-option");
@@ -347,9 +344,6 @@ public class HttpContractTests
                 case "Hedge":
                     options.Hedge = null!;
                     break;
-                case "ConcurrencyLimit":
-                    options.ConcurrencyLimit = null!;
-                    break;
                 case "CircuitBreaker":
                     options.CircuitBreaker = null!;
                     break;
@@ -358,9 +352,6 @@ public class HttpContractTests
                     break;
                 case "Handler":
                     options.Handler = null!;
-                    break;
-                case "Routing":
-                    options.Routing = null!;
                     break;
             }
         })).Throws<ArgumentException>();


### PR DESCRIPTION
Closes #386

## Summary
- make standard hedging concurrency limiting opt-in with `null` meaning disabled
- make standard hedging routing nullable, matching the regular HTTP option convention
- preserve configured authority-local limiter behavior and configuration binding
- update HTTP/Polly docs, generated API metadata, benchmarks, and concurrency regressions

## Breaking changes
- `StandardHedgeShieldOptions.ConcurrencyLimit` becomes nullable and defaults to `null`
- `StandardHedgeShieldOptions.Routing` becomes nullable and defaults to `null`

## Validation
- `dotnet build Kevlar.slnx -c Release`
- core tests: net8.0 1,251 passed; net10.0 1,285 passed
- integration tests: 173 passed
- logging tests: 49 passed
- `pwsh scripts/Verify-ApiDocs.ps1`
- `pwsh scripts/Verify-Docs.ps1`