### PR TITLE
test(stress): expose scaling bottlenecks

### DIFF
--- a/.github/scripts/stress_docs.py
+++ b/.github/scripts/stress_docs.py
@@ -38,17 +38,36 @@ def fmt_duration(value):
     )
     if total_seconds >= 60:
         return f"{total_seconds / 60:g} minutes"
+    if total_seconds == 1:
+        return "1 second"
     return f"{total_seconds:g} seconds"
 
 
-def build_page(data, commit):
-    results = {result["library"]: result for result in data["results"]}
-    if set(results) != {"Kevlar", "Polly"}:
-        raise ValueError("Expected exactly one Kevlar result and one Polly result")
+def fmt_seconds(value):
+    if value >= 1:
+        return f"{value:.2f} s"
+    return f"{value * 1000:.2f} ms"
 
-    kevlar = results["Kevlar"]
-    polly = results["Polly"]
-    throughput_ratio = kevlar["operationsPerSecond"] / polly["operationsPerSecond"]
+
+SCENARIO_LABELS = {
+    "SharedRatioPipeline": "Shared timeout → retry → ratio breaker",
+    "TimeoutRetryPipeline": "Shared timeout → retry",
+    "PerWorkerRatioPipeline": "Per-worker timeout → retry → ratio breaker",
+}
+
+
+def build_page(data, commit):
+    results = data["results"]
+    worker_counts = sorted({result["workers"] for result in results})
+    workers_description = " and ".join(str(workers) for workers in worker_counts)
+    grouped = {}
+    for result in results:
+        key = (result["scenario"], result["workers"])
+        grouped.setdefault(key, {})[result["library"]] = result
+
+    if not grouped or any(set(pair) != {"Kevlar", "Polly"} for pair in grouped.values()):
+        raise ValueError("Expected one Kevlar and one Polly result per scenario")
+
     timestamp = datetime.fromisoformat(data["timestamp"]).strftime("%Y-%m-%d %H:%M UTC")
     run_commit = commit or data.get("commit", "")[:7]
     suffix = f" (commit `{run_commit}`)" if run_commit else ""
@@ -73,33 +92,49 @@ def build_page(data, commit):
         "",
         "## Latest result",
         "",
-        "| Library | Throughput | Operations | Allocated | Allocated/op | Managed heap (before / after) | GC collections (0 / 1 / 2) |",
-        "|---|---:|---:|---:|---:|---:|---:|",
+        "| Scenario | Workers | Library | Throughput | CPU | Allocated | Allocated/op | GC pause | GC collections (0 / 1 / 2) | Process lock contentions |",
+        "|---|---:|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
 
