### PR TITLE
perf(circuit): remove closed success lock

### DIFF
--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -33,10 +33,13 @@ internal sealed class CircuitBreakerCore
     private readonly Queue<TransitionPublication> _pendingTransitions = new();
     private readonly AsyncLocal<TransitionPublication?>? _ambientPublication;
 
-    private readonly long[] _bucketFailures = new long[BucketCount];
-    private readonly long[] _bucketSuccesses = new long[BucketCount];
+    private readonly RatioBucket?[] _ratioBuckets = new RatioBucket?[BucketCount];
+    private TimestampOrigin? _systemTimestampOrigin;
+    private RatioBucket? _currentRatioBucket;
     private double _currentBucketStart = double.NaN;
+    private double _currentBucketEnd = double.NaN;
     private int _currentBucketIndex;
+    private int _systemRatioFastPathEnabled = 1;
 
     private volatile CircuitState _state = CircuitState.Closed;
     private double _latestTimestamp;
@@ -396,14 +399,59 @@ internal sealed class CircuitBreakerCore
         KevlarContext context,
         long admissionGeneration)
     {
+        if (TryRecordRatioSuccessFast(timeProvider, admissionGeneration))
+        {
+            return;
+        }
+
         Publish(RecordSuccessCore(timeProvider, context, admissionGeneration));
     }
 
     public ValueTask RecordSuccessAsync(
         TimeProvider timeProvider,
         KevlarContext context,
-        long admissionGeneration) =>
-        PublishAsync(RecordSuccessCore(timeProvider, context, admissionGeneration));
+        long admissionGeneration)
+    {
+        return TryRecordRatioSuccessFast(timeProvider, admissionGeneration)
+            ? default
+            : PublishAsync(RecordSuccessCore(timeProvider, context, admissionGeneration));
+    }
+
+    private bool TryRecordRatioSuccessFast(
+        TimeProvider timeProvider,
+        long admissionGeneration)
+    {
+        if (_failureRatio is null
+            || Volatile.Read(ref _systemRatioFastPathEnabled) == 0
+            || !ReferenceEquals(timeProvider, TimeProvider.System))
+        {
+            return false;
+        }
+
+        var origin = Volatile.Read(ref _systemTimestampOrigin);
+        var bucket = Volatile.Read(ref _currentRatioBucket);
+        if (origin is null || bucket is null)
+        {
+            return false;
+        }
+
+        var providerTimestamp = Stopwatch.GetTimestamp();
+        var elapsedTimestamp = unchecked(providerTimestamp - origin.ProviderTimestamp);
+        var timestamp = origin.TimelineTimestamp + (elapsedTimestamp * origin.TimestampScale);
+        if (timestamp >= Volatile.Read(ref _currentBucketEnd)
+            || Volatile.Read(ref _systemRatioFastPathEnabled) == 0
+            || _state != CircuitState.Closed
+            || admissionGeneration != Volatile.Read(ref _admissionGeneration))
+        {
+            return false;
+        }
+
+        // Bucket instances are never reused. A concurrent rollover or reset can detach this
+        // bucket, making a late increment harmless instead of racing an in-place clear.
+        Volatile.Write(ref _consecutiveFailures, 0);
+        Interlocked.Increment(ref bucket.Successes);
+        return true;
+    }
 
     private TransitionPublication? RecordSuccessCore(
         TimeProvider timeProvider,
@@ -427,10 +475,11 @@ internal sealed class CircuitBreakerCore
 
             if (_state == CircuitState.Closed)
             {
-                _consecutiveFailures = 0;
+                Volatile.Write(ref _consecutiveFailures, 0);
                 if (_failureRatio is not null)
                 {
-                    _bucketSuccesses[AdvanceBucket(timeProvider)]++;
+                    var bucket = AdvanceBucket(timeProvider);
+                    Interlocked.Increment(ref bucket.Successes);
                 }
             }
 
@@ -763,41 +812,52 @@ internal sealed class CircuitBreakerCore
         double timestamp,
         out CircuitBreakerFailureStatistics statistics)
     {
-        _consecutiveFailures++;
+        var consecutiveFailures = Interlocked.Increment(ref _consecutiveFailures);
         if (_consecutiveFailureLimit is { } limit)
         {
             statistics = new CircuitBreakerFailureStatistics(
                 FailureRate: 1,
-                FailureCount: _consecutiveFailures,
-                ConsecutiveFailures: _consecutiveFailures);
-            return _consecutiveFailures >= limit;
+                FailureCount: consecutiveFailures,
+                ConsecutiveFailures: consecutiveFailures);
+            return consecutiveFailures >= limit;
         }
 
         var bucket = AdvanceBucket(timestamp);
