### PR TITLE
docs(retry): document defaults and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ using var response = await shield.ExecuteAsync(
     ct => client.GetAsync("https://example.com", ct));
 ```
 
-`Retry(3)` means three retries after the initial call: up to 4 total attempts. It uses exponential
-backoff with equal jitter by default. The cancellation token passed to your delegate is
-important—it is how timeouts and abandoned attempts stop the underlying work.
+`Retry(3)` means three retries after the initial call: up to 4 total attempts. Its default backoff
+is exponential from 250 ms with factor 2, equal jitter, and a 30-second cap. It retries ordinary
+exceptions such as `HttpRequestException`, but treats the `TaskCanceledException` from
+`HttpClient.Timeout` as cancellation. To retry that timeout and HTTP 5xx/429 responses, use
+`HttpShield.WhenTransient()` from `Kevlar.Extensions.Http`. The cancellation token passed to your
+delegate is important—it is how timeouts and abandoned attempts stop the underlying work.
 
 When you combine strategies, the first strategy is the outermost, just like ASP.NET middleware:
 

--- a/docs/api/Kevlar.Shield-1.yml
+++ b/docs/api/Kevlar.Shield-1.yml
@@ -378,7 +378,12 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Retries handled outcomes up to <code class="paramref">maxRetries</code> times with the default exponential jittered backoff.
+  summary: >-
+    Retries handled outcomes up to <code class="paramref">maxRetries</code> times with
+
+    <xref href="Kevlar.Backoff.Default" data-throw-if-not-resolved="false"></xref>: exponential from 250 milliseconds with factor 2, equal
+
+    jitter, and a 30-second cap.
   example: []
   syntax:
     content: public Shield<TResult> Retry(int maxRetries = 3)
@@ -482,7 +487,10 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Retries handled outcomes indefinitely with the default exponential jittered backoff.
+  summary: >-
+    Retries handled outcomes indefinitely with <xref href="Kevlar.Backoff.Default" data-throw-if-not-resolved="false"></xref>: exponential
+
+    from 250 milliseconds with factor 2, equal jitter, and a 30-second cap.
   example: []
   syntax:
     content: public Shield<TResult> RetryForever()
@@ -4858,6 +4866,13 @@ references:
   - name: " "
   - name: TResult
   - name: )
+- uid: Kevlar.Backoff.Default
+  commentId: P:Kevlar.Backoff.Default
+  isExternal: true
+  href: Kevlar.Backoff.html#Kevlar_Backoff_Default
+  name: Default
+  nameWithType: Backoff.Default
+  fullName: Kevlar.Backoff.Default
 - uid: Kevlar.Shield`1.Retry*
   commentId: Overload:Kevlar.Shield`1.Retry
   isExternal: true

--- a/docs/api/Kevlar.Shield.yml
+++ b/docs/api/Kevlar.Shield.yml
@@ -170,7 +170,12 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Retries failed executions up to <code class="paramref">maxRetries</code> times with the default exponential jittered backoff.
+  summary: >-
+    Retries failed executions up to <code class="paramref">maxRetries</code> times with
+
+    <xref href="Kevlar.Backoff.Default" data-throw-if-not-resolved="false"></xref>: exponential from 250 milliseconds with factor 2, equal
+
+    jitter, and a 30-second cap.
   example: []
   syntax:
     content: public static Shield Retry(int maxRetries = 3)
@@ -269,7 +274,10 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Retries failed executions indefinitely with the default exponential jittered backoff.
+  summary: >-
+    Retries failed executions indefinitely with <xref href="Kevlar.Backoff.Default" data-throw-if-not-resolved="false"></xref>: exponential
+
+    from 250 milliseconds with factor 2, equal jitter, and a 30-second cap.
   example: []
   syntax:
     content: public static Shield RetryForever()
@@ -10061,6 +10069,13 @@ references:
     isExternal: true
     href: https://learn.microsoft.com/dotnet/api/system.threading.cancellationtoken
   - name: )
+- uid: Kevlar.Backoff.Default
+  commentId: P:Kevlar.Backoff.Default
+  isExternal: true
+  href: Kevlar.Backoff.html#Kevlar_Backoff_Default
+  name: Default
+  nameWithType: Backoff.Default
+  fullName: Kevlar.Backoff.Default
 - uid: Kevlar.Shield.Retry*
   commentId: Overload:Kevlar.Shield.Retry
   isExternal: true

--- a/docs/api/Kevlar.ShieldExtensions.yml
+++ b/docs/api/Kevlar.ShieldExtensions.yml
@@ -79,7 +79,12 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Appends a retry of handled exceptions, up to <code class="paramref">maxRetries</code> times, with the default exponential jittered backoff.
+  summary: >-
+    Appends a retry of handled exceptions, up to <code class="paramref">maxRetries</code> times, with
+
+    <xref href="Kevlar.Backoff.Default" data-throw-if-not-resolved="false"></xref>: exponential from 250 milliseconds with factor 2, equal
+
+    jitter, and a 30-second cap.
   example: []
   syntax:
     content: public static Shield Retry(this Shield shield, int maxRetries = 3)
@@ -189,7 +194,10 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Appends a retry that never gives up, with the default exponential jittered backoff.
+  summary: >-
+    Appends a retry that never gives up, with <xref href="Kevlar.Backoff.Default" data-throw-if-not-resolved="false"></xref>: exponential from
+
+    250 milliseconds with factor 2, equal jitter, and a 30-second cap.
   example: []
   syntax:
     content: public static Shield RetryForever(this Shield shield)
@@ -1350,6 +1358,13 @@ references:
   name: System
   nameWithType: System
   fullName: System
+- uid: Kevlar.Backoff.Default
+  commentId: P:Kevlar.Backoff.Default
+  isExternal: true
+  href: Kevlar.Backoff.html#Kevlar_Backoff_Default
+  name: Default
+  nameWithType: Backoff.Default
+  fullName: Kevlar.Backoff.Default
 - uid: Kevlar.ShieldExtensions.Retry*
   commentId: Overload:Kevlar.ShieldExtensions.Retry
   isExternal: true

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -46,9 +46,19 @@ if (attempts != 4)
 }
 ```
 
