### PR TITLE
fix(packaging): separate analyzer symbols

### DIFF
--- a/scripts/Verify-Packages.ps1
+++ b/scripts/Verify-Packages.ps1
@@ -104,8 +104,22 @@ function Get-ExpectedSymbolAssets([string]$PackageId)
     if ($PackageId -eq 'Kevlar')
     {
         $assets += @(
-            'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.pdb'
+            'lib/netstandard2.0/Kevlar.Analyzers.pdb'
         )
+    }
+
+    return $assets
+}
+
+function Get-ExpectedAssemblyAssets([string]$PackageId)
+{
+    $assets = @(
+        Get-ExpectedSymbolAssets $PackageId |
+            Where-Object { $_ -ne 'lib/netstandard2.0/Kevlar.Analyzers.pdb' } |
+            ForEach-Object { $_ -replace '\.pdb$', '.dll' })
+    if ($PackageId -eq 'Kevlar')
+    {
+        $assets += 'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.dll'
     }
 
     return $assets
@@ -396,6 +410,12 @@ foreach ($packageId in $expectedDependencies.Keys)
     try
     {
         $entries = @($archive.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+        $packagePdbs = @($entries | Where-Object { $_ -like '*.pdb' })
+        if ($packagePdbs.Count -gt 0)
+        {
+            throw "$packageId package contains PDB assets: $($packagePdbs -join ', ')."
+        }
+
         $nuspecEntry = @($archive.Entries | Where-Object { $_.FullName -like '*.nuspec' })
         Assert-Equal "$packageId nuspec count" $nuspecEntry.Count 1
 
@@ -559,8 +579,7 @@ foreach ($packageId in $expectedDependencies.Keys)
             Assert-Set "$packageId analyzer assets" `
                 ($entries | Where-Object { $_ -match '^analyzers/' }) `
                 @(
-                    'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.dll',
-                    'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.pdb'
+                    'analyzers/dotnet/roslyn4.8/cs/Kevlar.Analyzers.dll'
                 )
         }
         elseif ($entries | Where-Object { $_ -match '^analyzers/' })
@@ -737,7 +756,7 @@ try
     {
         $packageFile = Join-Path $packageDirectory "$packageId.$Version.nupkg"
         $repeatPackageFile = Join-Path $repeatPackages "$packageId.$Version.nupkg"
-        foreach ($assemblyAsset in (Get-ExpectedSymbolAssets $packageId) -replace '\.pdb$', '.dll')
+        foreach ($assemblyAsset in Get-ExpectedAssemblyAssets $packageId)
         {
             Assert-Equal `
                 "$packageId deterministic assembly $assemblyAsset" `

--- a/src/Kevlar/Kevlar.csproj
+++ b/src/Kevlar/Kevlar.csproj
@@ -31,11 +31,22 @@
           Pack="true"
           PackagePath="analyzers/dotnet/roslyn4.8/cs"
           Visible="false" />
-    <None Include="$(ArtifactsPath)\bin\Kevlar.Analyzers\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.pdb"
-          Pack="true"
-          PackagePath="analyzers/dotnet/roslyn4.8/cs"
-          Visible="false" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificDebugSymbolsInPackage>
+      $(TargetsForTfmSpecificDebugSymbolsInPackage);IncludeAnalyzerDebugSymbols
+    </TargetsForTfmSpecificDebugSymbolsInPackage>
+  </PropertyGroup>
+
+  <Target Name="IncludeAnalyzerDebugSymbols" Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup>
+      <TfmSpecificDebugSymbolsFile Include="$(ArtifactsPath)\bin\Kevlar.Analyzers\$(Configuration.ToLowerInvariant())\Kevlar.Analyzers.pdb">
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+        <TargetPath>Kevlar.Analyzers.pdb</TargetPath>
+      </TfmSpecificDebugSymbolsFile>
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Kevlar.Tests" />


### PR DESCRIPTION
## Summary
- remove `Kevlar.Analyzers.pdb` from the main `Kevlar.nupkg`
- preserve analyzer symbols and SourceLink in `Kevlar.snupkg`
- reject PDB assets in every main package and verify analyzer DLL determinism independently from symbol layout

## Validation
- `dotnet build Kevlar.slnx -c Release --nologo`
- `dotnet pack Kevlar.slnx -c Release --no-build -p:PackageOutputPath=artifacts/package/issue437-local --nologo`
- `pwsh scripts/Verify-Packages.ps1 -PackagesPath artifacts/package/issue437-local -Version 0.0.0-local`

Closes #437