### PR TITLE
feat(http): add AllowReplay request extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- `HttpRequestMessage.AllowReplay()` opts one known-idempotent POST, PATCH, or custom-method
+  request into retries and hedges, mirroring `DisableReplay()`. The last call wins, and content
+  replay rules still apply. The HTTP guide now separates rebuilding the message from method safety
+  and documents the idempotency-key pattern for replayed writes.
+
 ## [1.0.0] - 2026-08-27
 
 Kevlar 1.0 establishes the stable Shield API: composable retry, timeout, circuit-breaker,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
-### Added
-
-- `HttpRequestMessage.AllowReplay()` opts one known-idempotent POST, PATCH, or custom-method
-  request into retries and hedges, mirroring `DisableReplay()`. The last call wins, and content
-  replay rules still apply. The HTTP guide now separates rebuilding the message from method safety
-  and documents the idempotency-key pattern for replayed writes.
-
 ## [1.0.0] - 2026-08-27
 
 Kevlar 1.0 establishes the stable Shield API: composable retry, timeout, circuit-breaker,

--- a/docs/api/.manifest
+++ b/docs/api/.manifest
@@ -285,6 +285,7 @@
   "Kevlar.Extensions.Http.KevlarHttpKeys.RequestMethod": "Kevlar.Extensions.Http.KevlarHttpKeys.yml",
   "Kevlar.Extensions.Http.KevlarHttpKeys.RequestUri": "Kevlar.Extensions.Http.KevlarHttpKeys.yml",
   "Kevlar.Extensions.Http.KevlarHttpRequestExtensions": "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.yml",
+  "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay(System.Net.Http.HttpRequestMessage)": "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.yml",
   "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.DisableReplay(System.Net.Http.HttpRequestMessage)": "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.yml",
   "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.WithKevlarCancellationToken(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)": "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.yml",
   "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.WithKevlarProperties(System.Net.Http.HttpRequestMessage,System.Action{Kevlar.KevlarProperties})": "Kevlar.Extensions.Http.KevlarHttpRequestExtensions.yml",

--- a/docs/api/Kevlar.Extensions.Http.KevlarHttpRequestExtensions.yml
+++ b/docs/api/Kevlar.Extensions.Http.KevlarHttpRequestExtensions.yml
@@ -5,6 +5,7 @@ items:
   id: KevlarHttpRequestExtensions
   parent: Kevlar.Extensions.Http
   children:
+  - Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay(System.Net.Http.HttpRequestMessage)
   - Kevlar.Extensions.Http.KevlarHttpRequestExtensions.DisableReplay(System.Net.Http.HttpRequestMessage)
   - Kevlar.Extensions.Http.KevlarHttpRequestExtensions.WithKevlarCancellationToken(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)
   - Kevlar.Extensions.Http.KevlarHttpRequestExtensions.WithKevlarProperties(System.Net.Http.HttpRequestMessage,System.Action{Kevlar.KevlarProperties})
@@ -128,6 +129,41 @@ items:
   nameWithType.vb: KevlarHttpRequestExtensions.WithShieldName(HttpRequestMessage, String)
   fullName.vb: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.WithShieldName(System.Net.Http.HttpRequestMessage, String)
   name.vb: WithShieldName(HttpRequestMessage, String)
