### PR TITLE
fix(hedge): normalize negative delays

### DIFF
--- a/docs/api/Kevlar.HedgeOptions-1.yml
+++ b/docs/api/Kevlar.HedgeOptions-1.yml
@@ -267,7 +267,9 @@ items:
 
     <xref href="System.TimeSpan.Zero" data-throw-if-not-resolved="false"></xref> launches all attempts at once;
 
-    <xref href="System.Threading.Timeout.InfiniteTimeSpan" data-throw-if-not-resolved="false"></xref> hedges only on failure.
+    any negative value hedges only on failure and is normalized to
+
+    <xref href="System.Threading.Timeout.InfiniteTimeSpan" data-throw-if-not-resolved="false"></xref>.
 
     Default 1 second.
   example: []

--- a/docs/api/Kevlar.HedgeOptions.yml
+++ b/docs/api/Kevlar.HedgeOptions.yml
@@ -199,7 +199,9 @@ items:
 
     <xref href="System.TimeSpan.Zero" data-throw-if-not-resolved="false"></xref> launches all attempts at once;
 
-    <xref href="System.Threading.Timeout.InfiniteTimeSpan" data-throw-if-not-resolved="false"></xref> hedges only on failure.
+    any negative value hedges only on failure and is normalized to
+
+    <xref href="System.Threading.Timeout.InfiniteTimeSpan" data-throw-if-not-resolved="false"></xref>.
 
     Default 1 second.
   example: []

--- a/docs/api/Kevlar.Shield-1.yml
+++ b/docs/api/Kevlar.Shield-1.yml
@@ -778,8 +778,13 @@ items:
     parameters:
     - id: maxHedgedAttempts
       type: System.Int32
+      description: Maximum additional attempts after the primary attempt.
     - id: delay
       type: System.TimeSpan
