### PR TITLE
perf(timeout): gate ignored timing

### DIFF
--- a/src/Kevlar/Internal/KevlarMetrics.cs
+++ b/src/Kevlar/Internal/KevlarMetrics.cs
@@ -157,6 +157,17 @@ internal static class KevlarMetrics
         return KevlarTelemetry.IsEventEnabled(context);
     }
 
+    public static bool TimeoutIgnoredEnabled(KevlarContext context)
+    {
+#if NET8_0_OR_GREATER
+        if (Timeouts.Enabled)
+        {
+            return true;
+        }
+#endif
+        return KevlarTelemetry.IsEventEnabled(context);
+    }
+
 #if NET9_0_OR_GREATER
     public static bool CircuitStateEnabled => CircuitStateGauge.Enabled || CircuitInstances.Enabled;
     public static bool ConcurrencyStateEnabled =>

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -103,7 +103,8 @@ internal sealed class TimeoutStrategy : Strategy
             : CancellationTokenSource.CreateLinkedTokenSource(priorToken);
         ITimer? timer = null;
         ValueTask<Outcome<T>> execution;
-        var startedAt = context.TimeProvider.GetTimestamp();
+        var recordTimeoutIgnored = KevlarMetrics.TimeoutIgnoredEnabled(context);
+        var startedAt = recordTimeoutIgnored ? context.TimeProvider.GetTimestamp() : 0;
 
         try
         {
@@ -141,7 +142,15 @@ internal sealed class TimeoutStrategy : Strategy
 
         if (!execution.IsCompletedSuccessfully)
         {
-            return AwaitAsync(execution, context, priorToken, timeoutSource, timer, timeout, startedAt);
+            return AwaitAsync(
+                execution,
+                context,
+                priorToken,
+                timeoutSource,
+                timer,
+                timeout,
+                startedAt,
+                recordTimeoutIgnored);
         }
 
         var outcome = execution.Result;
@@ -153,7 +162,8 @@ internal sealed class TimeoutStrategy : Strategy
                 priorToken,
                 timeoutSource,
                 timer,
-                startedAt));
+                startedAt,
+                recordTimeoutIgnored));
         }
 
         return CompleteCancellationAsync(
@@ -173,7 +183,8 @@ internal sealed class TimeoutStrategy : Strategy
         CancellationTokenSource timeoutSource,
         ITimer? timer,
         TimeSpan timeout,
-        long startedAt)
+        long startedAt,
+        bool recordTimeoutIgnored)
     {
         Outcome<T> outcome;
 
@@ -195,7 +206,8 @@ internal sealed class TimeoutStrategy : Strategy
                 priorToken,
                 timeoutSource,
                 timer,
-                startedAt);
+                startedAt,
+                recordTimeoutIgnored);
         }
 
         return await CompleteCancellationAsync(
@@ -214,14 +226,15 @@ internal sealed class TimeoutStrategy : Strategy
         CancellationToken priorToken,
         CancellationTokenSource timeoutSource,
         ITimer? timer,
-        long startedAt)
+        long startedAt,
+        bool recordTimeoutIgnored)
     {
         context.CancellationToken = priorToken;
         timer?.Dispose();
         var timeoutIgnored = !priorToken.IsCancellationRequested && timeoutSource.IsCancellationRequested;
         timeoutSource.Dispose();
 
-        if (timeoutIgnored)
+        if (timeoutIgnored && recordTimeoutIgnored)
         {
             KevlarMetrics.TimeoutIgnored(
                 context,


### PR DESCRIPTION
## Summary

- avoid reading the time-provider timestamp on ordinary timeout completions when ignored-timeout telemetry is disabled
- preserve ignored-timeout metrics and telemetry by snapshotting enablement at execution start
- follow the existing duration/attempt telemetry gating pattern

## Benchmark

BenchmarkDotNet 0.15.8, default job, .NET 10.0.11, Windows 11, Intel i7-12700K. Same command before and after:

`dotnet run -c Release --project benchmarks/Kevlar.Benchmarks -- --filter *TimeoutBenchmarks.Kevlar_HappyPath* *TimeoutBenchmarks.Polly_HappyPath*`

| Method | Before | After | Change | Allocated |
|---|---:|---:|---:|---:|
| Kevlar_HappyPath | 149.1 ns | 123.3 ns | -17.3% | 0 B |
| Polly_HappyPath (control) | 131.9 ns | 127.3 ns | -3.5% | 0 B |

Kevlar moves from 13.0% slower than Polly to 3.1% faster. The control also improved slightly, but Kevlar's 17.3% gain is substantially larger.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --framework net10.0 --no-build -- --timeout 5m` (1402 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release --framework net8.0 --no-build -- --timeout 5m` (1368 passed)