### PR TITLE
perf(fallback): add void fast path

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/FallbackBenchmarks.cs
@@ -8,7 +8,8 @@ namespace Kevlar.Benchmarks;
 /// <summary>
 /// Fallback strategy: the pass-through path (execution succeeds, fallback unused) and
 /// the triggered path (execution throws, fallback value substituted).
-/// Polly only offers fallback on typed pipelines, so both sides use typed pipelines.
+/// Polly only offers fallback on typed pipelines, so comparative groups use typed pipelines.
+/// Kevlar's void pass-through is measured against an empty void shield.
 /// </summary>
 [MemoryDiagnoser]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
@@ -20,6 +21,8 @@ public class FallbackBenchmarks
     private static readonly Shield<int> KevlarFallback = Shield.For<int>()
         .When<InvalidOperationException>()
         .FallbackTo(7);
+
+    private static readonly Shield KevlarVoidFallback = Shield.Fallback(static _ => default);
 
     private static readonly Shield<int> KevlarCompletedAsyncNotification = Shield.For<int>()
         .When<InvalidOperationException>()
@@ -50,6 +53,13 @@ public class FallbackBenchmarks
 
     [BenchmarkCategory("PassThrough"), Benchmark]
     public ValueTask<int> Polly_PassThrough() => PollyFallback.ExecuteAsync(static _ => new ValueTask<int>(42));
+
+    [BenchmarkCategory("VoidPassThrough"), Benchmark(Baseline = true)]
+    public ValueTask Kevlar_EmptyVoid() => Shield.Empty.ExecuteAsync(static _ => ValueTask.CompletedTask);
+
+    [BenchmarkCategory("VoidPassThrough"), Benchmark]
+    public ValueTask Kevlar_VoidPassThrough() =>
+        KevlarVoidFallback.ExecuteAsync(static _ => ValueTask.CompletedTask);
 
     [BenchmarkCategory("Triggered"), Benchmark(Baseline = true)]
     public ValueTask<int> Kevlar_Triggered() => KevlarFallback.ExecuteAsync(static _ => throw PrimaryError);

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -246,9 +246,13 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
                     "FallbackOptions recovery delegate");
             }
 
-            return fallback.IsCompletedSuccessfully
-                ? new ValueTask<Outcome<T>>(Outcome<T>.FromResult(default!))
-                : AwaitFallbackAsync<T>(fallback);
+            if (!fallback.IsCompletedSuccessfully)
+            {
+                return AwaitFallbackAsync<T>(fallback);
+            }
+
+            fallback.GetAwaiter().GetResult();
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromResult(default!));
         }
         catch (Exception fallbackFailure)
         {

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -179,23 +179,38 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
 
     public override string Describe() => "Fallback";
 
-    public override async ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
+    public override ValueTask<Outcome<T>> ExecuteAsync<T, TState>(Continuation<T, TState> next, KevlarContext context)
     {
         var strategyIndex = context.StrategyIndex;
-        var outcome = await next.InvokeAsync(context).ConfigureAwait(false);
+        var execution = next.InvokeAsync(context);
+        return execution.IsCompletedSuccessfully
+            ? HandleOutcome(execution.Result, context, strategyIndex)
+            : AwaitOutcomeAsync(execution, context, strategyIndex);
+    }
 
+    private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(
+        ValueTask<Outcome<T>> execution,
+        KevlarContext context,
+        int strategyIndex)
+    {
+        var outcome = await execution.ConfigureAwait(false);
+        return await HandleOutcome(outcome, context, strategyIndex).ConfigureAwait(false);
+    }
+
+    private ValueTask<Outcome<T>> HandleOutcome<T>(Outcome<T> outcome, KevlarContext context, int strategyIndex)
+    {
         if (outcome.Exception is not { } exception
             || !_judge.ShouldHandle(in outcome, context, attempt: 0, strategyIndex))
         {
-            return outcome;
+            return new ValueTask<Outcome<T>>(outcome);
         }
 
         if (typeof(T) != typeof(Nothing))
         {
-            return Outcome<T>.FromException(new InvalidOperationException(
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(new InvalidOperationException(
                 "Fallback on a non-generic Shield applies only to void executions. " +
                 "For executions that return a value, build a result-aware shield with " +
-                "Shield.For<T>() and use its Fallback overloads."));
+                "Shield.For<T>() and use its Fallback overloads.")));
         }
 
         KevlarMetrics.Fallback(context, _telemetryName, in outcome);
@@ -203,14 +218,23 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
         if (_onFallback is not null)
         {
             var fallbackEvent = new FallbackEvent(exception, context);
-            await CallbackInvoker.InvokeAsync(
+            var notification = CallbackInvoker.InvokeAsync(
                 _onFallback,
                 fallbackEvent,
                 CallbackErrorKind.Fallback,
                 context,
-                "FallbackOptions.OnFallback").ConfigureAwait(false);
+                "FallbackOptions.OnFallback");
+            if (!notification.IsCompletedSuccessfully)
+            {
+                return AwaitNotificationAsync<T>(notification, exception, context);
+            }
         }
 
+        return InvokeFallback<T>(exception, context);
+    }
+
+    private ValueTask<Outcome<T>> InvokeFallback<T>(Exception exception, KevlarContext context)
+    {
         try
         {
             var fallback = _fallback(exception, context.CancellationToken);
@@ -222,12 +246,35 @@ internal sealed class VoidFallbackStrategy : Strategy, IFallbackStrategyInspecti
                     "FallbackOptions recovery delegate");
             }
 
