### PR TITLE
perf(circuit): avoid closed admission lock

### DIFF
--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -38,7 +38,7 @@ internal sealed class CircuitBreakerCore
     private double _currentBucketStart = double.NaN;
     private int _currentBucketIndex;
 
-    private CircuitState _state = CircuitState.Closed;
+    private volatile CircuitState _state = CircuitState.Closed;
     private double _latestTimestamp;
     private double _openUntilTimestamp;
     private int _consecutiveFailures;
@@ -310,6 +310,14 @@ internal sealed class CircuitBreakerCore
         transition = null;
         admissionGeneration = 0;
         rejection = null;
+
+        if (_state == CircuitState.Closed)
+        {
+            // Closed executions reserve no exclusive state. A concurrent transition increments
+            // the generation so its in-flight outcome cannot affect the new circuit generation.
+            admissionGeneration = Volatile.Read(ref _admissionGeneration);
+            return true;
+        }
 
         lock (_gate)
         {

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -311,11 +311,13 @@ internal sealed class CircuitBreakerCore
         admissionGeneration = 0;
         rejection = null;
 
-        if (_state == CircuitState.Closed)
+        var observedGeneration = Volatile.Read(ref _admissionGeneration);
+        if (_state == CircuitState.Closed
+            && observedGeneration == Volatile.Read(ref _admissionGeneration))
         {
             // Closed executions reserve no exclusive state. A concurrent transition increments
             // the generation so its in-flight outcome cannot affect the new circuit generation.
-            admissionGeneration = Volatile.Read(ref _admissionGeneration);
+            admissionGeneration = observedGeneration;
             return true;
         }
 
@@ -746,7 +748,7 @@ internal sealed class CircuitBreakerCore
         lock (_gate)
         {
             CancelPendingOpening();
-            _admissionGeneration++;
+            Interlocked.Increment(ref _admissionGeneration);
             ResetMetrics();
             _probeInFlight = false;
             _lastException = null;
@@ -904,7 +906,7 @@ internal sealed class CircuitBreakerCore
         _state = next;
         if (next is CircuitState.Open or CircuitState.Isolated)
         {
-            _admissionGeneration++;
+            Interlocked.Increment(ref _admissionGeneration);
         }
         else if (next == CircuitState.Closed)
         {

--- a/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
@@ -166,17 +166,28 @@ public class CircuitBreakerStateReportingTests
 
         for (var iteration = 0; iteration < 100; iteration++)
         {
-            using var bothAdmitted = new Barrier(participantCount: 2);
-            var success = Task.Run(async () => await shield.ExecuteOutcomeAsync<int>(_ =>
+            var bothAdmitted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var admittedCount = 0;
+            var success = shield.ExecuteOutcomeAsync<int>(async _ =>
             {
-                bothAdmitted.SignalAndWait();
-                return new ValueTask<int>(42);
-            }));
-            var failure = Task.Run(async () => await shield.ExecuteOutcomeAsync<int>(_ =>
+                if (Interlocked.Increment(ref admittedCount) == 2)
+                {
+                    bothAdmitted.SetResult();
+                }
+
+                await bothAdmitted.Task;
+                return 42;
+            }).AsTask();
+            var failure = shield.ExecuteOutcomeAsync<int>(async _ =>
             {
-                bothAdmitted.SignalAndWait();
+                if (Interlocked.Increment(ref admittedCount) == 2)
+                {
+                    bothAdmitted.SetResult();
+                }
+
+                await bothAdmitted.Task;
                 throw new InvalidOperationException("open");
-            }));
+            }).AsTask();
 
             var outcomes = await Task.WhenAll(success, failure);
 

--- a/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
@@ -154,6 +154,40 @@ public class CircuitBreakerStateReportingTests
     }
 
     [Test]
+    public async Task Concurrent_Closed_Success_Does_Not_Override_Opening()
+    {
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.ConsecutiveFailures = 1;
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+        });
+
+        for (var iteration = 0; iteration < 100; iteration++)
+        {
+            using var bothAdmitted = new Barrier(participantCount: 2);
+            var success = Task.Run(async () => await shield.ExecuteOutcomeAsync<int>(_ =>
+            {
+                bothAdmitted.SignalAndWait();
+                return new ValueTask<int>(42);
+            }));
+            var failure = Task.Run(async () => await shield.ExecuteOutcomeAsync<int>(_ =>
+            {
+                bothAdmitted.SignalAndWait();
+                throw new InvalidOperationException("open");
+            }));
+
+            var outcomes = await Task.WhenAll(success, failure);
+
+            await Assert.That(outcomes[0].IsSuccess).IsTrue();
+            await Assert.That(outcomes[1].Exception).IsTypeOf<InvalidOperationException>();
+            await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+            monitor.Reset();
+        }
+    }
+
+    [Test]
     public async Task Stale_Failure_Does_Not_Reopen_HalfOpen()
     {
         var timeProvider = new FakeTimeProvider();

--- a/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerStateReportingTests.cs
@@ -164,38 +164,23 @@ public class CircuitBreakerStateReportingTests
             options.Monitor = monitor;
         });
 
