### PR TITLE
perf(partitioned): bypass gate for idle warm hits

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/PartitioningBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/PartitioningBenchmarks.cs
@@ -16,6 +16,12 @@ public class PartitioningBenchmarks
 
     private readonly PartitionedShield<int> _warm = new(
         static _ => Shield.Retry(0, Backoff.None));
+    private readonly PartitionedShield<int> _warmWithIdleExpiration = new(
+        static _ => Shield.Retry(0, Backoff.None),
+        new PartitionedShieldOptions<int>
+        {
+            IdleExpiration = TimeSpan.FromMinutes(10),
+        });
     private readonly PartitionedShield<int> _evicting = new(
         static _ => Shield.Retry(0, Backoff.None),
         new PartitionedShieldOptions<int> { MaxPartitions = 1 });
@@ -26,11 +32,16 @@ public class PartitioningBenchmarks
     {
         _ = ConcurrentWarm.GetShield(42);
         _ = _warm.GetShield(42);
+        _ = _warmWithIdleExpiration.GetShield(42);
         _ = _evicting.GetShield(0);
     }
 
-    [BenchmarkCategory("WarmLookup"), Benchmark]
+    [BenchmarkCategory("WarmLookup"), Benchmark(Baseline = true)]
     public Shield Warm_Lookup() => _warm.GetShield(42);
+
+    [BenchmarkCategory("WarmLookup"), Benchmark]
+    public Shield Warm_Lookup_With_Idle_Expiration() =>
+        _warmWithIdleExpiration.GetShield(42);
 
     [BenchmarkCategory("WarmLookupContended"), Benchmark(OperationsPerInvoke = ConcurrentLookupsPerInvoke)]
     public int Warm_Concurrent_Lookups()

--- a/src/Kevlar/Internal/PartitionCache.cs
+++ b/src/Kevlar/Internal/PartitionCache.cs
@@ -97,7 +97,7 @@ internal sealed class PartitionCache<TKey, TShield>
     public TShield Get(TKey key)
     {
         ValidateKey(key);
-        if (TryGetWarm(key, out var shield))
+        if (TryGetWarm(key, out var shield, out _))
         {
             return shield;
         }
@@ -109,7 +109,7 @@ internal sealed class PartitionCache<TKey, TShield>
     {
         ValidateKey(key);
 
-        if (TryGetWarm(key, out var shield))
+        if (TryGetWarm(key, out var shield, out _))
         {
             return new ValueTask<TShield>(shield);
         }
@@ -120,20 +120,14 @@ internal sealed class PartitionCache<TKey, TShield>
     public bool TryGet(TKey key, out TShield? shield)
     {
         ValidateKey(key);
-        if (_idleExpiration is null)
+        if (TryGetWarm(key, out shield, out var pruneDue))
         {
-            lock (_gate)
-            {
-                if (_entries.TryGetValue(key, out var entry))
-                {
-                    Touch(entry, now: 0);
-                    shield = entry.Shield;
-                    return true;
-                }
+            return true;
+        }
 
-                shield = null;
-                return false;
-            }
+        if (!pruneDue)
+        {
+            return false;
         }
 
         shield = TryGetSlowAsync(key).AsTask().GetAwaiter().GetResult();
@@ -652,18 +646,29 @@ internal sealed class PartitionCache<TKey, TShield>
 
     private long Timestamp() => _idleExpiration is null ? 0 : _timeProvider.GetTimestamp();
 
-    private bool TryGetWarm(TKey key, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TShield? shield)
+    private bool TryGetWarm(
+        TKey key,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out TShield? shield,
+        out bool pruneDue)
     {
-        if (_idleExpiration is null)
+        lock (_gate)
         {
-            lock (_gate)
+            var now = Timestamp();
+            if (_idleExpiration is { } idleExpiration
+                && _leastRecentlyUsed is { } leastRecentlyUsed
+                && _timeProvider.GetElapsedTime(leastRecentlyUsed.LastAccess, now) >= idleExpiration)
             {
-                if (_entries.TryGetValue(key, out var existing))
-                {
-                    Touch(existing, now: 0);
-                    shield = existing.Shield;
-                    return true;
-                }
+                shield = null;
+                pruneDue = true;
+                return false;
+            }
+
+            pruneDue = false;
+            if (_entries.TryGetValue(key, out var existing))
+            {
+                Touch(existing, now);
+                shield = existing.Shield;
+                return true;
             }
         }
 

--- a/tests/Kevlar.Tests/PartitionedShieldTests.cs
+++ b/tests/Kevlar.Tests/PartitionedShieldTests.cs
@@ -1,9 +1,37 @@
+using Kevlar.Internal;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Kevlar.Tests;
 
 public class PartitionedShieldTests
 {
+    [Test]
+    public async Task Warm_Idle_Expiration_Hit_Does_Not_Wait_For_Mutation_Gate()
+    {
+        var cache = new PartitionCache<string, Shield>(
+            static _ => new ValueTask<Shield>(Shield.Empty),
+            new PartitionCacheOptions<string, Shield>(
+                maxPartitions: 10,
+                idleExpiration: TimeSpan.FromMinutes(1),
+                TimeProvider.System,
+                onCreated: null,
+                onEvicted: null),
+            comparer: null);
+        var first = cache.Get("tenant");
+        var mutationGate = (SemaphoreSlim)typeof(PartitionCache<string, Shield>)
+            .GetField("_mutationGate", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(cache)!;
+
+        await mutationGate.WaitAsync();
+        var lookup = cache.GetAsync("tenant");
+        var completedSynchronously = lookup.IsCompletedSuccessfully;
+        mutationGate.Release();
+        var second = await lookup;
+
+        await Assert.That(completedSynchronously).IsTrue();
+        await Assert.That(second).IsSameReferenceAs(first);
+    }
+
     [Test]
     public async Task Concurrent_First_Lookup_Creates_One_Partition()
     {


### PR DESCRIPTION
## Summary

- serve non-expired warm partition hits under the cache lock even when IdleExpiration is configured
- enter the async mutation gate only for creation or when the LRU shows expiration pruning is due
- keep opportunistic expiration and TryGet semantics intact
- add a held-gate regression and permanent warm lookup benchmark

Closes #429

## Benchmark

BenchmarkDotNet ShortRun, .NET 10, Windows, i7-12700K:

| Case | Mean | Allocated |
|---|---:|---:|
| warm lookup, no expiration | 11.87 ns | 0 B |
| warm lookup, 10m idle expiration | 31.05 ns | 0 B |

The idle path now remains a synchronous lock/dictionary/timestamp hit instead of serializing through SemaphoreSlim and sync-over-async.

## Validation

- dotnet build Kevlar.slnx -c Release
- dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m (1,276 passed)
- dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m (1,310 passed)
- BenchmarkDotNet Dry and Short jobs for *PartitioningBenchmarks.Warm_Lookup*