+- uid: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay(System.Net.Http.HttpRequestMessage)
+  commentId: M:Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay(System.Net.Http.HttpRequestMessage)
+  id: AllowReplay(System.Net.Http.HttpRequestMessage)
+  isExtensionMethod: true
+  parent: Kevlar.Extensions.Http.KevlarHttpRequestExtensions
+  langs:
+  - csharp
+  - vb
+  name: AllowReplay(HttpRequestMessage)
+  nameWithType: KevlarHttpRequestExtensions.AllowReplay(HttpRequestMessage)
+  fullName: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay(System.Net.Http.HttpRequestMessage)
+  type: Method
+  assemblies:
+  - Kevlar.Extensions.Http
+  namespace: Kevlar.Extensions.Http
+  summary: >-
+    Permits retries, hedges, and other additional attempts for this request even though its
+
+    HTTP method is not replay-safe. Content must still be replayable.
+  remarks: >-
+    Opt in only when the server treats the operation as idempotent, for example because the
+
+    request carries an idempotency key that the server deduplicates. Clones preserve headers,
+
+    so every attempt sends the same key.
+  example: []
+  syntax:
+    content: public static HttpRequestMessage AllowReplay(this HttpRequestMessage request)
+    parameters:
+    - id: request
+      type: System.Net.Http.HttpRequestMessage
+    return:
+      type: System.Net.Http.HttpRequestMessage
+    content.vb: Public Shared Function AllowReplay(request As HttpRequestMessage) As HttpRequestMessage
+  overload: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay*
 - uid: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.DisableReplay(System.Net.Http.HttpRequestMessage)
   commentId: M:Kevlar.Extensions.Http.KevlarHttpRequestExtensions.DisableReplay(System.Net.Http.HttpRequestMessage)
   id: DisableReplay(System.Net.Http.HttpRequestMessage)
@@ -666,6 +702,13 @@ references:
   nameWithType.vb: String
   fullName.vb: String
   name.vb: String
+- uid: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay*
+  commentId: Overload:Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay
+  isExternal: true
+  href: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.html#Kevlar_Extensions_Http_KevlarHttpRequestExtensions_AllowReplay_System_Net_Http_HttpRequestMessage_
+  name: AllowReplay
+  nameWithType: KevlarHttpRequestExtensions.AllowReplay
+  fullName: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay
 - uid: Kevlar.Extensions.Http.KevlarHttpRequestExtensions.DisableReplay*
   commentId: Overload:Kevlar.Extensions.Http.KevlarHttpRequestExtensions.DisableReplay
   isExternal: true

--- a/docs/docs/cookbook.md
+++ b/docs/docs/cookbook.md
@@ -26,8 +26,10 @@ services.AddHttpClient("catalog", client =>
     });
 ```
 
-Keep unsafe HTTP methods single-attempt unless the application has an idempotency contract. For
-dynamic configuration, use the configuration-backed overload described in [HTTP resilience](http.md).
+Keep unsafe HTTP methods single-attempt unless the application has an idempotency contract. When
+it does, send an idempotency key and call `AllowReplay()` on that request; see
+[method safety](http.md#method-safety). For dynamic configuration, use the configuration-backed
+overload described in [HTTP resilience](http.md).
 
 ## Database query with recovery value
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -35,15 +35,19 @@ Remember that `Retry(3)` means one initial attempt plus at most three retries.
 
 ## Why did my POST run once or throw `HttpRequestReplayException`?
 
-HTTP retries and hedges need a fresh request per attempt. Method safety and content replayability
-are separate requirements. POST, PATCH, and custom methods require `AllowUnsafeMethodReplay = true`
-or a `RequestFactory`. Their content must also be replayable: select buffering, supply a
+HTTP retries and hedges need a fresh request per attempt. Kevlar rebuilds the message itself, so
+the gate is not cloning: method safety and content replayability are separate requirements. POST,
+PATCH, and custom methods stay single-attempt until you opt in, because only the caller knows
+whether the server can safely execute the operation twice. Opt in with `request.AllowReplay()` for
+one known-idempotent request, `AllowUnsafeMethodReplay = true` for a whole client, or a
+`RequestFactory`. Their content must also be replayable: select buffering, supply a
 `RequestFactory`, or use content supported by the `NoBuffer` policy. A `HttpRequestReplayException`
 indicates a replay configuration failure such as a null request from the factory or content
-exceeding the requested buffer limit. See [HTTP replay safety](http.md#safe-request-replay).
+exceeding the requested buffer limit. See [method safety](http.md#method-safety).
 
 Do not enable unsafe replay blindly. Prefer idempotency keys and server-side deduplication for
-operations that create or mutate data.
+operations that create or mutate data; clones preserve headers, so every attempt sends the same
+key.
 
 ## Why are some metrics missing on .NET 8?
 

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -350,7 +350,10 @@ then decide whether an additional attempt may be sent:
 2. **Is it safe to send twice?** A semantic question about the operation. Only the caller can
    answer it for POST, PATCH, and custom methods.
 
-When either check fails, the shield stays single-attempt for that request instead of failing it.
+When method replay is suppressed, or `NoBuffer` rejects non-replayable content, the shield stays
+single-attempt for that request instead of failing it. With `Buffer`, content that exceeds
+`MaxBufferSize` or fails serialization throws `HttpRequestReplayException` before the first
+transport attempt.
 
 ### Rebuilding the message
 

--- a/docs/docs/http.md
+++ b/docs/docs/http.md
@@ -273,8 +273,8 @@ services.AddHttpClient("api")
 
 ## Per-request options
 
-Attach execution properties, select a shield, suppress replay, or link another cancellation token
-without changing the named client's defaults:
+Attach execution properties, select a shield, allow or suppress replay, or link another
+cancellation token without changing the named client's defaults:
 
 ```csharp
 using Kevlar.Extensions.Http;