-:::tip The default is the good one
-Bare `Shield.Retry(3)` gives exponential backoff **with equal jitter**, 250ms base, capped at 30s. Jitter prevents retry storms where every failed caller retries in lockstep; you'd have configured this anyway.
-:::
+## Defaults
+
+Bare `Retry(n)` and `RetryForever()` use `Backoff.Default`:
+
+| Setting | Default |
+|---|---|
+| Curve | Exponential |
+| Base delay | 250 ms |
+| Factor | 2 |
+| Jitter | Equal: each delay is scaled by a value in [0.5, 1.5) |
+| Maximum delay | 30 seconds |
+
+The cap also applies to `RetryForever()`. Equal jitter prevents callers from retrying in lockstep.
 
 ## Backoff
 

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -78,7 +78,11 @@ public sealed class Shield : IShieldLifecycle
 
     // ── Static factories ────────────────────────────────────────────────────────────────
 
-    /// <summary>Retries failed executions up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
+    /// <summary>
+    /// Retries failed executions up to <paramref name="maxRetries"/> times with
+    /// <see cref="Backoff.Default"/>: exponential from 250 milliseconds with factor 2, equal
+    /// jitter, and a 30-second cap.
+    /// </summary>
     /// <param name="maxRetries">
     /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
     /// total attempts — the initial call plus 3 retries.
@@ -100,7 +104,10 @@ public sealed class Shield : IShieldLifecycle
     /// </remarks>
     public static Shield Retry(Action<RetryOptions> configure) => ShieldExtensions.Retry(Empty, configure);
 
