### PR TITLE
chore(deps): upgrade Reservoir to 1.7.0

### DIFF
--- a/.github/scripts/benchmark_aba.py
+++ b/.github/scripts/benchmark_aba.py
@@ -1,0 +1,131 @@
+"""Run a commit comparison sequentially on one Actions runner and retain evidence."""
+
+import datetime
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+
+def run(command, cwd, log):
+    with log.open("w", encoding="utf-8") as output:
+        result = subprocess.run(command, cwd=cwd, stdout=output, stderr=subprocess.STDOUT)
+    if result.returncode:
+        print(log.read_text(encoding="utf-8")[-12000:], flush=True)
+        raise RuntimeError(f"Command failed ({result.returncode}); see {log}")
+
+
+def read_results(directory):
+    results = {}
+    for report in sorted(directory.glob("results/*-report-full-compressed.json")):
+        for benchmark in json.loads(report.read_text())["Benchmarks"]:
+            name = benchmark["FullName"]
+            statistics = benchmark.get("Statistics")
+            if not statistics or not all(
+                math.isfinite(statistics[field]) and statistics[field] > 0
+                for field in ("Mean", "Median")
+            ):
+                raise RuntimeError(f"Missing or invalid measurements: {name}")
+            if name in results:
+                raise RuntimeError(f"Duplicate benchmark: {name}")
+            results[name] = benchmark
+    if not results:
+        raise RuntimeError(f"No successful benchmark reports in {directory}")
+    return results
+
+
+def main():
+    repository = Path.cwd()
+    root = Path(os.environ["RUNNER_TEMP"]) / "benchmark-aba"
+    evidence = root / "results"
+    evidence.mkdir(parents=True, exist_ok=False)
+    commits = {"A": os.environ["BASELINE_SHA"], "B": os.environ["CANDIDATE_SHA"]}
+    if any(not re.fullmatch(r"[0-9a-fA-F]{40}", sha) for sha in commits.values()):
+        raise ValueError("Both refs must be full immutable commit SHAs")
+    filters = shlex.split(os.environ["BENCHMARK_FILTER"])
+    if not filters or any(value.startswith("-") for value in filters):
+        raise ValueError("Provide one or more space-separated benchmark glob filters")
+    metadata = {
+        "commits": commits,
+        "filters": filters,
+        "runner": {key: os.environ.get(key) for key in (
+            "RUNNER_NAME", "RUNNER_OS", "RUNNER_ARCH", "ImageOS", "ImageVersion",
+            "GITHUB_RUN_ID", "GITHUB_RUN_ATTEMPT",
+        )},
+        "packages": {},
+        "phases": [],
+    }
+    run(["dotnet", "--info"], repository, evidence / "dotnet-info.log")
+    run(["lscpu"], repository, evidence / "cpu-info.log")
+    project = Path("benchmarks/Kevlar.Benchmarks")
+    command = ["dotnet", "run", "-c", "Release", "--no-build", "--",
+               "--filter", *filters, "--exporters", "json"]
+    worktrees = {}
+    dry_results = {}
+    for label, sha in commits.items():
+        worktree = root / label
+        worktrees[label] = worktree
+        run(["git", "worktree", "add", "--detach", str(worktree), sha],
+            repository, evidence / f"{label}-checkout.log")
+        run(["dotnet", "build", str(project / "Kevlar.Benchmarks.csproj"), "-c", "Release"],
+            worktree, evidence / f"{label}-build.log")
+        assets = json.loads((worktree / project / "obj/project.assets.json").read_text())
+        packages = sorted(key for key, value in assets["libraries"].items()
+                          if value["type"] == "package")
+        metadata["packages"][label] = packages
+        print(f"{label}: {sha}; Reservoir: {[p for p in packages if p.startswith('Reservoir/')]}",
+              flush=True)
+        run([*command, "--job", "Dry", "--artifacts", str(evidence / f"{label}-dry")],
+            worktree / project, evidence / f"{label}-dry.log")
+        dry_results[label] = read_results(evidence / f"{label}-dry")
+    if dry_results["A"].keys() != dry_results["B"].keys():
+        raise RuntimeError("Baseline and candidate select different benchmark cases")
+    (evidence / "metadata.json").write_text(json.dumps(metadata, indent=2))
+    measured = {}
+    for phase, label in (("A1", "A"), ("B", "B"), ("A2", "A")):
+        timing = {"phase": phase, "start": datetime.datetime.now(datetime.timezone.utc).isoformat()}
+        print(f"Starting {phase}: {len(dry_results[label])} benchmarks", flush=True)
+        run([*command, "--artifacts", str(evidence / phase)],
+            worktrees[label] / project, evidence / f"{phase}.log")
+        measured[phase] = read_results(evidence / phase)
+        if measured[phase].keys() != dry_results[label].keys():
+            raise RuntimeError(f"Incomplete results for {phase}")
+        timing["end"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        metadata["phases"].append(timing)
+        (evidence / "metadata.json").write_text(json.dumps(metadata, indent=2))
+        print(f"Completed {phase}", flush=True)
+
+    lines = ["# A-B-A benchmark comparison", "",
+             f"A: `{commits['A']}`", f"B: `{commits['B']}`", "",
+             "Sequential A1 → B → A2 on the same runner, using BenchmarkDotNet default jobs.",
+             "Medians are ns/op; negative changes mean faster. Allocations are bytes/op.",
+             "B change uses the arithmetic mean of A1 and A2 medians. Drift is A2/A1 − 1.",
+             "Drift above 5% is flagged; these descriptive comparisons are not significance tests.", "",
+             "| Benchmark | A1 ns | B ns | A2 ns | B change | A drift | A1/B/A2 bytes |",
+             "|---|---:|---:|---:|---:|---:|---:|"]
+    for name in sorted(measured["A1"]):
+        rows = [measured[phase][name] for phase in ("A1", "B", "A2")]
+        a1, b, a2 = (row["Statistics"]["Median"] for row in rows)
+        change = (b / ((a1 + a2) / 2) - 1) * 100
+        drift = (a2 / a1 - 1) * 100
+        memory = "/".join(str(row.get("Memory", {}).get("BytesAllocatedPerOperation", "n/a"))
+                          for row in rows)
+        flag = " ⚠" if abs(drift) > 5 else ""
+        lines.append(f"| {name.removeprefix('Kevlar.Benchmarks.')} | {a1:.2f} | {b:.2f} | "
+                     f"{a2:.2f} | {change:+.2f}% | {drift:+.2f}%{flag} | {memory} |")
+    lines.extend(["", "## Resolved package differences", ""])
+    for label, other in (("A", "B"), ("B", "A")):
+        difference = sorted(set(metadata["packages"][label]) - set(metadata["packages"][other]))
+        lines.append(f"{label} only: {', '.join(difference) or 'none'}")
+    summary = "\n".join(lines) + "\n"
+    (evidence / "summary.md").write_text(summary, encoding="utf-8")
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as output:
+        output.write(summary)
+    print(summary, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/benchmark_aba.py
+++ b/.github/scripts/benchmark_aba.py
@@ -72,7 +72,10 @@ def main():
             repository, evidence / f"{label}-checkout.log")
         run(["dotnet", "build", str(project / "Kevlar.Benchmarks.csproj"), "-c", "Release"],
             worktree, evidence / f"{label}-build.log")
-        assets = json.loads((worktree / project / "obj/project.assets.json").read_text())
+        assets_log = evidence / f"{label}-assets-path.log"
+        run(["dotnet", "msbuild", str(project / "Kevlar.Benchmarks.csproj"),
+             "-p:Configuration=Release", "-getProperty:ProjectAssetsFile"], worktree, assets_log)
+        assets = json.loads(Path(assets_log.read_text().strip()).read_text())
         packages = sorted(key for key, value in assets["libraries"].items()
                           if value["type"] == "package")
         metadata["packages"][label] = packages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -81,7 +81,7 @@ jobs:
     name: A-B-A Benchmarks
     if: github.event_name == 'workflow_dispatch' && inputs.comparison_ref != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,6 +18,10 @@ on:
         description: 'Benchmark filter (e.g. *Retry*, *Pipeline*)'
         required: false
         default: '*'
+      comparison_ref:
+        description: 'Optional baseline commit SHA for an A-B-A comparison against the dispatched commit'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -31,6 +35,7 @@ concurrency:
 jobs:
   run-benchmarks:
     name: Run Benchmarks
+    if: inputs.comparison_ref == ''
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -71,6 +76,37 @@ jobs:
           name: benchmark-results
           path: benchmarks/Kevlar.Benchmarks/BenchmarkResults/results/**
           retention-days: 30
+
+  compare-benchmarks:
+    name: A-B-A Benchmarks
+    if: github.event_name == 'workflow_dispatch' && inputs.comparison_ref != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run baseline, candidate, and baseline on the same runner
+        env:
+          BASELINE_SHA: ${{ inputs.comparison_ref }}
+          CANDIDATE_SHA: ${{ github.sha }}
+          BENCHMARK_FILTER: ${{ inputs.benchmark_filter || '*' }}
+        run: python3 .github/scripts/benchmark_aba.py
+
+      - name: Upload comparison evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-aba-results
+          path: ${{ runner.temp }}/benchmark-aba/results/
+          retention-days: 30
+          if-no-files-found: error
 
   benchmark-history:
     name: Store Benchmark History

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
-    <PackageVersion Include="Reservoir" Version="[1.4.0,2.0.0)" />
+    <PackageVersion Include="Reservoir" Version="[1.7.0,2.0.0)" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
 
     <!-- Satellites -->

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ SDK or later. Older compiler hosts skip the analyzer assets; the runtime library
 available. `Kevlar.Testing` supports callback recording on `netstandard2.0`, but deterministic time
 and metric capture require .NET 8 or later.
 
-The core package depends on `Reservoir` `[1.4.0, 2.0.0)` on every target. Its `netstandard2.0`
+The core package depends on `Reservoir` `[1.7.0, 2.0.0)` on every target. Its `netstandard2.0`
 asset also uses `Microsoft.Bcl.AsyncInterfaces`, `Microsoft.Bcl.TimeProvider`, and
 `System.Threading.Tasks.Extensions`. See the [support policy](https://thomhurst.github.io/Kevlar/docs/support-policy)
 for integration-package dependency floors, package lockstep, and the release support window.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -53,7 +53,7 @@ then edit its project file to target .NET Framework and enable the language feat
 The HTTP example also needs the explicit `using System.Net.Http;` shown above because .NET
 Framework does not supply that implicit using. Expect MSBuild to generate binding redirects for the
 transitive compatibility dependencies: `Microsoft.Bcl.AsyncInterfaces` 8.0.0,
-`Microsoft.Bcl.TimeProvider` 8.0.1, `Reservoir` 1.4.0,
+`Microsoft.Bcl.TimeProvider` 8.0.1, `Reservoir` 1.7.0,
 `System.Runtime.CompilerServices.Unsafe` 6.1.2, `System.Threading.Tasks.Extensions` 4.6.3, and
 `System.ValueTuple` 4.5.0.
 

--- a/docs/docs/support-policy.md
+++ b/docs/docs/support-policy.md
@@ -43,7 +43,7 @@ application. Test-only and build-only dependencies are not part of this package 
 | `System.Runtime.CompilerServices.Unsafe` | `6.1.2` | `Kevlar.Chaos` |
 | `Grpc.Core.Api` | `2.83.0` | `Kevlar.Extensions.Grpc` |
 | `Grpc.Net.ClientFactory` | `2.83.0` | `Kevlar.Extensions.Grpc` |
-| `Reservoir` | `[1.4.0, 2.0.0)` | `Kevlar` |
+| `Reservoir` | `[1.7.0, 2.0.0)` | `Kevlar` |
 
 Package verification rejects accidental dependency floors above major version 8, except for the
 documented gRPC and Reservoir version lines. Raising a floor is a compatibility decision and must

--- a/src/Kevlar/README.md
+++ b/src/Kevlar/README.md
@@ -34,7 +34,7 @@ settings and an explicit `using System.Net.Http;`:
 ```
 
 Expect MSBuild to generate binding redirects for the transitive compatibility dependencies:
-`Microsoft.Bcl.AsyncInterfaces` 8.0.0, `Microsoft.Bcl.TimeProvider` 8.0.1, `Reservoir` 1.4.0,
+`Microsoft.Bcl.AsyncInterfaces` 8.0.0, `Microsoft.Bcl.TimeProvider` 8.0.1, `Reservoir` 1.7.0,
 `System.Runtime.CompilerServices.Unsafe` 6.1.2, `System.Threading.Tasks.Extensions` 4.6.3, and
 `System.ValueTuple` 4.5.0.
 


### PR DESCRIPTION
Raises Reservoir's minimum supported version from 1.4.0 to 1.7.0, retaining the existing `< 2.0.0` upper bound, and updates the dependency documentation.

Adds an optional `comparison_ref` to the Benchmarks workflow. It pins both commits, builds and dry-validates the selected benchmarks, then runs A1 → B → A2 sequentially on one runner. Artifacts retain resolved dependencies, runner/SDK details, raw results, allocations, and median comparisons with baseline drift. Comparison runs do not publish benchmark history or docs. The 240-minute allowance covers three full suites plus preparation.

### Performance results

Both A-B-A runs completed successfully with .NET SDK 10.0.400 / runtime 10.0.11 on Ubuntu 24.04. **Reservoir 1.4.0 → 1.7.0 was the only resolved package difference in both runs.** Timing changes compare the candidate median with the arithmetic mean of the two baseline medians; negative means faster.

- [Initial 18-case A-B-A](https://github.com/thomhurst/Kevlar/actions/runs/34159342050), AMD EPYC 9V74: nested synchronous execution was **15.61% slower**, and timeout happy path was **12.54% slower**, with baseline drift of +1.59% and +1.99%. Four other cases had >5% baseline drift and are inconclusive. The remaining timing changes were within approximately 4%. All zero-allocation cases remained at 0 B/op; the allocating yielding-hedge case changed from 2511 to 2512 B/op.
- [Focused four-case A-B-A repeat](https://github.com/thomhurst/Kevlar/actions/runs/34160732368), Intel Xeon Platinum 8573C: nested synchronous execution was **+1.81%**, and timeout happy path **−0.45%**, with baseline drift of +1.31% and +0.05%. Both remained at 0 B/op; Polly control changes were within 1.65%.

**The large slowdowns did not reproduce on Intel, but an AMD-specific regression remains unresolved.** Each experiment used one runner for all three phases; the two experiments landed on different CPU families. These are descriptive measurements, not a statistical equivalence claim. The upgrade should not be presented as a demonstrated performance improvement.

A is `8706edeb477ef4177e51c795e4cc4862f86d2db3` in both runs. Initial B is `8b13a3996f962dec2ae98b4cce5e3d23c43bde5b`; repeat B is the current PR head `442bbae2dd73666961ad915861c585c1dabd8e43`. The only difference between the two B commits is the workflow timeout.

### Validation

[Latest CI](https://github.com/thomhurst/Kevlar/actions/runs/34159681387): Windows build/tests passed. Linux builds, tests, and package verification passed, then API metadata freshness failed on seven files. [Baseline main CI](https://github.com/thomhurst/Kevlar/actions/runs/34120664901) fails the same check on the same files. Coverage was consequently skipped. Allocation gates (.NET 8/10), documentation build, deterministic model tests, and stress smoke tests passed. Linux CI still needs to be green before merge.

The Claude review job fails because its Actions configuration lacks Anthropic credentials. Local builds were deferred because the mandatory shared performance-lock checkout is unavailable. Python syntax and `git diff --check` passed; both benchmark workflow executions succeeded.

Documentation screenshots are unavailable: the browser connection failed, and automatic approval review rejected the local screenshot command as blocked by policy.

<details>
<summary>Initial A-B-A: all 18 cases</summary>
# A-B-A benchmark comparison

A: `8706edeb477ef4177e51c795e4cc4862f86d2db3`
B: `8b13a3996f962dec2ae98b4cce5e3d23c43bde5b`

Sequential A1 → B → A2 on the same runner, using BenchmarkDotNet default jobs.
Medians are ns/op; negative changes mean faster. Allocations are bytes/op.
B change uses the arithmetic mean of A1 and A2 medians. Drift is A2/A1 − 1.
Drift above 5% is flagged; these descriptive comparisons are not significance tests.

| Benchmark | A1 ns | B ns | A2 ns | B change | A drift | A1/B/A2 bytes |
|---|---:|---:|---:|---:|---:|---:|
| HedgingBenchmarks.CompletedAsyncHook | 3448.83 | 3420.48 | 3449.54 | -0.83% | +0.02% | 1144/1144/1144 |
| HedgingBenchmarks.FixedHedge | 3451.47 | 3360.48 | 3421.25 | -2.21% | -0.88% | 1144/1144/1144 |
| HedgingBenchmarks.GeneratedAction | 3821.69 | 3824.48 | 3833.26 | -0.08% | +0.30% | 1360/1360/1360 |
| HedgingBenchmarks.KevlarPrimaryWins | 251.08 | 257.32 | 244.61 | +3.82% | -2.58% | 0/0/0 |
| HedgingBenchmarks.PollyPrimaryWins | 380.20 | 382.14 | 373.76 | +1.37% | -1.69% | 0/0/0 |
| HedgingBenchmarks.YieldingAsyncHook | 7090.43 | 7163.06 | 7090.10 | +1.03% | -0.00% | 2511/2512/2511 |
| OverheadBenchmarks.Kevlar_EmptyContextState | 107.62 | 99.03 | 97.00 | -3.21% | -9.86% ⚠ | 0/0/0 |
| OverheadBenchmarks.Kevlar_NestedEmptyAsync | 167.31 | 186.38 | 191.15 | +3.99% | +14.25% ⚠ | 0/0/0 |
| OverheadBenchmarks.Kevlar_NestedEmptySync | 113.33 | 132.07 | 115.13 | +15.61% | +1.59% | 0/0/0 |
| OverheadBenchmarks.Polly_Empty | 47.20 | 47.01 | 47.80 | -1.03% | +1.26% | 0/0/0 |
| PipelineBenchmarks.Kevlar_RatioTimeoutRetryBreaker | 278.65 | 283.82 | 295.18 | -1.08% | +5.93% ⚠ | 0/0/0 |
| PipelineBenchmarks.Kevlar_TokenBucketRatioFiveStrategyChain | 400.95 | 394.76 | 396.09 | -0.94% | -1.21% | 0/0/0 |
| PipelineBenchmarks.Kevlar_TokenBucketRatioFiveStrategyChainSync | 363.40 | 350.48 | 352.34 | -2.06% | -3.04% | 0/0/0 |
| TimeoutBenchmarks.Kevlar_AsyncHookConfigured_HappyPath | 166.86 | 168.91 | 164.60 | +1.92% | -1.35% | 0/0/0 |
| TimeoutBenchmarks.Kevlar_AsynchronousGenerator_HappyPath | 1377.02 | 1388.86 | 1360.15 | +1.48% | -1.23% | 560/560/560 |
| TimeoutBenchmarks.Kevlar_HappyPath | 161.98 | 184.11 | 165.21 | +12.54% | +1.99% | 0/0/0 |
| TimeoutBenchmarks.Kevlar_SynchronousGenerator_HappyPath | 179.89 | 177.01 | 169.28 | +1.39% | -5.90% ⚠ | 0/0/0 |
| TimeoutBenchmarks.Polly_HappyPath | 167.21 | 164.04 | 160.79 | +0.02% | -3.84% | 0/0/0 |

## Resolved package differences

A only: Reservoir/1.4.0
B only: Reservoir/1.7.0

</details>

<details>
<summary>Focused A-B-A repeat: all four cases</summary>

# A-B-A benchmark comparison

A: `8706edeb477ef4177e51c795e4cc4862f86d2db3`
B: `442bbae2dd73666961ad915861c585c1dabd8e43`

Sequential A1 → B → A2 on the same runner, using BenchmarkDotNet default jobs.
Medians are ns/op; negative changes mean faster. Allocations are bytes/op.
B change uses the arithmetic mean of A1 and A2 medians. Drift is A2/A1 − 1.
Drift above 5% is flagged; these descriptive comparisons are not significance tests.

| Benchmark | A1 ns | B ns | A2 ns | B change | A drift | A1/B/A2 bytes |
|---|---:|---:|---:|---:|---:|---:|
| OverheadBenchmarks.Kevlar_NestedEmptySync | 154.99 | 158.83 | 157.02 | +1.81% | +1.31% | 0/0/0 |
| OverheadBenchmarks.Polly_Empty | 50.93 | 51.34 | 50.80 | +0.94% | -0.25% | 0/0/0 |
| TimeoutBenchmarks.Kevlar_HappyPath | 170.14 | 169.41 | 170.22 | -0.45% | +0.05% | 0/0/0 |
| TimeoutBenchmarks.Polly_HappyPath | 164.89 | 165.35 | 171.36 | -1.65% | +3.92% | 0/0/0 |

## Resolved package differences

A only: Reservoir/1.4.0
B only: Reservoir/1.7.0

</details>

