### PR TITLE
perf(strategies): pool suspended state

### DIFF
--- a/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
+++ b/src/Kevlar/Strategies/CircuitBreaker/CircuitBreakerStrategy.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -96,6 +97,9 @@ internal sealed class CircuitBreakerStrategy : Strategy
             : AwaitOutcomeAsync(execution, context, admissionGeneration);
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,

--- a/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
+++ b/src/Kevlar/Strategies/ConcurrencyLimit/ConcurrencyLimitStrategy.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -182,6 +183,9 @@ internal sealed class ConcurrencyLimitStrategy : Strategy
         return new ValueTask<Outcome<T>>(outcome);
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<Outcome<T>> AwaitExecutionAsync<T>(ValueTask<Outcome<T>> execution)
     {
         try

--- a/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
+++ b/src/Kevlar/Strategies/Fallback/FallbackStrategy.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -54,6 +55,9 @@ internal sealed class FallbackStrategy<TResult> : Strategy, IFallbackStrategyIns
             : AwaitOutcomeAsync(execution, context, strategyIndex);
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<Outcome<T>> AwaitOutcomeAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,

--- a/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
+++ b/src/Kevlar/Strategies/Hedging/HedgingStrategy.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 using Reservoir;
 
@@ -191,6 +192,9 @@ internal sealed class HedgingStrategy : Strategy
             strategyIndex);
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<Outcome<T>> ExecuteCoreAsync<T, TState>(
         Continuation<T, TState> next,
         KevlarContext context,

--- a/src/Kevlar/Strategies/Retry/RetryStrategy.cs
+++ b/src/Kevlar/Strategies/Retry/RetryStrategy.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 
 namespace Kevlar.Strategies;
@@ -183,6 +184,9 @@ internal sealed class RetryStrategy : Strategy
         }
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<Outcome<T>> ExecuteCoreAsync<T, TState>(
         Continuation<T, TState> next,
         KevlarContext context,

--- a/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
+++ b/src/Kevlar/Strategies/Timeout/TimeoutStrategy.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Kevlar.Internal;
 using Reservoir;
 
@@ -176,6 +177,9 @@ internal sealed class TimeoutStrategy : Strategy
             timeout);
     }
 
+#if NET8_0_OR_GREATER
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<Outcome<T>> AwaitAsync<T>(
         ValueTask<Outcome<T>> execution,
         KevlarContext context,


### PR DESCRIPTION
## Summary

- pool six strategy-local state machines whose executions genuinely suspend
- keep `netstandard2.0` on existing builders
- exclude unproven async hook, generator, rejection, and rate-limit helpers

## Motivation

#478 added deterministic suspension benchmarks and pooled shared pipeline wrappers. Each selected strategy still retained one measurable state-machine allocation.

.NET 10 ShortRun results relative to #478:

| Path | Before | After | Mean before | Mean after |
|---|---:|---:|---:|---:|
| Retry | 408 B | 0 B | 349 ns | 279 ns |
| Circuit breaker | 200 B | 0 B | 332 ns | 285 ns |
| Timeout | 232 B | 0 B | 381 ns | 337 ns |
| Concurrency limit | 184 B | 0 B | 316 ns | 273 ns |
| Fallback | 192 B | 0 B | 318 ns | 278 ns |
| Hedge | 1312 B | 696 B | 962 ns | 823 ns |

Separate tests of timeout generators, fallback notifications, and hedge callbacks showed no allocation improvement, so those state machines remain unchanged. Rate limiting already reached zero allocation after #478 and needs no local builder override.

## Validation

- `dotnet build Kevlar.slnx -c Release`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net10.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.Tests -c Release -f net8.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.AllocationTests -c Release -f net10.0 --no-build -- --timeout 5m`
- `dotnet run --project tests/Kevlar.AllocationTests -c Release -f net8.0 --no-build -- --timeout 5m`
- BenchmarkDotNet ShortRun: `AsyncSuspensionBenchmarks`