-        _bucketFailures[bucket]++;
+        bucket.Failures++;
 
         long failures = 0, total = 0;
         for (var i = 0; i < BucketCount; i++)
         {
-            failures += _bucketFailures[i];
-            total += _bucketFailures[i] + _bucketSuccesses[i];
+            var sample = _ratioBuckets[i];
+            if (sample is null)
+            {
+                continue;
+            }
+
+            var bucketFailures = sample.Failures;
+            failures += bucketFailures;
+            total += bucketFailures + Interlocked.Read(ref sample.Successes);
         }
 
         var failureRate = (double)failures / total;
         statistics = new CircuitBreakerFailureStatistics(
             failureRate,
             failures,
-            _consecutiveFailures);
+            consecutiveFailures);
         return total >= _minimumThroughput && failureRate >= _failureRatio!.Value;
     }
 
-    private int AdvanceBucket(TimeProvider timeProvider) => AdvanceBucket(GetCurrentTimestamp(timeProvider));
+    private RatioBucket AdvanceBucket(TimeProvider timeProvider) =>
+        AdvanceBucket(GetCurrentTimestamp(timeProvider));
 
-    private int AdvanceBucket(double timestamp)
+    private RatioBucket AdvanceBucket(double timestamp)
     {
+        var currentBucket = _currentRatioBucket;
         if (double.IsNaN(_currentBucketStart))
         {
             _currentBucketStart = timestamp;
+            currentBucket = new RatioBucket();
+            _ratioBuckets[_currentBucketIndex] = currentBucket;
         }
         else
         {
@@ -811,37 +871,55 @@ internal sealed class CircuitBreakerCore
                 for (var i = 1; i <= advance; i++)
                 {
                     var index = (_currentBucketIndex + i) % BucketCount;
-                    _bucketFailures[index] = 0;
-                    _bucketSuccesses[index] = 0;
+                    _ratioBuckets[index] = null;
                 }
 
                 _currentBucketIndex = (_currentBucketIndex + advance) % BucketCount;
                 _currentBucketStart = advance == BucketCount
                     ? timestamp
                     : _currentBucketStart + (advance * _bucketDurationTimestampUnits);
+                currentBucket = new RatioBucket();
+                _ratioBuckets[_currentBucketIndex] = currentBucket;
             }
         }
 
