### PR TITLE
docs: explain runtime caveats

### DIFF
--- a/docs/api/Kevlar.CircuitBreakerMonitor.yml
+++ b/docs/api/Kevlar.CircuitBreakerMonitor.yml
@@ -53,7 +53,16 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Forces every bound circuit open. Executions are rejected until <xref href="Kevlar.CircuitBreakerMonitor.Reset" data-throw-if-not-resolved="false"></xref> is called.
+  summary: >-
+    Forces every bound circuit open. Executions are rejected until <xref href="Kevlar.CircuitBreakerMonitor.Reset" data-throw-if-not-resolved="false"></xref> is called.
+
+    A non-reentrant caller blocks until transition observers complete; use
+
+    <xref href="Kevlar.CircuitBreakerMonitor.IsolateAsync" data-throw-if-not-resolved="false"></xref> when an <xref href="Kevlar.CircuitBreakerOptions.OnStateChanged" data-throw-if-not-resolved="false"></xref>
+
+    callback may yield. A call made from a transition observer queues its transition and returns
+
+    before that queued transition reaches observers.
   example: []
   syntax:
     content: public void Isolate()
@@ -104,7 +113,16 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Closes every bound circuit and clears all failure metrics.
+  summary: >-
+    Closes every bound circuit and clears all failure metrics. A non-reentrant caller blocks
+
+    until transition observers complete; use <xref href="Kevlar.CircuitBreakerMonitor.ResetAsync" data-throw-if-not-resolved="false"></xref> when an
+
+    <xref href="Kevlar.CircuitBreakerOptions.OnStateChanged" data-throw-if-not-resolved="false"></xref> callback may yield. A call made from a
+
+    transition observer queues its transition and returns before that queued transition reaches
+
+    observers.
   example: []
   syntax:
     content: public void Reset()
@@ -464,6 +482,34 @@ references:
     href: Kevlar.CircuitBreakerMonitor.html#Kevlar_CircuitBreakerMonitor_Reset
   - name: (
   - name: )
+- uid: Kevlar.CircuitBreakerMonitor.IsolateAsync
+  commentId: M:Kevlar.CircuitBreakerMonitor.IsolateAsync
+  isExternal: true
+  href: Kevlar.CircuitBreakerMonitor.html#Kevlar_CircuitBreakerMonitor_IsolateAsync
+  name: IsolateAsync()
+  nameWithType: CircuitBreakerMonitor.IsolateAsync()
+  fullName: Kevlar.CircuitBreakerMonitor.IsolateAsync()
+  spec.csharp:
+  - uid: Kevlar.CircuitBreakerMonitor.IsolateAsync
+    name: IsolateAsync
+    isExternal: true
+    href: Kevlar.CircuitBreakerMonitor.html#Kevlar_CircuitBreakerMonitor_IsolateAsync
+  - name: (
+  - name: )
+  spec.vb:
+  - uid: Kevlar.CircuitBreakerMonitor.IsolateAsync
+    name: IsolateAsync
+    isExternal: true
+    href: Kevlar.CircuitBreakerMonitor.html#Kevlar_CircuitBreakerMonitor_IsolateAsync
+  - name: (
+  - name: )
+- uid: Kevlar.CircuitBreakerOptions.OnStateChanged
+  commentId: P:Kevlar.CircuitBreakerOptions.OnStateChanged
+  isExternal: true
+  href: Kevlar.CircuitBreakerOptions.html#Kevlar_CircuitBreakerOptions_OnStateChanged
+  name: OnStateChanged
+  nameWithType: CircuitBreakerOptions.OnStateChanged
+  fullName: Kevlar.CircuitBreakerOptions.OnStateChanged
 - uid: Kevlar.CircuitBreakerMonitor.Isolate*
   commentId: Overload:Kevlar.CircuitBreakerMonitor.Isolate
   isExternal: true
@@ -583,13 +629,6 @@ references:
   name: CircuitState
   nameWithType: CircuitState
   fullName: Kevlar.CircuitState
-- uid: Kevlar.CircuitBreakerOptions.OnStateChanged
-  commentId: P:Kevlar.CircuitBreakerOptions.OnStateChanged
-  isExternal: true
-  href: Kevlar.CircuitBreakerOptions.html#Kevlar_CircuitBreakerOptions_OnStateChanged
-  name: OnStateChanged
-  nameWithType: CircuitBreakerOptions.OnStateChanged
-  fullName: Kevlar.CircuitBreakerOptions.OnStateChanged
 - uid: Kevlar.CircuitBreakerMonitor.Isolate
   commentId: M:Kevlar.CircuitBreakerMonitor.Isolate
   isExternal: true