+      description: >-
+        The delay between attempts. Zero launches attempts in parallel; any negative value launches
+
+        another attempt only after a handled failure.
     return:
       type: Kevlar.Shield`1
     content.vb: Public Function Hedge(maxHedgedAttempts As Integer, delay As TimeSpan) As Shield(Of TResult)

--- a/docs/api/Kevlar.Shield.yml
+++ b/docs/api/Kevlar.Shield.yml
@@ -569,8 +569,13 @@ items:
     parameters:
     - id: maxHedgedAttempts
       type: System.Int32
+      description: Maximum additional attempts after the primary attempt.
     - id: delay
       type: System.TimeSpan
+      description: >-
+        The delay between attempts. Zero launches attempts in parallel; any negative value launches
+
+        another attempt only after a handled failure.
     return:
       type: Kevlar.Shield
     content.vb: Public Shared Function Hedge(maxHedgedAttempts As Integer, delay As TimeSpan) As Shield

--- a/docs/api/Kevlar.ShieldExtensions.yml
+++ b/docs/api/Kevlar.ShieldExtensions.yml
@@ -522,10 +522,16 @@ items:
     parameters:
     - id: shield
       type: Kevlar.Shield
+      description: The shield to append hedging to.
     - id: maxHedgedAttempts
       type: System.Int32
+      description: Maximum additional attempts after the primary attempt.
     - id: delay
       type: System.TimeSpan
+      description: >-
+        The delay between attempts. Zero launches attempts in parallel; any negative value launches
+
+        another attempt only after a handled failure.
     return:
       type: Kevlar.Shield
     content.vb: Public Shared Function Hedge(shield As Shield, maxHedgedAttempts As Integer, delay As TimeSpan) As Shield

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -677,7 +677,7 @@ if (pollyLimiterOptions.DefaultRateLimiterOptions.PermitLimit != 1000 ||
 | hedging `ActionGenerator` | `HedgeOptions.ActionGenerator` delegate |
 | circuit `BreakDurationGenerator` returning `ValueTask<TimeSpan>` | `BreakDurationGenerator` returning `ValueTask<TimeSpan>` |
 | hedging `DelayGenerator` returning `ValueTask<TimeSpan>` | `HedgeOptions.DelayGenerator` returning `ValueTask<TimeSpan>`; `HedgeDelayEvent` exposes `AttemptNumber`, `Context`, and `Elapsed` |
-| hedging `Delay = TimeSpan.FromSeconds(-1)` to disable scheduled hedges | `Delay = Timeout.InfiniteTimeSpan`; other negative values are rejected |
+| any negative hedging `Delay` | any negative `HedgeOptions.Delay`; normalized to `Timeout.InfiniteTimeSpan` for failure-only hedging |
 | `OnRetry` / `OnTimeout` / `OnHedging` / `OnFallback` / `OnRejected` returning `ValueTask` | `OnRetry` / `OnTimeout` / `OnHedge` / `OnFallback` / `OnRejected` returning `ValueTask` |
 | `OnOpened` / `OnClosed` / `OnHalfOpened` | one `OnStateChanged` callback returning `ValueTask` |
 

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -109,8 +109,8 @@ zero/infinite meanings apply. Generator exceptions fail the execution and cancel
 ### Special delay values
 
 - `TimeSpan.Zero` — race **all** attempts at once.
-- Any negative delay, including `Timeout.InfiniteTimeSpan` — never hedge on latency; launch the
-  next attempt **only when the previous one fails**.
+- Any negative fixed `HedgeOptions.Delay`, including `Timeout.InfiniteTimeSpan` — never hedge on
+  latency; launch the next attempt **only when the previous one fails**.
 - Any delay: a handled failure always launches the next attempt *immediately*, without waiting out the rest of the delay.
 
 Zero delay removes timer staggering and starts scheduling the primary plus all

--- a/docs/docs/strategies/hedging.md
+++ b/docs/docs/strategies/hedging.md
@@ -109,7 +109,8 @@ zero/infinite meanings apply. Generator exceptions fail the execution and cancel
 ### Special delay values
 
 - `TimeSpan.Zero` — race **all** attempts at once.
-- `Timeout.InfiniteTimeSpan` — never hedge on latency; launch the next attempt **only when the previous one fails**.
+- Any negative delay, including `Timeout.InfiniteTimeSpan` — never hedge on latency; launch the
+  next attempt **only when the previous one fails**.
 - Any delay: a handled failure always launches the next attempt *immediately*, without waiting out the rest of the delay.
 
 ## The rules

--- a/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
+++ b/src/Kevlar.Extensions.Http/StandardHttpConfigurationBinder.cs
@@ -308,10 +308,6 @@ internal static class StandardHttpConfigurationBinder
             "must be positive or Timeout.InfiniteTimeSpan");
         Ensure(options.Hedge.MaxHedgedAttempts >= 0, configuration.GetSection("Hedge:MaxHedgedAttempts"), "must not be negative");
         Ensure(
-            options.Hedge.Delay >= TimeSpan.Zero || options.Hedge.Delay == Timeout.InfiniteTimeSpan,
-            configuration.GetSection("Hedge:Delay"),
-            "must be non-negative or Timeout.InfiniteTimeSpan");
-        Ensure(
             IsValidStandardTimeout(options.AttemptTimeout),
             TimeoutSection(configuration, nameof(options.AttemptTimeout)),
             "must be positive or Timeout.InfiniteTimeSpan");

--- a/src/Kevlar/Shield.cs
+++ b/src/Kevlar/Shield.cs
@@ -147,6 +147,11 @@ public sealed class Shield : IShieldLifecycle
     /// hedge that later loses. Prefer <see cref="For{TResult}"/>, where result clauses decide which
     /// attempt is acceptable, or confirm the action is safe to repeat.
     /// </remarks>
+    /// <param name="maxHedgedAttempts">Maximum additional attempts after the primary attempt.</param>
+    /// <param name="delay">
+    /// The delay between attempts. Zero launches attempts in parallel; any negative value launches
+    /// another attempt only after a handled failure.
+    /// </param>
     public static Shield Hedge(int maxHedgedAttempts, TimeSpan delay) => ShieldExtensions.Hedge(Empty, maxHedgedAttempts, delay);
 
     /// <summary>Adds a hedging strategy configured via <paramref name="configure"/>.</summary>

--- a/src/Kevlar/ShieldExtensions.cs
+++ b/src/Kevlar/ShieldExtensions.cs
@@ -183,6 +183,12 @@ public static class ShieldExtensions
     /// hedge that later loses. Prefer <c>Shield.For&lt;T&gt;()</c>, where result clauses decide which
     /// attempt is acceptable, or confirm the action is safe to repeat.
     /// </remarks>
+    /// <param name="shield">The shield to append hedging to.</param>
+    /// <param name="maxHedgedAttempts">Maximum additional attempts after the primary attempt.</param>
+    /// <param name="delay">
+    /// The delay between attempts. Zero launches attempts in parallel; any negative value launches
+    /// another attempt only after a handled failure.
+    /// </param>
     public static Shield Hedge(this Shield shield, int maxHedgedAttempts, TimeSpan delay)
     {
         Throw.IfNull(shield, nameof(shield));
@@ -190,10 +196,6 @@ public static class ShieldExtensions
             maxHedgedAttempts < 0,
             nameof(maxHedgedAttempts),
             "Maximum hedged attempts must be non-negative.");
-        Throw.IfOutOfRange(
-            delay < TimeSpan.Zero && delay != System.Threading.Timeout.InfiniteTimeSpan,
-            nameof(delay),
-            "Delay must be non-negative or Timeout.InfiniteTimeSpan.");
         Throw.IfOutOfRange(delay > DelayHelper.MaximumDelay, nameof(delay), "Delay exceeds the runtime timer limit.");
         return shield.Hedge(options =>
         {

--- a/src/Kevlar/ShieldOfT.cs
+++ b/src/Kevlar/ShieldOfT.cs
@@ -283,16 +283,17 @@ public sealed class Shield<TResult> : IShieldLifecycle
     }
 
     /// <summary>Races the primary with up to <paramref name="maxHedgedAttempts"/> additional attempts staggered by <paramref name="delay"/>; first acceptable outcome wins.</summary>
+    /// <param name="maxHedgedAttempts">Maximum additional attempts after the primary attempt.</param>
+    /// <param name="delay">
+    /// The delay between attempts. Zero launches attempts in parallel; any negative value launches
+    /// another attempt only after a handled failure.
+    /// </param>
     public Shield<TResult> Hedge(int maxHedgedAttempts, TimeSpan delay)
     {
         Throw.IfOutOfRange(
             maxHedgedAttempts < 0,
             nameof(maxHedgedAttempts),
             "Maximum hedged attempts must be non-negative.");
-        Throw.IfOutOfRange(
-            delay < TimeSpan.Zero && delay != System.Threading.Timeout.InfiniteTimeSpan,
-            nameof(delay),
-            "Delay must be non-negative or Timeout.InfiniteTimeSpan.");
         Throw.IfOutOfRange(delay > DelayHelper.MaximumDelay, nameof(delay), "Delay exceeds the runtime timer limit.");
         return Hedge(options =>
         {

--- a/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgeOptions.cs
@@ -42,7 +42,8 @@ public sealed class HedgeOptions
     /// <summary>
     /// Time to wait before launching the next attempt while the current ones are still running.
     /// <see cref="TimeSpan.Zero"/> launches all attempts at once;
-    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> hedges only on failure.
+    /// any negative value hedges only on failure and is normalized to
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/>.
     /// Default 1 second.
     /// </summary>
     public TimeSpan Delay { get; set; } = TimeSpan.FromSeconds(1);

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -49,12 +49,6 @@ internal sealed class HedgingStrategy : Strategy
             options.MaxHedgedAttempts,
             "must be non-negative");
         ConfigurationValidation.ThrowIf(
-            options.Delay < TimeSpan.Zero && options.Delay != System.Threading.Timeout.InfiniteTimeSpan,
-            optionsType,
-            nameof(options.Delay),
-            options.Delay,
-            "must be non-negative or Timeout.InfiniteTimeSpan");
-        ConfigurationValidation.ThrowIf(
             options.Delay > DelayHelper.MaximumDelay,
             optionsType,
             nameof(options.Delay),
@@ -63,7 +57,9 @@ internal sealed class HedgingStrategy : Strategy
 
         _judge = judge;
         _maxHedgedAttempts = options.MaxHedgedAttempts;
-        _delay = options.Delay;
+        _delay = options.Delay < TimeSpan.Zero
+            ? System.Threading.Timeout.InfiniteTimeSpan
+            : options.Delay;
         _delayGenerator = options.DelayGenerator;
         _onHedge = onHedge;
         _actionGenerator = actionGenerator;

--- a/tests/Kevlar.Tests/DescribeTests.cs
+++ b/tests/Kevlar.Tests/DescribeTests.cs
@@ -73,6 +73,13 @@ public class DescribeTests
             .IsEqualTo("ConcurrencyLimit(10)");
         await Assert.That(Shield.Hedge(2, TimeSpan.FromMilliseconds(100)).ToString())
             .IsEqualTo("Hedge(2 extra, delay 100ms)");
+        const string failureOnlyHedge = "Hedge(2 extra, delay infinite)";
+        await Assert.That(Shield.Hedge(2, TimeSpan.FromSeconds(-1)).ToString())
+            .IsEqualTo(failureOnlyHedge);
+        await Assert.That(Shield.Hedge(2, Timeout.InfiniteTimeSpan).ToString())
+            .IsEqualTo(failureOnlyHedge);
+        await Assert.That(Shield.For<int>().Hedge(2, TimeSpan.FromSeconds(-1)).ToString())
+            .IsEqualTo(failureOnlyHedge);
         await Assert.That(Shield.Hedge(options =>
         {
             options.MaxHedgedAttempts = 2;

--- a/tests/Kevlar.Tests/HedgingTests.cs
+++ b/tests/Kevlar.Tests/HedgingTests.cs
@@ -124,6 +124,30 @@ public class HedgingTests
     }
 
     [Test]
+    public async Task Any_Negative_Delay_Hedges_Only_On_Handled_Failure()
+    {
+        var attempts = 0;
+        var shield = Shield.Hedge(options =>
+        {
+            options.MaxHedgedAttempts = 1;
+            options.Delay = TimeSpan.FromSeconds(-1);
+        });
+
+        var result = await shield.ExecuteAsync(_ =>
+        {
+            if (Interlocked.Increment(ref attempts) == 1)
+            {
+                throw new InvalidOperationException("first fails");
+            }
+
+            return new ValueTask<int>(42);
+        });
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Typed_OnHedge_Receives_The_Handled_Outcome()
     {
         HedgeEvent<string>? observed = null;

--- a/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
+++ b/tests/Kevlar.Tests/HttpConfigurationReloadTests.cs
@@ -224,6 +224,17 @@ public class HttpConfigurationReloadTests
     }
 
     [Test]
+    public async Task Hedge_Section_Accepts_Negative_Delay()
+    {
+        var configuration = BuildConfiguration(("Hedge:Delay", "-00:00:01"));
+        var services = new ServiceCollection();
+        services.AddHttpClient("client").AddStandardHedgeShield(configuration);
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<IHttpClientFactory>().CreateClient("client");
+    }
+
+    [Test]
     public async Task Hedge_Section_Leaves_Optional_Stages_Null_When_Absent()
     {
         var configuration = BuildConfiguration(("Hedge:MaxHedgedAttempts", "0"));

--- a/tests/Kevlar.Tests/OptionsValidationTests.cs
+++ b/tests/Kevlar.Tests/OptionsValidationTests.cs
@@ -19,7 +19,6 @@ public class OptionsValidationTests
             new(() => Shield.CircuitBreaker(options => options.SamplingWindow = TimeSpan.Zero), "CircuitBreakerOptions", "SamplingWindow", "00:00:00"),
             new(() => Shield.CircuitBreaker(options => options.BreakDuration = TimeSpan.Zero), "CircuitBreakerOptions", "BreakDuration", "00:00:00"),
             new(() => Shield.Hedge(options => options.MaxHedgedAttempts = -1), "HedgeOptions", "MaxHedgedAttempts", "-1"),
-            new(() => Shield.Hedge(options => options.Delay = TimeSpan.FromSeconds(-1)), "HedgeOptions", "Delay", "-00:00:01"),
             new(() => Shield.RateLimit(options => options.Permits = 0), "RateLimitOptions", "Permits", "0"),
             new(() => Shield.RateLimit(options => options.Window = TimeSpan.Zero), "RateLimitOptions", "Window", "00:00:00"),
             new(() => Shield.RateLimit(options => options.Burst = 0), "RateLimitOptions", "Burst", "0"),
@@ -182,10 +181,9 @@ public class OptionsValidationTests
     }
 
     [Test]
-    public async Task Hedge_Rejects_Invalid_Options()
+    public async Task Hedge_Rejects_Negative_Attempt_Count()
     {
         await Assert.That(() => Shield.Hedge(-1, TimeSpan.Zero)).Throws<ArgumentOutOfRangeException>();
-        await Assert.That(() => Shield.Hedge(1, TimeSpan.FromSeconds(-5))).Throws<ArgumentOutOfRangeException>();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- normalize every negative hedge delay to `Timeout.InfiniteTimeSpan`
- align quick overloads and standard HTTP configuration with failure-only hedging semantics
- cover option, untyped, typed, description, and configuration paths
- document Polly parity and special delay values

Closes #438

## Validation
- `dotnet build Kevlar.slnx -c Release -p:Version=1.0.0-local`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m` (1277 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m` (1311 passed)
- `dotnet run --project tests/Kevlar.IntegrationTests -c Release --no-build -- --timeout 5m` (176 passed)
- `pwsh scripts/Verify-Docs.ps1`
- `pwsh scripts/Verify-ApiDocs.ps1`
- `npm ci` and `npm run build` in `docs/`