-    for library in ("Kevlar", "Polly"):
-        result = results[library]
+    for (scenario, workers), pair in grouped.items():
+        for library in ("Kevlar", "Polly"):
+            result = pair[library]
+            cpu = result["cpuSeconds"] / result["elapsedSeconds"] * 100
+            lines.append(
+                f"| {SCENARIO_LABELS.get(scenario, scenario)} | {workers} | {library} | "
+                f"{fmt_count(result['operationsPerSecond'])} ops/s | {cpu:.0f}% | "
+                f"{fmt_bytes(result['allocatedBytes'])} | {result['bytesPerOperation']:.2f} B | "
+                f"{fmt_seconds(result['gcPauseSeconds'])} | "
+                f"{result['gen0Collections']} / "
+                f"{result['gen1Collections']} / {result['gen2Collections']} | "
+                f"{fmt_count(result['lockContentions'])} |"
+            )
+
+    lines += [
+        "",
+        "## Comparisons",
+        "",
+        "| Scenario | Workers | Kevlar / Polly throughput |",
+        "|---|---:|---:|",
+    ]
+
+    for (scenario, workers), pair in grouped.items():
+        ratio = pair["Kevlar"]["operationsPerSecond"] / pair["Polly"]["operationsPerSecond"]
         lines.append(
-            f"| {library} | {fmt_count(result['operationsPerSecond'])} ops/s | "
-            f"{fmt_count(result['operations'])} | {fmt_bytes(result['allocatedBytes'])} | "
-            f"{result['bytesPerOperation']:.2f} B | "
-            f"{fmt_bytes(result['managedBytesBefore'])} / {fmt_bytes(result['managedBytesAfter'])} | "
-            f"{result['gen0Collections']} / "
-            f"{result['gen1Collections']} / {result['gen2Collections']} |"
+            f"| {SCENARIO_LABELS.get(scenario, scenario)} | {workers} | **{ratio:.2f}×** |"
         )
 
     lines += [
         "",
-        f"Kevlar completed **{throughput_ratio:.2f}×** as many operations per second as Polly in this run.",
-        "",
         "## Method",
         "",
-        f"- {data['workers']} parallel workers; "
+        f"- {workers_description} parallel workers; "
         f"{fmt_duration(data['totalDuration'])} total measured time, split equally "
-        f"between libraries across {data.get('measurementRounds', 1)} alternating rounds.",
-        f"- Each pipeline warmed for {fmt_duration(data['warmup'])} before measurement.",
-        "- Each operation returns `42` successfully through Timeout(10 s) → Retry(3, no delay) → CircuitBreaker(10% over 30 s, min 100, break 5 s).",
-        "- Process-wide allocation counters include all worker threads. GC counts are captured separately for each phase.",
+        f"between scenarios and libraries across {data.get('measurementRounds', 1)} alternating rounds.",
+        f"- Each scenario and library warmed for {fmt_duration(data['warmup'])} before measurement.",
+        "- Shared and per-worker ratio-breaker scenarios run Timeout(10 s) → Retry(3, no delay) → CircuitBreaker(10% over 30 s, min 100, break 5 s).",
+        "- Timeout/retry isolates pipeline overhead from circuit-breaker shared-state contention.",
+        "- Process-wide CPU, allocation, GC pause, collection, and managed-lock contention counters are captured separately for each phase.",
         f"- Peak working set for the shared process: {fmt_bytes(data['peakWorkingSetBytes'])}.",
         "",
         "## Environment",

--- a/benchmarks/Kevlar.StressTests/StressPhaseResult.cs
+++ b/benchmarks/Kevlar.StressTests/StressPhaseResult.cs
@@ -1,14 +1,19 @@
 namespace Kevlar.StressTests;
 
 internal sealed record StressPhaseResult(
+    string Scenario,
     string Library,
+    int Workers,
     long Operations,
     double ElapsedSeconds,
     double OperationsPerSecond,
+    double CpuSeconds,
     long AllocatedBytes,
     double BytesPerOperation,
     long ManagedBytesBefore,
     long ManagedBytesAfter,
+    double GcPauseSeconds,
     int Gen0Collections,
     int Gen1Collections,
-    int Gen2Collections);
+    int Gen2Collections,
+    long LockContentions);

--- a/benchmarks/Kevlar.StressTests/StressRunner.cs
+++ b/benchmarks/Kevlar.StressTests/StressRunner.cs
@@ -14,20 +14,35 @@ internal static class StressRunner
     private const int PartitionKeys = 10_000;
     private const int MaxPartitions = 1_000;
 
-    private static readonly Shield KevlarShield = Shield
-        .Timeout(TimeSpan.FromSeconds(10))
-        .Retry(3, Backoff.None)
-        .CircuitBreaker(options =>
-        {
-            options.FailureRatio = 0.1;
-            options.MinimumThroughput = 100;
-            options.SamplingWindow = TimeSpan.FromSeconds(30);
-            options.BreakDuration = TimeSpan.FromSeconds(5);
-        });
+    private static readonly Shield KevlarSharedRatioPipeline = CreateKevlarRatioPipeline();
+    private static readonly Shield KevlarTimeoutRetryPipeline = CreateKevlarTimeoutRetryPipeline();
+    private static readonly ResiliencePipeline PollySharedRatioPipeline = CreatePollyRatioPipeline();
+    private static readonly ResiliencePipeline PollyTimeoutRetryPipeline = CreatePollyTimeoutRetryPipeline();
 