--- a/docs/api/Kevlar.CircuitBreakerOptions-1.yml
+++ b/docs/api/Kevlar.CircuitBreakerOptions-1.yml
@@ -446,7 +446,9 @@ items:
 
     <a href="https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/default">default</a> from a synchronous callback. The event context is valid only
 
-    until the returned task completes.
+    until the returned task completes. A publisher arriving during an active drain waits for
+
+    the earlier handlers; an execution may therefore occupy a thread-pool thread until they return.
   example: []
   syntax:
     content: public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChanged { get; set; }

--- a/docs/api/Kevlar.CircuitBreakerOptions-1.yml
+++ b/docs/api/Kevlar.CircuitBreakerOptions-1.yml
@@ -446,9 +446,13 @@ items:
 
     <a href="https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/default">default</a> from a synchronous callback. The event context is valid only
 
-    until the returned task completes. A publisher arriving during an active drain waits for
+    until the returned task completes. A non-reentrant publisher arriving during an active drain
 
-    the earlier handlers; an execution may therefore occupy a thread-pool thread until they return.
+    waits for the earlier handlers; an execution may therefore occupy a thread-pool thread until
+
+    they return. A publisher reentered from <code>OnStateChanged</code> or <code>StateChanged</code> is queued
+
+    and returns before the queued transition's observers run.
   example: []
   syntax:
     content: public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChanged { get; set; }

--- a/docs/api/Kevlar.CircuitBreakerOptions.yml
+++ b/docs/api/Kevlar.CircuitBreakerOptions.yml
@@ -353,9 +353,13 @@ items:
 
     <a href="https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/default">default</a> from a synchronous callback. The event context is valid only
 
-    until the returned task completes. A publisher arriving during an active drain waits for
+    until the returned task completes. A non-reentrant publisher arriving during an active drain
 
-    the earlier handlers; an execution may therefore occupy a thread-pool thread until they return.
+    waits for the earlier handlers; an execution may therefore occupy a thread-pool thread until
+
+    they return. A publisher reentered from <code>OnStateChanged</code> or <code>StateChanged</code> is queued
+
+    and returns before the queued transition's observers run.
   example: []
   syntax:
     content: public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChanged { get; set; }

--- a/docs/api/Kevlar.CircuitBreakerOptions.yml
+++ b/docs/api/Kevlar.CircuitBreakerOptions.yml
@@ -353,7 +353,9 @@ items:
 
     <a href="https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/default">default</a> from a synchronous callback. The event context is valid only
 
-    until the returned task completes.
+    until the returned task completes. A publisher arriving during an active drain waits for
+
+    the earlier handlers; an execution may therefore occupy a thread-pool thread until they return.
   example: []
   syntax:
     content: public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChanged { get; set; }

--- a/docs/api/Kevlar.ConcurrencyLimitOptions.yml
+++ b/docs/api/Kevlar.ConcurrencyLimitOptions.yml
@@ -126,7 +126,10 @@ items:
   assemblies:
   - Kevlar
   namespace: Kevlar
-  summary: Maximum executions allowed to wait for a slot. Default 0 (reject immediately when full).
+  summary: >-
+    Maximum executions allowed to wait for a slot. Default 0 (reject immediately when full).
+
+    The queue has no built-in timeout; compose a timeout outside this strategy to bound the wait.
   example: []
   syntax:
     content: public int QueueLimit { get; set; }

--- a/docs/api/Kevlar.HedgeOptions-1.yml
+++ b/docs/api/Kevlar.HedgeOptions-1.yml
@@ -31,6 +31,10 @@ items:
     <xref href="Kevlar.HedgeOptions%601" data-throw-if-not-resolved="false"></xref> and <xref href="Kevlar.HedgeOptions" data-throw-if-not-resolved="false"></xref> are standalone sibling types
 
     with matching shared property names and defaults.
+
+    If no attempt produces an acceptable outcome, the final outcome processed by the coordinator
+
+    surfaces; selection among attempts already completed is not chronological.
   example: []
   syntax:
     content: public sealed class HedgeOptions<TResult>
@@ -265,7 +269,11 @@ items:
   summary: >-
     Time to wait before launching the next attempt while the current ones are still running.
 
-    <xref href="System.TimeSpan.Zero" data-throw-if-not-resolved="false"></xref> launches all attempts at once;
+    <xref href="System.TimeSpan.Zero" data-throw-if-not-resolved="false"></xref> removes timer staggering and starts scheduling the original and
+
+    all additional attempts, even when the original completes synchronously. Callbacks and
+
+    cancellation checks can still delay or prevent an additional delegate from starting;
 
     <xref href="System.Threading.Timeout.InfiniteTimeSpan" data-throw-if-not-resolved="false"></xref> hedges only on failure.
 