-        for (var iteration = 0; iteration < 100; iteration++)
+        var successStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSuccess = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var success = shield.ExecuteOutcomeAsync<int>(async _ =>
         {
-            var bothAdmitted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            var admittedCount = 0;
-            var success = shield.ExecuteOutcomeAsync<int>(async _ =>
-            {
-                if (Interlocked.Increment(ref admittedCount) == 2)
-                {
-                    bothAdmitted.SetResult();
-                }
+            successStarted.SetResult();
+            await releaseSuccess.Task;
+            return 42;
+        }).AsTask();
+        await successStarted.Task;
 
-                await bothAdmitted.Task;
-                return 42;
-            }).AsTask();
-            var failure = shield.ExecuteOutcomeAsync<int>(async _ =>
-            {
-                if (Interlocked.Increment(ref admittedCount) == 2)
-                {
-                    bothAdmitted.SetResult();
-                }
+        var failure = await shield.ExecuteOutcomeAsync<int>(_ => throw new InvalidOperationException("open"));
+        releaseSuccess.SetResult();
+        var successOutcome = await success;
 
-                await bothAdmitted.Task;
-                throw new InvalidOperationException("open");
-            }).AsTask();
-
-            var outcomes = await Task.WhenAll(success, failure);
-
-            await Assert.That(outcomes[0].IsSuccess).IsTrue();
-            await Assert.That(outcomes[1].Exception).IsTypeOf<InvalidOperationException>();
-            await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
-            monitor.Reset();
-        }
+        await Assert.That(successOutcome.IsSuccess).IsTrue();
+        await Assert.That(failure.Exception).IsTypeOf<InvalidOperationException>();
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- bypass the circuit breaker gate for closed-state admission
- retain locked handling for open, half-open, and isolated states
- use admission generations to keep transition-crossing outcomes stale
- add a concurrent success/opening regression test

## Motivation

Profiling the timeout/retry/ratio-breaker stress workload showed closed circuit admission contending on the same gate as success accounting. Closed admission reserves no exclusive state, while the existing admission generation already prevents an in-flight outcome from mutating a later circuit generation.

This removes one of two global lock acquisitions from every successful closed-circuit execution without changing transition behavior.

## Benchmarks

Local Windows 11, .NET 10.0.11, i7-12700K. Four alternating rounds, 24 seconds total.

| Workers | Kevlar/Polly before | Kevlar/Polly after | Kevlar throughput change |
|---:|---:|---:|---:|
| 4 | 0.77x | 1.43x | +50% |
| 8 | 0.93x | 1.37x | +52% |

BenchmarkDotNet composed pipeline happy path:

| Library | Mean | Allocated |
|---|---:|---:|
| Kevlar | 242.2 ns | 0 B |
| Polly | 418.0 ns | 48 B |

## Validation

- `dotnet build Kevlar.slnx -c Release`
- unit tests, net8.0: 1,368 passed
- unit tests, net10.0: 1,402 passed
- integration tests: 177 passed
- analyzer tests: 299 passed
- concurrent circuit race test: 100 iterations passed
- BenchmarkDotNet ratio timeout/retry/breaker short run
- stress worker sweep at 1, 2, 4, and 8 workers