-    private static readonly ResiliencePipeline PollyPipeline = new ResiliencePipelineBuilder()
+    private static Shield CreateKevlarTimeoutRetryPipeline() => Shield
+        .Timeout(TimeSpan.FromSeconds(10))
+        .Retry(3, Backoff.None);
+
+    private static Shield CreateKevlarRatioPipeline() => CreateKevlarTimeoutRetryPipeline()
+        .CircuitBreaker(ConfigureKevlarRatioBreaker);
+
+    private static void ConfigureKevlarRatioBreaker(CircuitBreakerOptions options)
+    {
+        options.FailureRatio = 0.1;
+        options.MinimumThroughput = 100;
+        options.SamplingWindow = TimeSpan.FromSeconds(30);
+        options.BreakDuration = TimeSpan.FromSeconds(5);
+    }
+
+    private static ResiliencePipelineBuilder CreatePollyTimeoutRetryBuilder() => new ResiliencePipelineBuilder()
         .AddTimeout(new TimeoutStrategyOptions { Timeout = TimeSpan.FromSeconds(10) })
-        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3, Delay = TimeSpan.Zero })
+        .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3, Delay = TimeSpan.Zero });
+
+    private static ResiliencePipeline CreatePollyTimeoutRetryPipeline() =>
+        CreatePollyTimeoutRetryBuilder().Build();
+
+    private static ResiliencePipeline CreatePollyRatioPipeline() =>
+        CreatePollyTimeoutRetryBuilder()
         .AddCircuitBreaker(new CircuitBreakerStrategyOptions
         {
             FailureRatio = 0.1,
@@ -39,37 +54,61 @@ internal static class StressRunner
 
     public static async Task<StressRunResult> RunAsync(StressOptions options)
     {
-        var phaseDuration = TimeSpan.FromTicks(options.Duration.Ticks / (MeasurementRounds * 2));
-        Console.WriteLine(
-            $"Running {options.Workers} workers for {MeasurementRounds} alternating rounds " +
-            $"of {phaseDuration:g} per library ({options.Duration:g} total measured time).");
+        var cases = CreateCases(options.Workers);
+        var phaseDuration = TimeSpan.FromTicks(
+            options.Duration.Ticks / (MeasurementRounds * cases.Count * 2));
+        if (phaseDuration == TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                "Duration is too short for the stress scenario matrix.");
+        }
 
-        await WarmUpAsync("Polly", ExecutePollyAsync, options);
-        await WarmUpAsync("Kevlar", ExecuteKevlarAsync, options);
+        Console.WriteLine(
+            $"Running {cases.Count} scenarios for {MeasurementRounds} alternating rounds " +
+            $"of {phaseDuration:g} per library and scenario ({options.Duration:g} total measured time).");
+
+        foreach (var stressCase in cases)
+        {
+            await WarmUpAsync(stressCase, "Polly", stressCase.PollyOperations, options.Warmup);
+            await WarmUpAsync(stressCase, "Kevlar", stressCase.KevlarOperations, options.Warmup);
+        }
+
         await RunPartitionStressAsync();
 
-        var phases = new List<StressPhaseResult>(MeasurementRounds * 2);
-        for (var round = 0; round < MeasurementRounds; round++)
+        var phases = new List<StressPhaseResult>(MeasurementRounds * cases.Count * 2);
+        foreach (var stressCase in cases)
         {
-            if (round % 2 == 0)
+            for (var round = 0; round < MeasurementRounds; round++)
             {
-                phases.Add(await MeasureAsync("Polly", ExecutePollyAsync, phaseDuration, options.Workers, round));
-                phases.Add(await MeasureAsync("Kevlar", ExecuteKevlarAsync, phaseDuration, options.Workers, round));
-            }
-            else
-            {
-                phases.Add(await MeasureAsync("Kevlar", ExecuteKevlarAsync, phaseDuration, options.Workers, round));
-                phases.Add(await MeasureAsync("Polly", ExecutePollyAsync, phaseDuration, options.Workers, round));
+                if (round % 2 == 0)
+                {
+                    phases.Add(await MeasureAsync(stressCase, "Polly", stressCase.PollyOperations, phaseDuration, round));
+                    phases.Add(await MeasureAsync(stressCase, "Kevlar", stressCase.KevlarOperations, phaseDuration, round));
+                }
+                else
+                {
+                    phases.Add(await MeasureAsync(stressCase, "Kevlar", stressCase.KevlarOperations, phaseDuration, round));
+                    phases.Add(await MeasureAsync(stressCase, "Polly", stressCase.PollyOperations, phaseDuration, round));
+                }
             }
         }
 
-        var results = new[] { Aggregate("Polly", phases), Aggregate("Kevlar", phases) };
+        var results = cases
+            .SelectMany(stressCase => new[]
+            {
+                Aggregate(stressCase, "Polly", phases),
+                Aggregate(stressCase, "Kevlar", phases),
+            })
+            .ToArray();
         foreach (var result in results)
         {
             Console.WriteLine(
-                $"{result.Library} total: {result.OperationsPerSecond:N0} ops/s, " +
+                $"{result.Scenario} ({result.Workers} workers), {result.Library}: " +
+                $"{result.OperationsPerSecond:N0} ops/s, " +
                 $"{result.BytesPerOperation:N2} B/op, " +
-                $"{result.AllocatedBytes / 1_048_576d:N1} MiB allocated.");
+                $"{result.GcPauseSeconds * 1_000:N1} ms GC pause, " +
+                $"{result.LockContentions:N0} lock contentions.");
         }
 
         using var process = Process.GetCurrentProcess();
@@ -89,95 +128,125 @@ internal static class StressRunner
     }
 
     private static async Task WarmUpAsync(
+        StressCase stressCase,
         string library,
-        Func<ValueTask<int>> operation,
-        StressOptions options)
+        Func<ValueTask<int>>[] operations,
+        TimeSpan duration)
     {
-        if (options.Warmup == TimeSpan.Zero)
+        if (duration == TimeSpan.Zero)
         {
             return;
         }
 
-        Console.WriteLine($"Warming {library} for {options.Warmup:g}...");
-        await RunWorkersAsync(operation, options.Warmup, options.Workers);
+        Console.WriteLine(
+            $"Warming {stressCase.Name} ({stressCase.Workers} workers), {library}, for {duration:g}...");
+        await RunWorkersAsync(operations, duration);
     }
 
     private static async Task<StressPhaseResult> MeasureAsync(
+        StressCase stressCase,
         string library,
-        Func<ValueTask<int>> operation,
+        Func<ValueTask<int>>[] operations,
         TimeSpan duration,
-        int workers,
         int round)
     {
         ForceCollection();
+        using var process = Process.GetCurrentProcess();
+        process.Refresh();
+        var cpuBefore = process.TotalProcessorTime;
         var allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
         var managedBefore = GC.GetTotalMemory(forceFullCollection: false);
+        var gcPauseBefore = GC.GetTotalPauseDuration();
         var gen0Before = GC.CollectionCount(0);
         var gen1Before = GC.CollectionCount(1);
         var gen2Before = GC.CollectionCount(2);
-
-        Console.WriteLine($"Measuring {library}, round {round + 1}/{MeasurementRounds}, for {duration:g}...");
-        var stopwatch = Stopwatch.StartNew();
-        var operations = await RunWorkersAsync(operation, duration, workers);
-        stopwatch.Stop();
-        if (operations == 0)
-        {
-            throw new InvalidOperationException($"{library} completed no operations.");
-        }
-
-        var allocatedBytes = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
-        var result = new StressPhaseResult(
-            library,
-            operations,
-            stopwatch.Elapsed.TotalSeconds,
-            operations / stopwatch.Elapsed.TotalSeconds,
-            allocatedBytes,
-            allocatedBytes / (double)operations,
-            managedBefore,
-            GC.GetTotalMemory(forceFullCollection: false),
-            GC.CollectionCount(0) - gen0Before,
-            GC.CollectionCount(1) - gen1Before,
-            GC.CollectionCount(2) - gen2Before);
+        var lockContentionsBefore = Monitor.LockContentionCount;
 
         Console.WriteLine(
-            $"{library} round {round + 1}: {result.OperationsPerSecond:N0} ops/s, " +
-            $"{result.BytesPerOperation:N2} B/op, {result.AllocatedBytes / 1_048_576d:N1} MiB allocated.");
+            $"Measuring {stressCase.Name} ({stressCase.Workers} workers), {library}, " +
+            $"round {round + 1}/{MeasurementRounds}, for {duration:g}...");
+        var stopwatch = Stopwatch.StartNew();
+        var operationCount = await RunWorkersAsync(operations, duration);
+        stopwatch.Stop();
+        if (operationCount == 0)
+        {
+            throw new InvalidOperationException(
+                $"{stressCase.Name}, {library} completed no operations.");
+        }
+
+        process.Refresh();
+        var allocatedBytes = GC.GetTotalAllocatedBytes(precise: true) - allocatedBefore;
+        var result = new StressPhaseResult(
+            stressCase.Name,
+            library,
+            stressCase.Workers,
+            operationCount,
+            stopwatch.Elapsed.TotalSeconds,
+            operationCount / stopwatch.Elapsed.TotalSeconds,
+            (process.TotalProcessorTime - cpuBefore).TotalSeconds,
+            allocatedBytes,
+            allocatedBytes / (double)operationCount,
+            managedBefore,
+            GC.GetTotalMemory(forceFullCollection: false),
+            (GC.GetTotalPauseDuration() - gcPauseBefore).TotalSeconds,
+            GC.CollectionCount(0) - gen0Before,
+            GC.CollectionCount(1) - gen1Before,
+            GC.CollectionCount(2) - gen2Before,
+            Monitor.LockContentionCount - lockContentionsBefore);
+
+        Console.WriteLine(
+            $"{stressCase.Name}, {library} round {round + 1}: " +
+            $"{result.OperationsPerSecond:N0} ops/s, {result.BytesPerOperation:N2} B/op, " +
+            $"{result.GcPauseSeconds * 1_000:N1} ms GC pause, " +
+            $"{result.LockContentions:N0} lock contentions.");
         return result;
     }
 