-        return _currentBucketIndex;
+        Volatile.Write(ref _currentRatioBucket, currentBucket);
+        Volatile.Write(
+            ref _currentBucketEnd,
+            _currentBucketStart + _bucketDurationTimestampUnits);
+        return currentBucket!;
     }
 
     private void ResetMetrics()
     {
-        _consecutiveFailures = 0;
+        Volatile.Write(ref _consecutiveFailures, 0);
+        Volatile.Write(ref _currentRatioBucket, null);
         _currentBucketStart = double.NaN;
+        Volatile.Write(ref _currentBucketEnd, double.NaN);
         _currentBucketIndex = 0;
-        Array.Clear(_bucketFailures, 0, BucketCount);
-        Array.Clear(_bucketSuccesses, 0, BucketCount);
+        Array.Clear(_ratioBuckets, 0, BucketCount);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private double GetCurrentTimestamp(TimeProvider timeProvider)
     {
+        if (!ReferenceEquals(timeProvider, TimeProvider.System))
+        {
+            // Alternate providers share a normalized timeline protected by _gate. Once one is
+            // observed, keep every provider on that path so their epochs cannot diverge.
+            Volatile.Write(ref _systemRatioFastPathEnabled, 0);
+        }
+
         var timestamp = timeProvider.GetTimestamp();
         if (!_timestampOrigins.TryGetValue(timeProvider, out var origin))
         {
             origin = new TimestampOrigin(timeProvider, timestamp, _latestTimestamp);
             _timestampOrigins.Add(timeProvider, origin);
+            if (ReferenceEquals(timeProvider, TimeProvider.System))
+            {
+                Volatile.Write(ref _systemTimestampOrigin, origin);
+            }
+
             return _latestTimestamp;
         }
 
@@ -890,6 +968,13 @@ internal sealed class CircuitBreakerCore
         public double TimelineTimestamp { get; }
 
         public double TimestampScale { get; }
+    }
+
+    private sealed class RatioBucket
+    {
+        public long Failures;
+
+        public long Successes;
     }
 
     private TransitionPublication ChangeState(

--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerCore.cs
@@ -37,7 +37,6 @@ internal sealed class CircuitBreakerCore
     private TimestampOrigin? _systemTimestampOrigin;
     private RatioBucket? _currentRatioBucket;
     private double _currentBucketStart = double.NaN;
-    private double _currentBucketEnd = double.NaN;
     private int _currentBucketIndex;
     private int _systemRatioFastPathEnabled = 1;
 
@@ -438,7 +437,7 @@ internal sealed class CircuitBreakerCore
         var providerTimestamp = Stopwatch.GetTimestamp();
         var elapsedTimestamp = unchecked(providerTimestamp - origin.ProviderTimestamp);
         var timestamp = origin.TimelineTimestamp + (elapsedTimestamp * origin.TimestampScale);
-        if (timestamp >= Volatile.Read(ref _currentBucketEnd)
+        if (timestamp >= bucket.EndTimestamp
             || Volatile.Read(ref _systemRatioFastPathEnabled) == 0
             || _state != CircuitState.Closed
             || admissionGeneration != Volatile.Read(ref _admissionGeneration))
@@ -856,7 +855,7 @@ internal sealed class CircuitBreakerCore
         if (double.IsNaN(_currentBucketStart))
         {
             _currentBucketStart = timestamp;
-            currentBucket = new RatioBucket();
+            currentBucket = CreateRatioBucket();
             _ratioBuckets[_currentBucketIndex] = currentBucket;
         }
         else
@@ -878,24 +877,23 @@ internal sealed class CircuitBreakerCore
                 _currentBucketStart = advance == BucketCount
                     ? timestamp
                     : _currentBucketStart + (advance * _bucketDurationTimestampUnits);
-                currentBucket = new RatioBucket();
+                currentBucket = CreateRatioBucket();
                 _ratioBuckets[_currentBucketIndex] = currentBucket;
             }
         }
 
         Volatile.Write(ref _currentRatioBucket, currentBucket);
-        Volatile.Write(
-            ref _currentBucketEnd,
-            _currentBucketStart + _bucketDurationTimestampUnits);
         return currentBucket!;
     }
+
+    private RatioBucket CreateRatioBucket() =>
+        new(_currentBucketStart + _bucketDurationTimestampUnits);
 
     private void ResetMetrics()
     {
         Volatile.Write(ref _consecutiveFailures, 0);
         Volatile.Write(ref _currentRatioBucket, null);
         _currentBucketStart = double.NaN;
-        Volatile.Write(ref _currentBucketEnd, double.NaN);
         _currentBucketIndex = 0;
         Array.Clear(_ratioBuckets, 0, BucketCount);
     }
@@ -972,6 +970,13 @@ internal sealed class CircuitBreakerCore
 
     private sealed class RatioBucket
     {
+        public RatioBucket(double endTimestamp)
+        {
+            EndTimestamp = endTimestamp;
+        }
+
+        public double EndTimestamp { get; }
+
         public long Failures;
 
         public long Successes;

--- a/tests/Kevlar.Tests/CircuitBreakerEdgeCaseTests.cs
+++ b/tests/Kevlar.Tests/CircuitBreakerEdgeCaseTests.cs
@@ -388,6 +388,51 @@ public class CircuitBreakerEdgeCaseTests
     }
 
     [Test]
