### PR TITLE
docs: correct NU1608 behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,8 +230,8 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
 - State gauges now aggregate identical shield-name and strategy-index series across partitioned
   shields. Circuit breakers expose `kevlar.circuit_breaker.instances` counts grouped by state.
 - Coupled satellite packages exact-pin their `Kevlar` dependencies. Partial upgrades of
-  dependency injection, logging, and gRPC packages fail restore with `NU1608` instead of risking
-  runtime failures from incompatible internals.
+  dependency injection, logging, and gRPC packages raise `NU1608`; treat that warning as an error
+  to prevent runtime failures from incompatible internals.
 - Retry and hedging dispose superseded result values. `IAsyncDisposable` is preferred over
   `IDisposable`; disposal failures are isolated through `CallbackErrorKind.ResultDisposal`, while
   the selected terminal result remains caller-owned. The `netstandard2.0` package carries the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ Pipelines stay immutable, allocation-conscious, observable, and explicit about e
   methods assigned to hooks on shields executed synchronously. Completed `ValueTask` delegates are
   not reported.
 - `Kevlar.Testing`, `Kevlar.Extensions.RateLimiting`, and other packages that use core internals
-  require the exact matching `Kevlar` version; NuGet reports skew as `NU1608`.
+  require the exact matching `Kevlar` version; NuGet reports skew as `NU1605` or `NU1608`.
 - HTTP retry and hedging stop after the first outcome when a request method or body cannot be
   replayed safely. The original response or exception is preserved while other resilience stages
   still observe the attempt.
@@ -155,7 +155,7 @@ Pipelines stay immutable, allocation-conscious, observable, and explicit about e
 **Upgrading from 0.x**
 
 Remove any direct `Kevlar.Analyzers` package reference; analyzers ship inside `Kevlar`. Upgrade all
-`Kevlar.*` packages together when exact version constraints report `NU1608`.
+`Kevlar.*` packages together when exact version constraints report `NU1605` or `NU1608`.
 
 <!-- upgrade-from-0.x:start -->
 | Before | After |
@@ -230,8 +230,8 @@ _ = Shield.Empty.Wrap(Shield.Retry(1));
 - State gauges now aggregate identical shield-name and strategy-index series across partitioned
   shields. Circuit breakers expose `kevlar.circuit_breaker.instances` counts grouped by state.
 - Coupled satellite packages exact-pin their `Kevlar` dependencies. Partial upgrades of
-  dependency injection, logging, and gRPC packages raise `NU1608`; treat that warning as an error
-  to prevent runtime failures from incompatible internals.
+  dependency injection, logging, and gRPC packages raise `NU1605` or `NU1608`; treat those
+  warnings as errors to prevent runtime failures from incompatible internals.
 - Retry and hedging dispose superseded result values. `IAsyncDisposable` is preferred over
   `IDisposable`; disposal failures are isolated through `CallbackErrorKind.ResultDisposal`, while
   the selected terminal result remains caller-owned. The `netstandard2.0` package carries the

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Kevlar, you build an immutable `Shield`, reuse it, and use it with ordinary dele
 dotnet add package Kevlar
 ```
 
-Install all coupled `Kevlar.*` packages at the same version. Their exact NuGet dependencies reject
-partial upgrades early; see the [package lockstep policy](https://thomhurst.github.io/Kevlar/docs/support-policy#kevlar-package-lockstep).
+Install all coupled `Kevlar.*` packages at the same version. Their exact NuGet dependencies warn
+about partial upgrades with `NU1608`; see the [package lockstep policy](https://thomhurst.github.io/Kevlar/docs/support-policy#kevlar-package-lockstep).
 
 ```csharp
 using Kevlar;

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Kevlar, you build an immutable `Shield`, reuse it, and use it with ordinary dele
 dotnet add package Kevlar
 ```
 
-Install all coupled `Kevlar.*` packages at the same version. Their exact NuGet dependencies warn
-about partial upgrades with `NU1608`; see the [package lockstep policy](https://thomhurst.github.io/Kevlar/docs/support-policy#kevlar-package-lockstep).
+Install all coupled `Kevlar.*` packages at the same version. NuGet reports partial upgrades with
+`NU1605` or `NU1608`; see the [package lockstep policy](https://thomhurst.github.io/Kevlar/docs/support-policy#kevlar-package-lockstep).
 
 ```csharp
 using Kevlar;

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -58,9 +58,17 @@ dependencies enforce this for `Kevlar.Testing`, `Kevlar.Extensions.Http`,
 so it exact-pins both `Kevlar` and `Kevlar.Extensions.DependencyInjection`.
 
 Upgrade these packages together. If package versions are managed centrally, assign one version to
-the coupled package set. A partial upgrade fails restore with `NU1608` instead of allowing a mixed
-version deployment that could fail at runtime. `Kevlar.Chaos` uses only public APIs and is not part
-of this lockstep set.
+the coupled package set. A partial upgrade raises the `NU1608` warning but restore can still
+succeed, allowing a mixed-version deployment that could fail at runtime. To reject version skew,
+treat `NU1608` as an error in the consuming project or a shared build properties file:
+
+```xml
+<PropertyGroup>
+  <WarningsAsErrors>$(WarningsAsErrors);NU1608</WarningsAsErrors>
+</PropertyGroup>
+```
+
+`Kevlar.Chaos` uses only public APIs and is not part of this lockstep set.
 
 ## Security support
 

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -58,13 +58,15 @@ dependencies enforce this for `Kevlar.Testing`, `Kevlar.Extensions.Http`,
 so it exact-pins both `Kevlar` and `Kevlar.Extensions.DependencyInjection`.
 
 Upgrade these packages together. If package versions are managed centrally, assign one version to
-the coupled package set. A partial upgrade raises the `NU1608` warning but restore can still
-succeed, allowing a mixed-version deployment that could fail at runtime. To reject version skew,
-treat `NU1608` as an error in the consuming project or a shared build properties file:
+the coupled package set. A satellite-first upgrade can raise the package-downgrade warning
+`NU1605`; other version skew can raise the dependency-constraint warning `NU1608`. Depending on
+client settings, restore can still succeed and allow a mixed-version deployment that fails at
+runtime. To reject version skew, treat both warnings as errors in the consuming project or a
+shared build properties file:
 
 ```xml
 <PropertyGroup>
-  <WarningsAsErrors>$(WarningsAsErrors);NU1608</WarningsAsErrors>
+  <WarningsAsErrors>$(WarningsAsErrors);NU1605;NU1608</WarningsAsErrors>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
## Summary
- describe NU1608 accurately as a warning that does not block restore
- show consumers how to promote NU1608 to an error
- correct the historical changelog claim

Closes #432

## Validation
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-Changelog.ps1`
- `npm ci` and `npm run build` in `docs/`