-    private static StressPhaseResult Aggregate(string library, List<StressPhaseResult> phases)
+    private static StressPhaseResult Aggregate(
+        StressCase stressCase,
+        string library,
+        List<StressPhaseResult> phases)
     {
-        var matching = phases.Where(result => result.Library == library).ToArray();
+        var matching = phases
+            .Where(result => result.Scenario == stressCase.Name
+                && result.Workers == stressCase.Workers
+                && result.Library == library)
+            .ToArray();
         var operations = matching.Sum(result => result.Operations);
         var elapsedSeconds = matching.Sum(result => result.ElapsedSeconds);
         var allocatedBytes = matching.Sum(result => result.AllocatedBytes);
 
         return new StressPhaseResult(
+            stressCase.Name,
             library,
+            stressCase.Workers,
             operations,
             elapsedSeconds,
             operations / elapsedSeconds,
+            matching.Sum(result => result.CpuSeconds),
             allocatedBytes,
             allocatedBytes / (double)operations,
             matching[0].ManagedBytesBefore,
             matching[^1].ManagedBytesAfter,
+            matching.Sum(result => result.GcPauseSeconds),
             matching.Sum(result => result.Gen0Collections),
             matching.Sum(result => result.Gen1Collections),
-            matching.Sum(result => result.Gen2Collections));
+            matching.Sum(result => result.Gen2Collections),
+            matching.Sum(result => result.LockContentions));
     }
 
     private static async Task<long> RunWorkersAsync(
-        Func<ValueTask<int>> operation,
-        TimeSpan duration,
-        int workerCount)
+        Func<ValueTask<int>>[] operations,
+        TimeSpan duration)
     {
         var deadline = Stopwatch.GetTimestamp() + (long)(duration.TotalSeconds * Stopwatch.Frequency);
-        var workers = new Task<long>[workerCount];
+        var workers = new Task<long>[operations.Length];
         for (var worker = 0; worker < workers.Length; worker++)
         {
+            var operation = operations[worker];
             workers[worker] = Task.Run(async () =>
             {
-                var operations = 0L;
+                var operationCount = 0L;
                 while (Stopwatch.GetTimestamp() < deadline)
                 {
                     var result = await operation().ConfigureAwait(false);
@@ -186,10 +255,10 @@ internal static class StressRunner
                         throw new InvalidOperationException($"Workload returned {result}; expected 42.");
                     }
 
-                    operations++;
+                    operationCount++;
                 }
 
-                return operations;
+                return operationCount;
             });
         }
 
