### PR TITLE
docs(execution): add UI context recipe

### DIFF
--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -63,15 +63,16 @@ TaskScheduler uiScheduler = TaskScheduler.FromCurrentSynchronizationContext();
 await shield.ExecuteAsync(
     ct => new ValueTask(Task.Factory.StartNew(
         () => UpdateUiAsync(ct),
-        CancellationToken.None,
+        ct,
         TaskCreationOptions.DenyChildAttach,
         uiScheduler).Unwrap()),
     cancellationToken);
 ```
 
-Capture the scheduler on the UI thread. Pass Kevlar's effective `ct` into the UI operation, as
-shown. Apply the same explicit dispatch inside any UI-affine fallback or notification hook. This is
-an allocation-bearing opt-in at the call site; ordinary execution retains its zero-allocation,
+Capture the scheduler on the UI thread. Pass Kevlar's effective `ct` to both the dispatch and the UI
+operation, as shown, so timeout or hedge cancellation can stop work that is still queued. Apply the
+same explicit dispatch inside any UI-affine fallback or notification hook. This is an
+allocation-bearing opt-in at the call site; ordinary execution retains its zero-allocation,
 context-free continuation behavior.
 
 `ExecutionContext` still flows normally. `AsyncLocal<T>` values visible to the caller flow into actions and strategy callbacks, while parallel hedge attempts receive isolated logical snapshots so one attempt's mutations do not leak into another or a later execution. Calling Kevlar from work started under `ExecutionContext.SuppressFlow()` keeps that flow suppressed.

--- a/docs/docs/executing.md
+++ b/docs/docs/executing.md
@@ -49,6 +49,31 @@ Your delegate receives a `CancellationToken` that combines your outer token with
 
 Kevlar invokes the first user delegate inline when no preceding strategy defers execution, so it initially sees the caller's current `SynchronizationContext`. A queued limiter execution and other deferred work may first invoke the delegate with no `SynchronizationContext`. Internal asynchronous continuations use `ConfigureAwait(false)` and do not marshal back to the caller's context; a later retry, fallback, timeout callback, or hedge may likewise run with no `SynchronizationContext`. Your own delegate controls whether its own awaits capture a context.
 
+### UI-thread delegates
+
+Kevlar has no `ContinueOnCapturedContext` switch. When every attempt must enter WPF, MAUI, WinUI,
+or another UI context, capture its scheduler before execution and marshal inside the action. Because
+retry and hedging invoke the action again, this schedules every attempt rather than only the final
+continuation:
+
+<!-- doc-test-ignore: UpdateUiAsync represents application-specific UI work. -->
+```csharp
+TaskScheduler uiScheduler = TaskScheduler.FromCurrentSynchronizationContext();
+
+await shield.ExecuteAsync(
+    ct => new ValueTask(Task.Factory.StartNew(
+        () => UpdateUiAsync(ct),
+        CancellationToken.None,
+        TaskCreationOptions.DenyChildAttach,
+        uiScheduler).Unwrap()),
+    cancellationToken);
+```
+
+Capture the scheduler on the UI thread. Pass Kevlar's effective `ct` into the UI operation, as
+shown. Apply the same explicit dispatch inside any UI-affine fallback or notification hook. This is
+an allocation-bearing opt-in at the call site; ordinary execution retains its zero-allocation,
+context-free continuation behavior.
+
 `ExecutionContext` still flows normally. `AsyncLocal<T>` values visible to the caller flow into actions and strategy callbacks, while parallel hedge attempts receive isolated logical snapshots so one attempt's mutations do not leak into another or a later execution. Calling Kevlar from work started under `ExecutionContext.SuppressFlow()` keeps that flow suppressed.
 
 Synchronous `Execute` never pumps a `SynchronizationContext`. Retry delays and limiter queues block

--- a/docs/docs/polly-migration.md
+++ b/docs/docs/polly-migration.md
@@ -200,7 +200,7 @@ neither context may be retained.
 | `ResiliencePipelineBuilder.Name` / `InstanceName` | `WithName` / `KevlarContext.ShieldName` |
 | Top-level `ExecuteAsync(callback, context)` | `ExecuteWithContextAsync(callback)` |
 | Nested `inner.ExecuteAsync(callback, context)` | `inner.ExecuteWithContextAsync(parentContext, callback)` |
-| `ContinueOnCapturedContext` | no equivalent; Kevlar library awaits do not capture the caller's context |
+| `ContinueOnCapturedContext` | no global switch; [capture the UI scheduler and dispatch inside the action](executing.md#ui-thread-delegates) |
 
 Do not retain either library's pooled context beyond the current callback or execution delegate.
 


### PR DESCRIPTION
## Summary

- document the supported alternative to ContinueOnCapturedContext
- capture a UI TaskScheduler before shield execution and dispatch inside the action so every retry/hedge attempt is marshaled
- clarify cancellation, hook dispatch, and allocation tradeoffs
- link the recipe from the Polly migration table

Closes #443

## Validation

- pwsh scripts/Verify-Docs.ps1