### PR TITLE
docs(readme): add runnable DI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ state-sharing rules.
 
 ## HTTP and dependency injection
 
-`Kevlar.Extensions.Http` provides a ready-to-use `HttpClientFactory` pipeline:
+`Kevlar.Extensions.Http` provides a ready-to-use `HttpClientFactory` pipeline. In an ASP.NET Core
+app using `Microsoft.NET.Sdk.Web`:
 
 ```csharp
 using Microsoft.AspNetCore.Builder;

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ part or supply your own shield. POST, PATCH, and custom methods remain single-at
 explicitly enable replay for operations that are safe to repeat.
 
 `Kevlar.Extensions.DependencyInjection` adds named, configuration-bound shields and
-`IKevlarRegistry`:
+`IKevlarRegistry`. In a standalone console project, install the concrete
+`Microsoft.Extensions.DependencyInjection` package as well; it provides `BuildServiceProvider()`:
 
 ```csharp
 using System;

--- a/README.md
+++ b/README.md
@@ -143,17 +143,39 @@ state-sharing rules.
 `Kevlar.Extensions.Http` provides a ready-to-use `HttpClientFactory` pipeline:
 
 ```csharp
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
-services.AddHttpClient("api")
+var builder = WebApplication.CreateBuilder();
+
+builder.Services.AddHttpClient("api")
     .AddStandardShield();
 ```
 
 The standard shield has a 30-second total timeout, three jittered retries that honour
 `Retry-After`, a circuit breaker, and a 10-second timeout per attempt. You can configure every
 part or supply your own shield. POST, PATCH, and custom methods remain single-attempt unless you
-explicitly enable replay for operations that are safe to repeat. `Kevlar.Extensions.DependencyInjection` adds named,
-configuration-bound shields and `IKevlarRegistry`.
+explicitly enable replay for operations that are safe to repeat.
+
+`Kevlar.Extensions.DependencyInjection` adds named, configuration-bound shields and
+`IKevlarRegistry`:
+
+```csharp
+using System;
+using Kevlar;
+using Kevlar.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+
+services.AddShield("database", Shield
+    .Timeout(TimeSpan.FromSeconds(10))
+    .Retry(3));
+
+using var serviceProvider = services.BuildServiceProvider();
+var registry = serviceProvider.GetRequiredService<IKevlarRegistry>();
+var databaseShield = registry.GetShield("database");
+```
 
 ## Packages
 

--- a/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
+++ b/tests/Kevlar.DocTests/Kevlar.DocTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Kevlar" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Chaos" VersionOverride="$(KevlarPackageVersion)" />
     <PackageReference Include="Kevlar.Extensions.DependencyInjection" VersionOverride="$(KevlarPackageVersion)" />


### PR DESCRIPTION
## Summary
- make the README HTTP example a runnable minimal ASP.NET Core program
- add a complete named-shield registration and `IKevlarRegistry` resolution example
- give the snippet harness an ASP.NET Core framework reference

Closes #433

## Validation
- `dotnet build Kevlar.slnx -c Release -p:Version=1.0.0-local`
- `dotnet pack Kevlar.slnx -c Release --no-build -p:Version=1.0.0-local`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0-local -NoImplicitUsings`
- `pwsh scripts/Verify-Docs.ps1`