@@ -233,9 +302,63 @@ internal static class StressRunner
             $"{partitions.EvictionCount:N0} evicted.");
     }
 
-    private static ValueTask<int> ExecuteKevlarAsync() =>
-        KevlarShield.ExecuteAsync(static _ => new ValueTask<int>(42));
+    private static IReadOnlyList<StressCase> CreateCases(int workers)
+    {
+        var cases = new List<StressCase>
+        {
+            CreateSharedRatioCase(workers: 1),
+        };
 
-    private static ValueTask<int> ExecutePollyAsync() =>
-        PollyPipeline.ExecuteAsync(static _ => new ValueTask<int>(42));
+        if (workers > 1)
+        {
+            cases.Add(CreateSharedRatioCase(workers));
+        }
+
+        cases.Add(CreateTimeoutRetryCase(workers));
+        if (workers > 1)
+        {
+            cases.Add(CreatePerWorkerRatioCase(workers));
+        }
+
+        return cases;
+    }
+
+    private static StressCase CreateSharedRatioCase(int workers) => new(
+        "SharedRatioPipeline",
+        workers,
+        Repeat(workers, CreateKevlarOperation(KevlarSharedRatioPipeline)),
+        Repeat(workers, CreatePollyOperation(PollySharedRatioPipeline)));
+
+    private static StressCase CreateTimeoutRetryCase(int workers) => new(
+        "TimeoutRetryPipeline",
+        workers,
+        Repeat(workers, CreateKevlarOperation(KevlarTimeoutRetryPipeline)),
+        Repeat(workers, CreatePollyOperation(PollyTimeoutRetryPipeline)));
+
+    private static StressCase CreatePerWorkerRatioCase(int workers)
+    {
+        var kevlarOperations = Enumerable.Range(0, workers)
+            .Select(_ => CreateKevlarOperation(CreateKevlarRatioPipeline()))
+            .ToArray();
+        var pollyOperations = Enumerable.Range(0, workers)
+            .Select(_ => CreatePollyOperation(CreatePollyRatioPipeline()))
+            .ToArray();
+
+        return new StressCase("PerWorkerRatioPipeline", workers, kevlarOperations, pollyOperations);
+    }
+
+    private static Func<ValueTask<int>>[] Repeat(int count, Func<ValueTask<int>> operation) =>
+        Enumerable.Repeat(operation, count).ToArray();
+
+    private static Func<ValueTask<int>> CreateKevlarOperation(Shield pipeline) =>
+        () => pipeline.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    private static Func<ValueTask<int>> CreatePollyOperation(ResiliencePipeline pipeline) =>
+        () => pipeline.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    private sealed record StressCase(
+        string Name,
+        int Workers,
+        Func<ValueTask<int>>[] KevlarOperations,
+        Func<ValueTask<int>>[] PollyOperations);
 }