--- a/docs/api/Kevlar.HedgeOptions.yml
+++ b/docs/api/Kevlar.HedgeOptions.yml
@@ -35,6 +35,10 @@ items:
 
     Hedging requires asynchronous execution.
 
+    If no attempt produces an acceptable outcome, the final outcome processed by the coordinator
+
+    surfaces; selection among attempts already completed is not chronological.
+
     Before an additional attempt starts, callbacks run in this order: <xref href="Kevlar.HedgeOptions.DelayGenerator" data-throw-if-not-resolved="false"></xref>,
 
     <xref href="Kevlar.HedgeOptions.OnHedge" data-throw-if-not-resolved="false"></xref>, then <xref href="Kevlar.HedgeOptions.ActionGenerator" data-throw-if-not-resolved="false"></xref>. Caller cancellation is checked
@@ -197,7 +201,11 @@ items:
   summary: >-
     Time to wait before launching the next attempt while the current ones are still running.
 
-    <xref href="System.TimeSpan.Zero" data-throw-if-not-resolved="false"></xref> launches all attempts at once;
+    <xref href="System.TimeSpan.Zero" data-throw-if-not-resolved="false"></xref> removes timer staggering and starts scheduling the original and
+
+    all additional attempts, even when the original completes synchronously. Callbacks and
+
+    cancellation checks can still delay or prevent an additional delegate from starting;
 
     <xref href="System.Threading.Timeout.InfiniteTimeSpan" data-throw-if-not-resolved="false"></xref> hedges only on failure.
 

--- a/docs/api/Kevlar.KevlarDiagnostics.yml
+++ b/docs/api/Kevlar.KevlarDiagnostics.yml
@@ -220,7 +220,9 @@ items:
 
     subscriber is isolated: subscriber failures are swallowed and do not prevent later
 
-    subscribers from running.
+    subscribers from running. This event is process-global, not scoped to a shield or service
+
+    provider; unsubscribe handlers when their lifetime ends.
   example: []
   syntax:
     content: public static event Action<CallbackErrorEvent>? OnCallbackError

--- a/docs/api/Kevlar.KevlarProperties.yml
+++ b/docs/api/Kevlar.KevlarProperties.yml
@@ -27,6 +27,10 @@ items:
     custom data between the caller, execution delegate, and strategy callbacks. The bag is
 
     pooled with its context and must not be retained beyond the current callback or delegate.
+
+    A completion callback receives this same live bag immediately before it is recycled; copy
+
+    required values into caller-owned state rather than retaining the bag.
   example: []
   syntax:
     content: public sealed class KevlarProperties

--- a/docs/api/Kevlar.RetryOptions-1.yml
+++ b/docs/api/Kevlar.RetryOptions-1.yml
@@ -42,6 +42,12 @@ items:
     If the caller's cancellation token is cancelled by the time the callbacks complete, the retry
 
     stops and surfaces caller cancellation.
+
+    Cancellation during the retry delay surfaces an <xref href="System.OperationCanceledException" data-throw-if-not-resolved="false"></xref> with
+
+    no inner exception. The handled outcome is no longer retained, and <xref href="Kevlar.RetryOptions%601.OnRetry" data-throw-if-not-resolved="false"></xref> has
+
+    already run for the suppressed attempt.
   example: []
   syntax:
     content: public sealed class RetryOptions<TResult>
@@ -500,6 +506,14 @@ references:
   fullName: Kevlar.RetryOptions<TResult>.OnRetry
   nameWithType.vb: RetryOptions(Of TResult).OnRetry
   fullName.vb: Kevlar.RetryOptions(Of TResult).OnRetry
+- uid: System.OperationCanceledException
+  commentId: T:System.OperationCanceledException
+  parent: System
+  isExternal: true
+  href: https://learn.microsoft.com/dotnet/api/system.operationcanceledexception
+  name: OperationCanceledException
+  nameWithType: OperationCanceledException
+  fullName: System.OperationCanceledException
 - uid: Kevlar
   commentId: N:Kevlar
   isExternal: true

--- a/docs/api/Kevlar.RetryOptions.yml
+++ b/docs/api/Kevlar.RetryOptions.yml
@@ -35,6 +35,12 @@ items:
     returning <a href="https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/default">default</a>) add no overhead and remain compatible with synchronous
 
     <code>Execute</code>.
+
+    Cancellation during the retry delay surfaces an <xref href="System.OperationCanceledException" data-throw-if-not-resolved="false"></xref> with
+
+    no inner exception. The handled outcome is no longer retained, and <xref href="Kevlar.RetryOptions.OnRetry" data-throw-if-not-resolved="false"></xref> has
+
+    already run for the suppressed attempt.
   example: []
   syntax:
     content: public sealed class RetryOptions
