### PR TITLE
docs(execution): add UI context recipe

### DIFF
--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -89,8 +89,10 @@ var uiRetryShield = Shield.Retry(options =>
 
 Do not synchronously block while waiting for the shield: a single-threaded context must remain
 free to run the scheduled work.
-Hedged delegates are serialized by a single UI thread, and cancellation can prevent work that is
-still queued from starting. The `async` scheduled lambda accepts either a `Task`- or
+Only individual UI-thread segments are serialized; async hedge attempts can interleave when one
+reaches an incomplete `await`. Use an explicit async gate if each whole attempt must complete before
+another starts. Cancellation can prevent work that is still queued from starting. The `async`
+scheduled lambda accepts either a `Task`- or
 `ValueTask`-returning UI method; result-bearing variants preserve `TResult` through the unwrapped
 `Task<TResult>`.
 

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -67,9 +67,27 @@ await shield.ExecuteAsync(
 ```
 
 Kevlar invokes this wrapper again for every retry or hedge, so each attempt is scheduled onto the
-captured context. Capture the scheduler only while running on the intended UI context. Apply the
-same wrapper to a strategy hook when that hook also touches UI state. Do not synchronously block
-while waiting for the shield: a single-threaded context must remain free to run the scheduled work.
+captured context. Capture the scheduler only while running on the intended UI context. Strategy
+hooks return `ValueTask`; make the hook itself `async` and await the scheduled `Task`:
+
+<!-- doc-test-ignore: viewModel represents the application's UI-bound implementation. -->
+```csharp
+var uiRetryShield = Shield.Retry(options =>
+{
+    options.OnRetry = async retry =>
+    {
+        await Task.Factory.StartNew(
+                async () => await viewModel.ShowRetryAsync(retry.AttemptNumber),
+                retry.Context.CancellationToken,
+                TaskCreationOptions.DenyChildAttach,
+                uiScheduler)
+            .Unwrap();
+    };
+});
+```
+
+Do not synchronously block while waiting for the shield: a single-threaded context must remain
+free to run the scheduled work.
 Hedged delegates are serialized by a single UI thread, and cancellation can prevent work that is
 still queued from starting. The `async` scheduled lambda accepts either a `Task`- or
 `ValueTask`-returning UI method; result-bearing variants preserve `TResult` through the unwrapped

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -49,6 +49,30 @@ Your delegate receives a `CancellationToken` that combines your outer token with
 
 Kevlar invokes the first user delegate inline when no preceding strategy defers execution, so it initially sees the caller's current `SynchronizationContext`. A queued limiter execution and other deferred work may first invoke the delegate with no `SynchronizationContext`. Internal asynchronous continuations use `ConfigureAwait(false)` and do not marshal back to the caller's context; a later retry, fallback, timeout callback, or hedge may likewise run with no `SynchronizationContext`. Your own delegate controls whether its own awaits capture a context.
 
+When every attempt must enter a UI context, capture its scheduler on the UI thread before calling
+Kevlar, then schedule the delegate explicitly:
+
+<!-- doc-test-ignore: viewModel represents the application's UI-bound implementation. -->
+```csharp
+var uiScheduler = TaskScheduler.FromCurrentSynchronizationContext();
+
+await shield.ExecuteAsync(
+    ct => Task.Factory.StartNew(
+            () => viewModel.RefreshAsync(ct),
+            ct,
+            TaskCreationOptions.DenyChildAttach,
+            uiScheduler)
+        .Unwrap(),
+    cancellationToken);
+```
+
+Kevlar invokes this wrapper again for every retry or hedge, so each attempt is scheduled onto the
+captured context. Capture the scheduler only while running on the intended UI context. Apply the
+same wrapper to a strategy hook when that hook also touches UI state. Do not synchronously block
+while waiting for the shield: a single-threaded context must remain free to run the scheduled work.
+Hedged delegates are serialized by a single UI thread, and cancellation can prevent work that is
+still queued from starting.
+
 `ExecutionContext` still flows normally. `AsyncLocal<T>` values visible to the caller flow into actions and strategy callbacks, while parallel hedge attempts receive isolated logical snapshots so one attempt's mutations do not leak into another or a later execution. Calling Kevlar from work started under `ExecutionContext.SuppressFlow()` keeps that flow suppressed.
 
 Synchronous `Execute` never pumps a `SynchronizationContext`. Retry delays and limiter queues block

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -76,9 +76,10 @@ var uiRetryShield = Shield.Retry(options =>
 {
     options.OnRetry = async retry =>
     {
+        var ct = retry.Context.CancellationToken;
         await Task.Factory.StartNew(
-                async () => await viewModel.ShowRetryAsync(retry.AttemptNumber),
-                retry.Context.CancellationToken,
+                async () => await viewModel.ShowRetryAsync(retry.AttemptNumber, ct),
+                ct,
                 TaskCreationOptions.DenyChildAttach,
                 uiScheduler)
             .Unwrap();

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -58,7 +58,7 @@ var uiScheduler = TaskScheduler.FromCurrentSynchronizationContext();
 
 await shield.ExecuteAsync(
     ct => Task.Factory.StartNew(
-            () => viewModel.RefreshAsync(ct),
+            async () => await viewModel.RefreshAsync(ct),
             ct,
             TaskCreationOptions.DenyChildAttach,
             uiScheduler)
@@ -71,7 +71,9 @@ captured context. Capture the scheduler only while running on the intended UI co
 same wrapper to a strategy hook when that hook also touches UI state. Do not synchronously block
 while waiting for the shield: a single-threaded context must remain free to run the scheduled work.
 Hedged delegates are serialized by a single UI thread, and cancellation can prevent work that is
-still queued from starting.
+still queued from starting. The `async` scheduled lambda accepts either a `Task`- or
+`ValueTask`-returning UI method; result-bearing variants preserve `TResult` through the unwrapped
+`Task<TResult>`.
 
 `ExecutionContext` still flows normally. `AsyncLocal<T>` values visible to the caller flow into actions and strategy callbacks, while parallel hedge attempts receive isolated logical snapshots so one attempt's mutations do not leak into another or a later execution. Calling Kevlar from work started under `ExecutionContext.SuppressFlow()` keeps that flow suppressed.
 

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -200,7 +200,7 @@ neither context may be retained.
 | `ResiliencePipelineBuilder.Name` / `InstanceName` | `WithName` / `KevlarContext.ShieldName` |
 | Top-level `ExecuteAsync(callback, context)` | `ExecuteWithContextAsync(callback)` |
 | Nested `inner.ExecuteAsync(callback, context)` | `inner.ExecuteWithContextAsync(parentContext, callback)` |
-| `ContinueOnCapturedContext` | no equivalent; Kevlar library awaits do not capture the caller's context |
+| `ContinueOnCapturedContext` | no context flag; capture `TaskScheduler.FromCurrentSynchronizationContext()` on the UI thread and schedule each delegate or hook invocation explicitly |
 
 Do not retain either library's pooled context beyond the current callback or execution delegate.
 


### PR DESCRIPTION
## Summary
- document the issue's explicit marshal-back alternative instead of adding engine-wide context capture
- show how to capture a UI `TaskScheduler` and schedule every retry/hedge delegate invocation
- call out hook wrapping, deadlock, hedging serialization, and queued-cancellation behavior
- update the Polly `ContinueOnCapturedContext` migration mapping

This leaves Kevlar's default `ConfigureAwait(false)` behavior and opt-out hot-path allocations unchanged.

## Validation
- `pwsh scripts/Verify-Docs.ps1`
- `npm ci`
- `npm run build`

Closes #443