-    /// <summary>Retries failed executions indefinitely with the default exponential jittered backoff.</summary>
+    /// <summary>
+    /// Retries failed executions indefinitely with <see cref="Backoff.Default"/>: exponential
+    /// from 250 milliseconds with factor 2, equal jitter, and a 30-second cap.
+    /// </summary>
     public static Shield RetryForever() => ShieldExtensions.RetryForever(Empty);
 
     /// <summary>Retries failed executions indefinitely with the given backoff.</summary>

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -9,7 +9,11 @@ namespace Kevlar;
 /// </summary>
 public static class ShieldExtensions
 {
-    /// <summary>Appends a retry of handled exceptions, up to <paramref name="maxRetries"/> times, with the default exponential jittered backoff.</summary>
+    /// <summary>
+    /// Appends a retry of handled exceptions, up to <paramref name="maxRetries"/> times, with
+    /// <see cref="Backoff.Default"/>: exponential from 250 milliseconds with factor 2, equal
+    /// jitter, and a 30-second cap.
+    /// </summary>
     /// <param name="shield">The shield to append the retry to.</param>
     /// <param name="maxRetries">
     /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
@@ -59,7 +63,10 @@ public static class ShieldExtensions
         return shield.Append(new RetryStrategy(options, judge));
     }
 
-    /// <summary>Appends a retry that never gives up, with the default exponential jittered backoff.</summary>
+    /// <summary>
+    /// Appends a retry that never gives up, with <see cref="Backoff.Default"/>: exponential from
+    /// 250 milliseconds with factor 2, equal jitter, and a 30-second cap.
+    /// </summary>
     /// <param name="shield">The shield to append the retry to.</param>
     public static Shield RetryForever(this Shield shield) => shield.RetryForever(Backoff.Default);
 

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -123,7 +123,11 @@ public sealed class Shield<TResult> : IShieldLifecycle
 
     // ── Strategy chaining ───────────────────────────────────────────────────────────────
 
-    /// <summary>Retries handled outcomes up to <paramref name="maxRetries"/> times with the default exponential jittered backoff.</summary>
+    /// <summary>
+    /// Retries handled outcomes up to <paramref name="maxRetries"/> times with
+    /// <see cref="Backoff.Default"/>: exponential from 250 milliseconds with factor 2, equal
+    /// jitter, and a 30-second cap.
+    /// </summary>
     /// <param name="maxRetries">
     /// The number of <em>retries</em>, not the number of attempts: <c>Retry(3)</c> makes up to 4
     /// total attempts — the initial call plus 3 retries.
@@ -174,7 +178,10 @@ public sealed class Shield<TResult> : IShieldLifecycle
         return Append(RetryStrategy.Create(options, judge));
     }
 
-    /// <summary>Retries handled outcomes indefinitely with the default exponential jittered backoff.</summary>
+    /// <summary>
+    /// Retries handled outcomes indefinitely with <see cref="Backoff.Default"/>: exponential
+    /// from 250 milliseconds with factor 2, equal jitter, and a 30-second cap.
+    /// </summary>
     public Shield<TResult> RetryForever() => RetryForever(Backoff.Default);
 
     /// <summary>Retries handled outcomes indefinitely with the given backoff.</summary>


### PR DESCRIPTION
## Summary
- clarify that core retry treats `HttpClient.Timeout` as cancellation and point HTTP users to `HttpShield.WhenTransient()`
- document the exact default exponential curve, jitter, and cap across README, API comments, and retry guide
- refresh generated API metadata

Closes #435

## Validation
- `dotnet build Kevlar.slnx -c Release -p:Version=1.0.0-local`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m` (1275 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (1309 passed)
- `pwsh scripts/Verify-DocSnippets.ps1 -PackagesPath artifacts/package/release -Version 1.0.0-local -NoImplicitUsings`
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-ApiDocs.ps1`
- `npm ci` and `npm run build` in `docs/`