+    public async Task Ratio_Mode_Counts_Concurrent_Successes_Exactly()
+    {
+        const int workerCount = 4;
+        const int successesPerWorker = 100;
+        const int expectedSuccesses = workerCount * successesPerWorker;
+        var monitor = new CircuitBreakerMonitor();
+        var shield = Shield.CircuitBreaker(options =>
+        {
+            options.FailureRatio = 0.5;
+            options.MinimumThroughput = expectedSuccesses * 2;
+            options.SamplingWindow = TimeSpan.FromMinutes(1);
+            options.BreakDuration = TimeSpan.FromMinutes(1);
+            options.Monitor = monitor;
+        });
+        var readyWorkers = 0;
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var workers = Enumerable.Range(0, workerCount).Select(_ => Task.Run(async () =>
+        {
+            if (Interlocked.Increment(ref readyWorkers) == workerCount)
+            {
+                start.SetResult();
+            }
+
+            await start.Task;
+            for (var success = 0; success < successesPerWorker; success++)
+            {
+                await shield.ExecuteAsync(static _ => new ValueTask<int>(42));
+            }
+        }));
+        await Task.WhenAll(workers);
+
+        for (var failure = 1; failure < expectedSuccesses; failure++)
+        {
+            await shield.ExecuteOutcomeAsync<int>(static _ => throw new InvalidOperationException());
+        }
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Closed);
+
+        await shield.ExecuteOutcomeAsync<int>(static _ => throw new InvalidOperationException());
+
+        await Assert.That(monitor.State).IsEqualTo(CircuitState.Open);
+    }
+
+    [Test]
     public async Task Reset_Closes_The_Circuit_And_Clears_Failure_History()
     {
         var monitor = new CircuitBreakerMonitor();


### PR DESCRIPTION
## Summary

- record closed ratio-breaker successes without taking the circuit state gate
- replace rolling bucket instances instead of clearing counters in place
- keep failures, bucket rollover, transitions, and custom time-provider timelines locked
- add an exact concurrent ratio-accounting regression test

Depends on #473 for the stress scenario matrix and diagnostics used below.

## Motivation

After closed admission became lock-free, every successful ratio-breaker execution still serialized in success accounting. Replace-on-rollover buckets let in-flight atomic increments safely land on detached bucket instances while state transitions remain generation-protected.

## Benchmarks

Local Windows 11, .NET 10.0.11, i7-12700K. Same 60-second stress matrix before and after.

| Scenario | Before | After | Change | Kevlar/Polly before | Kevlar/Polly after |
|---|---:|---:|---:|---:|---:|
| Shared ratio pipeline, 1 worker | 3.52M ops/s | 3.81M ops/s | +8.1% | 1.56x | 1.75x |
| Shared ratio pipeline, 4 workers | 5.25M ops/s | 8.60M ops/s | +63.7% | 1.30x | 2.15x |

Shared four-worker process lock contentions fell from 5,768 to 3. The per-worker and timeout/retry controls ran 10.9-14.2% slower in the after run, so the shared-pipeline gain is not explained by a faster machine interval. Shared/per-worker Kevlar scaling improved from 47.5% to 87.3%.

BenchmarkDotNet default job:

| Benchmark | Before | After | Change | Allocated |
|---|---:|---:|---:|---:|
| Ratio breaker, closed success | 132.3 ns | 111.0 ns | -16.1% | 0 B |
| Timeout/retry/ratio pipeline | 242.3 ns | 222.4 ns | -8.2% | 0 B |

## Validation

- dotnet build Kevlar.slnx -c Release
- unit tests, net10.0: 1,403 passed
- unit tests, net8.0: 1,369 passed
- integration tests: 177 passed
- allocation tests, net10.0 and net8.0: 4 passed each
- circuit-breaker focused tests: 82 passed on each runtime
- concurrent ratio regression: 20/20 repeated runs
- BenchmarkDotNet default before/after runs
- 60-second stress matrix before/after runs