### PR TITLE
docs: explain .NET Framework setup

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -19,6 +19,7 @@ integrations and testing support.
 ## Protect your first call
 
 ```csharp
+using System.Net.Http;
 using Kevlar;
 
 var shield = Shield.Retry(3);
@@ -32,6 +33,31 @@ using var response = await shield.ExecuteAsync(
 exponential with equal jitter, starting at 250 ms and capped at 30 seconds. Always forward the
 cancellation token passed to your delegate; timeout and hedging strategies use it to stop
 abandoned work.
+
+:::note .NET Framework
+
+The .NET SDK console template does not accept `-f net48`. Create an SDK-style console project,
+then edit its project file to target .NET Framework and enable the language features used above:
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net48</TargetFramework>
+  <LangVersion>latest</LangVersion>
+</PropertyGroup>
+
+<ItemGroup>
+  <Reference Include="System.Net.Http" />
+</ItemGroup>
+```
+
+The HTTP example also needs the explicit `using System.Net.Http;` shown above because .NET
+Framework does not supply that implicit using. Expect MSBuild to generate binding redirects for the
+transitive compatibility dependencies: `Microsoft.Bcl.AsyncInterfaces` 8.0.0,
+`Microsoft.Bcl.TimeProvider` 8.0.1, `Reservoir` 1.4.0,
+`System.Runtime.CompilerServices.Unsafe` 6.1.2, `System.Threading.Tasks.Extensions` 4.6.3, and
+`System.ValueTuple` 4.5.0.
+
+:::
 
 Shields are immutable and thread-safe. Build one and reuse it. Reuse also preserves state: calls
 through the same shield share circuit-breaker and limiter state.

--- a/src/Kevlar/README.md
+++ b/src/Kevlar/README.md
@@ -16,5 +16,27 @@ var shield = Shield
     .CircuitBreaker(consecutiveFailures: 5, breakDuration: TimeSpan.FromSeconds(30));
 ```
 
+## .NET Framework
+
+For .NET Framework 4.6.2 or later, use an SDK-style project and edit the project file manually;
+`dotnet new console` does not accept `-f net48`. The getting-started HTTP sample needs these
+settings and an explicit `using System.Net.Http;`:
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net48</TargetFramework>
+  <LangVersion>latest</LangVersion>
+</PropertyGroup>
+
+<ItemGroup>
+  <Reference Include="System.Net.Http" />
+</ItemGroup>
+```
+
+Expect MSBuild to generate binding redirects for the transitive compatibility dependencies:
+`Microsoft.Bcl.AsyncInterfaces` 8.0.0, `Microsoft.Bcl.TimeProvider` 8.0.1, `Reservoir` 1.4.0,
+`System.Runtime.CompilerServices.Unsafe` 6.1.2, `System.Threading.Tasks.Extensions` 4.6.3, and
+`System.ValueTuple` 4.5.0.
+
 Start with the [Kevlar getting-started guide](https://thomhurst.github.io/Kevlar/docs/getting-started)
 or browse the [API reference](https://thomhurst.github.io/Kevlar/api/index.html).


### PR DESCRIPTION
## Summary
- document the SDK-style net48 project edits required by the first HTTP sample
- add the explicit `System.Net.Http` import and assembly reference
- list expected binding redirects and compatibility dependencies in both getting-started surfaces

Closes #434

## Validation
- `pwsh scripts/Verify-Docs.ps1`
- `dotnet build Kevlar.slnx -c Release -p:Version=1.0.0-local`
- `dotnet pack Kevlar.slnx -c Release --no-build -p:Version=1.0.0-local`
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0-local -NoImplicitUsings`
- `npm ci` and `npm run build` in `docs/`