### PR TITLE
fix(handling)!: preserve caller cancellation

### DIFF
--- a/docs/docs/handling-failures.md
+++ b/docs/docs/handling-failures.md
@@ -36,6 +36,12 @@ var allKevlarOutcomes = Shield.For<string>()
     .FallbackTo("unavailable");
 ```
 
+Caller cancellation is stronger than every handling clause. When the active caller token is
+cancelled and execution produces an `OperationCanceledException`, no reactive strategy handles the
+outcome—even under `When<Exception>()`—and the cancellation surfaces to the caller. An explicit
+clause can still handle a spontaneous `OperationCanceledException` when the caller token is not
+cancelled.
+
 When you execute with `ExecuteOutcomeAsync`, use `outcome.TryGetResult(out var result)` to
 consume a successful result without throwing. If it returns `false`, the final captured failure
 remains available through `outcome.Exception`.

--- a/docs/docs/strategies/circuit-breaker.md
+++ b/docs/docs/strategies/circuit-breaker.md
@@ -105,8 +105,9 @@ the circuit closes or is reset.
 
 :::info Unhandled exceptions don't move the circuit
 An exception outside the breaker's handling clause says nothing about downstream health — it counts
-as neither success nor failure. This includes caller cancellation unless the clause explicitly
-handles it. An unhandled half-open probe releases the probe slot without closing the circuit.
+as neither success nor failure. Caller cancellation is always unhandled while the caller's token is
+signaled, even when the clause matches `OperationCanceledException`. An unhandled half-open probe
+releases the probe slot without closing the circuit.
 :::
 
 ## Observing and controlling: `CircuitBreakerMonitor`

--- a/src/Kevlar/Internal/OutcomeJudge.cs
+++ b/src/Kevlar/Internal/OutcomeJudge.cs
@@ -35,7 +35,9 @@ internal abstract class OutcomeJudge
         int strategyIndex)
     {
         if (outcome.Exception is { } exception
-            && SynchronousExecutionGuard.IsRejection(exception))
+            && (SynchronousExecutionGuard.IsRejection(exception)
+                || (exception is OperationCanceledException
+                    && context?.CancellationToken.IsCancellationRequested == true)))
         {
             return false;
         }

--- a/tests/Kevlar.Tests/CircuitBreakerTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerTests.cs
@@ -177,6 +177,43 @@ public class CircuitBreakerTests
     }
 
     [Test]
+    public async Task Explicit_Exception_Handling_Does_Not_Count_Caller_Cancellation()
+    {
+        var transitions = 0;
+        var shield = Shield.When<Exception>().CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 2;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.OnStateChanged = _ =>
+            {
+                transitions++;
+                return default;
+            };
+        });
+
+        for (var executionIndex = 0; executionIndex < 3; executionIndex++)
+        {
+            using var cancellation = new CancellationTokenSource();
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var execution = shield.ExecuteAsync(async token =>
+            {
+                started.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return 1;
+            }, cancellation.Token).AsTask();
+
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            cancellation.Cancel();
+            var exception = await Assert.That(async () => await execution)
+                .Throws<OperationCanceledException>();
+            await Assert.That(exception!.CancellationToken).IsEqualTo(cancellation.Token);
+        }
+
+        await Assert.That(await shield.ExecuteAsync(_ => new ValueTask<int>(42))).IsEqualTo(42);
+        await Assert.That(transitions).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Ambient_Handling_Scopes_What_Trips_The_Circuit()
     {
         var shield = Shield.When<InvalidOperationException>().CircuitBreaker(1, TimeSpan.FromMinutes(1));

--- a/tests/Kevlar.Tests/FallbackContractTests.cs
+++ b/tests/Kevlar.Tests/FallbackContractTests.cs
@@ -138,6 +138,44 @@ public class FallbackContractTests
     }
 
     [Test]
+    public async Task Caller_Cancellation_Is_Not_Handled_By_Explicit_Exception_Fallback()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fallbackCalls = 0;
+        var notificationCalls = 0;
+        var shield = Shield.For<int>()
+            .When<Exception>()
+            .Fallback(
+                (_, _) =>
+                {
+                    fallbackCalls++;
+                    return new ValueTask<int>(-1);
+                },
+                options => options.OnFallback = _ =>
+                {
+                    notificationCalls++;
+                    return default;
+                });
+
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            started.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        var caught = await CaptureCancellationAsync(execution);
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.CancellationToken).IsEqualTo(cancellation.Token);
+        await Assert.That(fallbackCalls).IsEqualTo(0);
+        await Assert.That(notificationCalls).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Fallback_Outside_Timeout_Receives_Restored_Caller_Token()
     {
         var timeProvider = new FakeTimeProvider();

--- a/tests/Kevlar.Tests/MetricsTests.cs
+++ b/tests/Kevlar.Tests/MetricsTests.cs
@@ -1184,6 +1184,33 @@ public class MetricsTests
     }
 
     [Test]
+    public async Task Caller_Cancellation_Does_Not_Emit_Circuit_Transitions()
+    {
+        using var listener = new KevlarMeterListener();
+        var before = CircuitTransitionTotals(listener);
+        var shield = Shield.When<Exception>().CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+        });
+        using var cancellation = new CancellationTokenSource();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var execution = shield.ExecuteAsync(async token =>
+        {
+            started.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            return 1;
+        }, cancellation.Token).AsTask();
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+        await Assert.That(async () => await execution).Throws<OperationCanceledException>();
+
+        var after = CircuitTransitionTotals(listener);
+        await Assert.That(after).IsEquivalentTo(before);
+    }
+
+    [Test]
     public async Task Hedged_Attempts_Are_Counted()
     {
         using var listener = new KevlarMeterListener();


### PR DESCRIPTION
Closes #427

## What changed
- made `OutcomeJudge` reject caller-cancelled `OperationCanceledException` outcomes before any reactive predicate runs
- preserved explicit handling of spontaneous cancellation exceptions when the active token is not cancelled
- added fallback, circuit-state, and circuit-transition metric regressions
- documented that caller cancellation overrides every handling clause

## Why
`When<Exception>()` previously let fallback swallow caller cancellation and let circuit breakers count it as downstream failure. Centralizing the guard gives retry, hedging, fallback, circuit breaker, and custom reactive strategies one cancellation contract.

## Validation
- focused fallback test failed before the fix and passed after it
- three focused cancellation regressions passed
- `dotnet build Kevlar.slnx -c Release`
- full `Kevlar.Tests` net8.0: 1,278 passed
- full `Kevlar.Tests` net10.0: 1,312 passed
- `pwsh scripts/Verify-Docs.ps1`

## Compatibility
Behavioral breaking fix: an explicit handling clause can no longer recover caller-triggered cancellation. Spontaneous `OperationCanceledException` handling is unchanged. No public API shape or allocation-path changes.