@@ -306,6 +312,14 @@ references:
   name: OnRetry
   nameWithType: RetryOptions.OnRetry
   fullName: Kevlar.RetryOptions.OnRetry
+- uid: System.OperationCanceledException
+  commentId: T:System.OperationCanceledException
+  parent: System
+  isExternal: true
+  href: https://learn.microsoft.com/dotnet/api/system.operationcanceledexception
+  name: OperationCanceledException
+  nameWithType: OperationCanceledException
+  fullName: System.OperationCanceledException
 - uid: Kevlar
   commentId: N:Kevlar
   isExternal: true

--- a/docs/api/Kevlar.Strategy.yml
+++ b/docs/api/Kevlar.Strategy.yml
@@ -78,6 +78,12 @@ items:
   - Kevlar
   namespace: Kevlar
   summary: Executes the strategy around the rest of the pipeline.
+  remarks: >-
+    Returning an incomplete value task during synchronous shield execution causes the execution
+
+    boundary to block until it completes. Custom implementations should avoid capturing a
+
+    single-threaded synchronization context and should be invoked asynchronously when they yield.
   example: []
   syntax:
     content: public abstract ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)

--- a/docs/api/Kevlar.TimeoutOptions.yml
+++ b/docs/api/Kevlar.TimeoutOptions.yml
@@ -29,6 +29,14 @@ items:
     after timer cleanup and restoration of the caller's cancellation token. Hooks that complete
 
     synchronously add no overhead and remain compatible with synchronous <code>Execute</code>.
+
+    The strategy always awaits the delegate and translates only a direct
+
+    <xref href="System.OperationCanceledException" data-throw-if-not-resolved="false"></xref> into <xref href="Kevlar.TimeoutExceededException" data-throw-if-not-resolved="false"></xref>. A blocking
+
+    synchronous delegate that ignores cancellation cannot be timed out, and a wrapped cancellation
+
+    exception surfaces unchanged.
   example: []
   syntax:
     content: public sealed class TimeoutOptions
@@ -189,6 +197,21 @@ references:
   name: OnTimeout
   nameWithType: TimeoutOptions.OnTimeout
   fullName: Kevlar.TimeoutOptions.OnTimeout
+- uid: System.OperationCanceledException
+  commentId: T:System.OperationCanceledException
+  parent: System
+  isExternal: true
+  href: https://learn.microsoft.com/dotnet/api/system.operationcanceledexception
+  name: OperationCanceledException
+  nameWithType: OperationCanceledException
+  fullName: System.OperationCanceledException
+- uid: Kevlar.TimeoutExceededException
+  commentId: T:Kevlar.TimeoutExceededException
+  isExternal: true
+  href: Kevlar.TimeoutExceededException.html
+  name: TimeoutExceededException
+  nameWithType: TimeoutExceededException
+  fullName: Kevlar.TimeoutExceededException
 - uid: Kevlar
   commentId: N:Kevlar
   isExternal: true

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -53,6 +53,8 @@ Kevlar invokes the first user delegate inline when no preceding strategy defers 
 
 Synchronous `Execute` never pumps a `SynchronizationContext`. Retry delays and limiter queues block
 the calling thread until they complete, so prefer `ExecuteAsync` for delayed or queued work.
+When a retry delay uses `FakeTimeProvider`, another thread must advance that provider; otherwise the
+calling thread remains blocked indefinitely.
 
 ## Synchronous execution compatibility
 
@@ -76,6 +78,10 @@ rejected statically, before the action runs:
 | Multi-attempt hedging | Throws `NotSupportedException` before the action runs |
 | Any `UseRateLimiter` adapter | Throws `NotSupportedException` before the action runs; use `ExecuteAsync` |
 | Custom strategy returning an incomplete `ValueTask` | Blocks at the execution boundary; custom code must avoid capturing a single-threaded `SynchronizationContext` |
