### PR TITLE
fix(scripts): verify packaged analyzer

### DIFF
--- a/scripts/Verify-PublicApi.ps1
+++ b/scripts/Verify-PublicApi.ps1
@@ -35,7 +35,7 @@ try
                     $assemblyId = $packageId
                     $targetFramework = $Matches[1].ToLowerInvariant()
                 }
-                elseif ($entry.FullName -match '^analyzers/dotnet/cs/(Kevlar\.Analyzers)\.dll$')
+                elseif ($entry.FullName -match '^analyzers/dotnet/(?:roslyn[\d.]+/)?cs/(Kevlar\.Analyzers)\.dll$')
                 {
                     $assemblyId = $Matches[1]
                     $targetFramework = 'netstandard2.0'
@@ -62,9 +62,16 @@ try
         }
     }
 
-    if ($assemblies.Count -eq 0)
+    $expectedAssemblyIds = @(
+        Get-ChildItem -LiteralPath $BaselineRoot -Directory |
+            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'PublicAPI.Shipped.txt') -PathType Leaf } |
+            ForEach-Object Name |
+            Sort-Object -Unique)
+    $actualAssemblyIds = @($assemblies | ForEach-Object AssemblyId | Sort-Object -Unique)
+    $missingAssemblyIds = @($expectedAssemblyIds | Where-Object { $_ -notin $actualAssemblyIds })
+    if ($missingAssemblyIds.Count -gt 0)
     {
-        throw "No package assemblies were found in '$packageDirectory'."
+        throw "Expected package assemblies were not found in '$packageDirectory': $($missingAssemblyIds -join ', ')."
     }
 
     $toolProject = Join-Path $RepositoryRoot 'tools/Kevlar.ApiVerifier/Kevlar.ApiVerifier.csproj'

--- a/scripts/Verify-ReleaseWorkflow.ps1
+++ b/scripts/Verify-ReleaseWorkflow.ps1
@@ -74,6 +74,17 @@ foreach ($requiredVerification in @('Verify-ReleaseApiBaselines.ps1', 'Verify-Pu
     }
 }
 
+$publicApiVerificationScript = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'Verify-PublicApi.ps1') -Raw
+foreach ($requiredText in @(
+    '^analyzers/dotnet/(?:roslyn[\d.]+/)?cs/(Kevlar\.Analyzers)\.dll$',
+    'Expected package assemblies were not found'))
+{
+    if (-not $publicApiVerificationScript.Contains($requiredText, [StringComparison]::Ordinal))
+    {
+        throw "Public API package verification is missing '$requiredText'."
+    }
+}
+
 $dependencyTablePattern = [regex]'(?ms)^\$expectedDependencies = @\{(?<body>.*?)^\}\r?$'
 $dependencyTableMatch = $dependencyTablePattern.Match($packageVerificationScript)
 if (-not $dependencyTableMatch.Success)


### PR DESCRIPTION
## Summary

- discover Kevlar.Analyzers.dll in both legacy and versioned Roslyn analyzer package paths
- derive expected packaged assemblies from shipped API baselines and fail with their names when any are absent
- guard both verifier contracts in release-workflow validation

## Test plan

- [x] synthetic versioned analyzer package: 21 APIs verified
- [x] synthetic missing expected assembly: verifier fails and names it
- [x] analyzer baseline with one member removed: verifier reports that member missing
- [x] pwsh scripts/Verify-ReleaseWorkflow.ps1
- [x] dotnet build Kevlar.slnx -c Release --nologo

Closes #436