### PR DESCRIPTION
## Summary

- compare shared ratio pipelines at one and configured worker counts
- add timeout/retry-only and per-worker ratio-pipeline scenarios
- record CPU time, GC pause duration, and process lock contentions
- publish scenario-level Kevlar/Polly ratios in generated stress docs

## Motivation

Collection counts alone do not explain sustained throughput. Shared circuit-breaker contention can offset Kevlar's allocation and GC advantage, so the stress run now separates scaling, pipeline overhead, and shared-state costs while keeping the existing total duration budget.

## Local smoke result

Windows 11, .NET 10.0.11, 4 workers, 30 seconds total:

| Scenario | Kevlar / Polly |
|---|---:|
| Shared ratio pipeline, 1 worker | 1.58x |
| Shared ratio pipeline, 4 workers | 1.22x |
| Timeout/retry, 4 workers | 1.98x |
| Per-worker ratio pipeline, 4 workers | 1.94x |

Polly recorded 4.5-14.0 ms GC pause per scenario; Kevlar recorded no GC pause. Shared four-worker Kevlar recorded 1,507 process lock contentions versus 166 with per-worker breakers.

## Validation

- dotnet build Kevlar.slnx -c Release
- workflow-equivalent 30-second stress smoke
- generated stress documentation from new JSON schema