+
+Built-in strategies do not introduce an incomplete strategy-body `ValueTask` on the synchronous
+path. A custom `Strategy.ExecuteAsync` can, which turns synchronous `Execute` into
+sync-over-async; avoid captured contexts and prefer asynchronous execution for such strategies.
 
 [`KEV012`](analyzers.md#kev012-async-configuration-with-synchronous-execute) reports `async`
 delegates assigned to hooks or fallback recovery on a shield that is passed to `Execute`. A shield
@@ -198,7 +204,9 @@ await shield.ExecuteWithContextAsync(
 ```
 
 The callback receives `KevlarProperties`, not the pooled `KevlarContext`, so it cannot keep the
-execution alive accidentally. Copy any values you need into caller-owned state during the callback.
+execution alive accidentally. It is still the live pooled property bag and is recycled immediately
+after the callback returns. Copy any values you need into caller-owned state during the callback;
+never store the `KevlarProperties` reference for later use.
 Exceptions thrown by `onCompleted` are ignored and never replace the execution result or exception.
 For hedging, the callback sees properties from the winning attempt.
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -292,6 +292,10 @@ through `KevlarDiagnostics.OnCallbackError`, increments `kevlar.callback_errors`
 Each diagnostics subscriber is isolated too: one throwing subscriber cannot prevent later
 subscribers from receiving the error.
 
+`KevlarDiagnostics.OnCallbackError` is process-global, not scoped to a shield or dependency
+injection container. Unsubscribe handlers when their lifetime ends, especially in tests, to avoid
+cross-test callbacks and retained state.
+
 This differs from Polly, where a strategy-hook exception propagates to the caller. During migration,
 use `KevlarDiagnostics.OnCallbackError`, `AddKevlarLogging`, or `TelemetryRecorder` in tests to keep
 hook failures visible. See [semantic differences](polly-migration.md#semantic-differences).

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -148,7 +148,9 @@ and an empty property bag. Callbacks run outside the circuit lock, so they can r
 the synchronous or asynchronous monitor controls; a reentrant transition is queued behind the
 transition currently being delivered. Use `ResetAsync()` and `IsolateAsync()` when `OnStateChanged`
 may yield so the calling thread is not blocked; these methods await every bound breaker in binding
-order. If an observer throws,
+order. Transition publication is serialized per breaker. A publisher arriving while another thread
+drains observers waits for that drain; an execution can therefore occupy a thread-pool thread until
+the earlier handlers return. If an observer throws,
 later observers still run and the circuit keeps its new, usable state. Observer failures are
 reported through `KevlarDiagnostics.OnCallbackError` under the shared
 [callback-failure contract](../observability.md#callback-failures) and never replace an execution

--- a/docs/docs/strategies/concurrency-limit.md
+++ b/docs/docs/strategies/concurrency-limit.md
@@ -56,6 +56,9 @@ Cancelling a queued execution frees its queue place when the asynchronous wait o
 Queued cancellation is not rejection and invokes neither rejection hook. A pre-cancelled caller is
 stopped at the shield boundary before the limiter runs.
 
+`ConcurrencyLimit` has no queue timeout. To bound time spent waiting for a slot, compose a timeout
+outside it: `Shield.Timeout(queueBudget).ConcurrencyLimit(maxConcurrency, queueLimit: queueLimit)`.
+
 ## Why concurrency limits
 
 This is the classic *bulkhead* pattern, named after ship compartments: a breach floods one compartment, not the hull. Give each downstream dependency its own concurrency-limited shield and a slow dependency saturates *its* 10 slots — while the rest of your service keeps breathing. Kevlar names the strategy for what it does rather than the metaphor.

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -112,6 +112,10 @@ zero/infinite meanings apply. Generator exceptions fail the execution and cancel
 - `Timeout.InfiniteTimeSpan` — never hedge on latency; launch the next attempt **only when the previous one fails**.
 - Any delay: a handled failure always launches the next attempt *immediately*, without waiting out the rest of the delay.
 
+Zero delay launches the primary plus all `MaxHedgedAttempts` immediately, even when the primary
+delegate completes synchronously. If no attempt produces an acceptable outcome, the last completed
+outcome surfaces.
+
 ## The rules
 
 :::warning Your delegate runs concurrently

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -112,9 +112,11 @@ zero/infinite meanings apply. Generator exceptions fail the execution and cancel
 - `Timeout.InfiniteTimeSpan` — never hedge on latency; launch the next attempt **only when the previous one fails**.
 - Any delay: a handled failure always launches the next attempt *immediately*, without waiting out the rest of the delay.
 
-Zero delay launches the primary plus all `MaxHedgedAttempts` immediately, even when the primary
-delegate completes synchronously. If no attempt produces an acceptable outcome, the last completed
-outcome surfaces.
+Zero delay removes timer staggering and starts scheduling the primary plus all
+`MaxHedgedAttempts`, even when the primary delegate completes synchronously. Each additional
+delegate still waits for its callbacks and cancellation checks, so a yielding callback can delay or
+prevent its start. If no attempt produces an acceptable outcome, the final outcome processed by the
+coordinator surfaces; do not rely on chronological completion order when several are already done.
 
 ## The rules
 

--- a/docs/docs/strategies/retry.md
+++ b/docs/docs/strategies/retry.md
@@ -106,6 +106,11 @@ and identify the options type, property, and offending value.
 
 Order per retry: retry metrics are recorded → backoff computes the delay → effective cap (`MaxDelay ?? Backoff.MaxDelay`) clamps it → the awaited `DelayGenerator` may override it → the awaited `OnRetry` sees the final delay and handled outcome → a superseded disposable result is disposed → sleep. The generator's `null` and negative results are ignored, and the effective cap clamps its override.
 
+If cancellation arrives during that sleep, the next attempt never starts. Cancellation surfaces as
+an `OperationCanceledException` with no `InnerException`; the failure that triggered the retry is
+not retained. The `kevlar.retries` measurement and `OnRetry` have already run for that suppressed
+attempt, matching Polly's ordering.
+
 When result handling triggers another attempt, Kevlar disposes the handled result before the next
 attempt starts. It prefers `IAsyncDisposable.DisposeAsync()` when a result implements both disposal
 interfaces. `OnRetry` runs first so it can inspect the live result. The final result returned to the

--- a/docs/docs/strategies/timeout.md
+++ b/docs/docs/strategies/timeout.md
@@ -46,6 +46,12 @@ Two behaviours worth knowing:
   increments `kevlar.timeouts` with `outcome=ignored`, and does not invoke `OnTimeout`.
 - Cancellation from your own outer token is **not** reported as a timeout — it propagates as a normal `OperationCanceledException`.
 
+The strategy always awaits the delegate; it never returns early or abandons work. Consequently,
+synchronous `Execute` cannot time out a blocking delegate that ignores its token. Timeout
+classification also requires the delegate's direct outcome to be `OperationCanceledException`.
+Wrapping that cancellation in `AggregateException` or another exception surfaces the wrapper
+unchanged, and an outer retry may handle it like any other failure.
+
 ## Cancellation arbitration
 
 When cancellation signals overlap, the outcome is decided after the delegate completes:

--- a/src/Kevlar/KevlarDiagnostics.cs
+++ b/src/Kevlar/KevlarDiagnostics.cs
@@ -69,7 +69,8 @@ public static class KevlarDiagnostics
     /// <summary>
     /// Raised when a strategy notification, observer, or superseded-result disposal throws. Each
     /// subscriber is isolated: subscriber failures are swallowed and do not prevent later
-    /// subscribers from running.
+    /// subscribers from running. This event is process-global, not scoped to a shield or service
+    /// provider; unsubscribe handlers when their lifetime ends.
     /// </summary>
     public static event Action<CallbackErrorEvent>? OnCallbackError;
 

--- a/src/Kevlar/KevlarProperties.cs
+++ b/src/Kevlar/KevlarProperties.cs
@@ -6,6 +6,8 @@ namespace Kevlar;
 /// A strongly typed property bag carried by <see cref="KevlarContext"/> for passing
 /// custom data between the caller, execution delegate, and strategy callbacks. The bag is
 /// pooled with its context and must not be retained beyond the current callback or delegate.
+/// A completion callback receives this same live bag immediately before it is recycled; copy
+/// required values into caller-owned state rather than retaining the bag.
 /// </summary>
 public sealed class KevlarProperties
 {

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -47,8 +47,10 @@ public sealed class CircuitBreakerMonitor
 
     /// <summary>
     /// Forces every bound circuit open. Executions are rejected until <see cref="Reset"/> is called.
-    /// Blocks until transition observers complete; use <see cref="IsolateAsync"/> when an
-    /// <see cref="CircuitBreakerOptions.OnStateChanged"/> callback may yield.
+    /// A non-reentrant caller blocks until transition observers complete; use
+    /// <see cref="IsolateAsync"/> when an <see cref="CircuitBreakerOptions.OnStateChanged"/>
+    /// callback may yield. A call made from a transition observer queues its transition and returns
+    /// before that queued transition reaches observers.
     /// </summary>
     public void Isolate()
     {
@@ -74,9 +76,11 @@ public sealed class CircuitBreakerMonitor
     }
 
     /// <summary>
-    /// Closes every bound circuit and clears all failure metrics. Blocks until transition observers
-    /// complete; use <see cref="ResetAsync"/> when an
-    /// <see cref="CircuitBreakerOptions.OnStateChanged"/> callback may yield.
+    /// Closes every bound circuit and clears all failure metrics. A non-reentrant caller blocks
+    /// until transition observers complete; use <see cref="ResetAsync"/> when an
+    /// <see cref="CircuitBreakerOptions.OnStateChanged"/> callback may yield. A call made from a
+    /// transition observer queues its transition and returns before that queued transition reaches
+    /// observers.
     /// </summary>
     public void Reset()
     {

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerMonitor.cs
@@ -47,6 +47,8 @@ public sealed class CircuitBreakerMonitor
 
     /// <summary>
     /// Forces every bound circuit open. Executions are rejected until <see cref="Reset"/> is called.
+    /// Blocks until transition observers complete; use <see cref="IsolateAsync"/> when an
+    /// <see cref="CircuitBreakerOptions.OnStateChanged"/> callback may yield.
     /// </summary>
     public void Isolate()
     {
@@ -71,7 +73,11 @@ public sealed class CircuitBreakerMonitor
             : IsolateAllAsync(cores);
     }
 
-    /// <summary>Closes every bound circuit and clears all failure metrics.</summary>
+    /// <summary>
+    /// Closes every bound circuit and clears all failure metrics. Blocks until transition observers
+    /// complete; use <see cref="ResetAsync"/> when an
+    /// <see cref="CircuitBreakerOptions.OnStateChanged"/> callback may yield.
+    /// </summary>
     public void Reset()
     {
         foreach (var core in BoundCores())

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -69,7 +69,8 @@ public sealed class CircuitBreakerOptions
     /// <see cref="CircuitBreakerMonitor.StateChanged"/>. Transitions are delivered serially
     /// outside the circuit lock, so a slow handler delays later transition publishers. Return
     /// <see langword="default"/> from a synchronous callback. The event context is valid only
-    /// until the returned task completes.
+    /// until the returned task completes. A publisher arriving during an active drain waits for
+    /// the earlier handlers; an execution may therefore occupy a thread-pool thread until they return.
     /// </summary>
     public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChanged { get; set; }
 }

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerOptions.cs
@@ -69,8 +69,10 @@ public sealed class CircuitBreakerOptions
     /// <see cref="CircuitBreakerMonitor.StateChanged"/>. Transitions are delivered serially
     /// outside the circuit lock, so a slow handler delays later transition publishers. Return
     /// <see langword="default"/> from a synchronous callback. The event context is valid only
-    /// until the returned task completes. A publisher arriving during an active drain waits for
-    /// the earlier handlers; an execution may therefore occupy a thread-pool thread until they return.
+    /// until the returned task completes. A non-reentrant publisher arriving during an active drain
+    /// waits for the earlier handlers; an execution may therefore occupy a thread-pool thread until
+    /// they return. A publisher reentered from <c>OnStateChanged</c> or <c>StateChanged</c> is queued
+    /// and returns before the queued transition's observers run.
     /// </summary>
     public Func<CircuitBreakerStateChangedEvent, ValueTask>? OnStateChanged { get; set; }
 }

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitOptions.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitOptions.cs
@@ -18,7 +18,10 @@ public sealed class ConcurrencyLimitOptions
     /// <summary>Maximum concurrent executions. Default 10.</summary>
     public int MaxConcurrency { get; set; } = 10;
 
-    /// <summary>Maximum executions allowed to wait for a slot. Default 0 (reject immediately when full).</summary>
+    /// <summary>
+    /// Maximum executions allowed to wait for a slot. Default 0 (reject immediately when full).
+    /// The queue has no built-in timeout; compose a timeout outside this strategy to bound the wait.
+    /// </summary>
     public int QueueLimit { get; set; }
 
     /// <summary>

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -8,6 +8,7 @@ namespace Kevlar;
 /// <remarks>
 /// The executed delegate may be invoked multiple times concurrently — it must be safe to do so.
 /// Hedging requires asynchronous execution.
+/// If no attempt produces an acceptable outcome, the last completed outcome surfaces.
 /// Before an additional attempt starts, callbacks run in this order: <see cref="DelayGenerator"/>,
 /// <see cref="OnHedge"/>, then <see cref="ActionGenerator"/>. Caller cancellation is checked
 /// before callbacks and again before the generated operation starts.
@@ -41,7 +42,8 @@ public sealed class HedgeOptions
 
     /// <summary>
     /// Time to wait before launching the next attempt while the current ones are still running.
-    /// <see cref="TimeSpan.Zero"/> launches all attempts at once;
+    /// <see cref="TimeSpan.Zero"/> launches the original and all additional attempts at once,
+    /// even when the original completes synchronously;
     /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> hedges only on failure.
     /// Default 1 second.
     /// </summary>

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -8,7 +8,8 @@ namespace Kevlar;
 /// <remarks>
 /// The executed delegate may be invoked multiple times concurrently — it must be safe to do so.
 /// Hedging requires asynchronous execution.
-/// If no attempt produces an acceptable outcome, the last completed outcome surfaces.
+/// If no attempt produces an acceptable outcome, the final outcome processed by the coordinator
+/// surfaces; selection among attempts already completed is not chronological.
 /// Before an additional attempt starts, callbacks run in this order: <see cref="DelayGenerator"/>,
 /// <see cref="OnHedge"/>, then <see cref="ActionGenerator"/>. Caller cancellation is checked
 /// before callbacks and again before the generated operation starts.
@@ -42,8 +43,9 @@ public sealed class HedgeOptions
 
     /// <summary>
     /// Time to wait before launching the next attempt while the current ones are still running.
-    /// <see cref="TimeSpan.Zero"/> launches the original and all additional attempts at once,
-    /// even when the original completes synchronously;
+    /// <see cref="TimeSpan.Zero"/> removes timer staggering and starts scheduling the original and
+    /// all additional attempts, even when the original completes synchronously. Callbacks and
+    /// cancellation checks can still delay or prevent an additional delegate from starting;
     /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> hedges only on failure.
     /// Default 1 second.
     /// </summary>

--- a/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
@@ -6,7 +6,8 @@ namespace Kevlar;
 /// <remarks>
 /// <see cref="HedgeOptions{TResult}"/> and <see cref="HedgeOptions"/> are standalone sibling types
 /// with matching shared property names and defaults.
-/// If no attempt produces an acceptable outcome, the last completed outcome surfaces.
+/// If no attempt produces an acceptable outcome, the final outcome processed by the coordinator
+/// surfaces; selection among attempts already completed is not chronological.
 /// </remarks>
 public sealed class HedgeOptions<TResult>
 {

--- a/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptionsOfT.cs
@@ -6,6 +6,7 @@ namespace Kevlar;
 /// <remarks>
 /// <see cref="HedgeOptions{TResult}"/> and <see cref="HedgeOptions"/> are standalone sibling types
 /// with matching shared property names and defaults.
+/// If no attempt produces an acceptable outcome, the last completed outcome surfaces.
 /// </remarks>
 public sealed class HedgeOptions<TResult>
 {

--- a/src/Kevlar/Strategies/Retry/RetryOptions.cs
+++ b/src/Kevlar/Strategies/Retry/RetryOptions.cs
@@ -7,6 +7,9 @@ namespace Kevlar;
 /// stops and surfaces caller cancellation. Hooks that complete synchronously (for example by
 /// returning <see langword="default"/>) add no overhead and remain compatible with synchronous
 /// <c>Execute</c>.
+/// Cancellation during the retry delay surfaces an <see cref="OperationCanceledException"/> with
+/// no inner exception. The handled outcome is no longer retained, and <see cref="OnRetry"/> has
+/// already run for the suppressed attempt.
 /// </remarks>
 public sealed class RetryOptions
 {
@@ -77,6 +80,9 @@ public sealed class RetryOptions
 /// Before each retry, <see cref="DelayGenerator"/> runs and is awaited, then <see cref="OnRetry"/>.
 /// If the caller's cancellation token is cancelled by the time the callbacks complete, the retry
 /// stops and surfaces caller cancellation.
+/// Cancellation during the retry delay surfaces an <see cref="OperationCanceledException"/> with
+/// no inner exception. The handled outcome is no longer retained, and <see cref="OnRetry"/> has
+/// already run for the suppressed attempt.
 /// </remarks>
 public sealed class RetryOptions<TResult>
 {

--- a/src/Kevlar/Strategies/Timeout/TimeoutOptions.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutOptions.cs
@@ -6,6 +6,10 @@ namespace Kevlar;
 /// <see cref="Timeout"/> for that execution. When a timeout wins, <see cref="OnTimeout"/> runs
 /// after timer cleanup and restoration of the caller's cancellation token. Hooks that complete
 /// synchronously add no overhead and remain compatible with synchronous <c>Execute</c>.
+/// The strategy always awaits the delegate and translates only a direct
+/// <see cref="OperationCanceledException"/> into <see cref="TimeoutExceededException"/>. A blocking
+/// synchronous delegate that ignores cancellation cannot be timed out, and a wrapped cancellation
+/// exception surfaces unchanged.
 /// </remarks>
 public sealed class TimeoutOptions
 {

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -50,6 +50,11 @@ public abstract class Strategy
     /// <typeparam name="TState">Caller-supplied state threaded through the pipeline without allocation.</typeparam>
     /// <param name="next">The remainder of the pipeline, ending in the user's delegate.</param>
     /// <param name="context">The ambient execution context.</param>
+    /// <remarks>
+    /// Returning an incomplete value task during synchronous shield execution causes the execution
+    /// boundary to block until it completes. Custom implementations should avoid capturing a
+    /// single-threaded synchronization context and should be invoked asynchronously when they yield.
+    /// </remarks>
     public abstract ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- document eight deliberate runtime caveats on their strategy and execution pages
- add matching public XML documentation for timeout, retry, concurrency, context pooling, diagnostics, hedging, circuit publication, and custom strategies
- clarify safe alternatives for queue budgets, async circuit controls, completion-state copying, and global subscriptions

## Validation
- `pwsh scripts/Verify-Docs.ps1`
- `dotnet build Kevlar.slnx -c Release --nologo`
- `npm ci`
- `npm run build`

Closes #441