-            await fallback.ConfigureAwait(false);
-            return Outcome<T>.FromResult(default!);
+            return fallback.IsCompletedSuccessfully
+                ? new ValueTask<Outcome<T>>(Outcome<T>.FromResult(default!))
+                : AwaitFallbackAsync<T>(fallback);
         }
         catch (Exception fallbackFailure)
         {
-            return Outcome<T>.FromException(fallbackFailure);
+            return new ValueTask<Outcome<T>>(Outcome<T>.FromException(fallbackFailure));
+        }
+    }
+
+    private async ValueTask<Outcome<T>> AwaitNotificationAsync<T>(
+        ValueTask notification,
+        Exception exception,
+        KevlarContext context)
+    {
+        await notification.ConfigureAwait(false);
+        return await InvokeFallback<T>(exception, context).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<Outcome<T>> AwaitFallbackAsync<T>(ValueTask execution)
+    {
+        try
+        {
+            await execution.ConfigureAwait(false);
+            return Outcome<T>.FromResult(default!);
+        }
+        catch (Exception exception)
+        {
+            return Outcome<T>.FromException(exception);
         }
     }
 }

--- a/tests/Kevlar.Tests/VoidFallbackTests.cs
+++ b/tests/Kevlar.Tests/VoidFallbackTests.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks.Sources;
+
 namespace Kevlar.Tests;
 
 /// <summary>
@@ -192,6 +194,18 @@ public class VoidFallbackTests
     }
 
     [Test]
+    public async Task Synchronous_ValueTaskSource_Fallback_Is_Consumed_Once()
+    {
+        var source = new CompletionTrackingSource();
+        var shield = Shield.When<InvalidOperationException>()
+            .Fallback((_, _) => new ValueTask(source, token: 0));
+
+        await shield.ExecuteAsync(_ => throw new InvalidOperationException());
+
+        await Assert.That(source.ConsumptionCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task The_Static_Factory_Starts_A_Pipeline_With_A_Fallback()
     {
         Exception? seenException = null;
@@ -258,5 +272,23 @@ public class VoidFallbackTests
         await Assert.That(shield.ToString()).StartsWith("Fallback");
         await Assert.That(attempts).IsEqualTo(3);
         await Assert.That(recovered).IsTrue();
+    }
+
+    private sealed class CompletionTrackingSource : IValueTaskSource
+    {
+        private int _consumptionCount;
+
+        public int ConsumptionCount => Volatile.Read(ref _consumptionCount);
+
+        public void GetResult(short token) => Interlocked.Increment(ref _consumptionCount);
+
+        public ValueTaskSourceStatus GetStatus(short token) => ValueTaskSourceStatus.Succeeded;
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) =>
+            throw new InvalidOperationException("Source completed synchronously.");
     }
 }


### PR DESCRIPTION
## Summary

- add a synchronous fast path to the void fallback strategy
- defer async state machines to incomplete continuation, notification, and recovery operations
- consume synchronously completed custom `IValueTaskSource` recoveries exactly once
- add a permanent void pass-through benchmark against an empty void shield

## Benchmark

BenchmarkDotNet 0.15.8, default job, .NET 10.0.11, Windows 11, Intel i7-12700K. Same command before and after:

`dotnet run -c Release --project benchmarks/Kevlar.Benchmarks -- --filter *FallbackBenchmarks.Kevlar_EmptyVoid* *FallbackBenchmarks.Kevlar_VoidPassThrough*`

| Method | Before | After | Change | Allocated |
|---|---:|---:|---:|---:|
| Kevlar_VoidPassThrough | 108.29 ns | 91.89 ns | -15.1% | 0 B |
| Kevlar_EmptyVoid (control) | 14.23 ns | 15.35 ns | +7.9% | 0 B |

The control became slower while void fallback improved by 16.40 ns, supporting the fast-path change rather than an environment-wide speedup. The after result includes `GetResult()` consumption for synchronously completed custom `IValueTaskSource` recoveries.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release --framework net10.0 --no-build -- --timeout 5m` (1403 passed)
- `dotnet run --project tests/Kevlar.Tests -c Release --framework net8.0 --no-build -- --timeout 5m` (1369 passed)