### PR TITLE
perf(async): pool pipeline state machines

### DIFF
--- a/benchmarks/Kevlar.Benchmarks/AsyncSuspensionBenchmarks.cs
+++ b/benchmarks/Kevlar.Benchmarks/AsyncSuspensionBenchmarks.cs
@@ -1,0 +1,105 @@
+using System.Threading.Tasks.Sources;
+using BenchmarkDotNet.Attributes;
+
+namespace Kevlar.Benchmarks;
+
+/// <summary>
+/// Measures strategy execution when user work suspends once without allocating its own
+/// task or state machine. The reusable source completes only after Kevlar has returned
+/// the incomplete execution to this benchmark.
+/// </summary>
+[MemoryDiagnoser]
+public class AsyncSuspensionBenchmarks
+{
+    private static readonly Shield Empty = Shield.Empty;
+    private static readonly Shield Retry = Shield.Retry(0, Backoff.None);
+    private static readonly Shield CircuitBreaker = Shield.CircuitBreaker(
+        consecutiveFailures: 5,
+        breakDuration: TimeSpan.FromMinutes(1));
+    private static readonly Shield Timeout = Shield.Timeout(TimeSpan.FromMinutes(1));
+    private static readonly Shield RateLimit = Shield.RateLimit(
+        1_000_000_000,
+        perWindow: TimeSpan.FromSeconds(1));
+    private static readonly Shield ConcurrencyLimit = Shield.ConcurrencyLimit(1024);
+    private static readonly Shield<int> Fallback = Shield.For<int>().FallbackTo(7);
+    private static readonly Shield<int> Hedge = Shield.For<int>().Hedge(
+        1,
+        delay: TimeSpan.FromMinutes(1));
+
+    private readonly PendingValueTaskSource _source = new();
+
+    [Benchmark(Baseline = true)]
+    public ValueTask<int> EmptyShield() => Execute(Empty);
+
+    [Benchmark]
+    public ValueTask<int> RetryShield() => Execute(Retry);
+
+    [Benchmark]
+    public ValueTask<int> CircuitBreakerShield() => Execute(CircuitBreaker);
+
+    [Benchmark]
+    public ValueTask<int> TimeoutShield() => Execute(Timeout);
+
+    [Benchmark]
+    public ValueTask<int> RateLimitShield() => Execute(RateLimit);
+
+    [Benchmark]
+    public Task<int> RateLimitShieldAsTask() => ExecuteAsTask(RateLimit);
+
+    [Benchmark]
+    public ValueTask<int> ConcurrencyLimitShield() => Execute(ConcurrencyLimit);
+
+    [Benchmark]
+    public ValueTask<int> FallbackShield() => Execute(Fallback);
+
+    [Benchmark]
+    public ValueTask<int> HedgeShield() => Execute(Hedge);
+
+    private ValueTask<int> Execute(Shield shield)
+    {
+        var pending = _source.Prepare();
+        var execution = shield.ExecuteAsync(pending, static (operation, _) => operation);
+        _source.Complete();
+        return execution;
+    }
+
+    private ValueTask<int> Execute(Shield<int> shield)
+    {
+        var pending = _source.Prepare();
+        var execution = shield.ExecuteAsync(pending, static (operation, _) => operation);
+        _source.Complete();
+        return execution;
+    }
+
+    private Task<int> ExecuteAsTask(Shield shield)
+    {
+        var pending = _source.Prepare();
+        var execution = shield.ExecuteAsync(pending, static (operation, _) => operation).AsTask();
+        _source.Complete();
+        return execution;
+    }
+
+    private sealed class PendingValueTaskSource : IValueTaskSource<int>
+    {
+        private ManualResetValueTaskSourceCore<int> _source;
+
+        public ValueTask<int> Prepare()
+        {
+            _source.Reset();
+            return new ValueTask<int>(this, _source.Version);
+        }
+
+        public void Complete() => _source.SetResult(42);
+
+        public int GetResult(short token) => _source.GetResult(token);
+
+        public ValueTaskSourceStatus GetStatus(short token) => _source.GetStatus(token);
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) =>
+            _source.OnCompleted(continuation, state, token, flags);
+    }
+}

--- a/src/Kevlar/Internal/ShieldEngine.cs
+++ b/src/Kevlar/Internal/ShieldEngine.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Kevlar.Internal;
 
 /// <summary>Boundary plumbing shared by <see cref="Shield"/> and <see cref="Shield{TResult}"/>.</summary>
@@ -539,6 +541,9 @@ internal static class ShieldEngine
         return continuation.InvokeAsync(context);
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private static async ValueTask<Outcome<T>> InvokeAsync<TState, T>(AsyncCallback<TState, T> callback, KevlarContext context)
     {
         try
@@ -565,6 +570,9 @@ internal static class ShieldEngine
         }
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private static async ValueTask<T> AwaitAsync<T>(ValueTask<Outcome<T>> pipeline, KevlarContext context, long startedAt)
     {
         try

--- a/src/Kevlar/Strategy.cs
+++ b/src/Kevlar/Strategy.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 
 namespace Kevlar;
@@ -367,6 +368,9 @@ public readonly struct Continuation<T, TState>
         }
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private static async ValueTask<Outcome<T>> AwaitStrategyAsync(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,


### PR DESCRIPTION
## Summary

- use `PoolingAsyncValueTaskMethodBuilder<T>` for three measured pipeline suspension points
- retain existing builders for `netstandard2.0`
- add deterministic suspension benchmarks backed by a reusable `IValueTaskSource<int>`

## Motivation

Every incomplete strategy execution passed through three generic async wrappers. Their state-machine boxes accounted for 544 bytes per operation across retry, circuit breaker, timeout, rate limit, concurrency limit, and fallback measurements.

.NET 10 ShortRun allocation results:

| Path | Before | After |
|---|---:|---:|
| Retry | 952 B | 408 B |
| Circuit breaker | 744 B | 200 B |
| Timeout | 776 B | 232 B |
| Rate limit | 544 B | 0 B |
| Concurrency limit | 728 B | 184 B |
| Fallback | 736 B | 192 B |
| Hedge | 1760 B | 1312 B |

Calling `AsTask()` on the pooled rate-limit execution allocates 80 B, still well below the original 544 B direct path.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.AllocationTests -c Release -f net10.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.AllocationTests -c Release -f net8.0 --no-build -- --timeout 5m`
- BenchmarkDotNet ShortRun: `AsyncSuspensionBenchmarks`