@@ -292,10 +292,11 @@ using var response = await httpClient.SendAsync(request, cancellationToken);
 The property initializer runs once for the outer request execution and once for each separately
 executed endpoint-local shield. Retries reuse their context, while hedges copy the initialized
 properties into forked contexts instead of rerunning the initializer. Pooled properties are cleared
-after execution, so values do not leak to later requests. `DisableReplay` affects only this request.
-To allow an unsafe method for one known-idempotent request, set
-`KevlarHttp.GetRequestOptions(request).AllowReplay = true`; content must still satisfy the normal
-replay-safety rules.
+after execution, so values do not leak to later requests. `DisableReplay` and `AllowReplay` affect
+only this request, and the last call wins. `DisableReplay` keeps any request, including a GET,
+single-attempt. `AllowReplay` lets one known-idempotent POST, PATCH, or custom-method request retry
+or hedge; content must still satisfy the normal replay-safety rules. See
+[method safety](#method-safety) for the reasoning and the idempotency-key pattern.
 
 Choose one shield per request with the selector overload. Selection happens once, before the
 shield executes. A direct `.WithShield(shield)` request override takes precedence over the
@@ -340,12 +341,25 @@ object. A custom `RequestFactory` creates the complete request and must copy any
 
 ## Safe request replay
 
+Every retry and hedge needs a fresh `HttpRequestMessage`: .NET sends a message once, and one-shot
+content is consumed by the first send. Kevlar rebuilds the message for you. Two independent checks
+then decide whether an additional attempt may be sent:
+
+1. **Can the message be rebuilt?** A mechanical question about the content. Kevlar answers it
+   automatically for most requests.
+2. **Is it safe to send twice?** A semantic question about the operation. Only the caller can
+   answer it for POST, PATCH, and custom methods.
+
+When either check fails, the shield stays single-attempt for that request instead of failing it.
+
+### Rebuilding the message
+
 The first no-routing attempt sends the caller's original request directly. Additional attempts use
 clones that preserve method, URI, HTTP version and version policy, request headers, request options,
 and content headers. The handler owns every clone and every nonselected response; the caller owns
 the original request and the returned response.
 
-Replay behavior depends on the request:
+Content replay depends on `ContentReplayPolicy`:
 
 - `NoBuffer` (default) reuses inherently re-readable content such as `ByteArrayContent`,
   `StringContent`, `FormUrlEncodedContent`, and ordinary `JsonContent`. Positive-length content
@@ -358,20 +372,56 @@ Replay behavior depends on the request:
   generated bodies, signatures, or other request state that cannot be cloned. Factory requests are
   disposed by the handler.
 
-GET, HEAD, OPTIONS, TRACE, PUT, and DELETE can replay automatically. POST, PATCH, and custom methods
-require `AllowUnsafeMethodReplay = true` or a `RequestFactory`; only opt in when the operation is
-actually idempotent. If method or content cannot be replayed safely, retry and hedging remain
-single-attempt: the original response is returned or the original exception is rethrown without a
-retry delay or callback. Other stages, including timeout, circuit breaker, and concurrency limiting,
-still observe that attempt. A multi-attempt shield reports this decision once as the
-`attempts_suppressed` telemetry event and log 1009, with reason `replay_disabled`, `unsafe_method`,
-or `non_replayable_content`. The first `unsafe_method` suppression for a client is a Warning that
+### Method safety
+
+GET, HEAD, OPTIONS, TRACE, PUT, and DELETE are idempotent by definition
+([RFC 9110 §9.2.2](https://www.rfc-editor.org/rfc/rfc9110#section-9.2.2)), so Kevlar replays them
+automatically. POST, PATCH, and custom methods are not, and a perfect clone does not change that:
+the risk is the server executing the operation twice, not the client rebuilding the message. A
+hedged `POST /orders` is two concurrent order creations unless the server deduplicates them, and
+Kevlar cannot know whether it does. These methods therefore stay single-attempt until you opt in:
+
+| Opt-in | Scope | Use when |
+| --- | --- | --- |
+| `request.AllowReplay()` | one request | This request is idempotent, typically because it carries an idempotency key. |
+| `Handler.AllowUnsafeMethodReplay = true` | every request on the client | The API deduplicates every write, or the client only sends idempotent unsafe-method requests. |
+| `Handler.RequestFactory` | every request on the client | Each attempt needs a freshly built request (streams, signatures, generated bodies). Building every attempt yourself counts as opt-in. |
+
+Opting in does not skip the content check: a POST with one-shot content still needs `Buffer`,
+`LoadIntoBufferAsync()`, or a `RequestFactory`. `request.DisableReplay()` forces any request,
+including a GET, to stay single-attempt.
+
+The recommended pattern for a retried or hedged write is an idempotency key that the server
+deduplicates. Clones preserve headers, so every attempt carries the same key, and a duplicate
+delivery becomes a harmless repeat rather than a second order:
+
+```csharp
+using System.Net.Http.Json;
+using Kevlar.Extensions.Http;
+
+using var createOrder = new HttpRequestMessage(HttpMethod.Post, "orders")
+{
+    Content = JsonContent.Create(new { Sku = "sku-1", Quantity = 2 }),
+}.AllowReplay();
+createOrder.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString("N"));
+
+using var created = await httpClient.SendAsync(createOrder, cancellationToken);
+```
+
+### Suppressed attempts
+
+If method or content cannot be replayed safely, retry and hedging remain single-attempt: the
+original response is returned or the original exception is rethrown without a retry delay or
+callback. Other stages, including timeout, circuit breaker, and concurrency limiting, still observe
+that attempt. A multi-attempt shield reports this decision once as the `attempts_suppressed`
+telemetry event and log 1009, with reason `replay_disabled`, `unsafe_method`, or
+`non_replayable_content`. The first `unsafe_method` suppression for a client is a Warning that
 names the handler-wide and per-request opt-ins; later unsafe-method suppressions and other reasons
 are Information. Telemetry uses the matching Warning or Information severity. The
-`kevlar.http.replay_suppressed` counter carries the
-same bounded reason in `kevlar.suppression.reason`. `HttpRequestReplayException` is reserved for
-configuration failures such as a null factory result or content exceeding the requested buffer
-limit. Timeouts and caller cancellation flow to every attempt and request factory.
+`kevlar.http.replay_suppressed` counter carries the same bounded reason in
+`kevlar.suppression.reason`. `HttpRequestReplayException` is reserved for configuration failures
+such as a null factory result or content exceeding the requested buffer limit. Timeouts and caller
+cancellation flow to every attempt and request factory.
 
 ## Standard hedging
 
@@ -418,8 +468,9 @@ defaults through `TotalTimeout.Timeout`, `Hedge`, `CircuitBreaker`, and `Attempt
 Request replay is configured through `Handler` (`ContentReplayPolicy`, `MaxBufferSize`,
 `AllowUnsafeMethodReplay`, and `RequestFactory`); alternate endpoint authorities and ordering are
 configured through `Routing`. An empty endpoint list uses the request's authority. POST, PATCH, and
-custom methods still require the same explicit idempotency opt-in described above; registering the
-standard hedging pipeline does not make an unsafe operation safe to repeat.
+custom methods still require the same explicit [method-safety](#method-safety) opt-in, handler-wide
+or per request with `AllowReplay()`; registering the standard hedging pipeline does not make an
+unsafe operation safe to repeat.
 
 For a fully custom endpoint-aware pipeline, compose the outer and endpoint shields directly:
 

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -295,14 +295,15 @@ kevlarHedgeServices.AddHttpClient("hedged-catalog")
 
 Configure `Routing.Endpoints` only when attempts should use alternate authorities.
 
-Kevlar buffers only bounded content and does not replay unsafe methods by default. Enable
-`AllowUnsafeMethodReplay`, choose a bounded buffering policy, or supply a `RequestFactory` when a
-POST-like request is intentionally replayable. See [safe request replay](http.md#safe-request-replay).
-Per-request properties, shield overrides, replay opt-out, cancellation linking, selectors, and
-request-keyed partitions are covered in [per-request options](http.md#per-request-options).
-Use `WithKevlarProperties`, `WithShield`, `WithShieldName`, and
-`WithKevlarCancellationToken` to configure the corresponding request options fluently;
-`DisableReplay` opts out only that request.
+Kevlar buffers only bounded content and does not replay unsafe methods by default. Call
+`AllowReplay()` on a known-idempotent request, enable `AllowUnsafeMethodReplay` for a client,
+choose a bounded buffering policy, or supply a `RequestFactory` when a POST-like request is
+intentionally replayable. See [safe request replay](http.md#safe-request-replay).
+Per-request properties, shield overrides, replay opt-in and opt-out, cancellation linking,
+selectors, and request-keyed partitions are covered in
+[per-request options](http.md#per-request-options). Use `WithKevlarProperties`, `WithShield`,
+`WithShieldName`, and `WithKevlarCancellationToken` to configure the corresponding request options
+fluently; `AllowReplay` and `DisableReplay` opt only that request in or out.
 
 ## Telemetry
 
@@ -416,7 +417,7 @@ required.
 | Hedging | 1 additional attempt (2 total); delay 2 s | 1 additional attempt (2 total); delay 1 s |
 | Concurrency | permit limit 1,000; queue limit 0 | maximum concurrency 10; queue limit 0 |
 | Standard HTTP retry | 3 retries; exponential from 2 s; decorrelated jitter; no delay cap | 3 retries; exponential from 250 ms; equal jitter; 10 s cap; honours `Retry-After` |
-| Standard HTTP unsafe methods | POST, PATCH, DELETE, and custom methods are retried by default | POST, PATCH, and custom methods remain single-attempt unless `AllowUnsafeMethodReplay`, per-request `AllowReplay`, or a `RequestFactory` opts in |
+| Standard HTTP unsafe methods | POST, PATCH, DELETE, and custom methods are retried by default | POST, PATCH, and custom methods remain single-attempt unless `AllowUnsafeMethodReplay`, per-request `AllowReplay()`, or a `RequestFactory` opts in |
 | Standard HTTP circuit breaker | failure ratio 0.1; minimum throughput 100; sampling 30 s; break 5 s | failure ratio 0.5; minimum throughput 10; sampling 30 s; break 15 s |
 | Standard HTTP and hedging concurrency | permit limit 1,000; queue limit 0 | no limiter unless `ConcurrencyLimit` is configured |
 | Chaos | enabled; injection rate 0.001 | disabled; injection rate 1 |

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -156,7 +156,7 @@ Hedging trades extra load for lower tail latency. It shines for:
 - **Idempotent reads** against replicated backends — the second replica probably isn't having the same GC pause.
 - Latency SLOs where p99 matters more than average cost.
 
-Avoid it for writes that aren't idempotent (you may execute them twice!) and for dependencies that are slow because they're *overloaded* — hedging feeds the overload. Over HTTP, `Kevlar.Extensions.Http` enforces the first rule: POST, PATCH, and custom methods stay single-attempt until the request opts in with `AllowReplay()`, typically alongside an idempotency key — see [method safety](../http.md#method-safety). Pair it with a [circuit breaker](circuit-breaker.md) or [rate limit](rate-limit.md) when in doubt:
+Avoid it for writes that aren't idempotent (you may execute them twice!) and for dependencies that are slow because they're *overloaded* — hedging feeds the overload. Over HTTP, `Kevlar.Extensions.Http` enforces the first rule: POST, PATCH, and custom methods stay single-attempt until explicitly opted in per request with `AllowReplay()`, handler-wide with `AllowUnsafeMethodReplay`, or through a `RequestFactory`, typically alongside an idempotency key — see [method safety](../http.md#method-safety). Pair it with a [circuit breaker](circuit-breaker.md) or [rate limit](rate-limit.md) when in doubt:
 
 ```csharp
 var shield = Shield

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -156,7 +156,7 @@ Hedging trades extra load for lower tail latency. It shines for:
 - **Idempotent reads** against replicated backends — the second replica probably isn't having the same GC pause.
 - Latency SLOs where p99 matters more than average cost.
 
-Avoid it for writes that aren't idempotent (you may execute them twice!) and for dependencies that are slow because they're *overloaded* — hedging feeds the overload. Pair it with a [circuit breaker](circuit-breaker.md) or [rate limit](rate-limit.md) when in doubt:
+Avoid it for writes that aren't idempotent (you may execute them twice!) and for dependencies that are slow because they're *overloaded* — hedging feeds the overload. Over HTTP, `Kevlar.Extensions.Http` enforces the first rule: POST, PATCH, and custom methods stay single-attempt until the request opts in with `AllowReplay()`, typically alongside an idempotency key — see [method safety](../http.md#method-safety). Pair it with a [circuit breaker](circuit-breaker.md) or [rate limit](rate-limit.md) when in doubt:
 
 ```csharp
 var shield = Shield

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -309,8 +309,9 @@ if (response.StatusCode != HttpStatusCode.OK || attempts != 2 ||
 For handler-level replay tests, use a recording `HttpMessageHandler`. Return a transient response,
 then success; assert two sends, distinct request objects, and preserved method, URI, headers,
 options, and content. A POST or one-shot body should remain single-send unless the test explicitly
-sets `AllowUnsafeMethodReplay`, selects bounded buffering, or supplies a `RequestFactory`. See
-[safe request replay](http.md#safe-request-replay) for the ownership rules.
+calls `AllowReplay()` on the request, sets `AllowUnsafeMethodReplay`, selects bounded buffering, or
+supplies a `RequestFactory`. See [safe request replay](http.md#safe-request-replay) for the
+ownership rules.
 
 ## Testing partitioned shields
 

--- a/src/Kevlar.Extensions.Http/KevlarHttpRequestExtensions.cs
+++ b/src/Kevlar.Extensions.Http/KevlarHttpRequestExtensions.cs
@@ -44,6 +44,21 @@ public static class KevlarHttpRequestExtensions
         return request;
     }
 
+    /// <summary>
+    /// Permits retries, hedges, and other additional attempts for this request even though its
+    /// HTTP method is not replay-safe. Content must still be replayable.
+    /// </summary>
+    /// <remarks>
+    /// Opt in only when the server treats the operation as idempotent, for example because the
+    /// request carries an idempotency key that the server deduplicates. Clones preserve headers,
+    /// so every attempt sends the same key.
+    /// </remarks>
+    public static HttpRequestMessage AllowReplay(this HttpRequestMessage request)
+    {
+        KevlarHttp.GetRequestOptions(request).AllowReplay = true;
+        return request;
+    }
+
     /// <summary>Suppresses retries, hedges, and other additional attempts for this request.</summary>
     public static HttpRequestMessage DisableReplay(this HttpRequestMessage request)
     {

--- a/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
+++ b/src/Kevlar.Extensions.Http/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Kevlar.Extensions.Http.KevlarHttpRequestExtensions.AllowReplay(this System.Net.Http.HttpRequestMessage! request) -> System.Net.Http.HttpRequestMessage!

--- a/tests/Kevlar.IntegrationTests/HttpRequestOptionsTests.cs
+++ b/tests/Kevlar.IntegrationTests/HttpRequestOptionsTests.cs
@@ -104,13 +104,93 @@ public class HttpRequestOptionsTests
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/orders")
         {
             Content = new StringContent("payload"),
-        };
-        KevlarHttp.GetRequestOptions(request).AllowReplay = true;
+        }.AllowReplay();
 
         using var response = await client.SendAsync(request);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
         await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task AllowReplay_Enables_Hedged_Unsafe_Method_With_Same_Headers()
+    {
+        var idempotencyKeys = new ConcurrentQueue<string>();
+        using var client = CreateClient(
+            HttpShield.WhenTransient().Hedge(1, TimeSpan.Zero),
+            (request, _) =>
+            {
+                idempotencyKeys.Enqueue(request.Headers.TryGetValues("Idempotency-Key", out var values)
+                    ? string.Join(",", values)
+                    : "<missing>");
+                return Task.FromResult(new HttpResponseMessage(idempotencyKeys.Count == 1
+                    ? HttpStatusCode.ServiceUnavailable
+                    : HttpStatusCode.OK));
+            });
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/orders")
+        {
+            Content = new StringContent("payload"),
+        }.AllowReplay();
+        request.Headers.Add("Idempotency-Key", "order-42");
+
+        using var response = await client.SendAsync(request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(idempotencyKeys).IsEquivalentTo(["order-42", "order-42"]);
+    }
+
+    [Test]
+    public async Task AllowReplay_Does_Not_Bypass_Content_Replay_Safety()
+    {
+        var attempts = 0;
+        using var client = CreateClient(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            (_, _) =>
+            {
+                Interlocked.Increment(ref attempts);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            });
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/orders")
+        {
+            Content = new StreamContent(new MemoryStream([1, 2, 3])),
+        }.AllowReplay();
+
+        using var response = await client.SendAsync(request);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Last_Replay_Override_Wins()
+    {
+        var attempts = 0;
+        using var client = CreateClient(
+            HttpShield.WhenTransient().Retry(1, Backoff.None),
+            (_, _) =>
+            {
+                Interlocked.Increment(ref attempts);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            });
+        using var allowed = new HttpRequestMessage(HttpMethod.Get, "https://example.test/allowed")
+            .DisableReplay()
+            .AllowReplay();
+        using var disabled = new HttpRequestMessage(HttpMethod.Get, "https://example.test/disabled")
+            .AllowReplay()
+            .DisableReplay();
+
+        using (await client.SendAsync(allowed))
+        {
+        }
+
+        var allowedAttempts = attempts;
+        attempts = 0;
+        using (await client.SendAsync(disabled))
+        {
+        }
+
+        await Assert.That(allowedAttempts).IsEqualTo(2);
+        await Assert.That(attempts).IsEqualTo(1);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- add `HttpRequestMessage.AllowReplay()` as the fluent mirror of `DisableReplay()`, so one known-idempotent POST, PATCH, or custom-method request can opt into retries and hedges without reaching for `KevlarHttp.GetRequestOptions(request).AllowReplay = true`
- restructure the HTTP guide's "Safe request replay" section into **Rebuilding the message** (mechanical: Kevlar clones the message, content policy decides replayability), **Method safety** (semantic: RFC 9110 idempotent methods replay automatically, unsafe methods need the caller's opt-in because the risk is the server executing twice, not the client rebuilding the message), and **Suppressed attempts** (telemetry/log behaviour)
- document the three opt-ins side by side and add a runnable idempotency-key example for hedged/retried writes
- point FAQ, cookbook, hedging, testing, and migration pages at the new `AllowReplay()` and the method-safety section
- add integration tests: `AllowReplay()` enables a hedged POST with the same `Idempotency-Key` on every attempt, does not bypass content replay safety (one-shot `StreamContent` stays single-attempt), and the last `AllowReplay`/`DisableReplay` call wins

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `Kevlar.IntegrationTests`: 174 passed
- `Kevlar.Tests` net10.0 `Http*` classes: 152 passed
- `scripts/Build-ApiDocs.ps1 -SkipBuild` and `scripts/Verify-ApiDocs.ps1` (2381 UIDs, 157 public runtime types)
- `scripts/Verify-Docs.ps1`
- `scripts/Verify-DocSnippets.ps1 -NoImplicitUsings` with fresh `0.0.0-local` packages: 209 snippets compiled and executed on net8.0/net10.0
- `npm run build` in `docs/`

https://claude.ai/code/session_01V8FtSPYuhaoP4e4GA8WokR
